### PR TITLE
Refactor Credentials

### DIFF
--- a/magenta-cli/src/main/scala/magenta/cli/Main.scala
+++ b/magenta-cli/src/main/scala/magenta/cli/Main.scala
@@ -5,7 +5,7 @@ import java.io.File
 import json.{DeployInfoJsonReader, JsonReader}
 import scopt.OptionParser
 import HostList._
-import tasks.{Credentials, CommandLocator}
+import tasks.CommandLocator
 
 object Main extends scala.App {
 
@@ -140,8 +140,8 @@ object Main extends scala.App {
           Log.info("Executing...")
           val credentials = if (Config.jvmSsh) {
             val passphrase = System.console.readPassword("Please enter your passphrase:")
-            Credentials(System.getenv("USER"), passphrase.toString, Config.keyLocation)
-          } else Credentials(keyFileLocation = Config.keyLocation)
+            PassphraseProvided(System.getenv("USER"), passphrase.toString, Config.keyLocation)
+          } else SystemUser(keyFile = Config.keyLocation)
           tasks.foreach { task =>
             Log.context("Executing %s..." format task.fullDescription) {
               task.execute(credentials)

--- a/magenta-lib/src/main/scala/magenta/Credentials.scala
+++ b/magenta-lib/src/main/scala/magenta/Credentials.scala
@@ -1,0 +1,11 @@
+package magenta
+
+import java.io.File
+
+sealed trait Credentials {
+  def keyFile: Option[File]
+}
+
+case class PassphraseProvided(user: String, passphrase: String, keyFile: Option[File]) extends Credentials
+
+case class SystemUser(keyFile: Option[File]) extends Credentials

--- a/magenta-lib/src/main/scala/magenta/tasks/RemoteShellTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/RemoteShellTask.scala
@@ -1,53 +1,32 @@
 package magenta
 package tasks
 
-import java.io.File
 import com.decodified.scalassh.{SimplePasswordProducer, PublicKeyLogin, SSH}
-import com.decodified.scalassh.PublicKeyLogin._
-
+import com.decodified.scalassh.PublicKeyLogin.DefaultKeyLocations
 
 trait RemoteShellTask extends ShellTask {
   def host: Host
+
   def remoteCommandLine: CommandLine = remoteCommandLine(None)
-  def remoteCommandLine(credentials: Option[Credentials]): CommandLine = {
-    val keyFileArgs = for {
-      creds <- credentials.toList
-      file <- creds.keyFileLocation.toList
-      arg <- "-i" :: file.getPath :: Nil
-    } yield arg
+  def remoteCommandLine(credentials: Credentials): CommandLine = remoteCommandLine(Some(credentials))
+
+  protected def remoteCommandLine(credentials: Option[Credentials]): CommandLine = {
+    val keyFileArgs = credentials.flatMap(_.keyFile).toList.flatMap("-i" :: _.getPath :: Nil)
     CommandLine("ssh" :: "-qtt" :: keyFileArgs ::: host.connectStr :: commandLine.quoted :: Nil)
   }
 
-  override def execute(credentials: Credentials) { credentials.forScalaSsh match {
-    case Some(publicKeyLogin) => {
+  override def execute(credentials: Credentials) { credentials match {
+    case PassphraseProvided(user, pass, keyFile) =>
+      val publicKeyLogin =
+        PublicKeyLogin(user, SimplePasswordProducer(pass), keyFile map (_.getPath :: Nil) getOrElse DefaultKeyLocations)
       val credentialsForHost = host.connectAs match {
         case Some(username) => publicKeyLogin.copy(user = username)
         case None => publicKeyLogin
       }
-      SSH(host.name, credentialsForHost) { client =>
-        client.exec(commandLine.quoted)
-      }
-    }
-    case None => remoteCommandLine(Some(credentials)).run()
+      SSH(host.name, credentialsForHost)(_.exec(commandLine.quoted))
+    case SystemUser(keyFile) => remoteCommandLine(credentials).run()
   }}
 
   lazy val description = "on " + host.name
   override lazy val verbose = "$ " + remoteCommandLine.quoted
-}
-
-case class Credentials(
-  user: Option[String] = None,
-  passphrase: Option[String] = None,
-  keyFileLocation: Option[File] = None
-) {
-  lazy val forScalaSsh: Option[PublicKeyLogin] = for {
-    u <- user
-    p <- passphrase
-  } yield PublicKeyLogin(u, SimplePasswordProducer(p),
-      (keyFileLocation map (x => List(x.getPath))) getOrElse (DefaultKeyLocations))
-}
-
-object Credentials {
-  def apply(user: String, passphrase: String, keyFileLocation: Option[File]): Credentials =
-    Credentials(Some(user), Some(passphrase), keyFileLocation)
 }

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -17,10 +17,10 @@ object CommandLocator {
 
 case class CopyFile(host: Host, source: String, dest: String) extends ShellTask {
   def commandLine = List("rsync", "-rv", source, "%s:%s" format(host.connectStr, dest))
-  def commandLine(sshCredentials: Credentials): CommandLine = sshCredentials.keyFileLocation map { location =>
+  def commandLine(sshCredentials: Credentials): CommandLine = sshCredentials.keyFile map { location =>
     val shellCommand = CommandLine("ssh" :: "-i" :: location.getPath :: Nil).quoted
     CommandLine(commandLine.commandLine.head :: "-e" :: shellCommand :: commandLine.commandLine.tail)
-  } getOrElse (commandLine)
+  } getOrElse commandLine
 
   lazy val description = "%s -> %s:%s" format (source, host.connectStr, dest)
 

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -173,7 +173,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
       def commandLine = CommandLine(List("ls", "-l"))
     }
 
-    remoteTask.remoteCommandLine(Some(Credentials(keyFileLocation = Some(new File("foo"))))) should
+    remoteTask.remoteCommandLine(SystemUser(Some(new File("foo")))) should
       be (CommandLine(List("ssh", "-qtt", "-i", "foo", "some-host", "ls -l")))
   }
 
@@ -248,7 +248,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
   it should "specify custom remote shell for rsync if key-file specified" in {
     val task = CopyFile(Host("foo.com"), "/source", "/dest")
 
-    val command = task.commandLine(Credentials(keyFileLocation = Some(new File("key"))))
+    val command = task.commandLine(SystemUser(Some(new File("key"))))
 
     command.quoted should be ("""rsync -e "ssh -i key" -rv /source foo.com:/dest""")
   }
@@ -256,7 +256,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
   it should "not specify custom remote shell for rsync if no key-file specified" in {
     val task = CopyFile(Host("foo.com"), "/source", "/dest")
 
-    val command = task.commandLine(Credentials())
+    val command = task.commandLine(SystemUser(None))
 
     command.quoted should be ("""rsync -rv /source foo.com:/dest""")
   }
@@ -277,7 +277,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
     override val s3client = mock[AmazonS3Client]
   }
   
-  val fakeCredentials = Credentials()
+  val fakeCredentials = SystemUser(None)
 }
 
 


### PR DESCRIPTION
The aim was to make `Credentials` more self-documenting by factoring it into two subtypes which have clearly different uses: one for providing a username/passphrase to a JVM SSH library, and another for using the system's `ssh` executable.

(I originally did this while reviewing Phil's pull request as I was puzzling over which code paths were relevant when `user` and `passphrase` were defined/undefined.)
