### PR TITLE
Made a Package Type of AmazonWebServicesS3.

### DIFF
--- a/magenta-lib/src/main/scala/magenta/Package.scala
+++ b/magenta-lib/src/main/scala/magenta/Package.scala
@@ -14,12 +14,13 @@ case class Package(
   def mkAction(name: String): Action = pkgType.mkAction(name)
 
   lazy val pkgType = pkgTypeName match {
-    case "jetty-webapp" => new JettyWebappPackageType(this)
-    case "resin-webapp" => new ResinWebappPackageType(this)
-    case "django-webapp" => new DjangoWebappPackageType(this)
-    case "executable-jar-webapp" => new ExecutableJarWebappPackageType(this)
-    case "file" => new FilePackageType(this)
-    case "demo" => new DemoPackageType(this)
+    case "jetty-webapp" => JettyWebappPackageType(this)
+    case "resin-webapp" => ResinWebappPackageType(this)
+    case "django-webapp" => DjangoWebappPackageType(this)
+    case "executable-jar-webapp" => ExecutableJarWebappPackageType(this)
+    case "file" => FilePackageType(this)
+    case "demo" => DemoPackageType(this)
+    case "aws-s3" => AmazonWebServicesS3(this)
     case unknown => sys.error("Package type %s of package %s is unknown" format (unknown, name))
   }
 

--- a/magenta-lib/src/main/scala/magenta/Types.scala
+++ b/magenta-lib/src/main/scala/magenta/Types.scala
@@ -36,6 +36,23 @@ trait PackageType {
   def defaultData: Map[String, JValue] = Map.empty
 }
 
+case class AmazonWebServicesS3(pkg: Package) extends PackageType {
+  val name = "aws-s3"
+
+  lazy val staticDir = pkg.srcDir.getPath + "/"
+
+  //required configuration, you cannot upload without setting these
+  lazy val bucket = pkg.stringData("bucket")
+  lazy val cacheControl = pkg.stringData("cacheControl")
+
+  override val perAppActions: AppActionDefinition = {
+    case "uploadStaticFiles" => stage =>
+      List(
+        S3Upload(stage, bucket, new File(staticDir), Some(cacheControl))
+      )
+  }
+}
+
 private abstract case class PackageAction(pkg: Package, actionName: String) extends Action {
   def apps = pkg.apps
   def description = pkg.name + "." + actionName

--- a/magenta-lib/src/test/scala/magenta/PackageTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/PackageTypeTest.scala
@@ -6,10 +6,26 @@ import tasks._
 import java.io.File
 import net.liftweb.util.TimeHelpers._
 import net.liftweb.json.Implicits._
-import net.liftweb.json.JsonAST.{JArray, JString}
+import net.liftweb.json.JsonAST.{JValue, JArray, JString}
 
 
 class PackageTypeTest extends FlatSpec with ShouldMatchers {
+
+  "Amazon Web Services S3" should "have a uploadStaticFiles action" in {
+
+    val data: Map[String, JValue] = Map(
+      "bucket" -> "bucket-1234",
+      "cacheControl" -> "no-cache"
+    )
+
+    val p = Package("myapp", Set.empty, data, "aws-s3", new File("/tmp/packages/static-files"))
+
+    val deploy = AmazonWebServicesS3(p)
+
+    deploy.perAppActions("uploadStaticFiles")(Stage("CODE")) should be (
+      List(S3Upload(Stage("CODE"),"bucket-1234",new File("/tmp/packages/static-files"),Some("no-cache")))
+    )
+  }
 
   "jetty web app package type" should "have a deploy action" in {
     val p = Package("webapp", Set.empty, Map.empty, "jetty-webapp", new File("/tmp/packages/webapp"))

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -200,7 +200,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
 
     val file = new File("/file/path")
 
-    val request = task.putObjectRequestWithPublicRead("bucket", "foo/bar", file)
+    val request = task.putObjectRequestWithPublicRead("bucket", "foo/bar", file, Some("no-cache"))
 
     request.getBucketName should be ("bucket")
 
@@ -209,6 +209,8 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
     request.getFile should be (file)
 
     request.getKey should be ("foo/bar")
+
+    request.getMetadata.getCacheControl should be ("no-cache")
   }
 
   it should "correctly convert a file to a key" in {


### PR DESCRIPTION
This allows me to treat my file uploads separately to my deploy. It also allows me to package upload artifacts separately so I can upload them to different buckets and give them different cache headers (artifacts are treated differently to static files)

So you can write deploy.json like this...

{
    "packages":{
        "frontend-article":{
            "type":"executable-jar-webapp",
            "apps":["frontend::article"],
            "data":{
                "port":"9000",
                "bucket":"artifacts-83445s",
                "healthcheck_paths":[
                    "/pages/info/2011/oct/06/submitting-content-to-print-publications"
                ]
            }
        },
        "frontend-static":{
            "type":"aws-s3",
            "apps":["aws-s3"],
            "data":{
                "bucket":"artifacts-83445s",
                "cacheControl":"public, max-age=84000"
            }
        },
        "frontend-artifact":{
            "type":"aws-s3",
            "apps":["aws-s3"],
            "data":{
                "bucket":"artifacts-83445s",
                "cacheControl":"no-cache"
            }
        }
    },

```
"recipes":{
    "default":{
        "depends" : ["deploy"]
    },
    "deploy":{
        "actionsPerApp": ["frontend-static.uploadStaticFiles", "frontend-artifact.uploadStaticFiles"],
        "actionsPerHost": ["frontend-article.deploy"]
    }
}
```

}
