### PR TITLE
Deployinfo needn't be a file

### DIFF
--- a/magenta-cli/src/main/scala/magenta/cli/Main.scala
+++ b/magenta-cli/src/main/scala/magenta/cli/Main.scala
@@ -22,16 +22,11 @@ object Main extends scala.App {
     var keyLocation: Option[File] = None
     var jvmSsh = false
 
-    private var _di = "/opt/bin/deployinfo.json"
+    var deployInfo = "/opt/bin/deployinfo.json"
 
-    def deployInfo_=(s: String) {
-      _di = validFile(s).getPath
-    }
-    def deployInfo = _di
-
-   lazy val parsedDeployInfo = {
+    lazy val parsedDeployInfo = {
       import sys.process._
-      DeployInfoJsonReader.parse(_di.!!)
+      DeployInfoJsonReader.parse(deployInfo.!!)
     }
 
     private var _localArtifactDir: Option[File] = None


### PR DESCRIPTION
Since we're executing a command it seems excessively restrictive
to require there to be an executable file, when a command string
could also produce the same information.

For instance, I want to use "java -jar ec2-host-provider.jar"
