### PR TITLE
Add ability to use different keys for different apps and stages

### DIFF
--- a/magenta-cli/src/main/scala/magenta/cli/Main.scala
+++ b/magenta-cli/src/main/scala/magenta/cli/Main.scala
@@ -47,11 +47,11 @@ object Main extends scala.App {
     var keyLocation: Option[File] = None
     var jvmSsh = false
 
-    var deployInfo = "/opt/bin/deployinfo.json"
+    var deployInfoExecutable = "/opt/bin/deployinfo.json"
 
-    lazy val parsedDeployInfo = {
+    lazy val deployInfo = {
       import sys.process._
-      DeployInfoJsonReader.parse(deployInfo.!!)
+      DeployInfoJsonReader.parse(deployInfoExecutable.!!)
     }
 
     private var _localArtifactDir: Option[File] = None
@@ -90,7 +90,7 @@ object Main extends scala.App {
     separator("\n  Advanced options:")
     opt("local-artifact", "Path to local artifact directory (overrides <project> and <build>)",
       { dir => Config.localArtifactDir = Some(new File(dir)) })
-    opt("deployinfo", "use a different deployinfo script", { deployinfo => Config.deployInfo = deployinfo })
+    opt("deployinfo", "use a different deployinfo script", { deployinfo => Config.deployInfoExecutable = deployinfo })
     opt("path", "Path for deploy support scripts (default: '/opt/deploy/bin')", { path => CommandLocator.rootPath = path })
     opt("i", "keyLocation", "specify location of SSH key file", {keyLocation => Config.keyLocation = Some(validFile(keyLocation))})
     opt("j", "jvm-ssh", "perform ssh within the JVM, rather than shelling out to do so", { Config.jvmSsh = true })
@@ -129,7 +129,7 @@ object Main extends scala.App {
           val project = JsonReader.parse(new File(tmpDir, "deploy.json"))
 
           MessageBroker.verbose("Loaded: " + project)
-          val hostsInStage = Config.parsedDeployInfo.filter(_.stage == Config.stage)
+          val hostsInStage = Config.deployInfo.hosts.filter(_.stage == Config.stage)
           val hosts = Config.host map { h => hostsInStage.filter(_.name == h) } getOrElse hostsInStage
 
           val context = DeployContext(parameters,project,hosts)

--- a/magenta-lib/src/main/scala/magenta/json/DeployInfoJsonInputFile.scala
+++ b/magenta-lib/src/main/scala/magenta/json/DeployInfoJsonInputFile.scala
@@ -6,7 +6,8 @@ import io.Source
 import java.io.File
 
 case class DeployInfoJsonInputFile(
-  hosts: List[DeployInfoHost]
+  hosts: List[DeployInfoHost],
+  keys: List[DeployInfoKey]
 )
 
 
@@ -17,17 +18,22 @@ case class DeployInfoHost(
   stage: String
 )
 
+case class DeployInfoKey(
+  app: String,
+  stage: String,
+  accesskey: String,
+  comment: Option[String]
+)
+
 
 object DeployInfoJsonReader {
   private implicit val formats = DefaultFormats
 
-  def parse(f: File):  List[Host] = parse(Source.fromFile(f).mkString)
+  def parse(f: File): DeployInfo = parse(Source.fromFile(f).mkString)
 
-  def parse(inputFile: DeployInfoJsonInputFile): List[Host] = {
-    inputFile.hosts map { host => Host(host.hostname, Set(App(host.app)), host.stage) }
-  }
+  def parse(inputFile: DeployInfoJsonInputFile): DeployInfo = DeployInfo(inputFile)
 
-  def parse(s: String): List[Host] = {
+  def parse(s: String): DeployInfo = {
     parse(Extraction.extract[DeployInfoJsonInputFile](JsonParser.parse(s)))
   }
 

--- a/magenta-lib/src/test/scala/magenta/json/DeployInfoTest.scala
+++ b/magenta-lib/src/test/scala/magenta/json/DeployInfoTest.scala
@@ -11,13 +11,21 @@ class DeployInfoTest  extends FlatSpec with ShouldMatchers {
 {"group":"a", "stage":"CODE", "app":"microapp-cache", "hostname":"machost01.dc-code.gnl"},
 {"group":"b", "stage":"CODE", "app":"microapp-cache", "hostname":"machost51.dc-code.gnl"},
 {"group":"a", "stage":"QA", "app":"microapp-cache", "hostname":"machost01.dc-qa.gnl"}
-  
+  ],
+  "keys":[
+  {"app":"microapp-cache", "stage":"CODE", "accesskey":"AAA"},
+  {"app":"frontend-article", "stage":"CODE", "accesskey":"CCC"},
+  {"app":"frontend-.*", "stage":"CODE", "accesskey":"BBB"},
+  {"app":"frontend-gallery", "stage":"CODE", "accesskey":"SHADOWED"},
+  {"app":"microapp-cache", "stage":".*", "accesskey":"DDD"}
   ]}"""
+
   "json parser" should "parse deployinfo json" in {
     val parsed = DeployInfoJsonReader.parse(deployInfoSample)
-    parsed.size should be (3)
+    parsed.hosts.size should be (3)
+    parsed.keys.size should be (5)
 
-    val host = parsed(0)
+    val host = parsed.hosts(0)
     host should be (Host("machost01.dc-code.gnl", Set(App("microapp-cache")), "CODE"))
 //
 //     host.group should be ("a")
@@ -25,5 +33,35 @@ class DeployInfoTest  extends FlatSpec with ShouldMatchers {
 //     host.app should be ("microapp-cache")
 //     host.stage should be ("CODE")
    }
+
+  "deploy info" should "provide a distinct list of host attributes" in {
+    val parsed = DeployInfoJsonReader.parse(deployInfoSample)
+    parsed.knownHostStages.size should be(2)
+    parsed.knownHostApps.size should be(1)
+  }
+
+  it should "match an exact app and stage" in {
+    val di = DeployInfoJsonReader.parse(deployInfoSample)
+    di.firstMatchingKey(App("microapp-cache"),"CODE") should be(Some(Key("microapp-cache","CODE","AAA",None)))
+  }
+
+  it should "match on a regex" in {
+    val di = DeployInfoJsonReader.parse(deployInfoSample)
+    di.firstMatchingKey(App("frontend-front"),"CODE") should be(Some(Key("frontend-.*","CODE","BBB",None)))
+  }
+
+  it should "match the first in the list" in {
+    val di = DeployInfoJsonReader.parse(deployInfoSample)
+    di.firstMatchingKey(App("frontend-article"),"CODE") should be(Some(Key("frontend-article","CODE","CCC",None)))
+    di.firstMatchingKey(App("frontend-gallery"),"CODE") should be(Some(Key("frontend-.*","CODE","BBB",None)))
+  }
+
+  it should "not match bigger app or stage names" in {
+    val di = DeployInfoJsonReader.parse(deployInfoSample)
+    di.firstMatchingKey(App("frontend-article"),"CODE2") should be(None)
+    di.firstMatchingKey(App("frontend-article"),"NEWCODE") should be(None)
+    di.firstMatchingKey(App("new-microapp-cache"),"CODE") should be(None)
+    di.firstMatchingKey(App("microapp-cache-again"),"CODE") should be(None)
+  }
 
 }

--- a/riff-raff/app/Global.scala
+++ b/riff-raff/app/Global.scala
@@ -1,5 +1,5 @@
 import controllers.DeployLibrary
-import deployment.DeployInfo
+import deployment.DeployInfoManager
 import notification.IrcClient
 import play.{Application, GlobalSettings}
 
@@ -8,12 +8,12 @@ class Global extends GlobalSettings {
     // initialise message sinks
     IrcClient.init()
     DeployLibrary.init()
-    DeployInfo.start()
+    DeployInfoManager.start()
   }
 
   override def onStop(app: Application) {
     IrcClient.shutdown()
     DeployLibrary.shutdown()
-    DeployInfo.shutdown()
+    DeployInfoManager.shutdown()
   }
 }

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -6,8 +6,8 @@ import com.gu.management._
 import logback.LogbackLevelPage
 import com.gu.management.play.{ Management => PlayManagement }
 import com.gu.conf.ConfigurationFactory
-import sbt.IO
 import java.io.File
+import magenta.S3Credentials
 
 
 class Configuration(val application: String, val webappConfDirectory: String = "env") {
@@ -31,8 +31,10 @@ class Configuration(val application: String, val webappConfDirectory: String = "
   }
 
   object s3 {
-    lazy val accessKey = configuration.getStringProperty("s3.accessKey").getOrException("No S3 access key configured")
-    lazy val secretAccessKey = configuration.getStringProperty("s3.secretAccessKey").getOrException("No S3 secret access key configured")
+    def credentials(accessKey: String) = {
+      val secretKey = configuration.getStringProperty("s3.secretAccessKey.%s" format accessKey).getOrException("No S3 secret access key configured for %s" format accessKey)
+      S3Credentials(accessKey,secretKey)
+    }
   }
 
   object irc {

--- a/riff-raff/app/controllers/Application.scala
+++ b/riff-raff/app/controllers/Application.scala
@@ -1,16 +1,10 @@
 package controllers
 
-import play.api.data._
-import play.api.data.Forms._
-
 import play.api.mvc._
 import deployment._
 
 import play.api.Logger
-import conf.{TimedAction, Configuration}
-import magenta._
-import collection.mutable.ArrayBuffer
-import tasks.Task
+import conf.TimedAction
 
 trait Logging {
   implicit val log = Logger(getClass)
@@ -51,15 +45,7 @@ object Application extends Controller with Logging {
 
   def deployInfo(stage: String) = TimedAction {
     AuthAction { request =>
-      val stageAppHosts = DeployInfo.hostList filter { host =>
-        host.stage == stage || stage == ""
-      } groupBy { _.stage } mapValues { hostList =>
-        hostList.groupBy {
-          _.apps
-        }
-      }
-
-      Ok(views.html.deploy.hostInfo(request, stageAppHosts))
+      Ok(views.html.deploy.hostInfo(request))
     }
   }
 

--- a/riff-raff/app/controllers/Testing.scala
+++ b/riff-raff/app/controllers/Testing.scala
@@ -89,7 +89,7 @@ object Testing extends Controller with Logging {
         Deploy(DeployParameters(Deployer("Simon Hildrew"),Build("tools::deploy","131"),Stage("DEV"),RecipeName("default")))))
     )
 
-    val report = DeployRecord(Task.Deploy, UUID.randomUUID(), DeployParameters(Deployer("Simon Hildrew"),Build("tools::deploy","131"),Stage("DEV"),RecipeName("default")), KeyRing(null, Nil), input.toList)
+    val report = DeployRecord(Task.Deploy, UUID.randomUUID(), DeployParameters(Deployer("Simon Hildrew"),Build("tools::deploy","131"),Stage("DEV"),RecipeName("default")), input.toList)
 
     Ok(views.html.test.reportTest(request,report,verbose))
   }

--- a/riff-raff/app/deployment/actors.scala
+++ b/riff-raff/app/deployment/actors.scala
@@ -41,7 +41,8 @@ class DeployActor() extends Actor with Logging {
           resolveContext(artifactDir, record)
           DeployLibrary.await(uuid).context.foreach { realContext =>
             log.info("Executing deployContext")
-            realContext.execute(record.keyRing)
+            val keyRing = DeployInfoManager.keyRing(realContext)
+            realContext.execute(keyRing)
           }
         }
       }

--- a/riff-raff/app/deployment/model.scala
+++ b/riff-raff/app/deployment/model.scala
@@ -22,7 +22,7 @@ object Task extends Enumeration {
   val Preview = Value("Preview")
 }
 
-case class DeployRecord(taskType: Task.Type, uuid: UUID, parameters: DeployParameters, keyRing:KeyRing, messages: List[MessageStack] = Nil, context:Option[DeployContext] = None) {
+case class DeployRecord(taskType: Task.Type, uuid: UUID, parameters: DeployParameters, messages: List[MessageStack] = Nil, context:Option[DeployContext] = None) {
   lazy val report:ReportTree = DeployReport(messages, "Deployment Report")
   lazy val buildName = parameters.build.name
   lazy val buildId = parameters.build.id
@@ -34,7 +34,7 @@ case class DeployRecord(taskType: Task.Type, uuid: UUID, parameters: DeployParam
     this.copy(messages = messages ++ List(message))
   }
   def attachContext(project:Project): DeployRecord = {
-    this.copy(context = Some(parameters.toDeployContext(project,DeployInfo.hostList)))
+    this.copy(context = Some(parameters.toDeployContext(project,DeployInfoManager.hostList)))
   }
   def loggingContext[T](block: => T): T = {
     MessageBroker.deployContext(uuid, parameters) { block }

--- a/riff-raff/app/views/deploy/hostInfo.scala.html
+++ b/riff-raff/app/views/deploy/hostInfo.scala.html
@@ -1,22 +1,64 @@
-@(request: controllers.AuthenticatedRequest[AnyContent], stageAppHosts: Map[String,Map[Set[magenta.App],List[magenta.Host]]])
-
+@(request: controllers.AuthenticatedRequest[AnyContent])
+@import deployment.DeployInfoManager._
 
 @main("Deployment Information", request) {
 
 <h2>Deployment Information</h2>
 
-<p>This is a list of nodes that we know about:</p>
+<h3>Keys</h3>
+<hr/>
 
-@for((stage,appsHosts) <- stageAppHosts) {
-    <h3>@stage</h3>
-    @for((appList,hosts) <- appsHosts) {
-        <h4>@appList</h4>
-        <ul>
-            @for( host <- hosts ) {
-             <li>@host.name</li>
+<table class="table">
+    <thead><tr>
+        <th>App</th>
+        @deployInfo.knownKeyStages.map{ stage => <th>@stage.toString</th> }
+    </tr></thead>
+    <tbody>
+    @deployInfo.knownKeyApps.map { app =>
+    <tr>
+        <td><strong>@app.toString</strong></td>
+        @deployInfo.knownKeyStages.map{ stage =>
+        <td>
+            @if(deployInfo.stageAppToKeyMap.contains((stage,app))) {
+            <ul>
+                @deployInfo.stageAppToKeyMap((stage,app)).map { key => <li>@key.key @key.comment.map{ c => (@c) }</li> }
+            </ul>
+            } else {
+            -
             }
-        </ul>
+        </td>
+        }
+    </tr>
     }
+    </tbody>
+</table>
+
+<h3>Hosts</h3>
+<hr/>
+
+<table class="table">
+    <thead><tr>
+        <th>App</th>
+        @deployInfo.knownHostStages.map{ stage => <th>@stage</th> }
+    </tr></thead>
+    <tbody>
+@deployInfo.knownHostApps.map { appSet =>
+    <tr>
+    <td><strong>@appSet.map(_.name).mkString(", ")</strong></td>
+        @deployInfo.knownHostStages.map{ stage =>
+        <td>
+        @if(deployInfo.stageAppToHostMap.contains((stage,appSet))) {
+        <ul>
+            @deployInfo.stageAppToHostMap((stage,appSet)).map { host => <li>@host.name</li> }
+        </ul>
+            } else {
+            -
+            }
+        </td>
+        }
+    </tr>
 }
+    </tbody>
+</table>
 
 }

--- a/riff-raff/app/views/snippets/recordTable.scala.html
+++ b/riff-raff/app/views/snippets/recordTable.scala.html
@@ -16,7 +16,7 @@
     <tbody>
     @records.map{ record =>
     <tr>
-        <td>@record.report.startTime</td>
+        <td>@org.joda.time.format.DateTimeFormat.mediumDateTime.print(record.report.startTime)</td>
         <td><span class="label">@record.deployerName</span></td>
         <td><a href="@routes.Deployment.viewUUID(record.uuid.toString)"> @record.buildName @record.buildId @record.stage.name</a></td>
         <td>


### PR DESCRIPTION
- Key objects added to a new field in the deployinfo data to specify the
  access keys that match different apps and stages (using regexs)
- Configuration file contains the secret access keys
- Also improved deploy information page - this is now a table
