### PR TITLE
rsync expects target directory to exist.

### DIFF
--- a/magenta-lib/src/main/scala/magenta/Types.scala
+++ b/magenta-lib/src/main/scala/magenta/Types.scala
@@ -174,6 +174,7 @@ case class PuppetPackageType(pkg: Package) extends PackageType {
       val artifact_remote = "%s/%s".format(artifact_remote_directory, artifact)
 
       List(
+        Mkdir(host as user, artifact_remote_directory),
         CopyFile(host as user, artifact_local, artifact_remote),
         Unzip(host as user, artifact_remote, artifact_remote_directory),
         Link(host as user, artifact_remote_directory + "/puppet", link),

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -178,6 +178,10 @@ case class Unzip(host: Host, path: String, to: String) extends RemoteShellTask {
   def commandLine = List("/usr/bin/unzip", "-d", to, path)
 }
 
+case class Mkdir(host: Host, path: String) extends RemoteShellTask {
+	def commandLine = List("/bin/mkdir", "-p", path)
+}
+
 trait S3 {
   lazy val accessKey = Option(System.getenv.get("aws_access_key")).getOrElse{
     sys.error("Cannot authenticate, 'aws_access_key' must be set as a system property")


### PR DESCRIPTION
Fixup for Puppet deployment action.
