### PR TITLE
Implement option to use mongodb datastore

### DIFF
--- a/magenta-lib/src/main/scala/magenta/DeployContext.scala
+++ b/magenta-lib/src/main/scala/magenta/DeployContext.scala
@@ -26,11 +26,6 @@ case class DeployContext(parameters: DeployParameters, project: Project, stageHo
   val recipe = parameters.recipe.name
   val stage = parameters.stage
 
-  val hostNames = tasks
-    .flatMap(_.taskHosts)
-    .map(_.name)
-    .distinct
-
   def execute(keyRing: KeyRing) {
     MessageBroker.deployContext(parameters) {
       if (tasks.isEmpty) MessageBroker.fail("No tasks were found to execute. Ensure the app(s) are in the list supported by this stage/host.")

--- a/magenta-lib/src/main/scala/magenta/Resolver.scala
+++ b/magenta-lib/src/main/scala/magenta/Resolver.scala
@@ -5,10 +5,6 @@ import tasks.Task
 
 object Resolver {
 
-  def resolve( context: DeployContext ): List[Task] = {
-    resolve(context.project, context.recipe, context.stageHosts, context.stage)
-  }
-
   def resolve( project: Project, recipeName: String, hosts: List[Host], stage: Stage): List[Task] = {
     val recipe = project.recipes(recipeName)
 

--- a/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
+++ b/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
@@ -45,7 +45,6 @@ class DeployContextTest extends FlatSpec with ShouldMatchers with MockitoSugar {
     context.execute(keyRing)
     val task = context.tasks.head
 
-    verify(task, times(1)).taskHosts
     verify(task, times(1)).execute(keyRing)
     verifyNoMoreInteractions(task)
   }

--- a/project/MagentaBuild.scala
+++ b/project/MagentaBuild.scala
@@ -28,7 +28,7 @@ object MagentaBuild extends Build {
       testOptions in Test := Nil,
       jarName in assembly := "%s.jar" format name,
       excludedJars in assembly <<= (fullClasspath in assembly) map { cp =>
-        cp filter {_.data.getName == "io_2.9.1-0.11.2.jar"}
+        cp filter {jar => List("io_2.9.1-0.11.2.jar","specs_2.9.0-1-1.6.8.jar").contains(jar.data.getName)}
       },
       templatesImport ++= Seq(
         "magenta._",

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -43,6 +43,12 @@ class Configuration(val application: String, val webappConfDirectory: String = "
     }
   }
 
+  object mongo {
+    lazy val isConfigured = uri.isDefined
+    lazy val uri = configuration.getStringProperty("mongo.uri")
+    lazy val database = configuration.getStringProperty("mongo.database","riffraff")
+  }
+
   object irc {
     lazy val isConfigured = name.isDefined && host.isDefined && channel.isDefined
     lazy val name = configuration.getStringProperty("irc.name")

--- a/riff-raff/app/controllers/Testing.scala
+++ b/riff-raff/app/controllers/Testing.scala
@@ -24,6 +24,7 @@ import java.util.UUID
 import tasks.Task
 import play.api.data.Form
 import play.api.data.Forms._
+import org.joda.time.DateTime
 
 object Testing extends Controller with Logging {
   def reportTestPartial(verbose: Boolean) = NonAuthAction { implicit request =>
@@ -89,7 +90,7 @@ object Testing extends Controller with Logging {
         Deploy(DeployParameters(Deployer("Simon Hildrew"),Build("tools::deploy","131"),Stage("DEV"),RecipeName("default")))))
     )
 
-    val report = DeployRecord(Task.Deploy, UUID.randomUUID(), DeployParameters(Deployer("Simon Hildrew"),Build("tools::deploy","131"),Stage("DEV"),RecipeName("default")), DeployInfo(Nil, Map.empty), input.toList)
+    val report = DeployRecord(new DateTime(), Task.Deploy, UUID.randomUUID(), DeployParameters(Deployer("Simon Hildrew"),Build("tools::deploy","131"),Stage("DEV"),RecipeName("default")), input.toList)
 
     Ok(views.html.test.reportTest(request,report,verbose))
   }

--- a/riff-raff/app/controllers/authentication.scala
+++ b/riff-raff/app/controllers/authentication.scala
@@ -139,7 +139,7 @@ object Login extends Controller with Logging {
 
   def profile = TimedAction {
     AuthAction { request =>
-      val deployerRecords = DeployController.get.filter { record =>
+      val deployerRecords = DeployController.getDeploys().filter { record =>
         request.identity.map(_.fullName == record.deployerName).getOrElse(false)
       }.reverse
       Ok(views.html.auth.profile(request, deployerRecords))

--- a/riff-raff/app/datastore/datastore.scala
+++ b/riff-raff/app/datastore/datastore.scala
@@ -1,0 +1,40 @@
+package datastore
+
+import collection.mutable
+import java.util.UUID
+import deployment.DeployRecord
+import magenta.MessageStack
+import controllers.Logging
+
+trait DataStore {
+  def getDeploys(limit: Int): Iterable[DeployRecord]
+
+  def createDeploy(record:DeployRecord)
+  def updateDeploy(uuid:UUID, stack: MessageStack)
+  def getDeploy(uuid:UUID):Option[DeployRecord]
+}
+
+object DataStore extends DataStore with Logging {
+
+  var datastore: Option[DataStore] = None
+
+  def register(store: DataStore) {
+    if (datastore.isDefined) log.warn("Datastore registration has been overwritten (was %s, now %s)" format (datastore.get,store))
+    datastore = Some(store)
+  }
+  def unregisterAll() { datastore = None }
+
+  def createDeploy(record:DeployRecord) {
+    datastore.foreach(_.createDeploy(record))
+  }
+
+  def updateDeploy(uuid: UUID, stack: MessageStack) {
+    datastore.foreach(_.updateDeploy(uuid,stack))
+  }
+
+  def getDeploy(uuid: UUID): Option[DeployRecord] = datastore.flatMap(_.getDeploy(uuid))
+
+  def getDeploys(limit: Int): Iterable[DeployRecord] = datastore.map(_.getDeploys(limit)).getOrElse(Nil)
+}
+
+

--- a/riff-raff/app/datastore/mongodb.scala
+++ b/riff-raff/app/datastore/mongodb.scala
@@ -1,0 +1,88 @@
+package datastore
+
+import java.util.UUID
+import deployment.Task
+import lifecycle.Lifecycle
+import magenta._
+import com.mongodb.casbah.{MongoURI, MongoDB, MongoConnection}
+import com.mongodb.casbah.Imports._
+import conf.Configuration
+import controllers.Logging
+import com.novus.salat._
+import play.Application
+import play.api.Play
+import play.api.Play.current
+import deployment.DeployRecord
+import magenta.DeployParameters
+import magenta.MessageStack
+import magenta.Deployer
+import scala.Some
+import magenta.Build
+import com.mongodb.casbah.commons.conversions.scala.RegisterJodaTimeConversionHelpers
+
+object MongoDatastore extends Lifecycle with Logging {
+  def buildDatastore(app:Application) = try {
+    if (Configuration.mongo.isConfigured) {
+      val uri = MongoURI(Configuration.mongo.uri.get)
+      val mongoConn = MongoConnection(uri)
+      val mongoDB = mongoConn(uri.database.getOrElse(Configuration.mongo.database))
+      if (mongoDB.authenticate(uri.username.get,new String(uri.password.get))) {
+        RegisterJodaTimeConversionHelpers()
+        Some(new MongoDatastore(mongoDB, app.classloader()))
+      } else {
+        log.error("Authentication to mongoDB failed")
+        None
+      }
+    } else None
+  } catch {
+    case e:Throwable =>
+      log.error("Couldn't initialise MongoDB connection", e)
+      None
+  }
+
+  def init(app:Application) {
+    val datastore = buildDatastore(app)
+    datastore.foreach(DataStore.register(_))
+  }
+  def shutdown(app:Application) { DataStore.unregisterAll() }
+
+  val testUUID = UUID.randomUUID()
+  val testParams = DeployParameters(Deployer("Simon Hildrew"), Build("tools::deploy", "182"), Stage("DEV"))
+  val testRecord = DeployRecord(Task.Deploy, testUUID, testParams)
+  val testStack1 = MessageStack(List(Deploy(testParams)))
+  val testStack2 = MessageStack(List(Info("Test info message"),Deploy(testParams)))
+}
+
+class MongoDatastore(database: MongoDB, loader: ClassLoader) extends DataStore {
+  implicit val context = {
+    val context = new Context {
+      val name = "global"
+      override val typeHintStrategy = StringTypeHintStrategy(TypeHintFrequency.Always)
+    }
+    context.registerClassLoader(loader)
+    context.registerPerClassKeyOverride(classOf[DeployRecord], remapThis = "uuid", toThisInstead = "_id")
+    context
+  }
+
+  val recordGrater = grater[DeployRecord]
+  val stackGrater = grater[MessageStack]
+  val deployCollection = database("deploys")
+
+  def createDeploy(record: DeployRecord) {
+    val dbObject = recordGrater.asDBObject(record)
+    deployCollection insert dbObject
+  }
+  def updateDeploy(uuid: UUID, stack: MessageStack) {
+    val newMessageStack = stackGrater.asDBObject(stack)
+    deployCollection.update(MongoDBObject("_id" -> uuid), $push("messageStacks" -> newMessageStack))
+  }
+  def getDeploy(uuid: UUID): Option[DeployRecord] = {
+    val deploy = deployCollection.findOneByID(uuid)
+    deploy.map(recordGrater.asObject(_))
+  }
+
+  def getDeploys(limit: Int): Iterable[DeployRecord] = {
+    val deploys = deployCollection.find().sort(MongoDBObject("time" -> -1)).limit(limit)
+    deploys.toIterable.map(recordGrater.asObject(_))
+  }
+}

--- a/riff-raff/app/deployment/actors.scala
+++ b/riff-raff/app/deployment/actors.scala
@@ -95,11 +95,7 @@ class DeployActor() extends Actor with Logging {
     log.info("Reading deploy.json")
     MessageBroker.info("Reading deploy.json")
     val project = JsonReader.parse(new File(artifactDir, "deploy.json"))
-    val context = record.parameters.toDeployContext(project,record.deployInfo.hosts)
-    context.tasks
-    DeployController.updateWithContext() { record =>
-      record.attachContext(context)
-    }
+    val context = record.parameters.toDeployContext(project, DeployInfoManager.deployInfo.hosts)
     context
   }
 

--- a/riff-raff/app/lifecycle/Lifecycle.scala
+++ b/riff-raff/app/lifecycle/Lifecycle.scala
@@ -1,0 +1,20 @@
+package lifecycle
+
+import play.Application
+
+/**
+ * Any objects with this trait mixed in will automatically get
+ * instantiated and lifecycled.  init() called by the Global
+ * onStart() and shutdown called by onStop().
+ */
+trait Lifecycle {
+  def init(app: Application)
+  def shutdown(app: Application)
+}
+
+trait LifecycleWithoutApp extends Lifecycle {
+  def init(app:Application) {init()}
+  def shutdown(app:Application) {shutdown()}
+  def init()
+  def shutdown()
+}

--- a/riff-raff/app/notification/irc.scala
+++ b/riff-raff/app/notification/irc.scala
@@ -8,8 +8,9 @@ import com.gu.management.ManagementBuildInfo
 import magenta._
 import akka.actor.{Actor, ActorRef, Props, ActorSystem}
 import java.util.UUID
+import lifecycle.LifecycleWithoutApp
 
-object IrcClient {
+object IrcClient extends LifecycleWithoutApp {
   trait Event
   case class Notify(message: String) extends Event
 
@@ -38,9 +39,8 @@ object IrcClient {
     }
   }
 
-  def init(): Option[ActorRef] = {
+  def init() {
     MessageBroker.subscribe(sink)
-    actor
   }
 
   def shutdown() {

--- a/riff-raff/app/notification/mq.scala
+++ b/riff-raff/app/notification/mq.scala
@@ -14,12 +14,13 @@ import net.liftweb.json._
 import net.liftweb.json.Serialization.write
 import conf.Configuration
 import conf.Configuration.mq.QueueDetails
+import lifecycle.LifecycleWithoutApp
 
 /*
  Send deploy events to graphite
  */
 
-object MessageQueue {
+object MessageQueue extends LifecycleWithoutApp {
   trait Event
   case class Notify(event: AlertaEvent) extends Event
 

--- a/riff-raff/app/teamcity/continuous.scala
+++ b/riff-raff/app/teamcity/continuous.scala
@@ -5,8 +5,9 @@ import magenta.{Stage, Build => MagentaBuild, Deployer, DeployParameters}
 import controllers.{Logging, DeployController}
 import akka.agent.Agent
 import akka.actor.ActorSystem
+import lifecycle.LifecycleWithoutApp
 
-object ContinuousDeployment extends Logging {
+object ContinuousDeployment extends Logging with LifecycleWithoutApp {
 
   val system = ActorSystem("continuous")
   val buildToStageMap = Agent(continuousDeployment.buildToStageMap)(system)

--- a/riff-raff/app/utils/ScheduledAgent.scala
+++ b/riff-raff/app/utils/ScheduledAgent.scala
@@ -4,8 +4,9 @@ import akka.actor.ActorSystem
 import akka.agent.Agent
 import controllers.Logging
 import akka.util.{Timeout, Duration}
+import lifecycle.LifecycleWithoutApp
 
-object ScheduledAgent {
+object ScheduledAgent extends LifecycleWithoutApp {
   val scheduleSystem = ActorSystem("scheduled-agent")
 
   def apply[T](initialDelay: Duration, frequency: Duration)(block: => T): ScheduledAgent[T] = {
@@ -15,6 +16,8 @@ object ScheduledAgent {
   def apply[T](initialDelay: Duration, frequency: Duration, initialValue: T)(block: T => T): ScheduledAgent[T] = {
     new ScheduledAgent(initialDelay, frequency, initialValue, block, scheduleSystem)
   }
+
+  def init() {}
 
   def shutdown() {
     scheduleSystem.shutdown()

--- a/riff-raff/app/views/deploy/logSummary.scala.html
+++ b/riff-raff/app/views/deploy/logSummary.scala.html
@@ -7,8 +7,8 @@ case RunState.Failed => {
 <div class="alert alert-error">
     <h4 class="alert-heading">Deploy failed</h4>
     @record.report.failureMessage.map{ fail =>
-    <strong>@fail.exception.getMessage</strong>
-    <pre>@fail.exception.getStackTraceString</pre>
+    <strong>@fail.detail.message</strong>
+    <pre>@fail.detail.stackTrace</pre>
     }
 </div>
 }

--- a/riff-raff/app/views/deploy/previewContent.scala.html
+++ b/riff-raff/app/views/deploy/previewContent.scala.html
@@ -6,51 +6,50 @@ case RunState.Failed => {
 <div class="alert alert-error">
     <h4 class="alert-heading">Deploy failed</h4>
     @record.report.failureMessage.map{ fail =>
-    <strong>@fail.exception.getMessage</strong>
-    <pre>@fail.exception.getStackTraceString</pre>
+    <strong>@fail.detail.message</strong>
+    <pre>@fail.detail.stackTrace</pre>
     }
 </div>
+}
+case RunState.Completed => {
+    <div class="alert alert-success">
+        <h3>Preview of hosts affected and tasks that will be executed</h3>
+        @helper.form(action=routes.Deployment.processForm) {
+        <div>
+            <ul class="magenta-list">
+                @if(record.report.hostNames.isEmpty) {
+                    <li>No hosts found</li>
+                }
+                @record.report.hostNames.zipWithIndex.map { hostTuple =>
+                    <li><span class="preview-host"><input type="checkbox" name="hosts[@hostTuple._2]" value="@hostTuple._1" checked="true"/>@hostTuple._1</span></li>
+                }
+            </ul>
+        </div>
+        <div>
+            <ul class="magenta-list">
+                @if(record.report.tasks.isEmpty) {
+                <li>No tasks generated</li>
+                }
+                @record.report.tasks.map { task =>
+                <li><span class="preview-task">@task.fullDescription</span></li>
+                }
+            </ul>
+        </div>
+
+        <input type="hidden" name="project" value="@record.buildName"/>
+        <input type="hidden" name="build" value="@record.buildId"/>
+        <input type="hidden" name="stage" value="@record.stage.name"/>
+
+        <div class="actions">
+            <button name="action" type="submit" value="deploy" class="btn btn-danger">Deploy Now</button>
+            <a href="@routes.Application.index()" class="btn btn-inverse">Cancel</a>
+        </div>
+        }
+    </div>
 }
 case _ => {}
 } }
 
-@record.context.map{ context =>
-  <div class="alert alert-success">
-    <h3>Preview of hosts affected and tasks that will be executed</h3>
-      @helper.form(action=routes.Deployment.processForm) {
-      <div>
-    <ul class="magenta-list">
-        @if(context.hostNames.isEmpty) {
-          <li>No hosts found</li>
-        }
-        @context.hostNames.zipWithIndex.map { hostTuple =>
-        <li><span class="preview-host"><input type="checkbox" name="hosts[@hostTuple._2]" value="@hostTuple._1" checked="true"/>@hostTuple._1</span></li>
-
-        }
-    </ul>
-  </div>
-  <div>
-    <ul class="magenta-list">
-        @if(context.tasks.isEmpty) {
-        <li>No tasks generated</li>
-        }
-        @context.tasks.map { task =>
-        <li><span class="preview-task">@task.fullDescription</span></li>
-        }
-    </ul>
-  </div>
-
-      <input type="hidden" name="project" value="@record.buildName"/>
-      <input type="hidden" name="build" value="@record.buildId"/>
-      <input type="hidden" name="stage" value="@record.stage.name"/>
-
-      <div class="actions">
-          <button name="action" type="submit" value="deploy" class="btn btn-danger">Deploy Now</button>
-          <a href="@routes.Application.index()" class="btn btn-inverse">Cancel</a>
-      </div>
-      }
-  </div>
-}
 
 <ul class="magenta-reporttree">
     @snippets.reportTree(record.report)
@@ -58,7 +57,7 @@ case _ => {}
 
 <!-- @record.report.render.mkString("\n") -->
 
-@if(record.context.isDefined){
+@if(!record.report.isRunning){
 <script type="text/javascript">
     this.ajaxRefresh.disable();
 </script>

--- a/riff-raff/app/views/errorPage.scala.html
+++ b/riff-raff/app/views/errorPage.scala.html
@@ -10,7 +10,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </a>
-            <a class="brand" href="#">Riff Raff</a>
+            <a class="brand" href="/">Riff Raff</a>
             <!--/.nav-collapse -->
         </div>
     </div>

--- a/riff-raff/build.sbt
+++ b/riff-raff/build.sbt
@@ -6,6 +6,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "management-play" % "5.15",
   "com.gu" %% "management-logback" % "5.15",
   "com.gu" %% "configuration" % "3.6",
+  "com.novus" %% "salat" % "1.9.0",
   "org.pircbotx" % "pircbotx" % "1.7",
   "com.typesafe.akka" % "akka-agent" % "2.0.2",
   "org.clapper" %% "markwrap" % "0.5.4",

--- a/riff-raff/conf/application.conf
+++ b/riff-raff/conf/application.conf
@@ -32,7 +32,9 @@ application.langs="en"
 # Evolutions
 # ~~~~~
 # You can disable evolutions if needed
-# evolutionplugin=disabled
+evolutionplugin=disabled
+dbplugin=disabled
+ehcacheplugin=disabled
 
 # Logger
 # ~~~~~


### PR DESCRIPTION
The following changes have been implemented in this commit:
- Add support for persisting deploy information to a mongodb instance (see below)
- Refactor the way lifecycle management of singletons in Global is done
- Update errorPage to go to / when you click on the Riff-raff name

Persisting to mongodb has required refactoring a number of areas of magenta-lib and riff-raff
- magenta-lib - No longer hold copy of deploy information in DeployContext - this is now looked up when required
- magenta-lib - Create ThrowableDetail case class and implicit conversion from any Throwable to make storing deployment exceptions in mongo easy - this is now used in the messages sent by the MessageBroker
- magenta-lib - The time attribute previously on the Message trait has been removed and replaced by case class members on the MessageStack and MessageState implementations
- riff-raff - added casbah and salat
- riff-raff - added configuration for mongodb (mongo.uri) - disabled mongodb when not present
- riff-raff - added MongoDatastore to handle storing and retrieving deployment records
- riff-raff - modify DeployController to persist DeployRecord to mongo as well as in memory copy
- riff-raff - modify DeployRecord to no longer attach a deploy context
