### PR TITLE
Added task/package type for deploying R2 static

### DIFF
--- a/magenta-lib/src/main/scala/magenta/Package.scala
+++ b/magenta-lib/src/main/scala/magenta/Package.scala
@@ -23,6 +23,7 @@ case class Package(
     case "puppet" => PuppetPackageType(this)
     case "demo" => DemoPackageType(this)
     case "aws-s3" => AmazonWebServicesS3(this)
+    case UnzipToDocrootPackageType.name => UnzipToDocrootPackageType(this)
     case unknown => sys.error("Package type %s of package %s is unknown" format (unknown, name))
   }
 

--- a/magenta-lib/src/main/scala/magenta/r2types.scala
+++ b/magenta-lib/src/main/scala/magenta/r2types.scala
@@ -1,0 +1,32 @@
+package magenta
+
+import magenta.tasks.{ExtractToDocroots, CopyFile}
+import net.liftweb.json.JsonAST.JValue
+import net.liftweb.json.Implicits._
+
+case class UnzipToDocrootPackageType(pkg: Package) extends PackageType {
+  def name = UnzipToDocrootPackageType.name
+
+  override def defaultData = Map[String, JValue](
+    "locationInDocroot" -> ""
+  )
+
+  lazy val user = pkg.stringData("user")
+  lazy val zipInPkg = pkg.stringData("zip")
+  lazy val zipLocation = pkg.srcDir.getPath  + "/" + zipInPkg
+  lazy val docrootType = pkg.stringData("docrootType")
+  lazy val locationInDocroot = pkg.stringData("locationInDocroot")
+
+  override def perHostActions: HostActionDefinition = {
+
+    case "deploy" => host => {
+      List(
+        CopyFile(host as user, zipLocation, "/tmp"),
+        ExtractToDocroots(host, docrootType, locationInDocroot)
+      )
+    }
+  }
+}
+object UnzipToDocrootPackageType {
+  val name = "unzip-docroot"
+}

--- a/magenta-lib/src/main/scala/magenta/tasks/r2tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/r2tasks.scala
@@ -1,0 +1,7 @@
+package magenta.tasks
+
+import magenta.Host
+
+case class ExtractToDocroots(host: Host, docrootType: String, locationInDocroot: String) extends RemoteShellTask {
+  def commandLine = List("/opt/bin/deploy_static_files.sh", docrootType, locationInDocroot)
+}


### PR DESCRIPTION
I don't like this at all, but it seems the least worse option in the short term.  I don't want to tie this to moving to S3 and reproducing the websys owned docrootmanager.conf in deploy.json doesn't seem like a good plan.
