### PR TITLE
Make fileName overridable.

### DIFF
--- a/magenta-lib/src/main/scala/magenta/json/JsonInputFile.scala
+++ b/magenta-lib/src/main/scala/magenta/json/JsonInputFile.scala
@@ -15,7 +15,8 @@ case class JsonInputFile(
 case class JsonPackage(
   `type`: String,
   apps: List[String],
-  data: Option[Map[String, JValue]] = None
+  data: Option[Map[String, JValue]] = None,
+  fileName: Option[String] = None
 ) {
   def safeData = data getOrElse Map.empty
 }
@@ -79,7 +80,7 @@ object JsonReader {
       },
       jsonPackage.safeData,
       jsonPackage.`type`,
-      new File(artifactSrcDir, "/packages/%s" format(name))
+      new File(artifactSrcDir, "/packages/%s" format(jsonPackage.fileName.getOrElse(name)))
     )
 
 }

--- a/magenta-lib/src/test/scala/magenta/json/JsonReaderTest.scala
+++ b/magenta-lib/src/test/scala/magenta/json/JsonReaderTest.scala
@@ -111,4 +111,27 @@ class JsonReaderTest extends FlatSpec with ShouldMatchers {
     recipes.size should be(1)
     recipes("default") should be (Recipe("default", actionsPerHost = parsed.packages.values.map(_.mkAction("deploy"))))
   }
+
+  "json parser" should "default to using the package name for the file name" in {
+    val parsed = JsonReader.parse(minimalExample, new File("/tmp/abc"))
+
+    parsed.packages("dinky").srcDir should be(new File("/tmp/abc", "/packages/dinky"))
+  }
+
+  val withExplicitFileName = """
+{
+  "packages": {
+    "dinky": {
+      "type": "jetty-webapp",
+      "fileName": "awkward"
+    }
+  }
+}
+"""
+
+  "json parser" should "use override file name if specified" in {
+    val parsed = JsonReader.parse(withExplicitFileName, new File("/tmp/abc"))
+
+    parsed.packages("dinky").srcDir should be(new File("/tmp/abc", "/packages/awkward"))
+  }
 }


### PR DESCRIPTION
This is deliberately not documented, as I hope to get rid of it,
but it allows a sensile path for R2 static now.
