### PR TITLE
Distinguish between running and pending deploys

### DIFF
--- a/riff-raff/app/deployment/model.scala
+++ b/riff-raff/app/deployment/model.scala
@@ -33,6 +33,7 @@ case class DeployRecord(time: DateTime,
   lazy val deployerName = parameters.deployer.name
   lazy val stage = parameters.stage
   lazy val isRunning = report.isRunning
+  lazy val isDone = !isRunning && report.size > 1
 
   def +(message: MessageStack): DeployRecord = {
     this.copy(messageStacks = messageStacks ++ List(message))

--- a/riff-raff/app/views/deploy/log.scala.html
+++ b/riff-raff/app/views/deploy/log.scala.html
@@ -13,7 +13,7 @@ span.message-verbose {
 <div class="content" data-ajax-refresh="@routes.Deployment.updatesUUID(record.uuid.toString)">
 @deploy.logContent(request, record)
 </div>
-@if(record.report.isRunning){
+@if(!record.isDone){
 <script>
     $(function() { ajaxRefresh.enable(); });
 </script>

--- a/riff-raff/app/views/deploy/logContent.scala.html
+++ b/riff-raff/app/views/deploy/logContent.scala.html
@@ -10,7 +10,7 @@
 
 @logSummary(record)
 
-@if(!record.isRunning){
+@if(record.isDone){
     <script type="text/javascript">
       this.ajaxRefresh.disable();
     </script>

--- a/riff-raff/app/views/deploy/logSummary.scala.html
+++ b/riff-raff/app/views/deploy/logSummary.scala.html
@@ -2,6 +2,7 @@
 
 @defining(record.report.cascadeState) { state =>
 @state match {
+case RunState.NotRunning => { <div class="alert alert-info">Waiting to run</div> }
 case RunState.Completed => { <div class="alert alert-success">Deploy completed</div> }
 case RunState.Failed => {
 <div class="alert alert-error">

--- a/riff-raff/app/views/deploy/preview.scala.html
+++ b/riff-raff/app/views/deploy/preview.scala.html
@@ -13,7 +13,7 @@
 <div class="content" data-ajax-refresh="@routes.Deployment.updatesUUID(record.uuid.toString)">
     @deploy.previewContent(request, record)
 </div>
-@if(record.report.isRunning){
+@if(!record.isDone){
 <script>
     $(function() { ajaxRefresh.enable(); });
 </script>

--- a/riff-raff/app/views/deploy/previewContent.scala.html
+++ b/riff-raff/app/views/deploy/previewContent.scala.html
@@ -57,7 +57,7 @@ case _ => {}
 
 <!-- @record.report.render.mkString("\n") -->
 
-@if(!record.report.isRunning){
+@if(record.isDone){
 <script type="text/javascript">
     this.ajaxRefresh.disable();
 </script>

--- a/riff-raff/app/views/snippets/recordTable.scala.html
+++ b/riff-raff/app/views/snippets/recordTable.scala.html
@@ -28,6 +28,7 @@
             @state match {
             case RunState.Completed => { <span class="label label-success">Completed</span> }
             case RunState.Failed => { <span class="label label-important">Failed</span> }
+            case RunState.NotRunning => { <span class="label">Waiting</span> }
             case _ => {<span class="label label-info">Running</span>}
             }
             }


### PR DESCRIPTION
This also fixes a bug whereby AJAX refreshing of the deploy log can break until the log page is refreshed.

This goes some way to fix part of issue #43 by at least showing when a deploy is queued rather than running.
