### PR TITLE
Disregard user when sorting hosts by deployInfo

### DIFF
--- a/magenta-lib/src/main/scala/magenta/Resolver.scala
+++ b/magenta-lib/src/main/scala/magenta/Resolver.scala
@@ -25,7 +25,9 @@ object Resolver {
       }
       if (!recipe.actionsPerHost.isEmpty && perHostTasks.isEmpty) throw new NoHostsFoundException
 
-      val sortedPerHostTasks = perHostTasks.toSeq.sortBy(t => t.taskHost.map(_.name).getOrElse(""))
+      val sortedPerHostTasks = perHostTasks.toSeq.sortBy(t =>
+        t.taskHost.map(h => deployInfo.hosts.indexOf(h.copy(connectAs = None))).getOrElse(-1)
+      )
 
       dependenciesFromOtherRecipes ++ tasksToRunBeforeApp ++ sortedPerHostTasks
     }


### PR DESCRIPTION
I'm pretty sure this is the issue we saw.  Ultimately I think it shows that there's a distinction between a Connection and a Host, but this is the immediate fix.
