### PR TITLE
Suspend AlarmNotifications at start of an autoscale deploy and resume after

### DIFF
--- a/magenta-lib/src/main/scala/magenta/Types.scala
+++ b/magenta-lib/src/main/scala/magenta/Types.scala
@@ -74,10 +74,12 @@ case class AutoScaling(pkg: Package) extends PackageType {
   override val perAppActions: AppActionDefinition = {
     case "deploy" => (_, parameters) => {
       List(
+        SuspendAlarmNotifications(pkg.name, parameters.stage),
         TagCurrentInstancesWithTerminationTag(pkg.name, parameters.stage),
         DoubleSize(pkg.name, parameters.stage),
         WaitForStabilization(pkg.name, parameters.stage, pkg.intData("secondsToWait").toInt * 1000),
-        CullInstancesWithTerminationTag(pkg.name, parameters.stage)
+        CullInstancesWithTerminationTag(pkg.name, parameters.stage),
+        ResumeAlarmNotifications(pkg.name, parameters.stage)
       )
     }
     case "uploadArtifacts" => (_, parameters) =>

--- a/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
@@ -50,6 +50,24 @@ case class CullInstancesWithTerminationTag(packageName: String, stage: Stage) ex
   lazy val description = "Terminate instances with the termination tag for this deploy"
 }
 
+case class SuspendAlarmNotifications(packageName: String, stage: Stage) extends ASGTask {
+
+  def execute(asg: AutoScalingGroup, stopFlag: => Boolean)(implicit keyRing: KeyRing) {
+    suspendAlarmNotifications(asg.getAutoScalingGroupName)
+  }
+
+  lazy val description = "Suspending Alarm Notifications - group will no longer scale on any configured alarms"
+}
+
+case class ResumeAlarmNotifications(packageName: String, stage: Stage) extends ASGTask {
+
+  def execute(asg: AutoScalingGroup, stopFlag: => Boolean)(implicit keyRing: KeyRing) {
+    resumeAlarmNotifications(asg.getAutoScalingGroupName)
+  }
+
+  lazy val description = "Resuming Alarm Notifications - group will scale on any configured alarms"
+}
+
 trait ASGTask extends Task with ASG {
   def packageName: String
   def stage: Stage

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -72,6 +72,14 @@ trait ASG extends AWS {
       new DescribeAutoScalingGroupsRequest().withAutoScalingGroupNames(asg.getAutoScalingGroupName)
     ).getAutoScalingGroups.head
 
+  def suspendAlarmNotifications(name: String)(implicit keyRing: KeyRing) = client.suspendProcesses(
+    new SuspendProcessesRequest().withAutoScalingGroupName(name).withScalingProcesses("AlarmNotification")
+  )
+
+  def resumeAlarmNotifications(name: String)(implicit keyRing: KeyRing) = client.resumeProcesses(
+    new ResumeProcessesRequest().withAutoScalingGroupName(name).withScalingProcesses("AlarmNotification")
+  )
+
   def withPackageAndStage(packageName: String, stage: Stage)(implicit keyRing: KeyRing): Option[AutoScalingGroup] = {
     implicit def autoscalingGroup2HasTag(asg: AutoScalingGroup) = new {
       def hasTag(key: String, value: String) = asg.getTags exists { tag =>
@@ -122,7 +130,7 @@ trait EC2 extends AWS {
 
     client.createTags(request)
   }
-  
+
   def hasTag(instance: ASGInstance, key: String, value: String)(implicit keyRing: KeyRing): Boolean = {
     describe(instance).getTags() exists { tag =>
       tag.getKey() == key && tag.getValue() == value

--- a/magenta-lib/src/test/scala/magenta/packagetype/AutoScalingWithELBPackageTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/packagetype/AutoScalingWithELBPackageTypeTest.scala
@@ -19,10 +19,12 @@ class AutoScalingWithELBPackageTypeTest extends FlatSpec with ShouldMatchers {
     val autoscaling = new AutoScaling(p)
 
     autoscaling.perAppActions("deploy")(DeployInfo(), parameters()) should be (List(
+      SuspendAlarmNotifications("app", PROD),
       TagCurrentInstancesWithTerminationTag("app", PROD),
       DoubleSize("app", Stage("PROD")),
       WaitForStabilization("app", PROD, 15 * 60 * 1000),
-      CullInstancesWithTerminationTag("app", PROD)
+      CullInstancesWithTerminationTag("app", PROD),
+      ResumeAlarmNotifications("app", PROD)
     ))
   }
 
@@ -37,10 +39,12 @@ class AutoScalingWithELBPackageTypeTest extends FlatSpec with ShouldMatchers {
     val autoscaling = new AutoScaling(p)
 
     autoscaling.perAppActions("deploy")(DeployInfo(), parameters()) should be (List(
+      SuspendAlarmNotifications("app", PROD),
       TagCurrentInstancesWithTerminationTag("app", PROD),
       DoubleSize("app", PROD),
       WaitForStabilization("app", PROD, 3 * 60 * 1000),
-      CullInstancesWithTerminationTag("app", PROD)
+      CullInstancesWithTerminationTag("app", PROD),
+      ResumeAlarmNotifications("app", PROD)
     ))
   }
 }


### PR DESCRIPTION
This is so that autoscaling does not interfere with deploys.

![riff-raff](https://f.cloud.github.com/assets/76709/368898/56d05720-a2cb-11e2-8fe4-39bc27b83d32.png)
