### PR TITLE
Fail autoscale deploy if you do not have enough capacity

### DIFF
--- a/magenta-lib/src/main/scala/magenta/Types.scala
+++ b/magenta-lib/src/main/scala/magenta/Types.scala
@@ -74,6 +74,7 @@ case class AutoScaling(pkg: Package) extends PackageType {
   override val perAppActions: AppActionDefinition = {
     case "deploy" => (_, parameters) => {
       List(
+        CheckGroupSize(pkg.name, parameters.stage),
         SuspendAlarmNotifications(pkg.name, parameters.stage),
         TagCurrentInstancesWithTerminationTag(pkg.name, parameters.stage),
         DoubleSize(pkg.name, parameters.stage),

--- a/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
@@ -4,6 +4,19 @@ import magenta.{Build, MessageBroker, Stage, KeyRing}
 import com.amazonaws.services.autoscaling.model.{Instance, AutoScalingGroup}
 import collection.JavaConversions._
 
+case class CheckGroupSize(packageName: String, stage: Stage) extends ASGTask {
+  def execute(asg: AutoScalingGroup, stopFlag: => Boolean)(implicit keyRing: KeyRing) {
+    val doubleCapacity = asg.getDesiredCapacity * 2
+    if (asg.getMaxSize < doubleCapacity) {
+      MessageBroker.fail(
+        "Autoscaling group does not have the capacity to deploy current max = %d - desired max = %d" format (asg.getMaxSize, doubleCapacity))
+    }
+  }
+
+  lazy val description = "Checking there is enough capacity to deploy" format (
+    packageName, stage.name)
+}
+
 case class TagCurrentInstancesWithTerminationTag(packageName: String, stage: Stage) extends ASGTask {
   def execute(asg: AutoScalingGroup, stopFlag: => Boolean)(implicit keyRing: KeyRing) {
     EC2.setTag(asg.getInstances.toList, "Magenta", "Terminate")
@@ -13,13 +26,9 @@ case class TagCurrentInstancesWithTerminationTag(packageName: String, stage: Sta
 }
 
 case class DoubleSize(packageName: String, stage: Stage) extends ASGTask {
-  def execute(asg: AutoScalingGroup, stopFlag: => Boolean)(implicit keyRing: KeyRing) {
-    val doubleCapacity = asg.getDesiredCapacity * 2
-    if (asg.getMaxSize < doubleCapacity) {
-      maxCapacity(asg.getAutoScalingGroupName, doubleCapacity)
-    }
 
-    desiredCapacity(asg.getAutoScalingGroupName, doubleCapacity)
+  def execute(asg: AutoScalingGroup, stopFlag: => Boolean)(implicit keyRing: KeyRing) {
+    desiredCapacity(asg.getAutoScalingGroupName, asg.getDesiredCapacity * 2)
   }
 
   lazy val description = "Double the size of the auto-scaling group for package: %s, stage: %s" format (

--- a/magenta-lib/src/test/scala/magenta/packagetype/AutoScalingWithELBPackageTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/packagetype/AutoScalingWithELBPackageTypeTest.scala
@@ -19,6 +19,7 @@ class AutoScalingWithELBPackageTypeTest extends FlatSpec with ShouldMatchers {
     val autoscaling = new AutoScaling(p)
 
     autoscaling.perAppActions("deploy")(DeployInfo(), parameters()) should be (List(
+      CheckGroupSize("app", PROD),
       SuspendAlarmNotifications("app", PROD),
       TagCurrentInstancesWithTerminationTag("app", PROD),
       DoubleSize("app", Stage("PROD")),
@@ -39,6 +40,7 @@ class AutoScalingWithELBPackageTypeTest extends FlatSpec with ShouldMatchers {
     val autoscaling = new AutoScaling(p)
 
     autoscaling.perAppActions("deploy")(DeployInfo(), parameters()) should be (List(
+      CheckGroupSize("app", PROD),
       SuspendAlarmNotifications("app", PROD),
       TagCurrentInstancesWithTerminationTag("app", PROD),
       DoubleSize("app", PROD),


### PR DESCRIPTION
Autoscaling deploy will now fail if the Max Size of the group is not enough to double the desired instances.
#85

Rather than build it into DoubleSize I put it in early so it fails before we turn off autoscaling and such.

![max_size](https://f.cloud.github.com/assets/76709/397119/2f4fbdf0-a837-11e2-9149-586c87e11610.png)
