### PR TITLE
Order deploy tasks by host groups

### DIFF
--- a/magenta-lib/src/main/scala/magenta/Resolver.scala
+++ b/magenta-lib/src/main/scala/magenta/Resolver.scala
@@ -52,8 +52,11 @@ object Resolver {
         }
       }
 
+      val taskHosts = perHostTasks.flatMap(_.taskHost).toSet
+      val taskHostsInOriginalOrder = deployInfo.hosts.filter(h => taskHosts.contains(h.copy(connectAs = None)))
+      val groupedHosts = DeployInfo.transposeHostsByGroup(taskHostsInOriginalOrder)
       val sortedPerHostTasks = perHostTasks.toList.sortBy(t =>
-        t.taskHost.map(h => deployInfo.hosts.indexOf(h.copy(connectAs = None))).getOrElse(-1)
+        t.taskHost.map(h => groupedHosts.indexOf(h.copy(connectAs = None))).getOrElse(-1)
       )
 
       RecipeTasks(recipe, tasksToRunBeforeApp, sortedPerHostTasks)

--- a/magenta-lib/src/test/scala/magenta/json/DeployInfoTest.scala
+++ b/magenta-lib/src/test/scala/magenta/json/DeployInfoTest.scala
@@ -28,12 +28,85 @@ class DeployInfoTest  extends FlatSpec with ShouldMatchers {
 
     val host = parsed.hosts(0)
     host should be (Host("machost01.dc-code.gnl", Set(App("microapp-cache")), CODE.name, tags = Map("group" -> "a")))
-//
-//     host.group should be ("a")
-//     host.hostname should be ("machost01.dc-code.gnl")
-//     host.app should be ("microapp-cache")
-//     host.stage should be ("CODE")
    }
+
+  "host transposing" should "retain host ordering with no groups" in {
+    val hosts = List(Host("test1"), Host("test2"), Host("test3"))
+    DeployInfo.transposeHostsByGroup(hosts) should be(hosts)
+  }
+
+  it should "retain host ordering with one group" in {
+    val hosts = List(
+      Host("test1", tags=Map("group"->"one")),
+      Host("test2", tags=Map("group"->"one")),
+      Host("test3", tags=Map("group"->"one"))
+    )
+    DeployInfo.transposeHostsByGroup(hosts) should be(hosts)
+  }
+
+  it should "interleave two groups of identical length" in {
+    val hosts = List(
+      Host("test1", tags=Map("group"->"one")),
+      Host("test2", tags=Map("group"->"one")),
+      Host("test3", tags=Map("group"->"two")),
+      Host("test4", tags=Map("group"->"two"))
+    )
+    val orderedHosts = List(
+      Host("test1", tags=Map("group"->"one")),
+      Host("test3", tags=Map("group"->"two")),
+      Host("test2", tags=Map("group"->"one")),
+      Host("test4", tags=Map("group"->"two"))
+    )
+    DeployInfo.transposeHostsByGroup(hosts) should be(orderedHosts)
+  }
+
+  it should "interleave two groups different lengths" in {
+    val hosts = List(
+      Host("test1", tags=Map("group"->"one")),
+      Host("test2", tags=Map("group"->"one")),
+      Host("test3", tags=Map("group"->"two")),
+      Host("test4", tags=Map("group"->"two")),
+      Host("test5", tags=Map("group"->"two"))
+    )
+    val orderedHosts = List(
+      Host("test1", tags=Map("group"->"one")),
+      Host("test3", tags=Map("group"->"two")),
+      Host("test2", tags=Map("group"->"one")),
+      Host("test4", tags=Map("group"->"two")),
+      Host("test5", tags=Map("group"->"two"))
+    )
+    DeployInfo.transposeHostsByGroup(hosts) should be(orderedHosts)
+  }
+
+  it should "interleave three groups different lengths" in {
+    val hosts = List(
+      Host("test1", tags=Map("group"->"one")),
+      Host("test2", tags=Map("group"->"one")),
+      Host("test3", tags=Map("group"->"two")),
+      Host("test4", tags=Map("group"->"two")),
+      Host("test5", tags=Map("group"->"three")),
+      Host("test6", tags=Map("group"->"three")),
+      Host("test7", tags=Map("group"->"one")),
+      Host("test8", tags=Map("group"->"two")),
+      Host("test9", tags=Map("group"->"one")),
+      Host("testA", tags=Map("group"->"one")),
+      Host("testB", tags=Map("group"->"three"))
+    )
+    val orderedHosts = List(
+      Host("test1", tags=Map("group"->"one")),
+      Host("test5", tags=Map("group"->"three")),
+      Host("test3", tags=Map("group"->"two")),
+      Host("test2", tags=Map("group"->"one")),
+      Host("test6", tags=Map("group"->"three")),
+      Host("test4", tags=Map("group"->"two")),
+      Host("test7", tags=Map("group"->"one")),
+      Host("testB", tags=Map("group"->"three")),
+      Host("test8", tags=Map("group"->"two")),
+      Host("test9", tags=Map("group"->"one")),
+      Host("testA", tags=Map("group"->"one"))
+    )
+    DeployInfo.transposeHostsByGroup(hosts) should be(orderedHosts)
+  }
 
   "deploy info" should "provide a distinct list of host attributes" in {
     val parsed = DeployInfoJsonReader.parse(deployInfoSample)

--- a/riff-raff/app/controllers/Testing.scala
+++ b/riff-raff/app/controllers/Testing.scala
@@ -3,7 +3,7 @@ package controllers
 import play.api.mvc.Controller
 import magenta._
 import collection.mutable.ArrayBuffer
-import deployment.{DeployV2Record, TaskType}
+import deployment.{DeployInfoManager, DeployV2Record, TaskType}
 import java.util.UUID
 import tasks.Task
 import play.api.data.Form
@@ -81,6 +81,8 @@ object Testing extends Controller with Logging {
     )(TestForm.apply)
       (TestForm.unapply)
   )
+
+  def hosts = AuthAction { Ok(s"Deploy Info hosts:\n${DeployInfoManager.deployInfo.hosts.map(h => s"${h.name} - ${h.tags.get("group").getOrElse("n/a")}").mkString("\n")}") }
 
   def form =
     AuthAction { implicit request =>

--- a/riff-raff/app/views/deploy/deployInfoHosts.scala.html
+++ b/riff-raff/app/views/deploy/deployInfoHosts.scala.html
@@ -22,19 +22,7 @@
             <td><strong>@appSet.map(_.name).mkString(", ")</strong> (@deployInfo.stageAppToHostMap((stage,appSet)).size)</td>
             <td>
             @deployInfo.stageAppToHostMap((stage,appSet)).map{ host =>
-                @htmlTooltip(placement="left"){
-                    <table>
-                        <tbody>
-                            @host.tags.map { case (key, value) =>
-                                <tr>
-                                    <td><strong>@key:</strong></td><td>@value</td>
-                                </tr>
-                            }
-                        </tbody>
-                    </table>
-                }{
-                    @host.name
-                }
+                @snippets.hostWithTooltip(host, placement="left")
             }
             </td>
             </tr>

--- a/riff-raff/app/views/deploy/previewContent.scala.html
+++ b/riff-raff/app/views/deploy/previewContent.scala.html
@@ -18,7 +18,7 @@
                             <div><em>No hosts</em></div>
                         }
                         @recipeTasks.hosts.map { host =>
-                            <div class="no-hyphenation">@host.name</div>
+                            <div class="no-hyphenation">@snippets.hostWithTooltip(host, placement="right")</div>
                         }
                 </td>
                 <td>

--- a/riff-raff/app/views/snippets/hostWithTooltip.scala.html
+++ b/riff-raff/app/views/snippets/hostWithTooltip.scala.html
@@ -1,0 +1,19 @@
+@(host: magenta.Host, placement: String)
+@import html.helper.twitterBootstrap2.htmlTooltip
+
+@htmlTooltip(placement=placement){
+    <table>
+        <tbody>
+            <tr>
+                <td><strong>Name:</strong></td><td>@host.name</td>
+            </tr>
+        @host.tags.map { case (key, value) =>
+        <tr>
+            <td><strong>@key:</strong></td><td>@value</td>
+        </tr>
+        }
+        </tbody>
+    </table>
+}{
+    @host.name
+}

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -83,6 +83,7 @@ POST    /testing/actionUUID   controllers.Testing.actionUUID
 GET     /testing/view/:uuid controllers.Testing.debugLogViewer(uuid)
 GET     /testing/addStringUUID  controllers.Testing.transferAllUUIDs
 GET     /testing/testcharset    controllers.Testing.testcharset
+GET     /testing/deployinfo     controllers.Testing.hosts
 GET     /teamcity       controllers.Deployment.teamcity
 
 # Javascript routing


### PR DESCRIPTION
Riff-Raff needs to be more intelligent about the order it processes hosts.  Historically, it has used the ordering in the deployinfo file.  Now we finally make use of the 'group' tag on each host.  This tag indicates a logical cluster of nodes of which only one should be taken out of service at any one point in time.

The tasks are now reordered to rotate through each of the groups so we alternate between data centers, regions or availability zones as appropriate.

The hosts in the deployment info tab are shown in their expected execution order.

This was originally requested by identity so that their deploys don't take a whole DC down at once.
