### PR TITLE
Updating to latest Java SDK.

### DIFF
--- a/magenta-lib/build.sbt
+++ b/magenta-lib/build.sbt
@@ -13,7 +13,7 @@ libraryDependencies ++= Seq(
     "org.bouncycastle" % "bcpg-jdk16" % "1.46",
     "com.decodified" % "scala-ssh_2.10.0-RC1" % "0.6.3",
     "ch.qos.logback" % "logback-classic" % "1.0.3",
-    "com.amazonaws" % "aws-java-sdk" % "1.3.32",
+    "com.amazonaws" % "aws-java-sdk" % "1.4.5",
     "org.scalatest" %% "scalatest" % "1.9.1" % "test",
     "org.mockito" % "mockito-core" % "1.9.0" % "test",
     "com.github.scala-incubator.io" %% "scala-io-core" % "0.4.2",

--- a/magenta-lib/src/main/scala/magenta/Types.scala
+++ b/magenta-lib/src/main/scala/magenta/Types.scala
@@ -106,6 +106,7 @@ case class AutoScaling(pkg: Package) extends PackageType {
         DoubleSize(pkg.name, parameters.stage),
         WaitForStabilization(pkg.name, parameters.stage, pkg.intData("secondsToWait").toInt * 1000),
         CullInstancesWithTerminationTag(pkg.name, parameters.stage),
+        WaitForStabilization(pkg.name, parameters.stage, pkg.intData("secondsToWait").toInt * 1000),
         ResumeAlarmNotifications(pkg.name, parameters.stage)
       )
     }

--- a/magenta-lib/src/test/scala/magenta/packagetype/AutoScalingWithELBPackageTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/packagetype/AutoScalingWithELBPackageTypeTest.scala
@@ -25,6 +25,7 @@ class AutoScalingWithELBPackageTypeTest extends FlatSpec with ShouldMatchers {
       DoubleSize("app", Stage("PROD")),
       WaitForStabilization("app", PROD, 15 * 60 * 1000),
       CullInstancesWithTerminationTag("app", PROD),
+      WaitForStabilization("app", PROD, 15 * 60 * 1000),
       ResumeAlarmNotifications("app", PROD)
     ))
   }
@@ -46,6 +47,7 @@ class AutoScalingWithELBPackageTypeTest extends FlatSpec with ShouldMatchers {
       DoubleSize("app", PROD),
       WaitForStabilization("app", PROD, 3 * 60 * 1000),
       CullInstancesWithTerminationTag("app", PROD),
+      WaitForStabilization("app", PROD, 3 * 60 * 1000),
       ResumeAlarmNotifications("app", PROD)
     ))
   }


### PR DESCRIPTION
This solves the issue whereby the autoscaling group and the ELB are out of sync (have confirmed this locally).

There is an open ticket for this at https://jira.guprod.gnl/browse/WSA-121 which we can close once all done.

Also added another WaitForStabilisation as experience has shown us that culling can take some time.
