### PR TITLE
Show the deploy node hostname in the web interface

### DIFF
--- a/riff-raff/app/controllers/deployment.scala
+++ b/riff-raff/app/controllers/deployment.scala
@@ -50,8 +50,8 @@ object DeployController extends Logging with LifecycleWithoutApp {
 
   def create(recordType: TaskType.Value, params: DeployParameters): Record = {
     val uuid = java.util.UUID.randomUUID()
-    val hostNameMetadata = Map("riffraff-domain" -> conf.Configuration.domains.identityName,
-                               "riffraff-hostname" -> java.net.InetAddress.getLocalHost.getHostName)
+    val hostNameMetadata = Map(Record.RIFFRAFF_DOMAIN -> conf.Configuration.domains.identityName,
+                               Record.RIFFRAFF_HOSTNAME -> java.net.InetAddress.getLocalHost.getHostName)
     val record = DeployV2Record(recordType, uuid, params) ++ hostNameMetadata
     library send { _ + (uuid -> Agent(record)) }
     DocumentStoreConverter.saveDeploy(record)

--- a/riff-raff/app/deployment/model.scala
+++ b/riff-raff/app/deployment/model.scala
@@ -16,6 +16,11 @@ object TaskType extends Enumeration {
   val Preview = Value("Preview")
 }
 
+object Record {
+  val RIFFRAFF_HOSTNAME = "riffraff-hostname"
+  val RIFFRAFF_DOMAIN = "riffraff-domain"
+}
+
 trait Record {
   def time: DateTime
   def taskType: TaskType.Value

--- a/riff-raff/app/views/deploy/viewDeploy.scala.html
+++ b/riff-raff/app/views/deploy/viewDeploy.scala.html
@@ -10,6 +10,9 @@
 <div class="row-fluid">
 <div class="span8">
 <h2>@record.taskType of deploy for @record.buildName build @record.buildId@record.metaData.get("branch").map{ branch=> [@branch]} in @record.stage</h2>
+@record.metaData.get(deployment.Record.RIFFRAFF_HOSTNAME).map { hostname =>
+    <small>This deploy @if(record.isRunning) {is running} else {ran} on @hostname</small>
+}
 </div>
 <div class="span4">
 @if(record.isStalled) {

--- a/riff-raff/app/views/snippets/recordTable.scala.html
+++ b/riff-raff/app/views/snippets/recordTable.scala.html
@@ -40,6 +40,9 @@
         <td>@Some(record.recipe.name).filter(_ != "default").getOrElse(Html(""))</td>
         <td>@Some(record.parameters.hostList.size).filter(_ != 0).getOrElse(Html(""))</td>
         <td>
+            @htmlTooltip(placement="left"){
+                @record.metaData.get(deployment.Record.RIFFRAFF_HOSTNAME).getOrElse(Html(""))
+            }{
             @defining(record.taskType) { taskType =>
                 @taskType match {
                     case TaskType.Deploy => { }
@@ -52,6 +55,7 @@
             case RunState.Failed => { <span class="label label-important">Failed</span> }
             case RunState.NotRunning => { <span class="label">Waiting</span> }
             case _ => {<span class="label label-info">Running</span>}
+            }
             }
             }
         </td>


### PR DESCRIPTION
On a deploy log page, show the deploy host under the title
On the history page, show the deploy host as a tooltip on the status
