### PR TITLE
Add an option to allow files to be deleted during deploy

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -228,4 +228,9 @@ case class Mkdir(host: Host, path: String) extends RemoteShellTask {
 	def commandLine = List("/bin/mkdir", "-p", path)
 }
 
+case class DeleteFile(host: Host, target: String) extends RemoteShellTask {
+  def commandLine = List("rm", s"${target}")
+
+  override def fullDescription = s"${super.fullDescription}:${target}"
+}
 

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -319,6 +319,12 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
     task.requests.find(_.getFile == fileThree).get.getMetadata.getCacheControl should be("public; max-age=3600")
   }
 
+  "delete file task" should "use rm to delete the target" in {
+    val deletingFiles = DeleteFile(Host("some-host"), "/test/dir")
+    val command = deletingFiles.remoteCommandLine
+    command.quoted should be ("""ssh -qtt -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no some-host "rm /test/dir"""")
+  }
+
   private def createTempDir() = {
     val file = File.createTempFile("foo", "bar")
     file.delete()


### PR DESCRIPTION
Discussion would like to have this functionality as they have had a deploy failure mode
caused by old solr config files that had previously been deployed but no longer are.

The default functionality remains the same (i.e. no-op), adding a JSON array to the
predeployDeleteFiles key in data will delete the specified list of files.
