### PR TITLE
Add an option to allow more flexibility whilst copying files.

### DIFF
--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -181,7 +181,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
       be (CommandLine(List("ssh", "-qtt", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", "-i", "foo", "some-host", "ls -l")))
   }
 
-  it should "specify custom remote shell for rsync if key-file specified" in {
+  "CopyFile task" should "specify custom remote shell for rsync if key-file specified" in {
     val task = CopyFile(Host("foo.com"), "/source", "/dest")
 
     val command = task.commandLine(KeyRing(SystemUser(Some(new File("key")))))
@@ -197,6 +197,21 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
     command.quoted should be ("""rsync -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" -rpv /source foo.com:/dest""")
   }
 
+  it should "honour additive mode" in {
+    val task = CopyFile(Host("foo.com"), "/source", "/dest", CopyFile.ADDITIVE_MODE)
+
+    val command = task.commandLine(KeyRing(SystemUser(None)))
+
+    command.quoted should be ("""rsync -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" -rpv /source foo.com:/dest""")
+  }
+
+  it should "honour mirror mode" in {
+    val task = CopyFile(Host("foo.com"), "/source", "/dest", CopyFile.MIRROR_MODE)
+
+    val command = task.commandLine(KeyRing(SystemUser(None)))
+
+    command.quoted should be ("""rsync -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" -rpv --delete --delete-after /source foo.com:/dest""")
+  }
 
   "S3Upload task" should "upload a single file to S3" in {
 


### PR DESCRIPTION
Discussion would like to have this functionality as they have had a deploy failure mode
caused by old solr config files that had previously been deployed but no longer are, as
a result they want to be able to mirror files in such a way that old or missing files
are deleted.

The default functionality remains the same (i.e. no-op), adding a JSON array to the
copyRoots key in data will list multiple source roots from the package artifact directory
that should be copied to the target webapp root.

Similarly copyMode defaults to additive (the existing mode) but can be set to mirror which
in essence adds '--delete --delete-after' to the rsync command.
