### PR TITLE
DjangoWebApp: Add the ability to specify healthcheck urls to the deployment tasks

### DIFF
--- a/magenta-lib/src/test/scala/magenta/packagetype/PackageTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/packagetype/PackageTypeTest.scala
@@ -86,6 +86,7 @@ class PackageTypeTest extends FlatSpec with ShouldMatchers {
       Link(host as "django", Some("/django-apps/" + specificBuildFile.getName), "/django-apps/webapp"),
       ApacheGracefulRestart(host as "django"),
       WaitForPort(host, "80", 1 minute),
+      CheckUrls(host, "80", List.empty, 120000, 5),
       UnblockFirewall(host as "django")
     ))
   }


### PR DESCRIPTION
Django apps are currently not checking whether the app is running before the app is returned to the load balancer.

This is a rough and ready copy of the Webapp package CheckUrls functionality into Django Webapp.
