### PR TITLE
Add API endpoint for cancelling deploys

### DIFF
--- a/riff-raff/app/controllers/authentication.scala
+++ b/riff-raff/app/controllers/authentication.scala
@@ -40,7 +40,7 @@ object UserIdentity {
 }
 
 case class ApiIdentity(apiKey: ApiKey) extends Identity {
-  lazy val fullName = apiKey.application
+  lazy val fullName = s"API:${apiKey.application}"
 }
 
 case class AuthorisationRecord(email: String, approvedBy: String, approvedDate: DateTime)

--- a/riff-raff/app/docs/releases.md
+++ b/riff-raff/app/docs/releases.md
@@ -1,5 +1,9 @@
 ### Release notes
 
+#### 20th August 2013
+
+Add API endpoint for stopping deploys.
+
 #### 19th August 2013
 
 Add API endpoint for starting deploys.

--- a/riff-raff/app/docs/riffraff/api.md
+++ b/riff-raff/app/docs/riffraff/api.md
@@ -112,6 +112,18 @@ The response you receive will contain something like this:
 
 `recipe` and `hosts` are optional and default to `default` and the empty list respectively.
 
+Deploy stop endpoint
+--------------------
+
+`api/deploy/stop`
+
+This endpoint can be used to cancel a deploy (as much as is possible). This sets a stop flag which is periodically
+checked by the deploy which will then abandon further tasks and sub-tasks.
+
+To use this end point send a POST request with a `uuid` parameter which has the string representation of the deploy UUID
+that you wish to stop.
+
+
 Deploy Info endpoint
 --------------------
 

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -73,6 +73,7 @@ GET     /api/history                controllers.Api.history
 GET     /api/deployinfo             controllers.Api.deployinfo
 GET     /api/deploy/view            controllers.Api.view(uuid:String)
 POST    /api/deploy/request         controllers.Api.deploy
+POST    /api/deploy/stop            controllers.Api.stop
 
 GET     /api/historyGraph                controllers.Api.historyGraph
 


### PR DESCRIPTION
Add yet another API endpoint.

This also includes a prefix on 'fullName' output of an API key to prefix API: to the application name.
