### PR TITLE
Make an attempt to kill off long running deployinfo processes

### DIFF
--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -65,6 +65,8 @@ class Configuration(val application: String, val webappConfDirectory: String = "
       DeployInfoMode.values.find(_.toString.equalsIgnoreCase(name))
     }.getOrElse(DeployInfoMode.URL)
     lazy val staleMinutes: Int = configuration.getIntegerProperty("deployinfo.staleMinutes", 15)
+    lazy val refreshSeconds: Int = configuration.getIntegerProperty("deployinfo.refreshSeconds", 60)
+    lazy val timeoutSeconds: Int = configuration.getIntegerProperty("deployinfo.timeoutSeconds", 180)
   }
 
   lazy val domains = GuDomainsConfiguration(configuration, prefix = "domains")

--- a/riff-raff/app/docs/releases.md
+++ b/riff-raff/app/docs/releases.md
@@ -1,5 +1,27 @@
 ### Release notes
 
+#### 20th September 2013
+
+Add a timeout to the deployinfo poller. It will now try to kill off a process that has not exited after a timeout
+period.
+
+#### 19th September 2013
+
+Fixed another preview failure case, such that failures are more usefully presented to the user.
+
+Highlight to the end user when deploys are stale and added a boolean field to the deployinfo API.
+
+#### 16th September 2013
+
+Change how previews are implemented so that failures are not silently dropped.
+
+#### 3rd September 2013
+
+Metrics for number of concurrent tasks and task start latency have been added to make it easier to identify performance
+ issues.
+
+API date-times are now returned in the ISO8601 format
+
 #### 2nd September 2013
 
 Continuous deployment has been overhauled. Deploys can now be triggered either by a new build successfully completing

--- a/riff-raff/app/docs/riffraff/properties.md
+++ b/riff-raff/app/docs/riffraff/properties.md
@@ -17,6 +17,8 @@ deployment information
  - `deployinfo.mode` - How to interpret the location:
     - `URL` will interpret it as a URL holding the JSON data (using classpath: as the protocol will resolve something on the classpath).
     - `Execute` will interpret it as a local executable which will return JSON on stdout.
+ - `deployinfo.refreshSeconds` - The number of seconds between attempts to update the deployment information
+ - `deployinfo.timeoutSeconds` - When in `Execute` mode this will give up and attempt to kill the process if it hasn't exited after this number of seconds.
 
 auth
 ----


### PR DESCRIPTION
This will now use Process.destroy to kill off a deployinfo process
that is deemed to have locked up in some way. This sends a TERM to
the child process that was started, but doesn't deal with any
children that the process may have started itself.

There are some new configuration properties around this.

Also updated release notes.
