### PR TITLE
Create new package type for AWS deployment with EIP 

### DIFF
--- a/magenta-lib/src/main/scala/magenta/Package.scala
+++ b/magenta-lib/src/main/scala/magenta/Package.scala
@@ -20,6 +20,7 @@ case class Package(
   lazy val pkgType = pkgTypeName match {
     case "autoscaling" => AutoScaling(this)
     case "asg-elb" => AutoScaling(this)
+    case "asg-elb-eip" => AutoScalingWithAnElasticIP(this)
     case "elasticsearch" => ElasticSearch(this)
     case "jetty-webapp" => JettyWebappPackageType(this)
     case "resin-webapp" => ResinWebappPackageType(this)

--- a/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
@@ -88,6 +88,21 @@ case class ResumeAlarmNotifications(packageName: String, stage: Stage) extends A
   lazy val description = "Resuming Alarm Notifications - group will scale on any configured alarms"
 }
 
+case class SetElasticIPOfAnInstance(packageName: String, stage: Stage, elasticIP: String) extends ASGTask {
+
+  override def execute(asg: AutoScalingGroup, stopFlag: => Boolean)(implicit keyRing: KeyRing) {
+    val instanceId = asg.getInstances.head.getInstanceId
+    MessageBroker.info(s"Giving instance $instanceId the elastic IP $elasticIP...")
+    try {
+      EC2.setElasticIPOfInstance(instanceId, elasticIP)
+    } catch {
+      case e: Exception => MessageBroker.fail(s"Failed to associate elastic IP $elasticIP with instance $instanceId", e)
+    }
+  }
+
+  lazy val description = s"Associating elastic IP $elasticIP with a single instance in the group"
+}
+
 trait ASGTask extends Task with ASG {
   def packageName: String
   def stage: Stage

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -139,6 +139,10 @@ trait EC2 extends AWS {
 
   def describe(instance: ASGInstance)(implicit keyRing: KeyRing) = client.describeInstances(
     new DescribeInstancesRequest().withInstanceIds(instance.getInstanceId)).getReservations.flatMap(_.getInstances).head
+
+  def setElasticIPOfInstance(instanceId: String, elasticIP: String)(implicit keyRing: KeyRing) = {
+    client.associateAddress(new AssociateAddressRequest(instanceId, elasticIP))
+  }
 }
 
 object EC2 extends EC2 {

--- a/magenta-lib/src/test/scala/magenta/packagetype/AutoScalingWithAnElasticIPPackageTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/packagetype/AutoScalingWithAnElasticIPPackageTypeTest.scala
@@ -1,0 +1,68 @@
+package magenta.packagetype
+
+import magenta._
+import java.io.File
+import magenta.fixtures._
+import net.liftweb.json.Implicits._
+import net.liftweb.json.JsonAST.JValue
+import org.scalatest.FlatSpec
+import org.scalatest.matchers.ShouldMatchers
+import magenta.tasks._
+import magenta.AutoScalingWithAnElasticIP
+import magenta.Stage
+import magenta.Package
+
+class AutoScalingWithAnElasticIPPackageTypeTest extends FlatSpec with ShouldMatchers {
+
+  "An AutoScalingWithAnElasticIP package type" should "associate an elastic IP with an instance" in {
+
+    val elasticIP = "123.123.123.123"
+    val data: Map[String, JValue] = Map(
+      "bucket" -> "asg-bucket",
+      "elasticIP" -> elasticIP
+    )
+
+    val pkgType = new AutoScalingWithAnElasticIP(
+      Package("app", Set.empty, data, "asg-elb-eip", new File("/tmp/packages/webapp"))
+    )
+
+    pkgType.perAppActions("deploy")(DeployInfo(), parameters()) should be(List(
+      CheckGroupSize("app", PROD),
+      SuspendAlarmNotifications("app", PROD),
+      TagCurrentInstancesWithTerminationTag("app", PROD),
+      DoubleSize("app", Stage("PROD")),
+      WaitForStabilization("app", PROD, 15 * 60 * 1000),
+      HealthcheckGrace(0),
+      WaitForStabilization("app", PROD, 15 * 60 * 1000),
+      CullInstancesWithTerminationTag("app", PROD),
+      WaitForStabilization("app", PROD, 15 * 60 * 1000),
+      ResumeAlarmNotifications("app", PROD),
+      SetElasticIPOfAnInstance("app", PROD, elasticIP)
+    ))
+  }
+
+  it should "not associate an elastic IP if none has been set up" in {
+
+    val data: Map[String, JValue] = Map(
+      "bucket" -> "asg-bucket"
+    )
+
+    val pkgType = new AutoScalingWithAnElasticIP(
+      Package("app", Set.empty, data, "asg-elb-eip", new File("/tmp/packages/webapp"))
+    )
+
+    pkgType.perAppActions("deploy")(DeployInfo(), parameters()) should be(List(
+      CheckGroupSize("app", PROD),
+      SuspendAlarmNotifications("app", PROD),
+      TagCurrentInstancesWithTerminationTag("app", PROD),
+      DoubleSize("app", Stage("PROD")),
+      WaitForStabilization("app", PROD, 15 * 60 * 1000),
+      HealthcheckGrace(0),
+      WaitForStabilization("app", PROD, 15 * 60 * 1000),
+      CullInstancesWithTerminationTag("app", PROD),
+      WaitForStabilization("app", PROD, 15 * 60 * 1000),
+      ResumeAlarmNotifications("app", PROD)
+    ))
+  }
+
+}


### PR DESCRIPTION
The new package type is for deploying an autoscaling group where one of the instances in the group must have an elastic IP.  This is to enable a frontend box to make requests to Redshift running in a separate VPC.
