### PR TITLE
Allow documentation of actions and tasks within a deployment type to be generated

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -2,28 +2,22 @@ package magenta.deployment_type
 
 import magenta.tasks._
 import java.io.File
+import magenta.{DeployParameters, DeployInfo, Package}
 
 object AutoScaling  extends DeploymentType {
   val name = "autoscaling"
-  val documentation =
-    """
-      |Deploy to an autoscaling group in AWS.
-      |
-      |The approach of this deploy type is to:
-      |
-      | - upload a new application artifact to an S3 bucket (from which new instances download their application)
-      | - tag existing instances in the ASG with a termination tag
-      | - double the size of the auto-scaling group (new instances will have the new application)
-      | - wait for the new instances to enter service
-      | - terminate previously tagged instances
-      |
-      |The action checks whether the auto-scaling group maxsize is big enough before starting the process.
-      |
-      |It also suspends and resumes cloud watch alarms in order to prevent false alarms.
-      |
-      |This deploy type has two actions, `deploy` and `uploadArtifacts`. `uploadArtifacts` simply uploads the files
-      |in the package directory to the specified bucket. `deploy` carries out the auto-scaling group rotation.
-    """.stripMargin
+  lazy val documentation =
+    ("""Deploy to an autoscaling group in AWS.
+        |
+        |#### Possible actions:
+      """.stripMargin :: actionDocumentation.toList) mkString "\n\n"
+
+  lazy val actionDocumentation = for {
+    (name, actions) <- applicationActions
+  } yield {
+    val actionsDescription = actions map (a => s": ${a.description}") mkString "\n"
+    name + "\n" +actionsDescription
+  }
 
   val bucket = Param[String]("bucket",
     """
@@ -35,23 +29,30 @@ object AutoScaling  extends DeploymentType {
   val secondsToWait = Param("secondsToWait", "Number of seconds to wait for instances to enter service").default(15 * 60)
   val healthcheckGrace = Param("healthcheckGrace", "Number of seconds to wait for the AWS api to stabalise").default(0)
 
+  val applicationActions = Map(
+    "deploy" -> List(
+      CheckGroupSize,
+      SuspendAlarmNotifications,
+      TagCurrentInstancesWithTerminationTag,
+      DoubleSize,
+      WaitForStabilization(secondsToWait),
+      HealthcheckGrace(healthcheckGrace),
+      WaitForStabilization(secondsToWait),
+      CullInstancesWithTerminationTag,
+      ResumeAlarmNotifications
+    ),
+    "uploadArtifacts" -> List(
+      S3Upload(bucket)
+    )
+  )
+
   def perAppActions = {
-    case "deploy" => (pkg) => (_, parameters) => {
-      List(
-        CheckGroupSize(pkg, parameters),
-        SuspendAlarmNotifications(pkg, parameters),
-        TagCurrentInstancesWithTerminationTag(pkg, parameters),
-        DoubleSize(pkg, parameters),
-        WaitForStabilization(secondsToWait)(pkg, parameters),
-        HealthcheckGrace(healthcheckGrace)(pkg, parameters),
-        WaitForStabilization(secondsToWait)(pkg, parameters),
-        CullInstancesWithTerminationTag(pkg, parameters),
-        ResumeAlarmNotifications(pkg, parameters)
-      )
+    val pfs = for {
+      (name, actions) <- applicationActions
+    } yield new PartialFunction[String, Package => (DeployInfo, DeployParameters) => List[Task]] {
+      def apply(name: String) = (pkg) => (_, parameters) => actions map (_(pkg, parameters))
+      def isDefinedAt(actionName: String) = actionName == name
     }
-    case "uploadArtifacts" => (pkg) => (_, parameters) =>
-      List(
-        S3Upload(bucket)(pkg, parameters)
-      )
+    pfs.toSeq.reduce(_ orElse _)
   }
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -38,13 +38,13 @@ object AutoScaling  extends DeploymentType {
   def perAppActions = {
     case "deploy" => (pkg) => (_, parameters) => {
       List(
-        CheckGroupSize(pkg.name, parameters.stage),
+        CheckGroupSize(pkg, parameters),
         SuspendAlarmNotifications(pkg.name, parameters.stage),
-        TagCurrentInstancesWithTerminationTag(pkg.name, parameters.stage),
+        TagCurrentInstancesWithTerminationTag(pkg, parameters),
         DoubleSize(pkg.name, parameters.stage),
-        WaitForStabilization(pkg.name, parameters.stage, secondsToWait(pkg) * 1000),
+        WaitForStabilization(secondsToWait)(pkg, parameters),
         HealthcheckGrace(healthcheckGrace(pkg) * 1000),
-        WaitForStabilization(pkg.name, parameters.stage, secondsToWait(pkg) * 1000),
+        WaitForStabilization(secondsToWait)(pkg, parameters),
         CullInstancesWithTerminationTag(pkg.name, parameters.stage),
         ResumeAlarmNotifications(pkg.name, parameters.stage)
       )

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -39,19 +39,19 @@ object AutoScaling  extends DeploymentType {
     case "deploy" => (pkg) => (_, parameters) => {
       List(
         CheckGroupSize(pkg, parameters),
-        SuspendAlarmNotifications(pkg.name, parameters.stage),
+        SuspendAlarmNotifications(pkg, parameters),
         TagCurrentInstancesWithTerminationTag(pkg, parameters),
-        DoubleSize(pkg.name, parameters.stage),
+        DoubleSize(pkg, parameters),
         WaitForStabilization(secondsToWait)(pkg, parameters),
-        HealthcheckGrace(healthcheckGrace(pkg) * 1000),
+        HealthcheckGrace(healthcheckGrace)(pkg, parameters),
         WaitForStabilization(secondsToWait)(pkg, parameters),
-        CullInstancesWithTerminationTag(pkg.name, parameters.stage),
-        ResumeAlarmNotifications(pkg.name, parameters.stage)
+        CullInstancesWithTerminationTag(pkg, parameters),
+        ResumeAlarmNotifications(pkg, parameters)
       )
     }
     case "uploadArtifacts" => (pkg) => (_, parameters) =>
       List(
-        S3Upload(parameters.stage, bucket(pkg), new File(pkg.srcDir.getPath + "/"))
+        S3Upload(bucket)(pkg, parameters)
       )
   }
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -1,8 +1,7 @@
 package magenta.deployment_type
 
 import magenta.tasks._
-import java.io.File
-import magenta.{DeployParameters, DeployInfo, Package}
+import magenta.{Lookup, DeployParameters, DeployInfo, DeploymentPackage}
 
 object AutoScaling  extends DeploymentType {
   val name = "autoscaling"
@@ -49,7 +48,7 @@ object AutoScaling  extends DeploymentType {
   def perAppActions = {
     val pfs = for {
       (name, actions) <- applicationActions
-    } yield new PartialFunction[String, Package => (DeployInfo, DeployParameters) => List[Task]] {
+    } yield new PartialFunction[String, DeploymentPackage => (Lookup, DeployParameters) => List[Task]] {
       def apply(name: String) = (pkg) => (_, parameters) => actions map (_(pkg, parameters))
       def isDefinedAt(actionName: String) = actionName == name
     }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
@@ -28,7 +28,7 @@ object ElasticSearch extends DeploymentType {
     }
     case "uploadArtifacts" => (pkg) => (_, parameters) =>
       List(
-        S3Upload(parameters.stage, bucket(pkg), new File(pkg.srcDir.getPath + "/"))
+        S3UploadTask(parameters.stage, bucket(pkg), new File(pkg.srcDir.getPath + "/"))
       )
   }
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Fastly.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Fastly.scala
@@ -10,6 +10,6 @@ object Fastly  extends DeploymentType {
     """.stripMargin
 
   def perAppActions = {
-    case "deploy" => pkg => (_, parameters) => List(UpdateFastlyConfig(pkg))
+    case "deploy" => pkg => (_, parameters) => List(UpdateFastlyConfig(pkg, parameters))
   }
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/FileCopy.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/FileCopy.scala
@@ -10,7 +10,7 @@ object FileCopy extends DeploymentType {
     """.stripMargin
 
   override def perHostActions = {
-    case "deploy" => pkg => host => List(CopyFile(host, pkg.srcDir.getPath, "/"))
+    case "deploy" => pkg => host => List(CopyFile("/")(pkg, host))
   }
 
   def perAppActions = PartialFunction.empty

--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
@@ -3,7 +3,7 @@ package magenta.deployment_type
 import net.liftweb.json.JsonAST._
 import java.io.File
 import magenta.json.JValueExtractable
-import magenta.tasks.S3Upload
+import magenta.tasks.S3UploadTask
 
 object S3 extends DeploymentType {
   val name = "aws-s3"
@@ -88,7 +88,7 @@ object S3 extends DeploymentType {
         data.get.value
       }
       List(
-        S3Upload(parameters.stage,
+        S3UploadTask(parameters.stage,
           bucketName,
           new File(pkg.srcDir.getPath + "/"),
           cacheControl(pkg),

--- a/magenta-lib/src/main/scala/magenta/deployment_type/UnzipToDocroot.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/UnzipToDocroot.scala
@@ -2,7 +2,7 @@ package magenta.deployment_type
 
 import magenta.{MessageBroker, App, Host}
 import java.io.File
-import magenta.tasks.{ExtractToDocroots, CopyFile}
+import magenta.tasks.{ExtractToDocroots, CopyFileTask}
 
 
 object UnzipToDocroot  extends DeploymentType {
@@ -35,7 +35,7 @@ object UnzipToDocroot  extends DeploymentType {
       val host = Host(resourceLookup.data.datum("ddm", App("r2"), params.stage).
         getOrElse(MessageBroker.fail("no data found for ddm in " + params.stage.name)).value)
       List(
-        CopyFile(host as user(pkg), zipLocation.getPath, "/tmp"),
+        CopyFileTask(host as user(pkg), zipLocation.getPath, "/tmp"),
         ExtractToDocroots(host as user(pkg), "/tmp/" + zipLocation.getName, docrootType(pkg), locationInDocroot(pkg))
       )
     }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/WebApp.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/WebApp.scala
@@ -115,7 +115,7 @@ trait WebApp extends DeploymentType {
         case TRAILING_SLASH(withSlash) => withSlash
         case noTrailingSlash => s"$noTrailingSlash/"
       }
-      CopyFile(host as user(pkg), s"${pkg.srcDir.getPath}/$rootWithTrailingSlash",
+      CopyFileTask(host as user(pkg), s"${pkg.srcDir.getPath}/$rootWithTrailingSlash",
         s"/$containerName-apps/${servicename(pkg)}/$rootWithTrailingSlash", copyMode(pkg))
     }
   }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/WebApp.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/WebApp.scala
@@ -103,7 +103,7 @@ trait WebApp extends DeploymentType {
   def perAppActions = {
     case "uploadArtifacts" => pkg => (_, parameters) =>
       List(
-        S3Upload(parameters.stage, bucket(pkg), new File(pkg.srcDir.getPath))
+        S3UploadTask(parameters.stage, bucket(pkg), new File(pkg.srcDir.getPath))
       )
   }
 

--- a/magenta-lib/src/main/scala/magenta/deployment_type/WebApp.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/WebApp.scala
@@ -81,21 +81,21 @@ trait WebApp extends DeploymentType {
 
   override def perHostActions = {
     case "deploy" => pkg => host => {
-      BlockFirewall(host as user(pkg)) ::
+      BlockFirewallTask(host as user(pkg)) ::
       rootCopies(pkg, host) :::
       Restart(host as user(pkg), servicename(pkg)) ::
-      WaitForPort(host, port(pkg), waitseconds(pkg) * 1000) ::
-      CheckUrls(host, port(pkg), healthcheck_paths(pkg), checkseconds(pkg) * 1000, checkUrlReadTimeoutSeconds(pkg)) ::
-      UnblockFirewall(host as user(pkg)) ::
+      WaitForPortTask(host, port(pkg), waitseconds(pkg) * 1000) ::
+      CheckUrlsTask(host, port(pkg), healthcheck_paths(pkg), checkseconds(pkg) * 1000, checkUrlReadTimeoutSeconds(pkg)) ::
+      UnblockFirewallTask(host as user(pkg)) ::
       Nil
     }
     case "restart" => pkg => host => {
       List(
-        BlockFirewall(host as user(pkg)),
+        BlockFirewallTask(host as user(pkg)),
         Restart(host as user(pkg), servicename(pkg)),
-        WaitForPort(host, port(pkg), waitseconds(pkg) * 1000),
-        CheckUrls(host, port(pkg), healthcheck_paths(pkg), checkseconds(pkg) * 1000, checkUrlReadTimeoutSeconds(pkg)),
-        UnblockFirewall(host as user(pkg))
+        WaitForPortTask(host, port(pkg), waitseconds(pkg) * 1000),
+        CheckUrlsTask(host, port(pkg), healthcheck_paths(pkg), checkseconds(pkg) * 1000, checkUrlReadTimeoutSeconds(pkg)),
+        UnblockFirewallTask(host as user(pkg))
       )
     }
   }

--- a/magenta-lib/src/main/scala/magenta/json/JValueExtractable.scala
+++ b/magenta-lib/src/main/scala/magenta/json/JValueExtractable.scala
@@ -4,6 +4,7 @@ import net.liftweb.json.JsonAST._
 import net.liftweb.json.JsonAST.JString
 import net.liftweb.json.JsonAST.JInt
 import net.liftweb.json.JsonAST.JBool
+import java.io.File
 
 trait JValueExtractable[T] {
   def extract(json: JValue): Option[T]
@@ -27,5 +28,8 @@ object JValueExtractable {
   }
   implicit def ListExtractable[T](implicit jve: JValueExtractable[T]) = new JValueExtractable[List[T]] {
     def extract(json: JValue) = extractOption(JArray.unapply)(json) map (_.flatMap(jve.extract(_)))
+  }
+  implicit object FileExtractable extends JValueExtractable[File] {
+    def extract(json: JValue) = extractOption(JString.unapply)(json) map (new File(_))
   }
 }

--- a/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
@@ -1,8 +1,22 @@
 package magenta.tasks
 
-import magenta.{MessageBroker, Stage, KeyRing}
+import magenta._
 import com.amazonaws.services.autoscaling.model.AutoScalingGroup
 import collection.JavaConversions._
+import magenta.KeyRing
+import magenta.Stage
+import scala.Some
+import magenta.Package
+import magenta.deployment_type.Param
+
+object CheckGroupSize extends TaskFactory {
+  def apply(pkg: Package, parameters: DeployParameters) = CheckGroupSize(pkg.name, parameters.stage)
+  lazy val description = "Checking there is enough capacity to deploy"
+}
+
+trait TaskFactory extends ((Package, DeployParameters) => Task) {
+  def description: String
+}
 
 case class CheckGroupSize(packageName: String, stage: Stage) extends ASGTask {
   def execute(asg: AutoScalingGroup, stopFlag: => Boolean)(implicit keyRing: KeyRing) {
@@ -13,8 +27,12 @@ case class CheckGroupSize(packageName: String, stage: Stage) extends ASGTask {
     }
   }
 
-  lazy val description = "Checking there is enough capacity to deploy" format (
-    packageName, stage.name)
+  lazy val description = CheckGroupSize.description
+}
+
+object TagCurrentInstancesWithTerminationTag extends TaskFactory {
+  def description = "Tag existing instances of the auto-scaling group for termination"
+  def apply(pkg: Package, parameters: DeployParameters) = TagCurrentInstancesWithTerminationTag(pkg.name, parameters.stage)
 }
 
 case class TagCurrentInstancesWithTerminationTag(packageName: String, stage: Stage) extends ASGTask {
@@ -22,7 +40,7 @@ case class TagCurrentInstancesWithTerminationTag(packageName: String, stage: Sta
     EC2.setTag(asg.getInstances.toList, "Magenta", "Terminate")
   }
 
-  lazy val description = "Tag existing instances of the auto-scaling group for termination"
+  lazy val description = TagCurrentInstancesWithTerminationTag.description
 }
 
 case class DoubleSize(packageName: String, stage: Stage) extends ASGTask {
@@ -46,7 +64,13 @@ case class HealthcheckGrace(duration: Long) extends Task {
   def description = verbose
 }
 
-case class WaitForStabilization(packageName: String, stage: Stage, duration: Long) extends ASGTask
+case class WaitForStabilization(secondsToWait: Param[Int]) extends TaskFactory {
+  def description = "Check the desired number of hosts in ASG are up and in ELB"
+  def apply(pkg: Package, parameters: DeployParameters) =
+    WaitForStabilizationTask(pkg.name, parameters.stage, secondsToWait(pkg) * 1000)
+}
+
+case class WaitForStabilizationTask(packageName: String, stage: Stage, duration: Long) extends ASGTask
     with SlowRepeatedPollingCheck {
 
   def execute(asg: AutoScalingGroup, stopFlag: => Boolean)(implicit keyRing: KeyRing) {
@@ -56,6 +80,7 @@ case class WaitForStabilization(packageName: String, stage: Stage, duration: Lon
   }
 
   lazy val description: String = "Check the desired number of hosts in ASG are up and in ELB"
+//  WaitForStabilization.description
 }
 
 case class CullInstancesWithTerminationTag(packageName: String, stage: Stage) extends ASGTask {

--- a/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
@@ -5,11 +5,11 @@ import com.amazonaws.services.autoscaling.model.AutoScalingGroup
 import collection.JavaConversions._
 import magenta.KeyRing
 import magenta.Stage
-import magenta.Package
+import magenta.DeploymentPackage
 import magenta.deployment_type.Param
 
 object CheckGroupSize extends ApplicationTaskType {
-  def apply(pkg: Package, parameters: DeployParameters) = CheckGroupSize(pkg.name, parameters.stage)
+  def apply(pkg: DeploymentPackage, parameters: DeployParameters) = CheckGroupSize(pkg.name, parameters.stage)
   lazy val description = "Check there is enough capacity to deploy"
 }
 
@@ -27,7 +27,7 @@ case class CheckGroupSize(packageName: String, stage: Stage) extends ASGTask {
 
 object TagCurrentInstancesWithTerminationTag extends ApplicationTaskType {
   def description = "Tag existing instances of the auto-scaling group for termination"
-  def apply(pkg: Package, parameters: DeployParameters) = TagCurrentInstancesWithTerminationTag(pkg.name, parameters.stage)
+  def apply(pkg: DeploymentPackage, parameters: DeployParameters) = TagCurrentInstancesWithTerminationTag(pkg.name, parameters.stage)
 }
 
 case class TagCurrentInstancesWithTerminationTag(packageName: String, stage: Stage) extends ASGTask {
@@ -40,7 +40,7 @@ case class TagCurrentInstancesWithTerminationTag(packageName: String, stage: Sta
 
 object DoubleSize extends ApplicationTaskType {
   def description = "Double the size of the auto-scaling group"
-  def apply(pkg: Package, parameters: DeployParameters) = DoubleSize(pkg.name, parameters.stage)
+  def apply(pkg: DeploymentPackage, parameters: DeployParameters) = DoubleSize(pkg.name, parameters.stage)
 }
 
 case class DoubleSize(packageName: String, stage: Stage) extends ASGTask {
@@ -54,7 +54,7 @@ case class DoubleSize(packageName: String, stage: Stage) extends ASGTask {
 
 case class HealthcheckGrace(healthcheckGrace: Param[Int]) extends ApplicationTaskType {
   def description = s"Wait for a grace period before checking status"
-  def apply(pkg: Package, parameters: DeployParameters) = HealthcheckGraceTask(healthcheckGrace(pkg) * 1000)
+  def apply(pkg: DeploymentPackage, parameters: DeployParameters) = HealthcheckGraceTask(healthcheckGrace(pkg) * 1000)
 }
 
 case class HealthcheckGraceTask(duration: Long) extends Task {
@@ -70,7 +70,7 @@ case class HealthcheckGraceTask(duration: Long) extends Task {
 
 case class WaitForStabilization(secondsToWait: Param[Int]) extends ApplicationTaskType {
   def description = "Check the desired number of hosts in ASG are up and in ELB"
-  def apply(pkg: Package, parameters: DeployParameters) =
+  def apply(pkg: DeploymentPackage, parameters: DeployParameters) =
     WaitForStabilizationTask(pkg.name, parameters.stage, secondsToWait(pkg) * 1000)
 }
 
@@ -89,7 +89,7 @@ case class WaitForStabilizationTask(packageName: String, stage: Stage, duration:
 
 object CullInstancesWithTerminationTag extends ApplicationTaskType {
   def description = "Terminate instances with the termination tag for this deploy"
-  def apply(pkg: Package, parameters: DeployParameters) = CullInstancesWithTerminationTag(pkg.name, parameters.stage)
+  def apply(pkg: DeploymentPackage, parameters: DeployParameters) = CullInstancesWithTerminationTag(pkg.name, parameters.stage)
 }
 
 case class CullInstancesWithTerminationTag(packageName: String, stage: Stage) extends ASGTask {
@@ -106,7 +106,7 @@ case class CullInstancesWithTerminationTag(packageName: String, stage: Stage) ex
 
 object SuspendAlarmNotifications extends ApplicationTaskType {
   def description = "Suspend alarm notifications - group will no longer scale on any configured alarms"
-  def apply(pkg: Package, parameters: DeployParameters) = SuspendAlarmNotifications(pkg.name, parameters.stage)
+  def apply(pkg: DeploymentPackage, parameters: DeployParameters) = SuspendAlarmNotifications(pkg.name, parameters.stage)
 }
 
 case class SuspendAlarmNotifications(packageName: String, stage: Stage) extends ASGTask {
@@ -120,7 +120,7 @@ case class SuspendAlarmNotifications(packageName: String, stage: Stage) extends 
 
 object ResumeAlarmNotifications extends ApplicationTaskType {
   def description = "Resuming Alarm Notifications - group will scale on any configured alarms"
-  def apply(pkg: Package, parameters: DeployParameters) = ResumeAlarmNotifications(pkg.name, parameters.stage)
+  def apply(pkg: DeploymentPackage, parameters: DeployParameters) = ResumeAlarmNotifications(pkg.name, parameters.stage)
 }
 
 case class ResumeAlarmNotifications(packageName: String, stage: Stage) extends ASGTask {

--- a/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
@@ -13,10 +13,6 @@ object CheckGroupSize extends ApplicationAction {
   lazy val description = "Check there is enough capacity to deploy"
 }
 
-trait ApplicationAction extends ((Package, DeployParameters) => Task) {
-  def description: String
-}
-
 case class CheckGroupSize(packageName: String, stage: Stage) extends ASGTask {
   def execute(asg: AutoScalingGroup, stopFlag: => Boolean)(implicit keyRing: KeyRing) {
     val doubleCapacity = asg.getDesiredCapacity * 2

--- a/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
@@ -8,7 +8,7 @@ import magenta.Stage
 import magenta.Package
 import magenta.deployment_type.Param
 
-object CheckGroupSize extends ApplicationAction {
+object CheckGroupSize extends ApplicationTaskType {
   def apply(pkg: Package, parameters: DeployParameters) = CheckGroupSize(pkg.name, parameters.stage)
   lazy val description = "Check there is enough capacity to deploy"
 }
@@ -25,7 +25,7 @@ case class CheckGroupSize(packageName: String, stage: Stage) extends ASGTask {
   lazy val description = CheckGroupSize.description
 }
 
-object TagCurrentInstancesWithTerminationTag extends ApplicationAction {
+object TagCurrentInstancesWithTerminationTag extends ApplicationTaskType {
   def description = "Tag existing instances of the auto-scaling group for termination"
   def apply(pkg: Package, parameters: DeployParameters) = TagCurrentInstancesWithTerminationTag(pkg.name, parameters.stage)
 }
@@ -38,7 +38,7 @@ case class TagCurrentInstancesWithTerminationTag(packageName: String, stage: Sta
   lazy val description = TagCurrentInstancesWithTerminationTag.description
 }
 
-object DoubleSize extends ApplicationAction {
+object DoubleSize extends ApplicationTaskType {
   def description = "Double the size of the auto-scaling group"
   def apply(pkg: Package, parameters: DeployParameters) = DoubleSize(pkg.name, parameters.stage)
 }
@@ -52,7 +52,7 @@ case class DoubleSize(packageName: String, stage: Stage) extends ASGTask {
   lazy val description = s"${DoubleSize.description} for package: $packageName, stage: ${stage.name}"
 }
 
-case class HealthcheckGrace(healthcheckGrace: Param[Int]) extends ApplicationAction {
+case class HealthcheckGrace(healthcheckGrace: Param[Int]) extends ApplicationTaskType {
   def description = s"Wait for a grace period before checking status"
   def apply(pkg: Package, parameters: DeployParameters) = HealthcheckGraceTask(healthcheckGrace(pkg) * 1000)
 }
@@ -68,7 +68,7 @@ case class HealthcheckGraceTask(duration: Long) extends Task {
   def description = verbose
 }
 
-case class WaitForStabilization(secondsToWait: Param[Int]) extends ApplicationAction {
+case class WaitForStabilization(secondsToWait: Param[Int]) extends ApplicationTaskType {
   def description = "Check the desired number of hosts in ASG are up and in ELB"
   def apply(pkg: Package, parameters: DeployParameters) =
     WaitForStabilizationTask(pkg.name, parameters.stage, secondsToWait(pkg) * 1000)
@@ -87,7 +87,7 @@ case class WaitForStabilizationTask(packageName: String, stage: Stage, duration:
 //  WaitForStabilization.description
 }
 
-object CullInstancesWithTerminationTag extends ApplicationAction {
+object CullInstancesWithTerminationTag extends ApplicationTaskType {
   def description = "Terminate instances with the termination tag for this deploy"
   def apply(pkg: Package, parameters: DeployParameters) = CullInstancesWithTerminationTag(pkg.name, parameters.stage)
 }
@@ -104,7 +104,7 @@ case class CullInstancesWithTerminationTag(packageName: String, stage: Stage) ex
   lazy val description = "Terminate instances with the termination tag for this deploy"
 }
 
-object SuspendAlarmNotifications extends ApplicationAction {
+object SuspendAlarmNotifications extends ApplicationTaskType {
   def description = "Suspend alarm notifications - group will no longer scale on any configured alarms"
   def apply(pkg: Package, parameters: DeployParameters) = SuspendAlarmNotifications(pkg.name, parameters.stage)
 }
@@ -118,7 +118,7 @@ case class SuspendAlarmNotifications(packageName: String, stage: Stage) extends 
   lazy val description = SuspendAlarmNotifications.description
 }
 
-object ResumeAlarmNotifications extends ApplicationAction {
+object ResumeAlarmNotifications extends ApplicationTaskType {
   def description = "Resuming Alarm Notifications - group will scale on any configured alarms"
   def apply(pkg: Package, parameters: DeployParameters) = ResumeAlarmNotifications(pkg.name, parameters.stage)
 }

--- a/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
@@ -10,7 +10,7 @@ import magenta.deployment_type.Param
 
 object CheckGroupSize extends TaskFactory {
   def apply(pkg: Package, parameters: DeployParameters) = CheckGroupSize(pkg.name, parameters.stage)
-  lazy val description = "Checking there is enough capacity to deploy"
+  lazy val description = "Check there is enough capacity to deploy"
 }
 
 trait TaskFactory extends ((Package, DeployParameters) => Task) {
@@ -57,7 +57,7 @@ case class DoubleSize(packageName: String, stage: Stage) extends ASGTask {
 }
 
 case class HealthcheckGrace(healthcheckGrace: Param[Int]) extends TaskFactory {
-  def description = s"Grace period to wait before checking status"
+  def description = s"Wait for a grace period before checking status"
   def apply(pkg: Package, parameters: DeployParameters) = HealthcheckGraceTask(healthcheckGrace(pkg) * 1000)
 }
 
@@ -109,7 +109,7 @@ case class CullInstancesWithTerminationTag(packageName: String, stage: Stage) ex
 }
 
 object SuspendAlarmNotifications extends TaskFactory {
-  def description = "Suspending Alarm Notifications - group will no longer scale on any configured alarms"
+  def description = "Suspend alarm notifications - group will no longer scale on any configured alarms"
   def apply(pkg: Package, parameters: DeployParameters) = SuspendAlarmNotifications(pkg.name, parameters.stage)
 }
 

--- a/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
@@ -8,12 +8,12 @@ import magenta.Stage
 import magenta.Package
 import magenta.deployment_type.Param
 
-object CheckGroupSize extends TaskFactory {
+object CheckGroupSize extends ApplicationAction {
   def apply(pkg: Package, parameters: DeployParameters) = CheckGroupSize(pkg.name, parameters.stage)
   lazy val description = "Check there is enough capacity to deploy"
 }
 
-trait TaskFactory extends ((Package, DeployParameters) => Task) {
+trait ApplicationAction extends ((Package, DeployParameters) => Task) {
   def description: String
 }
 
@@ -29,7 +29,7 @@ case class CheckGroupSize(packageName: String, stage: Stage) extends ASGTask {
   lazy val description = CheckGroupSize.description
 }
 
-object TagCurrentInstancesWithTerminationTag extends TaskFactory {
+object TagCurrentInstancesWithTerminationTag extends ApplicationAction {
   def description = "Tag existing instances of the auto-scaling group for termination"
   def apply(pkg: Package, parameters: DeployParameters) = TagCurrentInstancesWithTerminationTag(pkg.name, parameters.stage)
 }
@@ -42,7 +42,7 @@ case class TagCurrentInstancesWithTerminationTag(packageName: String, stage: Sta
   lazy val description = TagCurrentInstancesWithTerminationTag.description
 }
 
-object DoubleSize extends TaskFactory {
+object DoubleSize extends ApplicationAction {
   def description = "Double the size of the auto-scaling group"
   def apply(pkg: Package, parameters: DeployParameters) = DoubleSize(pkg.name, parameters.stage)
 }
@@ -56,7 +56,7 @@ case class DoubleSize(packageName: String, stage: Stage) extends ASGTask {
   lazy val description = s"${DoubleSize.description} for package: $packageName, stage: ${stage.name}"
 }
 
-case class HealthcheckGrace(healthcheckGrace: Param[Int]) extends TaskFactory {
+case class HealthcheckGrace(healthcheckGrace: Param[Int]) extends ApplicationAction {
   def description = s"Wait for a grace period before checking status"
   def apply(pkg: Package, parameters: DeployParameters) = HealthcheckGraceTask(healthcheckGrace(pkg) * 1000)
 }
@@ -72,7 +72,7 @@ case class HealthcheckGraceTask(duration: Long) extends Task {
   def description = verbose
 }
 
-case class WaitForStabilization(secondsToWait: Param[Int]) extends TaskFactory {
+case class WaitForStabilization(secondsToWait: Param[Int]) extends ApplicationAction {
   def description = "Check the desired number of hosts in ASG are up and in ELB"
   def apply(pkg: Package, parameters: DeployParameters) =
     WaitForStabilizationTask(pkg.name, parameters.stage, secondsToWait(pkg) * 1000)
@@ -91,7 +91,7 @@ case class WaitForStabilizationTask(packageName: String, stage: Stage, duration:
 //  WaitForStabilization.description
 }
 
-object CullInstancesWithTerminationTag extends TaskFactory {
+object CullInstancesWithTerminationTag extends ApplicationAction {
   def description = "Terminate instances with the termination tag for this deploy"
   def apply(pkg: Package, parameters: DeployParameters) = CullInstancesWithTerminationTag(pkg.name, parameters.stage)
 }
@@ -108,7 +108,7 @@ case class CullInstancesWithTerminationTag(packageName: String, stage: Stage) ex
   lazy val description = "Terminate instances with the termination tag for this deploy"
 }
 
-object SuspendAlarmNotifications extends TaskFactory {
+object SuspendAlarmNotifications extends ApplicationAction {
   def description = "Suspend alarm notifications - group will no longer scale on any configured alarms"
   def apply(pkg: Package, parameters: DeployParameters) = SuspendAlarmNotifications(pkg.name, parameters.stage)
 }
@@ -122,7 +122,7 @@ case class SuspendAlarmNotifications(packageName: String, stage: Stage) extends 
   lazy val description = SuspendAlarmNotifications.description
 }
 
-object ResumeAlarmNotifications extends TaskFactory {
+object ResumeAlarmNotifications extends ApplicationAction {
   def description = "Resuming Alarm Notifications - group will scale on any configured alarms"
   def apply(pkg: Package, parameters: DeployParameters) = ResumeAlarmNotifications(pkg.name, parameters.stage)
 }

--- a/magenta-lib/src/main/scala/magenta/tasks/Action.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/Action.scala
@@ -1,0 +1,11 @@
+package magenta.tasks
+
+import magenta.{Host, DeployParameters, Package}
+
+trait ApplicationAction extends ((Package, DeployParameters) => Task) {
+  def description: String
+}
+
+trait HostAction extends ((Package, Host) => Task) {
+  def description: String
+}

--- a/magenta-lib/src/main/scala/magenta/tasks/FastlyTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/FastlyTasks.scala
@@ -1,9 +1,14 @@
 package magenta.tasks
 
-import magenta.{MessageBroker, KeyRing, DeploymentPackage}
+import magenta.{DeployParameters, MessageBroker, KeyRing, DeploymentPackage}
 import java.io.File
 import net.liftweb.json._
 import com.gu.fastly.api.FastlyApiClient
+
+object UpdateFastlyConfig extends ApplicationTaskType {
+  def description = "Update Fastly configuration"
+  def apply(pkg: DeploymentPackage, parameters: DeployParameters) = UpdateFastlyConfig(pkg)
+}
 
 case class UpdateFastlyConfig(pkg: DeploymentPackage) extends Task {
 

--- a/magenta-lib/src/main/scala/magenta/tasks/Task.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/Task.scala
@@ -7,7 +7,7 @@ trait Task {
   def execute(sshCredentials: KeyRing) { execute(sshCredentials, false) }
 
   // name of this task: normally no need to override this method
-  def name = getClass.getSimpleName
+  def name = getClass.getSimpleName.stripSuffix("Task")
 
   // end-user friendly description of this task
   // (will normally be prefixed by name before display)

--- a/magenta-lib/src/main/scala/magenta/tasks/TaskType.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/TaskType.scala
@@ -2,10 +2,10 @@ package magenta.tasks
 
 import magenta.{Host, DeployParameters, Package}
 
-trait ApplicationAction extends ((Package, DeployParameters) => Task) {
+trait ApplicationTaskType extends ((Package, DeployParameters) => Task) {
   def description: String
 }
 
-trait HostAction extends ((Package, Host) => Task) {
+trait HostTaskType extends ((Package, Host) => Task) {
   def description: String
 }

--- a/magenta-lib/src/main/scala/magenta/tasks/TaskType.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/TaskType.scala
@@ -1,11 +1,11 @@
 package magenta.tasks
 
-import magenta.{Host, DeployParameters, Package}
+import magenta.{Host, DeployParameters, DeploymentPackage}
 
-trait ApplicationTaskType extends ((Package, DeployParameters) => Task) {
+trait ApplicationTaskType extends ((DeploymentPackage, DeployParameters) => Task) {
   def description: String
 }
 
-trait HostTaskType extends ((Package, Host) => Task) {
+trait HostTaskType extends ((DeploymentPackage, Host) => Task) {
   def description: String
 }

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -22,7 +22,13 @@ object CopyFile {
   val MIRROR_MODE = "mirror"
   lazy val MODES = List(ADDITIVE_MODE, MIRROR_MODE)
 }
-case class CopyFile(host: Host, source: String, dest: String, copyMode: String = CopyFile.ADDITIVE_MODE) extends ShellTask {
+
+case class CopyFile(dest: String)  extends HostAction {
+  def description = s"Copy package files to $dest using rsync"
+  def apply(pkg: Package, host: Host) = CopyFileTask(host, pkg.srcDir.getPath, dest)
+}
+
+case class CopyFileTask(host: Host, source: String, dest: String, copyMode: String = CopyFile.ADDITIVE_MODE) extends ShellTask {
   override val taskHost = Some(host)
   val noHostKeyChecking = "-o" :: "UserKnownHostsFile=/dev/null" :: "-o" :: "StrictHostKeyChecking=no" :: Nil
 
@@ -50,7 +56,7 @@ case class CopyFile(host: Host, source: String, dest: String, copyMode: String =
 case class CompressedCopy(host: Host, source: Option[File], dest: String) extends CompositeTask with CompressedFilename {
   val tasks = Seq(
     Compress(source),
-    CopyFile(host, if (source.isEmpty) "unknown at preview time" else compressedPath, dest),
+    CopyFileTask(host, if (source.isEmpty) "unknown at preview time" else compressedPath, dest),
     Decompress(host, dest, source)
   )
 

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -23,7 +23,7 @@ object CopyFile {
   lazy val MODES = List(ADDITIVE_MODE, MIRROR_MODE)
 }
 
-case class CopyFile(dest: String)  extends HostAction {
+case class CopyFile(dest: String)  extends HostTaskType {
   def description = s"Copy package files to $dest using rsync"
   def apply(pkg: Package, host: Host) = CopyFileTask(host, pkg.srcDir.getPath, dest)
 }
@@ -97,7 +97,7 @@ trait CompressedFilename {
   def compressedName = sourceFile.getName + ".tar.bz2"
 }
 
-case class S3Upload(bucket: Param[String]) extends ApplicationAction {
+case class S3Upload(bucket: Param[String]) extends ApplicationTaskType {
   def description = "Upload the package to S3"
   def apply(pkg: Package, parameters: DeployParameters) =
     S3UploadTask(parameters.stage, bucket(pkg), new File(pkg.srcDir.getPath + "/"))

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -10,7 +10,7 @@ import scala._
 import java.io.{IOException, FileNotFoundException, File}
 import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest}
 import java.net.URL
-import magenta.deployment_type.PatternValue
+import magenta.deployment_type.{Param, PatternValue}
 
 object CommandLocator {
   var rootPath = "/opt/deploy/bin"
@@ -91,11 +91,13 @@ trait CompressedFilename {
   def compressedName = sourceFile.getName + ".tar.bz2"
 }
 
-object S3Upload {
-
+case class S3Upload(bucket: Param[String]) extends TaskFactory {
+  def description = "Upload the package to S3"
+  def apply(pkg: Package, parameters: DeployParameters) =
+    S3UploadTask(parameters.stage, bucket(pkg), new File(pkg.srcDir.getPath + "/"))
 }
 
-case class S3Upload( stage: Stage,
+case class S3UploadTask( stage: Stage,
                      bucket: String,
                      file: File,
                      cacheControlPatterns: List[PatternValue] = Nil,

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -25,7 +25,7 @@ object CopyFile {
 
 case class CopyFile(dest: String)  extends HostTaskType {
   def description = s"Copy package files to $dest using rsync"
-  def apply(pkg: Package, host: Host) = CopyFileTask(host, pkg.srcDir.getPath, dest)
+  def apply(pkg: DeploymentPackage, host: Host) = CopyFileTask(host, pkg.srcDir.getPath, dest)
 }
 
 case class CopyFileTask(host: Host, source: String, dest: String, copyMode: String = CopyFile.ADDITIVE_MODE) extends ShellTask {
@@ -99,7 +99,7 @@ trait CompressedFilename {
 
 case class S3Upload(bucket: Param[String]) extends ApplicationTaskType {
   def description = "Upload the package to S3"
-  def apply(pkg: Package, parameters: DeployParameters) =
+  def apply(pkg: DeploymentPackage, parameters: DeployParameters) =
     S3UploadTask(parameters.stage, bucket(pkg), new File(pkg.srcDir.getPath + "/"))
 }
 

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -91,7 +91,7 @@ trait CompressedFilename {
   def compressedName = sourceFile.getName + ".tar.bz2"
 }
 
-case class S3Upload(bucket: Param[String]) extends TaskFactory {
+case class S3Upload(bucket: Param[String]) extends ApplicationAction {
   def description = "Upload the package to S3"
   def apply(pkg: Package, parameters: DeployParameters) =
     S3UploadTask(parameters.stage, bucket(pkg), new File(pkg.srcDir.getPath + "/"))

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -91,6 +91,9 @@ trait CompressedFilename {
   def compressedName = sourceFile.getName + ".tar.bz2"
 }
 
+object S3Upload {
+
+}
 
 case class S3Upload( stage: Stage,
                      bucket: String,

--- a/magenta-lib/src/test/scala/magenta/ResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/ResolverTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.FlatSpec
 import org.scalatest.matchers.ShouldMatchers
 import java.io.File
 import scala.Some
-import tasks.{Task, CopyFile}
+import tasks.{Task, CopyFileTask}
 
 
 class ResolverTest extends FlatSpec with ShouldMatchers {
@@ -44,7 +44,7 @@ class ResolverTest extends FlatSpec with ShouldMatchers {
 
     tasks.size should be (1)
     tasks should be (List(
-      CopyFile(host, "/tmp/packages/htmlapp", "/")
+      CopyFileTask(host, "/tmp/packages/htmlapp", "/")
     ))
   }
 

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -22,9 +22,9 @@ class AutoScalingTest extends FlatSpec with ShouldMatchers {
       SuspendAlarmNotifications("app", PROD),
       TagCurrentInstancesWithTerminationTag("app", PROD),
       DoubleSize("app", Stage("PROD")),
-      WaitForStabilization("app", PROD, 15 * 60 * 1000),
+      WaitForStabilizationTask("app", PROD, 15 * 60 * 1000),
       HealthcheckGrace(0),
-      WaitForStabilization("app", PROD, 15 * 60 * 1000),
+      WaitForStabilizationTask("app", PROD, 15 * 60 * 1000),
       CullInstancesWithTerminationTag("app", PROD),
       ResumeAlarmNotifications("app", PROD)
     ))
@@ -44,9 +44,9 @@ class AutoScalingTest extends FlatSpec with ShouldMatchers {
       SuspendAlarmNotifications("app", PROD),
       TagCurrentInstancesWithTerminationTag("app", PROD),
       DoubleSize("app", PROD),
-      WaitForStabilization("app", PROD, 3 * 60 * 1000),
+      WaitForStabilizationTask("app", PROD, 3 * 60 * 1000),
       HealthcheckGrace(30000),
-      WaitForStabilization("app", PROD, 3 * 60 * 1000),
+      WaitForStabilizationTask("app", PROD, 3 * 60 * 1000),
       CullInstancesWithTerminationTag("app", PROD),
       ResumeAlarmNotifications("app", PROD)
     ))

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -23,7 +23,7 @@ class AutoScalingTest extends FlatSpec with ShouldMatchers {
       TagCurrentInstancesWithTerminationTag("app", PROD),
       DoubleSize("app", Stage("PROD")),
       WaitForStabilizationTask("app", PROD, 15 * 60 * 1000),
-      HealthcheckGrace(0),
+      HealthcheckGraceTask(0),
       WaitForStabilizationTask("app", PROD, 15 * 60 * 1000),
       CullInstancesWithTerminationTag("app", PROD),
       ResumeAlarmNotifications("app", PROD)
@@ -45,7 +45,7 @@ class AutoScalingTest extends FlatSpec with ShouldMatchers {
       TagCurrentInstancesWithTerminationTag("app", PROD),
       DoubleSize("app", PROD),
       WaitForStabilizationTask("app", PROD, 3 * 60 * 1000),
-      HealthcheckGrace(30000),
+      HealthcheckGraceTask(30000),
       WaitForStabilizationTask("app", PROD, 3 * 60 * 1000),
       CullInstancesWithTerminationTag("app", PROD),
       ResumeAlarmNotifications("app", PROD)

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -9,19 +9,19 @@ import net.liftweb.json.JsonAST._
 import fixtures._
 import magenta.deployment_type._
 import magenta.tasks.S3UploadTask
-import magenta.tasks.ApacheGracefulRestart
-import magenta.tasks.UnblockFirewall
+import magenta.tasks.ApacheGracefulRestartTask
+import magenta.tasks.UnblockFirewallTask
 import net.liftweb.json.JsonAST.JField
 import magenta.deployment_type.PatternValue
 import net.liftweb.json.JsonAST.JObject
-import magenta.tasks.CheckUrls
+import magenta.tasks.CheckUrlsTask
 import net.liftweb.json.JsonAST.JString
 import magenta.tasks.CompressedCopy
-import magenta.tasks.BlockFirewall
+import magenta.tasks.BlockFirewallTask
 import magenta.deployment_type.S3
 import magenta.tasks.Link
 import scala.Some
-import magenta.tasks.WaitForPort
+import magenta.tasks.WaitForPortTask
 import net.liftweb.json.JsonAST.JArray
 
 class DeploymentTypeTest extends FlatSpec with ShouldMatchers {
@@ -106,13 +106,13 @@ class DeploymentTypeTest extends FlatSpec with ShouldMatchers {
     val host = Host("host_name")
 
     Django.perHostActions("deploy")(p)(host) should be (List(
-      BlockFirewall(host as "django"),
+      BlockFirewallTask(host as "django"),
       CompressedCopy(host as "django", Some(specificBuildFile), "/django-apps/"),
       Link(host as "django", Some("/django-apps/" + specificBuildFile.getName), "/django-apps/webapp"),
-      ApacheGracefulRestart(host as "django"),
-      WaitForPort(host, 80, 1 minute),
-      CheckUrls(host, 80, List.empty, 120000, 5),
-      UnblockFirewall(host as "django")
+      ApacheGracefulRestartTask(host as "django"),
+      WaitForPortTask(host, 80, 1 minute),
+      CheckUrlsTask(host, 80, List.empty, 120000, 5),
+      UnblockFirewallTask(host as "django")
     ))
   }
 

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -8,7 +8,7 @@ import net.liftweb.json.Implicits._
 import net.liftweb.json.JsonAST._
 import fixtures._
 import magenta.deployment_type._
-import magenta.tasks.S3Upload
+import magenta.tasks.S3UploadTask
 import magenta.tasks.ApacheGracefulRestart
 import magenta.tasks.UnblockFirewall
 import net.liftweb.json.JsonAST.JField
@@ -40,7 +40,7 @@ class DeploymentTypeTest extends FlatSpec with ShouldMatchers {
 
     val thrown = evaluating {
       S3.perAppActions("uploadStaticFiles")(p)(lookupSingleHost, parameters(Stage("CODE"))) should be (
-        List(S3Upload(Stage("CODE"),"bucket-1234",new File("/tmp/packages/static-files"), List(PatternValue(".*", "no-cache"))))
+        List(S3UploadTask(Stage("CODE"),"bucket-1234",new File("/tmp/packages/static-files"), List(PatternValue(".*", "no-cache"))))
       )
     } should produce [NoSuchElementException]
 
@@ -57,7 +57,7 @@ class DeploymentTypeTest extends FlatSpec with ShouldMatchers {
     val p = DeploymentPackage("myapp", Set.empty, data, "aws-s3", new File("/tmp/packages/static-files"))
 
     S3.perAppActions("uploadStaticFiles")(p)(lookupSingleHost, parameters(Stage("CODE"))) should be (
-      List(S3Upload(Stage("CODE"),"bucket-1234",new File("/tmp/packages/static-files"), List(PatternValue(".*", "no-cache"))))
+      List(S3UploadTask(Stage("CODE"),"bucket-1234",new File("/tmp/packages/static-files"), List(PatternValue(".*", "no-cache"))))
     )
   }
 
@@ -74,7 +74,7 @@ class DeploymentTypeTest extends FlatSpec with ShouldMatchers {
 
     S3.perAppActions("uploadStaticFiles")(p)(lookupSingleHost, parameters(Stage("CODE"))) should be (
       List(
-        S3Upload(Stage("CODE"),"bucket-1234",new File("/tmp/packages/static-files"),
+        S3UploadTask(Stage("CODE"),"bucket-1234",new File("/tmp/packages/static-files"),
           List(PatternValue("^sub", "no-cache"), PatternValue(".*", "public; max-age:3600")))
       )
     )

--- a/magenta-lib/src/test/scala/magenta/deployment_type/JettyWebappTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/JettyWebappTest.scala
@@ -7,7 +7,7 @@ import net.liftweb.util.TimeHelpers._
 import net.liftweb.json.Implicits._
 import tasks.BlockFirewall
 import tasks.CheckUrls
-import tasks.CopyFile
+import tasks.CopyFileTask
 import tasks.Restart
 import tasks.UnblockFirewall
 import net.liftweb.json.JsonAST.JString
@@ -25,7 +25,7 @@ class JettyWebappTest  extends FlatSpec with ShouldMatchers {
 
     JettyWebapp.perHostActions("deploy")(p)(host) should be (List(
       BlockFirewall(host as "jetty"),
-      CopyFile(host as "jetty", "/tmp/packages/webapp/", "/jetty-apps/webapp/"),
+      CopyFileTask(host as "jetty", "/tmp/packages/webapp/", "/jetty-apps/webapp/"),
       Restart(host as "jetty", "webapp"),
       WaitForPort(host, 8080, 1 minute),
       CheckUrls(host, 8080, List("/webapp/management/healthcheck"), 2 minutes, 5),
@@ -50,7 +50,7 @@ class JettyWebappTest  extends FlatSpec with ShouldMatchers {
 
     JettyWebapp.perHostActions("deploy")(p)(host) should be (List(
       BlockFirewall(host as "jetty"),
-      CopyFile(host as "jetty", "/tmp/packages/webapp/", "/jetty-apps/webapp/"),
+      CopyFileTask(host as "jetty", "/tmp/packages/webapp/", "/jetty-apps/webapp/"),
       Restart(host as "jetty", "webapp"),
       WaitForPort(host, 8080, 1 minute),
       CheckUrls(host, 8080, urls, 2 minutes, 5),
@@ -66,13 +66,13 @@ class JettyWebappTest  extends FlatSpec with ShouldMatchers {
     val host = Host("host_name")
 
     JettyWebapp.perHostActions("deploy")(p)(host) should (contain[Task] (
-      CopyFile(host as "jetty", "/tmp/packages/webapp/", "/jetty-apps/webapp/")
+      CopyFileTask(host as "jetty", "/tmp/packages/webapp/", "/jetty-apps/webapp/")
     ) and contain[Task] (
       Restart(host as "jetty", "webapp")
     ))
 
     JettyWebapp.perHostActions("deploy")(p2)(host) should (contain[Task] (
-      CopyFile(host as "jetty", "/tmp/packages/webapp/", "/jetty-apps/microapps/")
+      CopyFileTask(host as "jetty", "/tmp/packages/webapp/", "/jetty-apps/microapps/")
     ) and contain[Task] (
       Restart(host as "jetty", "microapps")
     ))
@@ -87,9 +87,9 @@ class JettyWebappTest  extends FlatSpec with ShouldMatchers {
     val p = DeploymentPackage("webapp", Set.empty, Map("copyRoots" -> JArray(List("solr/conf/", "app"))), "jetty-webapp", new File("/tmp/packages/webapp"))
     val host = Host("host_name")
     JettyWebapp.perHostActions("deploy")(p)(host) should (contain[Task] (
-      CopyFile(host as "jetty", "/tmp/packages/webapp/solr/conf/", "/jetty-apps/webapp/solr/conf/")
+      CopyFileTask(host as "jetty", "/tmp/packages/webapp/solr/conf/", "/jetty-apps/webapp/solr/conf/")
     ) and contain[Task] (
-      CopyFile(host as "jetty", "/tmp/packages/webapp/app/", "/jetty-apps/webapp/app/")
+      CopyFileTask(host as "jetty", "/tmp/packages/webapp/app/", "/jetty-apps/webapp/app/")
     ))
   }
 
@@ -99,8 +99,8 @@ class JettyWebappTest  extends FlatSpec with ShouldMatchers {
 
     JettyWebapp.perHostActions("deploy")(p)(host) should be (List(
       BlockFirewall(host as "jetty"),
-      CopyFile(host as "jetty", "/tmp/packages/d2index/solr/conf/", "/jetty-apps/d2index/solr/conf/", CopyFile.MIRROR_MODE),
-      CopyFile(host as "jetty", "/tmp/packages/d2index/webapp/", "/jetty-apps/d2index/webapp/", CopyFile.MIRROR_MODE),
+      CopyFileTask(host as "jetty", "/tmp/packages/d2index/solr/conf/", "/jetty-apps/d2index/solr/conf/", CopyFile.MIRROR_MODE),
+      CopyFileTask(host as "jetty", "/tmp/packages/d2index/webapp/", "/jetty-apps/d2index/webapp/", CopyFile.MIRROR_MODE),
       Restart(host as "jetty", "d2index"),
       WaitForPort(host, 8080, 1 minute),
       CheckUrls(host, 8080, List("/d2index/management/healthcheck"), 2 minutes, 5),

--- a/magenta-lib/src/test/scala/magenta/deployment_type/JettyWebappTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/JettyWebappTest.scala
@@ -5,13 +5,13 @@ import tasks._
 import net.liftweb.json.JsonAST.{JArray, JString}
 import net.liftweb.util.TimeHelpers._
 import net.liftweb.json.Implicits._
-import tasks.BlockFirewall
-import tasks.CheckUrls
+import tasks.BlockFirewallTask
+import tasks.CheckUrlsTask
 import tasks.CopyFileTask
 import tasks.Restart
-import tasks.UnblockFirewall
+import tasks.UnblockFirewallTask
 import net.liftweb.json.JsonAST.JString
-import tasks.WaitForPort
+import tasks.WaitForPortTask
 import net.liftweb.json.JsonAST.JArray
 import org.scalatest.FlatSpec
 import org.scalatest.matchers.ShouldMatchers
@@ -24,12 +24,12 @@ class JettyWebappTest  extends FlatSpec with ShouldMatchers {
     val host = Host("host_name")
 
     JettyWebapp.perHostActions("deploy")(p)(host) should be (List(
-      BlockFirewall(host as "jetty"),
+      BlockFirewallTask(host as "jetty"),
       CopyFileTask(host as "jetty", "/tmp/packages/webapp/", "/jetty-apps/webapp/"),
       Restart(host as "jetty", "webapp"),
-      WaitForPort(host, 8080, 1 minute),
-      CheckUrls(host, 8080, List("/webapp/management/healthcheck"), 2 minutes, 5),
-      UnblockFirewall(host as "jetty")
+      WaitForPortTask(host, 8080, 1 minute),
+      CheckUrlsTask(host, 8080, List("/webapp/management/healthcheck"), 2 minutes, 5),
+      UnblockFirewallTask(host as "jetty")
     ))
   }
 
@@ -49,12 +49,12 @@ class JettyWebappTest  extends FlatSpec with ShouldMatchers {
     val host = Host("host_name")
 
     JettyWebapp.perHostActions("deploy")(p)(host) should be (List(
-      BlockFirewall(host as "jetty"),
+      BlockFirewallTask(host as "jetty"),
       CopyFileTask(host as "jetty", "/tmp/packages/webapp/", "/jetty-apps/webapp/"),
       Restart(host as "jetty", "webapp"),
-      WaitForPort(host, 8080, 1 minute),
-      CheckUrls(host, 8080, urls, 2 minutes, 5),
-      UnblockFirewall(host as "jetty")
+      WaitForPortTask(host, 8080, 1 minute),
+      CheckUrlsTask(host, 8080, urls, 2 minutes, 5),
+      UnblockFirewallTask(host as "jetty")
     ))
 
   }
@@ -98,13 +98,13 @@ class JettyWebappTest  extends FlatSpec with ShouldMatchers {
     val host = Host("host_name")
 
     JettyWebapp.perHostActions("deploy")(p)(host) should be (List(
-      BlockFirewall(host as "jetty"),
+      BlockFirewallTask(host as "jetty"),
       CopyFileTask(host as "jetty", "/tmp/packages/d2index/solr/conf/", "/jetty-apps/d2index/solr/conf/", CopyFile.MIRROR_MODE),
       CopyFileTask(host as "jetty", "/tmp/packages/d2index/webapp/", "/jetty-apps/d2index/webapp/", CopyFile.MIRROR_MODE),
       Restart(host as "jetty", "d2index"),
-      WaitForPort(host, 8080, 1 minute),
-      CheckUrls(host, 8080, List("/d2index/management/healthcheck"), 2 minutes, 5),
-      UnblockFirewall(host as "jetty")
+      WaitForPortTask(host, 8080, 1 minute),
+      CheckUrlsTask(host, 8080, List("/d2index/management/healthcheck"), 2 minutes, 5),
+      UnblockFirewallTask(host as "jetty")
     ))
   }
 }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/ResinWebappTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/ResinWebappTest.scala
@@ -4,11 +4,11 @@ import org.scalatest.FlatSpec
 import org.scalatest.matchers.ShouldMatchers
 import java.io.File
 import tasks._
-import tasks.BlockFirewall
-import tasks.CheckUrls
+import tasks.BlockFirewallTask
+import tasks.CheckUrlsTask
 import tasks.CopyFileTask
 import tasks.Restart
-import tasks.WaitForPort
+import tasks.WaitForPortTask
 import net.liftweb.util.TimeHelpers._
 import net.liftweb.json.Implicits._
 import net.liftweb.json.JsonAST.{JArray, JString}
@@ -21,12 +21,12 @@ class ResinWebappTest extends FlatSpec with ShouldMatchers {
     val host = Host("host_name")
 
     ResinWebapp.perHostActions("deploy")(p)(host) should be (List(
-      BlockFirewall(host as "resin"),
+      BlockFirewallTask(host as "resin"),
       CopyFileTask(host as "resin", "/tmp/packages/webapp/", "/resin-apps/webapp/"),
       Restart(host as "resin", "webapp"),
-      WaitForPort(host, 8080, 1 minute),
-      CheckUrls(host, 8080, List("/webapp/management/healthcheck"), 2 minutes, 5),
-      UnblockFirewall(host as "resin")
+      WaitForPortTask(host, 8080, 1 minute),
+      CheckUrlsTask(host, 8080, List("/webapp/management/healthcheck"), 2 minutes, 5),
+      UnblockFirewallTask(host as "resin")
     ))
   }
 
@@ -46,12 +46,12 @@ class ResinWebappTest extends FlatSpec with ShouldMatchers {
     val host = Host("host_name")
 
     ResinWebapp.perHostActions("deploy")(p)(host) should be (List(
-      BlockFirewall(host as "resin"),
+      BlockFirewallTask(host as "resin"),
       CopyFileTask(host as "resin", "/tmp/packages/webapp/", "/resin-apps/webapp/"),
       Restart(host as "resin", "webapp"),
-      WaitForPort(host, 8080, 1 minute),
-      CheckUrls(host, 8080, urls, 2 minutes, 5),
-      UnblockFirewall(host as "resin")
+      WaitForPortTask(host, 8080, 1 minute),
+      CheckUrlsTask(host, 8080, urls, 2 minutes, 5),
+      UnblockFirewallTask(host as "resin")
     ))
   }
 

--- a/magenta-lib/src/test/scala/magenta/deployment_type/ResinWebappTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/ResinWebappTest.scala
@@ -6,7 +6,7 @@ import java.io.File
 import tasks._
 import tasks.BlockFirewall
 import tasks.CheckUrls
-import tasks.CopyFile
+import tasks.CopyFileTask
 import tasks.Restart
 import tasks.WaitForPort
 import net.liftweb.util.TimeHelpers._
@@ -22,7 +22,7 @@ class ResinWebappTest extends FlatSpec with ShouldMatchers {
 
     ResinWebapp.perHostActions("deploy")(p)(host) should be (List(
       BlockFirewall(host as "resin"),
-      CopyFile(host as "resin", "/tmp/packages/webapp/", "/resin-apps/webapp/"),
+      CopyFileTask(host as "resin", "/tmp/packages/webapp/", "/resin-apps/webapp/"),
       Restart(host as "resin", "webapp"),
       WaitForPort(host, 8080, 1 minute),
       CheckUrls(host, 8080, List("/webapp/management/healthcheck"), 2 minutes, 5),
@@ -47,7 +47,7 @@ class ResinWebappTest extends FlatSpec with ShouldMatchers {
 
     ResinWebapp.perHostActions("deploy")(p)(host) should be (List(
       BlockFirewall(host as "resin"),
-      CopyFile(host as "resin", "/tmp/packages/webapp/", "/resin-apps/webapp/"),
+      CopyFileTask(host as "resin", "/tmp/packages/webapp/", "/resin-apps/webapp/"),
       Restart(host as "resin", "webapp"),
       WaitForPort(host, 8080, 1 minute),
       CheckUrls(host, 8080, urls, 2 minutes, 5),

--- a/magenta-lib/src/test/scala/magenta/deployment_type/UnzipToDocrootPackageTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/UnzipToDocrootPackageTypeTest.scala
@@ -8,8 +8,8 @@ import net.liftweb.json.JsonAST.JValue
 import net.liftweb.json.Implicits._
 import java.io.File
 import tasks._
-import tasks.CopyFile
 import magenta.DeploymentPackage
+import tasks.CopyFileTask
 
 class UnzipToDocrootTest extends FunSuite with ShouldMatchers{
   test("copies to host based on deployInfo data") {
@@ -25,7 +25,7 @@ class UnzipToDocrootTest extends FunSuite with ShouldMatchers{
     val diData = Map("ddm" -> List(Datum("*", PROD.name, "ddm.domain", None)))
 
     UnzipToDocroot.perAppActions("deploy")(p)(stubLookup(data = diData), parameters()) should be (List(
-      CopyFile(Host("ddm.domain", connectAs = Some("ddm-user")), "/tmp/packages/webapp/dir/files.zip", "/tmp"),
+      CopyFileTask(Host("ddm.domain", connectAs = Some("ddm-user")), "/tmp/packages/webapp/dir/files.zip", "/tmp"),
       ExtractToDocroots(Host("ddm.domain", connectAs = Some("ddm-user")), "/tmp/files.zip", "static", "the-app/static")
     ))
   }

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -183,7 +183,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
   }
 
   "CopyFile task" should "specify custom remote shell for rsync if key-file specified" in {
-    val task = CopyFile(Host("foo.com"), "/source", "/dest")
+    val task = CopyFileTask(Host("foo.com"), "/source", "/dest")
 
     val command = task.commandLine(KeyRing(SystemUser(Some(new File("key")))))
 
@@ -191,7 +191,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
   }
 
   it should "specify custom remote shell without keyfile if no key-file specified" in {
-    val task = CopyFile(Host("foo.com"), "/source", "/dest")
+    val task = CopyFileTask(Host("foo.com"), "/source", "/dest")
 
     val command = task.commandLine(KeyRing(SystemUser(None)))
 
@@ -199,7 +199,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
   }
 
   it should "honour additive mode" in {
-    val task = CopyFile(Host("foo.com"), "/source", "/dest", CopyFile.ADDITIVE_MODE)
+    val task = CopyFileTask(Host("foo.com"), "/source", "/dest", CopyFile.ADDITIVE_MODE)
 
     val command = task.commandLine(KeyRing(SystemUser(None)))
 
@@ -207,7 +207,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
   }
 
   it should "honour mirror mode" in {
-    val task = CopyFile(Host("foo.com"), "/source", "/dest", CopyFile.MIRROR_MODE)
+    val task = CopyFileTask(Host("foo.com"), "/source", "/dest", CopyFile.MIRROR_MODE)
 
     val command = task.commandLine(KeyRing(SystemUser(None)))
 

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -219,7 +219,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
     val fileToUpload = new File("/foo/bar/the-jar.jar")
 
 
-    val task = new S3Upload(Stage("CODE"), "bucket", fileToUpload) with StubS3
+    val task = new S3UploadTask(Stage("CODE"), "bucket", fileToUpload) with StubS3
 
     task.execute(fakeKeyRing)
     val s3Client = task.s3client(fakeKeyRing)
@@ -232,7 +232,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
 
     val baseDir = createTempDir()
 
-    val task = new S3Upload(Stage("CODE"), "bucket", baseDir)
+    val task = new S3UploadTask(Stage("CODE"), "bucket", baseDir)
 
     val file = new File("/file/path")
 
@@ -253,7 +253,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
     val baseDir = new File("/foo/bar/something").getParentFile
     val child = new File(baseDir, "the/file/name.txt")
 
-    val task = new S3Upload(Stage("CODE"), "bucket", baseDir)
+    val task = new S3UploadTask(Stage("CODE"), "bucket", baseDir)
 
     task.toKey(child) should be ("CODE/bar/the/file/name.txt")
   }
@@ -262,7 +262,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
     val baseDir = new File("/foo/bar/something").getParentFile
     val child = new File(baseDir, "the/file/name.txt")
 
-    val task = new S3Upload(Stage("CODE"), "bucket", baseDir, prefixStage = false)
+    val task = new S3UploadTask(Stage("CODE"), "bucket", baseDir, prefixStage = false)
 
     task.toKey(child) should be ("bar/the/file/name.txt")
   }
@@ -271,7 +271,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
     val baseDir = new File("/foo/bar/something").getParentFile
     val child = new File(baseDir, "the/file/name.txt")
 
-    val task = new S3Upload(Stage("CODE"), "bucket", baseDir, prefixPackage = false)
+    val task = new S3UploadTask(Stage("CODE"), "bucket", baseDir, prefixPackage = false)
 
     task.toKey(child) should be ("CODE/the/file/name.txt")
   }
@@ -280,7 +280,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
     val baseDir = new File("/foo/bar/something").getParentFile
     val child = new File(baseDir, "the/file/name.txt")
 
-    val task = new S3Upload(Stage("CODE"), "bucket", baseDir, prefixStage = false, prefixPackage = false)
+    val task = new S3UploadTask(Stage("CODE"), "bucket", baseDir, prefixStage = false, prefixPackage = false)
 
     task.toKey(child) should be ("the/file/name.txt")
   }
@@ -299,7 +299,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
     val fileThree = new File(subDir, "three.txt")
     fileThree.createNewFile()
 
-    val task = new S3Upload(Stage("CODE"), "bucket", baseDir) with StubS3 {
+    val task = new S3UploadTask(Stage("CODE"), "bucket", baseDir) with StubS3 {
       override val bucket = "bucket"
     }
 
@@ -326,7 +326,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
     fileThree.createNewFile()
 
     val cacheControlPatterns = List(PatternValue("^package/sub/", "public; max-age=3600"), PatternValue(".*", "no-cache"))
-    val task = new S3Upload(Stage("CODE"), "bucket", baseDir, cacheControlPatterns) with StubS3 {
+    val task = new S3UploadTask(Stage("CODE"), "bucket", baseDir, cacheControlPatterns) with StubS3 {
       override val bucket = "bucket"
     }
 

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -26,13 +26,13 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
   "block firewall task" should "use configurable path" in {
     val host = Host("some-host") as ("some-user")
 
-    val task = BlockFirewall(host)
+    val task = BlockFirewallTask(host)
 
     task.commandLine should be (CommandLine(List("if", "[", "-f", "/opt/deploy/bin/block-load-balancer", "];", "then", "/opt/deploy/bin/block-load-balancer", ";", "fi")))
     val rootPath = CommandLocator.rootPath
     CommandLocator.rootPath = "/bluergh/xxx"
 
-    val task2 = BlockFirewall(host)
+    val task2 = BlockFirewallTask(host)
 
     task2.commandLine should be (CommandLine(List("if", "[", "-f", "/bluergh/xxx/block-load-balancer", "];", "then", "/bluergh/xxx/block-load-balancer", ";", "fi")))
     CommandLocator.rootPath = rootPath
@@ -49,7 +49,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
   it should "call block script on path" in {
     val host = Host("some-host") as ("some-user")
 
-    val task = BlockFirewall(host)
+    val task = BlockFirewallTask(host)
 
     task.commandLine should be (CommandLine(List("if", "[", "-f", CommandLocator.rootPath+"/block-load-balancer", "];", "then", CommandLocator.rootPath+"/block-load-balancer", ";", "fi")))
   }
@@ -57,7 +57,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
   "unblock firewall task" should "call unblock script on path" in {
     val host = Host("some-host") as ("some-user")
 
-    val task = UnblockFirewall(host)
+    val task = UnblockFirewallTask(host)
 
     task.commandLine should be (CommandLine(List("if", "[", "-f", CommandLocator.rootPath+"/unblock-load-balancer", "];", "then", CommandLocator.rootPath+"/unblock-load-balancer", ";", "fi")))
   }
@@ -71,14 +71,14 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
   }
 
   "waitForPort task" should "fail after timeout" in {
-    val task = WaitForPort(Host("localhost"), 9998, 200 millis)
+    val task = WaitForPortTask(Host("localhost"), 9998, 200 millis)
     evaluating {
       task.execute(fakeKeyRing)
     } should produce [FailException]
   }
 
   it should "connect to open port" in {
-    val task = WaitForPort(Host("localhost"), 9998, 200 millis)
+    val task = WaitForPortTask(Host("localhost"), 9998, 200 millis)
     spawn {
       val server = new ServerSocket(9998)
       server.accept().close()
@@ -88,7 +88,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
   }
 
   it should "connect to an open port after a short time" in {
-    val task = WaitForPort(Host("localhost"), 9997, 1 seconds)
+    val task = WaitForPortTask(Host("localhost"), 9997, 1 seconds)
     spawn {
       Thread.sleep(600 millis)
       val server = new ServerSocket(9997)
@@ -100,14 +100,14 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
 
 
   "check_url task" should "fail after timeout" in {
-    val task = CheckUrls(Host("localhost"), 9997,List("/"), 200 millis, 5)
+    val task = CheckUrlsTask(Host("localhost"), 9997,List("/"), 200 millis, 5)
     evaluating {
       task.execute(fakeKeyRing)
     } should produce [FailException]
   }
 
   it should "get a 200 OK" in {
-    val task = CheckUrls(Host("localhost"), 9997, List("/"), 200 millis, 5)
+    val task = CheckUrlsTask(Host("localhost"), 9997, List("/"), 200 millis, 5)
     spawn {
       new TestServer().withResponse("HTTP/1.0 200 OK")
     }
@@ -116,7 +116,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
   }
 
   it should "fail on a 404 NOT FOUND" in {
-    val task = CheckUrls(Host("localhost"), 9997, List("/"), 200 millis, 5)
+    val task = CheckUrlsTask(Host("localhost"), 9997, List("/"), 200 millis, 5)
     spawn {
       new TestServer().withResponse("HTTP/1.0 404 NOT FOUND")
     }
@@ -126,7 +126,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
   }
 
   it should "fail on a 500 ERROR" in {
-    val task = CheckUrls(Host("localhost"), 9997, List("/"), 200 millis, 5)
+    val task = CheckUrlsTask(Host("localhost"), 9997, List("/"), 200 millis, 5)
     spawn {
       new TestServer().withResponse("HTTP/1.0 500 ERROR")
     }


### PR DESCRIPTION
I noticed with the move to the generated deployment type documentation that a lot of them contained repeated descriptions of actions and tasks which already have their behaviour documented. This an attempt to avoid that duplication and keep the documentation as tightly tied to the code as possible.