### PR TITLE
Add change freeze code

### DIFF
--- a/riff-raff/app/assets/js/modal-confirm.coffee
+++ b/riff-raff/app/assets/js/modal-confirm.coffee
@@ -1,9 +1,27 @@
-checkAndConfirm = ->
-  if $('#stage').val() == "PROD"
-    confirm("Digital Development is in change freeze until Monday the 7th of January 2013.\n\nAny deploys prior to this should be reviewed by your product manager or Mike Blakemore and discussed with Web Systems.\n\nPress OK if you still want to proceed or Cancel to abort.")
-  else
-    true
+clickFromModalDialog = false
+
+bindToButtons = ->
+  $('#modalConfirm').click =>
+    if clickFromModalDialog
+      true
+    else
+      stageList = $('#freezeModal').data("stages").split(",")
+      if jQuery.inArray($('#stage').val(), stageList) >= 0
+        $('#freezeModal').modal()
+        false
+      else
+        true
+
+  $('#freezeProceed').click =>
+    clickFromModalDialog = true
+    $('#modalConfirm').click()
+
+  $('#freezeCancel').click =>
+    $('#freezeModal').modal('hide')
 
 $ ->
-  $('#modalConfirm').submit => checkAndConfirm()
-
+  if (window.autoRefresh)
+    window.autoRefresh.postRefresh ->
+      bindToButtons()
+  else
+    bindToButtons()

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -19,6 +19,7 @@ import deployment.{DeployMetricsActor, GuDomainsConfiguration}
 import akka.util.{Switch => AkkaSwitch}
 import utils.{UnnaturalOrdering, ScheduledAgent}
 import scala.concurrent.duration._
+import org.joda.time.format.ISODateTimeFormat
 
 class Configuration(val application: String, val webappConfDirectory: String = "env") extends Logging {
   protected val configuration = ConfigurationFactory.getConfiguration(application, webappConfDirectory)
@@ -71,6 +72,14 @@ class Configuration(val application: String, val webappConfDirectory: String = "
   }
 
   lazy val domains = GuDomainsConfiguration(configuration, prefix = "domains")
+
+  object freeze {
+    private val formatter = ISODateTimeFormat.dateTime()
+    lazy val startDate = configuration.getStringProperty("freeze.startDate").map(formatter.parseDateTime)
+    lazy val endDate = configuration.getStringProperty("freeze.endDate").map(formatter.parseDateTime)
+    lazy val message = configuration.getStringProperty("freeze.message", "There is currently a change freeze. I'm not going to stop you, but you should think carefully about what you are about to do.")
+    lazy val stages = configuration.getStringPropertiesSplitByComma("freeze.stages")
+  }
 
   object housekeeping {
     lazy val summariseDeploysAfterDays = configuration.getIntegerProperty("housekeeping.summariseDeploysAfterDays", 90)

--- a/riff-raff/app/controllers/api.scala
+++ b/riff-raff/app/controllers/api.scala
@@ -14,7 +14,7 @@ import play.api.libs.functional.syntax._
 import com.mongodb.casbah.Imports._
 import deployment.{Record, DeployFilter, DeployInfoManager}
 import DeployInfoManager._
-import utils.Graph
+import utils.{ChangeFreeze, Graph}
 import magenta._
 import play.api.mvc.BodyParsers.parse
 import java.util.UUID
@@ -313,6 +313,8 @@ object Api extends Controller with Logging {
           recipe,
           hosts
         )
+        assert(!ChangeFreeze.frozen(stage), s"Deployment to $stage is frozen (API disabled, use the web interface if you need to deploy): ${ChangeFreeze.message}")
+
         val deployId = DeployController.deploy(params)
         Json.obj(
           "response" -> Json.obj(

--- a/riff-raff/app/controllers/deployment.scala
+++ b/riff-raff/app/controllers/deployment.scala
@@ -172,12 +172,6 @@ case class UuidForm(uuid:String, action:String)
 
 object Deployment extends Controller with Logging {
 
-  def changeFreeze[A](defrosted: A, frozen: A):A = {
-    val freezeInterval = new Interval(new DateTime(2012,12,19,0,1,0), new DateTime(2013,1,7,0,0,0))
-    val now = new DateTime()
-    if (freezeInterval.contains(now)) frozen else defrosted
-  }
-
   lazy val uuidForm = Form[UuidForm](
     mapping(
       "uuid" -> text(36,36),

--- a/riff-raff/app/docs/riffraff/administration/properties.md
+++ b/riff-raff/app/docs/riffraff/administration/properties.md
@@ -70,6 +70,17 @@ database
  - `mongo.uri` - A mongo [standard connection string](http://www.mongodb.org/display/DOCS/Connections)
  - `mongo.collectionPrefix` - Prefix on created collections (allows multiple Riff-Raff instances to use the same mongo database).  Must only contain characters valid in a collection name (letters, underscore, numbers - although not first character).
 
+freeze
+------
+
+Configure a change freeze (this disables deploys via the API, continuous deploys and presents a warning before
+letting uses deploy via the web interface).
+
+ - `freeze.startDate` - A ISO-8601 format date indicating the start of a change freeze
+ - `freeze.endDate` - A ISO-8601 format date indicating the start of a change freeze
+ - `freeze.stages` - The stages that should be considered as frozen (comma separated)
+ - `freeze.message` - A message to be displayed to users being warned that they are in a change freeze
+
 notifications
 -------------
 

--- a/riff-raff/app/utils/ChangeFreeze.scala
+++ b/riff-raff/app/utils/ChangeFreeze.scala
@@ -1,0 +1,35 @@
+package utils
+
+import org.joda.time.{Interval, DateTime}
+import conf.Configuration.freeze
+import org.joda.time.format.DateTimeFormat
+
+object ChangeFreeze {
+  lazy val stages = freeze.stages
+  lazy val message = freeze.message
+  lazy val freezeInterval =
+    (freeze.startDate, freeze.endDate) match {
+      case (Some(startDate:DateTime), Some(endDate:DateTime)) =>
+        Some(new Interval(startDate, endDate))
+      case _ => None
+    }
+
+  lazy val formatter = DateTimeFormat.longDateTime()
+  lazy val from:String = freeze.startDate.map(formatter.print).getOrElse("")
+  lazy val to:String = freeze.endDate.map(formatter.print).getOrElse("")
+
+  def choose[A](defrosted: A)(frozen: A):A =
+    if (freezeInterval.exists(_.contains(new DateTime()))) frozen else defrosted
+
+  def chooseWithStage[A](forStage: String)(defrosted: A)(frozen: A):A =
+    choose(defrosted) {
+      if (stages.contains(forStage)) {
+        frozen
+      } else {
+        defrosted
+      }
+    }
+
+  def frozen(stage:String) = chooseWithStage(stage)(false)(true)
+  def frozen = choose(false)(true)
+}

--- a/riff-raff/app/views/continuousDeployment/list.scala.html
+++ b/riff-raff/app/views/continuousDeployment/list.scala.html
@@ -1,9 +1,16 @@
 @(implicit request: controllers.AuthenticatedRequest[AnyContent], configs: Seq[ci.ContinuousDeploymentConfig])
+@import utils.ChangeFreeze
 @import org.joda.time.format.DateTimeFormat._
 @import ci.Trigger._
 
 @main("Continuous Deployment Configurations", request) {
 <h2>Continuous Deployment Configurations</h2>
+@if(ChangeFreeze.frozen) {
+    <div class="alert alert-danger">
+        <h4 class="alert-heading">Change Freeze</h4>
+        <p>There is currently a change freeze. This means that continuous deploys for @ChangeFreeze.stages.mkString(", ") are disabled.</p>
+    </div>
+}
 <hr/>
 <p><a class="btn btn-inverse" href="@routes.ContinuousDeployController.form()"><i class="icon-plus icon-white"></i> Add new configuration</a></p>
 <div class="content">

--- a/riff-raff/app/views/deploy/form.scala.html
+++ b/riff-raff/app/views/deploy/form.scala.html
@@ -6,7 +6,7 @@
 <div class="clearfix"><p>&nbsp;</p></div>
 
 <div class="span6">
-@helper.form(routes.Deployment.processForm, 'id -> "modalConfirm", 'class -> "well") {
+@helper.form(routes.Deployment.processForm, 'class -> "well") {
     <fieldset>
         <legend>What would you like to deploy?</legend>
 @helper.inputText(deployForm("project"), 'id -> "projectInput", Symbol("data-url") -> "/deployment/request/autoComplete/project", 'class -> "buildForm")
@@ -22,7 +22,7 @@ helper.options(resources.LookupSelector().stages.toList),
 
 <div class="actions">
     <button name="action" type="submit" value="preview" class="btn">Preview...</button>
-    <button name="action" type="submit" value="deploy" class="btn btn-primary">Deploy Now</button>
+    <button id="modalConfirm" name="action" type="submit" value="deploy" class="btn btn-primary">Deploy Now</button>
     <a href="@routes.Application.index()" class="btn btn-inverse">Cancel</a>
 </div>
     </fieldset>
@@ -32,4 +32,6 @@ helper.options(resources.LookupSelector().stages.toList),
 <div class="span6" id="deploy-info"></div>
 
 <div class="clearfix"></div>
+
+@snippets.changeFreezeDialog()
 }

--- a/riff-raff/app/views/deploy/preview.scala.html
+++ b/riff-raff/app/views/deploy/preview.scala.html
@@ -19,4 +19,6 @@
         @views.html.deploy.previewLoading(request, 0L)
     </div>
 
+    @snippets.changeFreezeDialog()
+
 }

--- a/riff-raff/app/views/deploy/previewContent.scala.html
+++ b/riff-raff/app/views/deploy/previewContent.scala.html
@@ -85,14 +85,14 @@
 
     <input type="hidden" name="project" value="@preview.projectName"/>
     <input type="hidden" name="build" value="@preview.build"/>
-    <input type="hidden" name="stage" value="@preview.stage"/>
+    <input id="stage" type="hidden" name="stage" value="@preview.stage"/>
     <input type="hidden" name="recipe" value="@preview.recipe"/>
 
         <hr/>
 
     <div class="actions">
         <button name="action" type="submit" value="preview" class="btn">Preview...</button>
-        <button name="action" type="submit" value="deploy" class="btn btn-primary">Deploy Now</button>
+        <button id="modalConfirm" name="action" type="submit" value="deploy" class="btn btn-primary">Deploy Now</button>
         <a href="@routes.Deployment.deploy()" class="btn btn-inverse">Cancel</a>
     </div>
 

--- a/riff-raff/app/views/snippets/changeFreezeDialog.scala.html
+++ b/riff-raff/app/views/snippets/changeFreezeDialog.scala.html
@@ -1,0 +1,20 @@
+@()
+@import utils.ChangeFreeze
+
+@if(ChangeFreeze.frozen){
+ <script src='@routes.Assets.at("js/modal-confirm.min.js")'></script>
+ <div id="freezeModal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="freezeModalLabel" aria-hidden="true" data-stages="@ChangeFreeze.stages.mkString(",")">
+     <div class="modal-header">
+         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+         <h3>Change Freeze</h3>
+     </div>
+     <div class="modal-body">
+         <p>A change freeze is in place from @ChangeFreeze.from to @ChangeFreeze.to</p>
+         <p>@Html(ChangeFreeze.message)</p>
+     </div>
+     <div class="modal-footer">
+         <button id="freezeCancel" type="button" class="btn btn-primary">Cancel</button>
+         <button id="freezeProceed" type="button" class="btn btn-danger">I understand, deploy anyway</a>
+     </div>
+ </div>
+}


### PR DESCRIPTION
This has rotted since last year, largely due to many new features having been added
in the interim. It has been fixed and improved:
- The config is now done in the properties file
- Web based deploys present a modal dialog
- API calls to disabled stages will fail
- Continuous deploys for disabled stages will not be triggered (a message is
  displayed to users to make this clear
