### PR TITLE
Add a type for purging files from Fastly

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
@@ -48,7 +48,7 @@ trait DeploymentType {
 object DeploymentType {
   def all: Seq[DeploymentType] = Seq(
     ElasticSearch, S3, AutoScaling, ExecutableJarWebapp, JettyWebapp, ResinWebapp, FileCopy, Django, Fastly,
-    UnzipToDocroot, CloudFormation
+    UnzipToDocroot, CloudFormation, FastlyPurge
   )
 }
 

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Fastly.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Fastly.scala
@@ -1,6 +1,6 @@
 package magenta.deployment_type
 
-import magenta.tasks.UpdateFastlyConfig
+import magenta.tasks.{PurgeFromFastly, UpdateFastlyConfig}
 
 object Fastly  extends DeploymentType {
   val name = "fastly"
@@ -12,4 +12,19 @@ object Fastly  extends DeploymentType {
   def perAppActions = {
     case "deploy" => pkg => (_, parameters) => List(UpdateFastlyConfig(pkg))
   }
+}
+
+object FastlyPurge extends DeploymentType {
+  val urls = Param[List[String]]("urls")
+
+  def perAppActions = {
+    case "purge" => pkg => (_, _) => List(PurgeFromFastly(urls(pkg)))
+  }
+
+  def documentation =
+    """
+      |Purges the files specified from the [fastly](http://www.fastly.com/) CDN caches via their API
+    """.stripMargin
+
+  def name = "fastly-purge"
 }

--- a/magenta-lib/src/main/scala/magenta/tasks/FastlyTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/FastlyTasks.scala
@@ -103,6 +103,17 @@ case class UpdateFastlyConfig(pkg: DeploymentPackage) extends Task {
 
 }
 
+case class PurgeFromFastly(urls: Seq[String]) extends Task{
+  def verbose = s"Purge $urls from Fastly caches"
+  def description = "Purge files from Fastly caches"
+
+  def execute(keyRing: KeyRing, stopFlag: => Boolean) = {
+    FastlyApiClientProvider.get(keyRing).map { client =>
+      urls.foreach(url => client.purge(url).get)
+    }
+  }
+}
+
 case class Version(number: Int, active: Option[Boolean])
 
 case class Vcl(name: String)


### PR DESCRIPTION
Whilst it doesn't really feel like a top-level deployment type, it's something we're currently doing manually as part of a deploy and I didn't want to bloat the S3 deployment type with it.  I don't know if there's some other mechanism that would make more sense, but it doesn't feel like a case for a hook.
