### PR TITLE
Fix elasticsearch deploy to use packagename when searching for ASG

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
@@ -20,10 +20,13 @@ object ElasticSearch extends DeploymentType with S3AclParams {
   def perAppActions = {
     case "deploy" => (pkg) => (_, parameters) => {
       List(
-        TagCurrentInstancesWithTerminationTag(name, parameters.stage),
-        DoubleSize(name, parameters.stage),
-        WaitForElasticSearchClusterGreen(name, parameters.stage, secondsToWait(pkg) * 1000),
-        CullElasticSearchInstancesWithTerminationTag(name, parameters.stage, secondsToWait(pkg) * 1000)
+        CheckGroupSize(pkg.name, parameters.stage),
+        SuspendAlarmNotifications(pkg.name, parameters.stage),
+        TagCurrentInstancesWithTerminationTag(pkg.name, parameters.stage),
+        DoubleSize(pkg.name, parameters.stage),
+        WaitForElasticSearchClusterGreen(pkg.name, parameters.stage, secondsToWait(pkg) * 1000),
+        CullElasticSearchInstancesWithTerminationTag(pkg.name, parameters.stage, secondsToWait(pkg) * 1000),
+        ResumeAlarmNotifications(pkg.name, parameters.stage)
       )
     }
     case "uploadArtifacts" => (pkg) => (_, parameters) =>


### PR DESCRIPTION
Make a couple of changes to the elastic search deploy:
- use the package name instead of the deploy type as the string used for tag searches
- add more tasks to give greater parity to the autoscaling deploy type
