### PR TITLE
Shorten deployment view header text

### DIFF
--- a/riff-raff/app/views/deploy/viewDeploy.scala.html
+++ b/riff-raff/app/views/deploy/viewDeploy.scala.html
@@ -9,7 +9,7 @@
 </style>
 <div class="row">
 <div class="col-md-8">
-<h2>@record.taskType of deploy for @record.buildName build @record.buildId@record.metaData.get("branch").map{ branch=> [@branch]} in @record.stage</h2>
+<h2>@record.taskType of @record.buildName build @record.buildId@record.metaData.get("branch").map{ branch=> [@branch]} in @record.stage</h2>
 @record.metaData.get(deployment.Record.RIFFRAFF_HOSTNAME).map { hostname =>
     <small>This deploy @if(record.isRunning) {is running} else {ran} on @hostname</small>
 }


### PR DESCRIPTION
After seeing **Deploy of deploy for** a million times, it starts to grate.
