### PR TITLE
Dk add file cleanup to django deploy

### DIFF
--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -96,7 +96,7 @@ class DeploymentTypeTest extends FlatSpec with ShouldMatchers {
       BlockFirewall(host as "django"),
       CompressedCopy(host as "django", Some(specificBuildFile), "/django-apps/"),
       Link(host as "django", Some("/django-apps/" + specificBuildFile.getName), "/django-apps/webapp"),
-      CleanupOldDeploys(host as "django", 0, "/django-apps/"),
+      CleanupOldDeploys(host as "django", 0, "/django-apps/", "test"),
       ApacheGracefulRestart(host as "django"),
       WaitForPort(host, 80, 1 minute),
       CheckUrls(host, 80, List.empty, 120000, 5),

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -370,7 +370,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
   "CleanupOldDeploy task" should "keep all deploys by default" in {
     val host = Host("some-host") as ("some-user")
 
-    val task = new CleanupOldDeploys(host, 0, "/tmp/")
+    val task = new CleanupOldDeploys(host, 0, "/tmp/", "test")
     val command = task.tasks
 
     command should be (Seq.empty)
@@ -389,11 +389,11 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
   it should "try to delete the last n deploys" in {
     val host = Host("some-host") as ("some-user")
 
-    val task = new deleteOldDeploys(host, 4, "/tmp/")
+    val task = new deleteOldDeploys(host, 4, "/tmp/", "test")
 
     val command = task.commandLine
 
-    command.quoted should be ("""ls -t --ignore="logs" /tmp/ | head -n -5 | xargs -x rm -rf""")
+    command.quoted should be ("""ls -tdr /django-apps/test?* | head -n -4 | xargs -t -n1 rm -rf""")
   }
 
   private def createTempDir(): File = {


### PR DESCRIPTION
Adding task to cleaning up old deploys.
This can be activated by adding:

``` json
"data": {
"deploysToKeep": Int
}
```

to deploy.json
It will keep all deploys by default.
This is only implemented in the django_webapp deploy type
