### PR TITLE
Don't propagate errors when looking for a build batch

### DIFF
--- a/riff-raff/app/ci/Every.scala
+++ b/riff-raff/app/ci/Every.scala
@@ -30,10 +30,11 @@ trait ContinuousIntegrationAPI {
 }
 
 object FailSafeObservable extends Logging {
-  def apply[T](f: Future[T], msg: => String): Observable[T] = Observable.from(f).onErrorResumeNext { e =>
-    log.error(msg, e)
-    Observable.empty
-  }
+  def apply[T](f: Future[T], msg: => String)(implicit ec: ExecutionContext): Observable[T] =
+    Observable.from(f).onErrorResumeNext { e =>
+      log.error(msg, e)
+      Observable.empty
+    }
 }
 
 object TeamCityAPI extends ContinuousIntegrationAPI with Logging {


### PR DESCRIPTION
Looking at today's logs, you can see that whilst polling of build types continues, polling for builds tails off at about 18:15.  I'm not 100% that this change will stop that happening, but it does reduce one possible point for an error to arise and propagate out to destroy the Observables.
