### PR TITLE
Avoid race condition when previewing

### DIFF
--- a/riff-raff/app/deployment/preview.scala
+++ b/riff-raff/app/deployment/preview.scala
@@ -19,6 +19,7 @@ import conf.Configuration
 import scala.concurrent._
 import akka.actor.ActorSystem
 import ExecutionContext.Implicits.global
+import duration._
 
 case class PreviewResult(future: Future[Preview], startTime: DateTime = new DateTime()) {
   def completed = future.isCompleted
@@ -41,7 +42,7 @@ object PreviewController {
     cleanupPreviews()
     val previewId = UUID.randomUUID()
     val previewFuture = future { Preview(parameters) }
-    agent.send{ _ + (previewId -> PreviewResult(previewFuture)) }
+    Await.ready(agent.alter{ _ + (previewId -> PreviewResult(previewFuture)) }, 1.second)
     previewId
   }
 


### PR DESCRIPTION
Under load, send might not have completed when the preview content template attempts to render resulting in an exception.  I've seen this happen a number of times.  By blocking on the update of the available previews we can avoid this.  There are definitely more heinous examples of blocking around in RiffRaff, so I'm not too worried about this one.
