### PR TITLE
Support a default bucket, based on Stack name

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -53,7 +53,13 @@ object AutoScaling  extends DeploymentType with S3AclParams {
     case "uploadArtifacts" => (pkg) => (lookup, parameters, stack) =>
       implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
       List(
-        S3Upload(stack, parameters.stage, bucket(pkg), new File(pkg.srcDir.getPath + "/"), publicReadAcl = publicReadAcl(pkg))
+        S3Upload(
+          stack,
+          parameters.stage,
+          bucket.get(pkg).orElse(stack.nameOption.map(stackName => s"$stackName-dist")).get,
+          new File(pkg.srcDir.getPath + "/"),
+          publicReadAcl = publicReadAcl(pkg)
+        )
       )
   }
 }


### PR DESCRIPTION
As well as meaning you have to configure one less thing, this allows something like status app to deploy to multiple stacks, with different keys.
