### PR TITLE
Check for existence before deletion, not for type:file

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/NativePackagerWebapp.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/NativePackagerWebapp.scala
@@ -2,7 +2,7 @@ package magenta.deployment_type
 
 import magenta.tasks._
 import magenta.tasks.CheckUrls
-import magenta.tasks.Restart
+import magenta.tasks.Service
 import magenta.tasks.BlockFirewall
 import scala.Some
 import magenta.tasks.WaitForPort
@@ -52,10 +52,11 @@ object NativePackagerWebapp extends WebApp {
 
       BlockFirewall(host as user(pkg)) ::
       CopyFile(host as user(pkg), s"${pkg.srcDir.getPath}/${tarball(pkg)}", remoteTarballLocation) ::
+      Service(host as user(pkg), servicename(pkg), "stop") ::
       RemoveFile(host as user(pkg), s"$applicationRoot/${applicationName(pkg)}", recursive=true) ::
       DecompressTarBall(host as user(pkg), remoteTarballLocation, applicationRoot) ::
       RemoveFile(host as user(pkg), remoteTarballLocation) ::
-      Restart(host as user(pkg), servicename(pkg)) ::
+      Service(host as user(pkg), servicename(pkg), "start") ::
       WaitForPort(host, port(pkg), waitseconds(pkg) * 1000) ::
       CheckUrls(host, port(pkg), healthcheck_paths(pkg), checkseconds(pkg) * 1000, checkUrlReadTimeoutSeconds(pkg)) ::
       UnblockFirewall(host as user(pkg)) ::

--- a/magenta-lib/src/main/scala/magenta/deployment_type/RPM.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/RPM.scala
@@ -56,7 +56,7 @@ object RPM extends DeploymentType {
       CopyFile(host as user(pkg), rpmFilePath, remoteTmpRpm) ::
       InstallRpm(host as user(pkg), remoteTmpRpm, noFileDigest(pkg)) ::
       RemoveFile(host as user(pkg), remoteTmpRpm) ::
-      services(pkg).map(service => Restart(host as user(pkg), service, serviceCommand(pkg))) :::
+      services(pkg).map(service => Service(host as user(pkg), service, serviceCommand(pkg))) :::
       port.get(pkg).toList.map(p => WaitForPort(host, p, 60 * 1000)) :::
       port.get(pkg).toList.map(p => CheckUrls(host, p, healthCheckPaths(pkg), checkseconds(pkg) * 1000, checkUrlReadTimeoutSeconds(pkg))) :::
       UnblockFirewall(host as user(pkg)) ::

--- a/magenta-lib/src/main/scala/magenta/deployment_type/WebApp.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/WebApp.scala
@@ -94,7 +94,7 @@ trait WebApp extends DeploymentType with S3AclParams {
 
       BlockFirewall(host as user(pkg)) ::
       rootCopies(pkg, host) :::
-      Restart(host as user(pkg), servicename(pkg)) ::
+      Service(host as user(pkg), servicename(pkg)) ::
       WaitForPort(host, port(pkg), waitseconds(pkg) * 1000) ::
       CheckUrls(host, port(pkg), healthcheck_paths(pkg), checkseconds(pkg) * 1000, checkUrlReadTimeoutSeconds(pkg)) ::
       UnblockFirewall(host as user(pkg)) ::
@@ -104,7 +104,7 @@ trait WebApp extends DeploymentType with S3AclParams {
       implicit val key = keyRing
       List(
         BlockFirewall(host as user(pkg)),
-        Restart(host as user(pkg), servicename(pkg)),
+        Service(host as user(pkg), servicename(pkg)),
         WaitForPort(host, port(pkg), waitseconds(pkg) * 1000),
         CheckUrls(host, port(pkg), healthcheck_paths(pkg), checkseconds(pkg) * 1000, checkUrlReadTimeoutSeconds(pkg)),
         UnblockFirewall(host as user(pkg))

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -156,7 +156,7 @@ case class BlockFirewall(host: Host)(implicit val keyRing: KeyRing) extends Remo
   def commandLine = CommandLocator conditional "block-load-balancer"
 }
 
-case class Restart(host: Host, appName: String, command: String = "restart")(implicit val keyRing: KeyRing) extends RemoteShellTask {
+case class Service(host: Host, appName: String, command: String = "restart")(implicit val keyRing: KeyRing) extends RemoteShellTask {
   def commandLine = List("sudo", "/sbin/service", appName, command)
 
   override lazy val description = s" of $appName using $command command"

--- a/magenta-lib/src/test/scala/magenta/deployment_type/JettyWebappTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/JettyWebappTest.scala
@@ -8,7 +8,7 @@ import net.liftweb.json.Implicits._
 import tasks.BlockFirewall
 import tasks.CheckUrls
 import tasks.CopyFile
-import tasks.Restart
+import tasks.Service
 import tasks.UnblockFirewall
 import net.liftweb.json.JsonAST.JString
 import tasks.WaitForPort
@@ -28,7 +28,7 @@ class JettyWebappTest  extends FlatSpec with ShouldMatchers {
     JettyWebapp.perHostActions("deploy")(p)(host, fakeKeyRing) should be (List(
       BlockFirewall(host as "jetty"),
       CopyFile(host as "jetty", "/tmp/packages/webapp/", "/jetty-apps/webapp/"),
-      Restart(host as "jetty", "webapp"),
+      Service(host as "jetty", "webapp"),
       WaitForPort(host, 8080, 1 minute),
       CheckUrls(host, 8080, List("/webapp/management/healthcheck"), 2 minutes, 5),
       UnblockFirewall(host as "jetty")
@@ -53,7 +53,7 @@ class JettyWebappTest  extends FlatSpec with ShouldMatchers {
     JettyWebapp.perHostActions("deploy")(p)(host, fakeKeyRing) should be (List(
       BlockFirewall(host as "jetty"),
       CopyFile(host as "jetty", "/tmp/packages/webapp/", "/jetty-apps/webapp/"),
-      Restart(host as "jetty", "webapp"),
+      Service(host as "jetty", "webapp"),
       WaitForPort(host, 8080, 1 minute),
       CheckUrls(host, 8080, urls, 2 minutes, 5),
       UnblockFirewall(host as "jetty")
@@ -70,13 +70,13 @@ class JettyWebappTest  extends FlatSpec with ShouldMatchers {
     JettyWebapp.perHostActions("deploy")(p)(host, fakeKeyRing) should (contain[Task] (
       CopyFile(host as "jetty", "/tmp/packages/webapp/", "/jetty-apps/webapp/")
     ) and contain[Task] (
-      Restart(host as "jetty", "webapp")
+      Service(host as "jetty", "webapp")
     ))
 
     JettyWebapp.perHostActions("deploy")(p2)(host, fakeKeyRing) should (contain[Task] (
       CopyFile(host as "jetty", "/tmp/packages/webapp/", "/jetty-apps/microapps/")
     ) and contain[Task] (
-      Restart(host as "jetty", "microapps")
+      Service(host as "jetty", "microapps")
     ))
   }
 
@@ -103,7 +103,7 @@ class JettyWebappTest  extends FlatSpec with ShouldMatchers {
       BlockFirewall(host as "jetty"),
       CopyFile(host as "jetty", "/tmp/packages/d2index/solr/conf/", "/jetty-apps/d2index/solr/conf/", CopyFile.MIRROR_MODE),
       CopyFile(host as "jetty", "/tmp/packages/d2index/webapp/", "/jetty-apps/d2index/webapp/", CopyFile.MIRROR_MODE),
-      Restart(host as "jetty", "d2index"),
+      Service(host as "jetty", "d2index"),
       WaitForPort(host, 8080, 1 minute),
       CheckUrls(host, 8080, List("/d2index/management/healthcheck"), 2 minutes, 5),
       UnblockFirewall(host as "jetty")

--- a/magenta-lib/src/test/scala/magenta/deployment_type/ResinWebappTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/ResinWebappTest.scala
@@ -7,7 +7,7 @@ import tasks._
 import tasks.BlockFirewall
 import tasks.CheckUrls
 import tasks.CopyFile
-import tasks.Restart
+import tasks.Service
 import tasks.WaitForPort
 import net.liftweb.util.TimeHelpers._
 import net.liftweb.json.Implicits._
@@ -25,7 +25,7 @@ class ResinWebappTest extends FlatSpec with ShouldMatchers {
     ResinWebapp.perHostActions("deploy")(p)(host, fakeKeyRing) should be (List(
       BlockFirewall(host as "resin"),
       CopyFile(host as "resin", "/tmp/packages/webapp/", "/resin-apps/webapp/"),
-      Restart(host as "resin", "webapp"),
+      Service(host as "resin", "webapp"),
       WaitForPort(host, 8080, 1 minute),
       CheckUrls(host, 8080, List("/webapp/management/healthcheck"), 2 minutes, 5),
       UnblockFirewall(host as "resin")
@@ -50,7 +50,7 @@ class ResinWebappTest extends FlatSpec with ShouldMatchers {
     ResinWebapp.perHostActions("deploy")(p)(host, fakeKeyRing) should be (List(
       BlockFirewall(host as "resin"),
       CopyFile(host as "resin", "/tmp/packages/webapp/", "/resin-apps/webapp/"),
-      Restart(host as "resin", "webapp"),
+      Service(host as "resin", "webapp"),
       WaitForPort(host, 8080, 1 minute),
       CheckUrls(host, 8080, urls, 2 minutes, 5),
       UnblockFirewall(host as "resin")

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -40,7 +40,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
   it should "support hosts with user name" in {
     val host = Host("some-host") as ("some-user")
 
-    val task = Restart(host, "app")
+    val task = Service(host, "app")
 
     task.remoteCommandLine should be (CommandLine(List("ssh", "-qtt", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", "some-user@some-host", "sudo /sbin/service app restart")))
   }
@@ -64,7 +64,7 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
   "restart task" should "perform service restart" in {
     val host = Host("some-host") as ("some-user")
 
-    val task = Restart(host, "myapp")
+    val task = Service(host, "myapp")
 
     task.commandLine should be (CommandLine(List("sudo", "/sbin/service", "myapp", "restart")))
   }


### PR DESCRIPTION
This check was always failing as the type was a directory and not a file. Using `-e` means that we check for any type.

Also modify the service stop and start times so that we don't remove files from underneath a process.
