### PR TITLE
Revert "Add tags to CI model and implement for TC"

### DIFF
--- a/riff-raff/app/ci/CIBuild.scala
+++ b/riff-raff/app/ci/CIBuild.scala
@@ -13,7 +13,6 @@ trait CIBuild {
   def number: String
   def id: Long
   def startTime: DateTime
-  def tags: List[String]
 }
 
 object CIBuild extends Logging {

--- a/riff-raff/app/ci/Every.scala
+++ b/riff-raff/app/ci/Every.scala
@@ -49,7 +49,7 @@ object TeamCityAPI extends ContinuousIntegrationAPI with Logging {
   def succesfulBuildBatch(job: Job)(implicit ec: ExecutionContext): Observable[Iterable[CIBuild]] = {
     FailSafeObservable({
       val startTime = DateTime.now()
-      TeamCityWS.url(s"/app/rest/builds?locator=status:SUCCESS,buildType:${job.id},branch:default:any&count=20&fields=build(id,number,status,startDate,branchName,buildTypeId,webUrl,tags)").get().flatMap { r =>
+      TeamCityWS.url(s"/app/rest/builds?locator=status:SUCCESS,buildType:${job.id},branch:default:any&count=20&fields=build(id,number,status,startDate,branchName,buildTypeId,webUrl)").get().flatMap { r =>
         TeamCityMetrics.ApiCallTimer.recordTimeSpent(DateTime.now.getMillis - startTime.getMillis)
         BuildSummary(r.xml, (id: String) => Future.successful(Some(job)), false)
       }

--- a/riff-raff/app/ci/teamcity/teamcity.scala
+++ b/riff-raff/app/ci/teamcity/teamcity.scala
@@ -57,7 +57,7 @@ trait TeamcityBuild extends CIBuild with Logging {
   def detail: Future[BuildDetail]
   def jobName = job.name
   def startTime = startDate
-  def tags: List[String]
+
   def jobId = job.id
 }
 
@@ -67,7 +67,6 @@ case class BuildSummary(id: Long,
                         status: String,
                         branchName: String,
                         startDate: DateTime,
-                        tags: List[String],
                         job: Job
                          ) extends TeamcityBuild {
   def detail: Future[BuildDetail] = BuildDetail(BuildLocator(id=Some(id)))
@@ -100,7 +99,6 @@ object BuildSummary extends Logging {
           build \ "@status" text,
           (build \ "@branchName").headOption.map(_.text).getOrElse("default"),
           TeamCity.dateTimeFormat.parseDateTime(build \ "startDate" text),
-          (build \ "tags" \ "tag").map(_.text).toList,
           bt
         )
       }
@@ -191,8 +189,7 @@ case class BuildDetail(
   startDate: DateTime,
   finishDate: DateTime,
   pinInfo: Option[PinInfo],
-  revision: Option[Revision],
-  tags: List[String]
+  revision: Option[Revision]
 ) extends TeamcityBuild {
   def detail = Future.successful(this)
   def buildTypeId = job.id
@@ -213,8 +210,7 @@ object BuildDetail {
       startDate = TeamCity.dateTimeFormat.parseDateTime(build \ "startDate" text),
       finishDate = TeamCity.dateTimeFormat.parseDateTime(build \ "finishDate" text),
       pinInfo = (build \ "pinInfo" headOption) map (PinInfo(_)),
-      revision = (build \ "revisions" \ "revision" headOption) map (Revision(_)),
-      tags = (build \ "tags" \ "tag").map(_.text).toList
+      revision = (build \ "revisions" \ "revision" headOption) map (Revision(_))
     )
   }
 }

--- a/riff-raff/app/controllers/deployment.scala
+++ b/riff-raff/app/controllers/deployment.scala
@@ -337,8 +337,7 @@ object Deployment extends Controller with Logging with LoginActions {
       p => p.number.contains(term) || p.branchName.contains(term)
     ).map { build =>
       val formatter = DateTimeFormat.forPattern("HH:mm d/M/yy")
-      val tags = if (build.tags.isEmpty) "" else build.tags.mkString("<", ", ", "> ")
-      val label = s"${build.number} [${build.branchName}] $tags(${formatter.print(build.startTime)})"
+      val label = "%s [%s] (%s)" format (build.number, build.branchName, formatter.print(build.startTime))
       Map("label" -> label, "value" -> build.number)
     }
     Ok(Json.toJson(possibleProjects))

--- a/riff-raff/test/ci/ContinuousDeploymentTest.scala
+++ b/riff-raff/test/ci/ContinuousDeploymentTest.scala
@@ -64,7 +64,6 @@ class ContinuousDeploymentTest extends FlatSpec with ShouldMatchers {
     def jobName = "project::job"
     def branchName = branch
     def jobId = "job1"
-    def tags: List[String] = Nil
 
     override def equals(other: scala.Any) = other match {
       case o: CIBuild => o.id == id
@@ -86,9 +85,9 @@ class ContinuousDeploymentTest extends FlatSpec with ShouldMatchers {
   val contDeployBranchConfigs = Seq(tdProdEnabled, tdCodeDisabled, td2ProdDisabled, td2QaBranchEnabled, td2ProdBranchEnabled)
 
   val tdBT = BuildType("bt204", "deploy", Project("project1", "tools"))
-  val tdB71 = BuildSummary(45397, "71", tdBT.id, "SUCCESS", "master", new DateTime(2013,1,25,14,42,47), Nil, tdBT)
+  val tdB71 = BuildSummary(45397, "71", tdBT.id, "SUCCESS", "master", new DateTime(2013,1,25,14,42,47), tdBT)
 
   val td2BT = BuildType("bt205", "deploy2", Project("project1", "tools"))
-  val td2B392 = BuildSummary(45400, "392", td2BT.id, "SUCCESS", "branch", new DateTime(2013,1,25,15,34,47), Nil, td2BT)
-  val otherBranch = BuildSummary(45401, "393", td2BT.id, "SUCCESS", "other", new DateTime(2013,1,25,15,34,47), Nil, td2BT)
+  val td2B392 = BuildSummary(45400, "392", td2BT.id, "SUCCESS", "branch", new DateTime(2013,1,25,15,34,47), td2BT)
+  val otherBranch = BuildSummary(45401, "393", td2BT.id, "SUCCESS", "other", new DateTime(2013,1,25,15,34,47), td2BT)
 }


### PR DESCRIPTION
This wasn't as easy as I thought as this violates the assumptions of having immutable build information (tags can be mutated later). Am reverting this and will work on a better solution that queries TC during autocompletion.
