### PR TITLE
Deploy: Preventative measure to fail deploys early when the associated...

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -77,6 +77,7 @@ object AutoScaling  extends DeploymentType with S3AclParams {
     case "deploy" => (pkg) => (lookup, parameters, stack) => {
       implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
       List(
+        CheckForStabilization(pkg, parameters.stage, stack),
         CheckGroupSize(pkg, parameters.stage, stack),
         SuspendAlarmNotifications(pkg, parameters.stage, stack),
         TagCurrentInstancesWithTerminationTag(pkg, parameters.stage, stack),

--- a/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
@@ -48,6 +48,13 @@ case class HealthcheckGrace(duration: Long)(implicit val keyRing: KeyRing) exten
   def description = verbose
 }
 
+case class CheckForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
+  def execute(asg: AutoScalingGroup, stopFlag: => Boolean) {
+    isStabilized(asg)
+  }
+  lazy val description: String = "Check the desired number of hosts in both the ASG and ELB are up and that the number of hosts match"
+}
+
 case class WaitForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Stack, duration: Long)(implicit val keyRing: KeyRing) extends ASGTask
     with SlowRepeatedPollingCheck {
 
@@ -67,7 +74,7 @@ case class WaitForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Sta
     def isRateExceeded(e: AmazonServiceException) = e.getStatusCode == 400 && e.getErrorCode == "Throttling"
   }
 
-  lazy val description: String = "Check the desired number of hosts in ASG are up and in ELB"
+  lazy val description: String = "Check the desired number of hosts in both the ASG and ELB are up and that the number of hosts match"
 }
 
 case class CullInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -22,6 +22,7 @@ class AutoScalingTest extends FlatSpec with ShouldMatchers {
     val p = DeploymentPackage("app", app, data, "asg-elb", new File("/tmp/packages/webapp"))
 
     AutoScaling.perAppActions("deploy")(p)(lookupEmpty, parameters(), UnnamedStack) should be (List(
+      CheckForStabilization(p, PROD, UnnamedStack),
       CheckGroupSize(p, PROD, UnnamedStack),
       SuspendAlarmNotifications(p, PROD, UnnamedStack),
       TagCurrentInstancesWithTerminationTag(p, PROD, UnnamedStack),
@@ -46,6 +47,7 @@ class AutoScalingTest extends FlatSpec with ShouldMatchers {
     val p = DeploymentPackage("app", app, data, "asg-elb", new File("/tmp/packages/webapp"))
 
     AutoScaling.perAppActions("deploy")(p)(lookupEmpty, parameters(), UnnamedStack) should be (List(
+      CheckForStabilization(p, PROD, UnnamedStack),
       CheckGroupSize(p, PROD, UnnamedStack),
       SuspendAlarmNotifications(p, PROD, UnnamedStack),
       TagCurrentInstancesWithTerminationTag(p, PROD, UnnamedStack),


### PR DESCRIPTION
... ELB and ASG have a different size. Fundamentally, this ensures that both the ASG and the ELB have the same number of hosts and that all of those hosts are healthy. This is the first check performed by an autoscaling backed deploy to ensure a deployable state. Prior to this, CAPI were seeing deploys fail through timing out because the waitForStabilization check would never resolve given an inconsistent state from the start, giving the deploy no chance of passing from the get go. This should allow the deploy to fail fast and not leave the application in a state of which needs to be tidied up by a developer (best case).
