### PR TITLE
Add custom mime-types for the S3 upload task

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
@@ -68,6 +68,22 @@ object S3 extends DeploymentType with S3AclParams {
     """.stripMargin
   )
 
+  val mimeTypes = Param[Map[String,String]]("mimeTypes",
+    """
+      |A map of file extension to MIME type.
+      |
+      |When a file is uploaded with a file extension that is in this map, the Content-Type header will be set to the
+      |MIME type provided.
+      |
+      |The example below adds the MIME type for Firefox plugins so that they install correctly rather than opening in
+      |the browser.
+      |
+      |    "mimeTypes": {
+      |      "xpi": "application/x-xpinstall"
+      |    }
+    """.stripMargin
+  ).default(Map.empty)
+
   implicit object PatternValueExtractable extends JValueExtractable[List[PatternValue]] {
     def extract(json: JValue) = json match {
       case JString(default) => Some(List(PatternValue(".*", default)))
@@ -100,7 +116,8 @@ object S3 extends DeploymentType with S3AclParams {
           prefixStage = prefixStage(pkg),
           prefixPackage = prefixPackage(pkg),
           prefixStack = prefixStack(pkg),
-          publicReadAcl = publicReadAcl(pkg)
+          publicReadAcl = publicReadAcl(pkg),
+          mimeTypeMap = mimeTypes(pkg)
         )
       )
     }

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -19,9 +19,10 @@ trait S3 extends AWS {
 }
 
 object S3 {
-  def putObjectRequest(bucket: String, key: String, file: File, cacheControlHeader: Option[String], publicReadAcl: Boolean) = {
+  def putObjectRequest(bucket: String, key: String, file: File, cacheControlHeader: Option[String], contentType: Option[String], publicReadAcl: Boolean) = {
     val metaData = new ObjectMetadata
-    cacheControlHeader foreach { metaData.setCacheControl(_) }
+    cacheControlHeader foreach metaData.setCacheControl
+    contentType foreach metaData.setContentType
     val req = new PutObjectRequest(bucket, key, file).withMetadata(metaData)
     if (publicReadAcl) req.withCannedAcl(PublicRead) else req
   }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -13,8 +13,8 @@ class DeploymentTypeTest extends FlatSpec with ShouldMatchers {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
 
   "Deployment types" should "automatically register params in the params Seq" in {
-    S3.params should have size(7)
-    S3.params.map(_.name).toSet should be(Set("prefixStage","prefixPackage", "prefixStack", "bucket","publicReadAcl","bucketResource","cacheControl"))
+    S3.params should have size 8
+    S3.params.map(_.name).toSet should be(Set("prefixStage","prefixPackage","prefixStack","bucket","publicReadAcl","bucketResource","cacheControl","mimeTypes"))
   }
 
   it should "throw a NoSuchElementException if a required parameter is missing" in {

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -366,6 +366,25 @@ class TasksTest extends FlatSpec with ShouldMatchers with MockitoSugar{
     task.requests.find(_.getFile == fileThree).get.getMetadata.getCacheControl should be("public; max-age=3600")
   }
 
+  it should "use overriden mime type" in {
+    val tempDir = createTempDir()
+    val baseDir = new File(tempDir, "package")
+    baseDir.mkdir()
+
+    val fileOne = new File(baseDir, "one.txt")
+    fileOne.createNewFile()
+    val fileTwo = new File(baseDir, "two.xpi")
+    fileTwo.createNewFile()
+
+    val mimeTypes = Map("xpi" -> "application/x-xpinstall")
+    val task = new S3Upload(UnnamedStack, Stage("CODE"), "bucket", baseDir, mimeTypeMap = mimeTypes) with StubS3 {
+      override val bucket = "bucket"
+    }
+
+    Option(task.requests.find(_.getFile == fileOne).get.getMetadata.getContentType) should be(None)
+    Option(task.requests.find(_.getFile == fileTwo).get.getMetadata.getContentType) should be(Some("application/x-xpinstall"))
+  }
+
   "CleanupOldDeploy task" should "keep all deploys by default" in {
     val host = Host("some-host") as ("some-user")
 


### PR DESCRIPTION
We are hosting a firefox plugin on S3 and this must serve with the correct MIME type for firefox
to facilitate installation.
