### PR TITLE
Improved waiting for stabilisation in Auto-Scaling deploys

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -71,7 +71,7 @@ object AutoScaling  extends DeploymentType with S3AclParams {
     """.stripMargin
   )
   val secondsToWait = Param("secondsToWait", "Number of seconds to wait for instances to enter service").default(15 * 60)
-  val healthcheckGrace = Param("healthcheckGrace", "Number of seconds to wait for the AWS api to stabilise").default(3)
+  val healthcheckGrace = Param("healthcheckGrace", "Number of seconds to wait for the AWS api to stabilise").default(20)
 
   def perAppActions = {
     case "deploy" => (pkg) => (lookup, parameters, stack) => {

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -27,7 +27,7 @@ class AutoScalingTest extends FlatSpec with ShouldMatchers {
       SuspendAlarmNotifications(p, PROD, UnnamedStack),
       TagCurrentInstancesWithTerminationTag(p, PROD, UnnamedStack),
       DoubleSize(p, PROD, UnnamedStack),
-      HealthcheckGrace(3000),
+      HealthcheckGrace(20000),
       WaitForStabilization(p, PROD, UnnamedStack, 15 * 60 * 1000),
       CullInstancesWithTerminationTag(p, PROD, UnnamedStack),
       ResumeAlarmNotifications(p, PROD, UnnamedStack)


### PR DESCRIPTION
We had a failing deploy on the Membership team, and took some time to discuss it with @philwills :

https://riffraff.gutools.co.uk/deployment/view/582120b7-0d4e-4759-8bdd-21d334b98aae

These are the relevant lines:

```
[11:28:04] task DoubleSize Double the size of the auto-scaling group in Stage(PROD) for apps App(frontend)
[11:28:04] task WaitForStabilization Check the desired number of hosts in both the ASG and ELB are up and that the number of hosts match
[11:28:05] task HealthcheckGrace Wait extra 0ms to let Load Balancer report correctly
[11:28:05] task WaitForStabilization Check the desired number of hosts in both the ASG and ELB are up and that the number of hosts match
[11:28:05] task CullInstancesWithTerminationTag Terminate instances with the termination tag for this deploy
[11:28:08] Unhandled exception in task CullInstancesWithTerminationTag Terminate instances with the termination tag for this deploy
[11:28:08] Unhandled exception in deploy for Membership::frontend (build 3589) to stage PROD
```

You can see that the 1st and 2nd `WaitForStabilizations` executed almost instantly (and we haven't had a `HealthcheckGrace` duration configured for our deploy, thus the intervening `HealthcheckGrace` executed instantly too). So, all these checks executed before the AWS API could catch up and report the updated values from the `DoubleSize` step. Consequently the deploy proceeded with only 3 instances in our ASG & ELB, not the desired double-capacity of 6, and then the instance-culling failed.

Setting a HealthcheckGrace would alleviate our problem - but then the first `WaitForStabilization` becomes completely pointless. So this commit removes the 1st `WaitForStabilization` - and sets the default `HealthcheckGrace` to 3 seconds, which hopefully is both harmless & helpful :smile: 

cc @jennysivapalan 
