### PR TITLE
Format exception lines nicely in the browser

### DIFF
--- a/riff-raff/app/views/errorPageException.scala.html
+++ b/riff-raff/app/views/errorPageException.scala.html
@@ -1,4 +1,4 @@
 @(error: Throwable)
 <h4 class="alert-heading">@error.getClass.getName: @error.getMessage</h4>
-<pre>@error.getStackTrace.mkString("\n")</pre>
+<pre>@error.getStackTrace.mkString("<span>", "</span></span>", "</span>")</pre>
 @if(error.getCause != null){@errorPageException(error.getCause)}


### PR DESCRIPTION
Upon receiving an exception on the riffraff deploy screen, the exception lines are meant to print out with newlines in between, but this doesn't work and the browser just ignores the newlines. You receive just a big long string.

This wraps each exception line in a `span`.