### PR TITLE
Use existing CloudFormation params

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -63,7 +63,7 @@ object CloudFormation extends DeploymentType {
 
       val globalParams = templateParameters(pkg)
       val stageParams = templateStageParameters(pkg).lift.apply(parameters.stage.name).getOrElse(Map())
-      val combinedParams = (globalParams ++ stageParams).mapValues(Some(_))
+      val combinedParams = globalParams ++ stageParams
 
       List(
         UpdateCloudFormationTask(

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -63,7 +63,7 @@ object CloudFormation extends DeploymentType {
 
       val globalParams = templateParameters(pkg)
       val stageParams = templateStageParameters(pkg).lift.apply(parameters.stage.name).getOrElse(Map())
-      val combinedParams = globalParams ++ stageParams
+      val combinedParams = (globalParams ++ stageParams).mapValues(Some(_))
 
       List(
         UpdateCloudFormationTask(

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -3,9 +3,9 @@ package magenta.deployment_type
 import java.io.File
 
 import magenta._
-import magenta.tasks.{TemplateParameter, CheckUpdateEventsTask, UpdateCloudFormationTask}
+import magenta.tasks._
+import magenta.tasks.UpdateCloudFormationTask._
 import org.json4s.JsonAST.JValue
-import org.json4s.JsonDSL._
 import org.scalatest.{FlatSpec, Matchers}
 import fixtures._
 
@@ -49,9 +49,9 @@ class CloudFormationTest extends FlatSpec with Matchers {
     val combined = task.combineParameters(templateParameters)
 
     combined should be(Map(
-      "param1" -> Some("value1"),
-      "Stack" -> Some("cfn"),
-      "Stage" -> Some("PROD")
+      "param1" -> StringValue("value1"),
+      "Stack" -> StringValue("cfn"),
+      "Stage" -> StringValue("PROD")
       ))
   }
 
@@ -70,9 +70,9 @@ class CloudFormationTest extends FlatSpec with Matchers {
     val combined = task.combineParameters(templateParameters)
 
     combined should be(Map(
-      "param1" -> Some("value1"),
-      "param3" -> None,
-      "Stage" -> Some(PROD.name)
+      "param1" -> StringValue("value1"),
+      "param3" -> UseExistingValue(),
+      "Stage" -> StringValue(PROD.name)
     ))
   }
 }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -49,9 +49,9 @@ class CloudFormationTest extends FlatSpec with Matchers {
     val combined = task.combineParameters(templateParameters)
 
     combined should be(Map(
-      "param1" -> StringValue("value1"),
-      "Stack" -> StringValue("cfn"),
-      "Stage" -> StringValue("PROD")
+      "param1" -> SpecifiedValue("value1"),
+      "Stack" -> SpecifiedValue("cfn"),
+      "Stage" -> SpecifiedValue("PROD")
       ))
   }
 
@@ -70,9 +70,9 @@ class CloudFormationTest extends FlatSpec with Matchers {
     val combined = task.combineParameters(templateParameters)
 
     combined should be(Map(
-      "param1" -> StringValue("value1"),
-      "param3" -> UseExistingValue(),
-      "Stage" -> StringValue(PROD.name)
+      "param1" -> SpecifiedValue("value1"),
+      "param3" -> UseExistingValue,
+      "Stage" -> SpecifiedValue(PROD.name)
     ))
   }
 }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -1,0 +1,78 @@
+package magenta.deployment_type
+
+import java.io.File
+
+import magenta._
+import magenta.tasks.{TemplateParameter, CheckUpdateEventsTask, UpdateCloudFormationTask}
+import org.json4s.JsonAST.JValue
+import org.json4s.JsonDSL._
+import org.scalatest.{FlatSpec, Matchers}
+import fixtures._
+
+import scalax.file.Path
+
+class CloudFormationTest extends FlatSpec with Matchers {
+  implicit val fakeKeyRing = KeyRing(SystemUser(None))
+
+  "cloudformation deployment type" should "have an updateStack action" in {
+    val data: Map[String, JValue] = Map()
+    val app = Seq(App("app"))
+    val stack = NamedStack("cfn")
+    val cfnStackName = s"cfn-app-PROD"
+    val p = DeploymentPackage("app", app, data, "cloudformation", new File("/tmp/packages/webapp"))
+
+    CloudFormation.perAppActions("updateStack")(p)(lookupEmpty, parameters(), stack) should be (List(
+      UpdateCloudFormationTask(
+        cfnStackName,
+        Path(p.srcDir) \ Path.fromString("""cloud-formation/cfn.json"""),
+        Map.empty,
+        PROD,
+        NamedStack("cfn"),
+        true
+      ),
+      CheckUpdateEventsTask(cfnStackName)
+    ))
+  }
+
+  "UpdateCloudFormationTask" should "substitute stack and stage parameters" in {
+    val task = UpdateCloudFormationTask(
+      "testStack",
+      Path.fromString("""cloud-formation/cfn.json"""),
+      Map("param1" -> "value1"),
+      PROD,
+      NamedStack("cfn"),
+      true
+    )
+
+    val templateParameters =
+      Seq(TemplateParameter("param1", false), TemplateParameter("Stack", false), TemplateParameter("Stage", false))
+    val combined = task.combineParameters(templateParameters)
+
+    combined should be(Map(
+      "param1" -> Some("value1"),
+      "Stack" -> Some("cfn"),
+      "Stage" -> Some("PROD")
+      ))
+  }
+
+  it should "default required parameters to use existing parameters" in {
+    val task = UpdateCloudFormationTask(
+      "testStack",
+      Path.fromString("""cloud-formation/cfn.json"""),
+      Map("param1" -> "value1"),
+      PROD,
+      NamedStack("cfn"),
+      true
+    )
+
+    val templateParameters =
+      Seq(TemplateParameter("param1", true), TemplateParameter("param3", false), TemplateParameter("Stage", false))
+    val combined = task.combineParameters(templateParameters)
+
+    combined should be(Map(
+      "param1" -> Some("value1"),
+      "param3" -> None,
+      "Stage" -> Some(PROD.name)
+    ))
+  }
+}


### PR DESCRIPTION
The AWS SDK now makes it possible to specify in an update call to a cloudformation stack that existing values should be reused.

This PR changes the behaviour so that this flag is automatically set for any parameter in a cloudformation template that has neither a default value, a value provided by the user nor a value generated by riff-raff itself (eg. Stack/Stage).

This following screenshot illustrates this at work. The CertificateARN parameter has no default or anything specified so is passed in as UseExistingValue.

<img width="959" alt="screen shot 2016-02-05 at 12 07 06" src="https://cloud.githubusercontent.com/assets/1236466/12845895/089284d6-cc01-11e5-85f1-bf6adcb6dae0.png">