### PR TITLE
Add support for YAML CloudFormation templates

### DIFF
--- a/magenta-lib/build.sbt
+++ b/magenta-lib/build.sbt
@@ -19,7 +19,9 @@ libraryDependencies ++= Seq(
     "org.parboiled" %% "parboiled" % "2.0.1",
     "com.gu" %% "management" % guardianManagementVersion,
     "com.gu" %% "fastly-api-client" % "0.2.4",
-    "io.reactivex" %% "rxscala" % "0.23.0"
+    "io.reactivex" %% "rxscala" % "0.23.0",
+    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % "2.7.1",
+    "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.1"
 )
 
 resourceDirectory in Compile := baseDirectory.value / "docs"

--- a/magenta-lib/build.sbt
+++ b/magenta-lib/build.sbt
@@ -4,6 +4,8 @@ resolvers ++= Seq(
     "spray repo" at "http://repo.spray.cc"
 )
 
+val awsVersion = "1.10.35"
+
 libraryDependencies ++= Seq(
     "net.databinder" %% "dispatch-http" % "0.8.10",
     "org.json4s" %% "json4s-native" % "3.2.11",
@@ -11,7 +13,13 @@ libraryDependencies ++= Seq(
     "org.bouncycastle" % "bcpg-jdk16" % "1.46",
     "com.decodified" %% "scala-ssh" % "0.7.0" exclude ("org.bouncycastle", "bcpkix-jdk15on"),
     "ch.qos.logback" % "logback-classic" % "1.1.2",
-    "com.amazonaws" % "aws-java-sdk" % "1.10.35",
+    "com.amazonaws" % "aws-java-sdk-core" % awsVersion,
+    "com.amazonaws" % "aws-java-sdk-autoscaling" % awsVersion,
+    "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
+    "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
+    "com.amazonaws" % "aws-java-sdk-elasticloadbalancing" % awsVersion,
+    "com.amazonaws" % "aws-java-sdk-lambda" % awsVersion,
+    "com.amazonaws" % "aws-java-sdk-cloudformation" % awsVersion,
     "org.scalatest" %% "scalatest" % "2.2.3" % "test",
     "org.mockito" % "mockito-core" % "1.10.19" % "test",
     "com.github.scala-incubator.io" %% "scala-io-core" % "0.4.3",

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -17,6 +17,9 @@ object CloudFormation extends DeploymentType {
       |This deployment type is not currently recommended for continuous deployment, as CloudFormation
       |will fail if you try to update a CloudFormation stack with a configuration that matches its
       | current state.
+      |
+      |If your CloudFormation template is in YAML format, it will be automatically converted to JSON
+      |before it is used.
     """.stripMargin
 
   val cloudFormationStackName = Param[String]("cloudFormationStackName",
@@ -29,7 +32,7 @@ object CloudFormation extends DeploymentType {
     documentation = "Whether to add '-`stage`' to the `cloudFormationStackName`, e.g. MyApp => MyApp-PROD"
   ).default(true)
   val templatePath = Param[String]("templatePath",
-    documentation = "Location of template to use within package"
+    documentation = "Location of template to use within package. If it has a standard YAML file extension (`.yml` or `.yaml`), the template will be converted from YAML to JSON."
   ).default("""cloud-formation/cfn.json""")
   val templateParameters = Param[Map[String, String]]("templateParameters",
     documentation = "Map of parameter names and values to be passed into template. `Stage` and `Stack` (if `defaultStacks` are specified) will be appropriately set automatically."

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -75,4 +75,50 @@ class CloudFormationTest extends FlatSpec with Matchers {
       "Stage" -> SpecifiedValue(PROD.name)
     ))
   }
+
+  "JsonConverter" should "convert YAML to JSON" in {
+    val yaml =
+      """
+        |AWSTemplateFormatVersion: 2010-09-09
+        |Description: 'Example CloudFormation template'
+        |Parameters:
+        |  FirstParam:
+        |    Description: An EC2 key pair
+        |    Type: AWS::EC2::KeyPair::KeyName
+      """.stripMargin
+
+    val expectedJson =
+      """
+        |{
+        |  "AWSTemplateFormatVersion":"2010-09-09",
+        |  "Description":"Example CloudFormation template",
+        |  "Parameters":{
+        |    "FirstParam":{
+        |      "Description":"An EC2 key pair",
+        |      "Type":"AWS::EC2::KeyPair::KeyName"
+        |    }
+        |  }
+        |}
+      """.stripMargin.trim
+
+    val yamlFile = Path.createTempFile(suffix = ".yml")
+    try {
+      yamlFile.append(yaml)
+      JsonConverter.convert(yamlFile) should be(expectedJson)
+    } finally {
+      yamlFile.delete()
+    }
+  }
+
+  "JsonConverter" should "assume a file with a non-YAML extension already contains JSON" in {
+    val json = """{"some":"json"}"""
+    val jsonFile = Path.createTempFile(suffix = ".template")
+    try {
+      jsonFile.append(json)
+      JsonConverter.convert(jsonFile) should be(json)
+    } finally {
+      jsonFile.delete()
+    }
+
+  }
 }


### PR DESCRIPTION
If the template file has a `.yml` or `.yaml` extension, it is assumed to be in YAML format and RiffRaff will convert it to JSON on the fly. Otherwise it is assumed to be in JSON format and will be used as-is.