### PR TITLE
Bump Casbah so that we work with MongoDB 3.2.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,3 @@
 organization := "com.gu"
 
-scalaVersion in ThisBuild := "2.11.5"
+scalaVersion in ThisBuild := "2.11.7"

--- a/riff-raff/build.sbt
+++ b/riff-raff/build.sbt
@@ -6,8 +6,6 @@ resolvers ++= Seq(
     "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 )
 
-ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) }
-
 libraryDependencies ++= Seq(
   "com.gu" %% "management-play" % guardianManagementPlayVersion exclude("javassist", "javassist"), // http://code.google.com/p/reflections/issues/detail?id=140
   "com.gu" %% "management-logback" % guardianManagementVersion,

--- a/riff-raff/build.sbt
+++ b/riff-raff/build.sbt
@@ -6,13 +6,15 @@ resolvers ++= Seq(
     "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 )
 
+ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) }
+
 libraryDependencies ++= Seq(
   "com.gu" %% "management-play" % guardianManagementPlayVersion exclude("javassist", "javassist"), // http://code.google.com/p/reflections/issues/detail?id=140
   "com.gu" %% "management-logback" % guardianManagementVersion,
   "com.gu" %% "configuration" % "4.0",
   "com.gu" %% "play-googleauth" % "0.2.2" exclude("com.google.guava", "guava-jdk5"),
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-  "org.mongodb" %% "casbah" % "2.7.4",
+  "org.mongodb" %% "casbah" % "3.1.0",
   "org.pircbotx" % "pircbotx" % "1.7",
   "com.typesafe.akka" %% "akka-agent" % "2.3.8",
   "org.clapper" %% "markwrap" % "1.0.2",


### PR DESCRIPTION
compose.io provides MongoDB 3.2.1 so the libraries we use must be compatible with that version. We're bumping to the latest version of Casbah as there is no reason to do otherwise.