### PR TITLE
Self deployment and version visibility

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
@@ -51,7 +51,7 @@ trait DeploymentType {
 object DeploymentType {
   def all: Seq[DeploymentType] = Seq(
     ElasticSearch, S3, AutoScaling, ExecutableJarWebapp, JettyWebapp, ResinWebapp, FileCopy, Django, Fastly,
-    UnzipToDocroot, CloudFormation, RPM, NativePackagerWebapp, Lambda, AmiCloudFormationParameter
+    UnzipToDocroot, CloudFormation, RPM, NativePackagerWebapp, Lambda, AmiCloudFormationParameter, SelfDeploy
   )
 }
 

--- a/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
@@ -1,0 +1,71 @@
+package magenta.deployment_type
+
+import java.io.File
+
+import magenta.tasks.{ChangeSwitch, S3Upload}
+
+object SelfDeploy extends DeploymentType with S3AclParams {
+  val name = "self-deploy"
+  val documentation =
+    """
+      |This is a special deployment type that can be used to self-deploy Riff-Raff.
+      |
+      |The approach is to upload a file to S3 and then hit a switch on the singleton instance.
+      |When the switch is hit it will shutdown with a specific exit code at the next
+      |opportunity (when it has finished deploys).
+    """.stripMargin
+
+  val bucket = Param[String]("bucket",
+    """
+      |S3 bucket name to upload artifact into.
+      |
+      |The path in the bucket is `<stack>/<stage>/<packageName>/<fileName>`.
+    """.stripMargin
+  )
+
+  val prefixStage = Param[Boolean]("prefixStage",
+    documentation = "Whether to prefix `stage` to the S3 location`"
+  ).default(true)
+  val prefixPackage = Param[Boolean]("prefixPackage",
+    documentation = "Whether to prefix `package` to the S3 location"
+  ).default(true)
+  val prefixStack = Param[Boolean]("prefixStack",
+    documentation = "Whether to prefix `stack` to the S3 location"
+  ).default(true)
+
+  val managementPort = Param[Int]("managementPort",
+    "For deferred deployment only: The port of the management pages containing the location of the switchboard"
+  ).default(18080)
+  val managementProtocol = Param[String]("managementProtocol",
+    "For deferred deployment only: The protocol of the management pages containing the location of the switchboard"
+  ).default("http")
+  val switchboardPath = Param[String]("switchboardPath",
+    "For deferred deployment only: The URL path on the host to the switchboard management page"
+  ).default("/management/switchboard")
+
+  def perAppActions = {
+    case "uploadArtifacts" => (pkg) => (lookup, parameters, stack) =>
+      implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
+      List(
+        S3Upload(
+          stack,
+          parameters.stage,
+          bucket.get(pkg).orElse(stack.nameOption.map(stackName => s"$stackName-dist")).get,
+          new File(pkg.srcDir.getPath + "/"),
+          prefixStage = prefixStage(pkg),
+          prefixStack = prefixStack(pkg),
+          prefixPackage = prefixPackage(pkg),
+          publicReadAcl = publicReadAcl(pkg)
+        )
+      )
+  }
+
+  override def perHostActions = {
+    case "selfDeploy" => pkg => (host, keyRing) => {
+      implicit val key = keyRing
+      ChangeSwitch(host, managementProtocol(pkg), managementPort(pkg), switchboardPath(pkg),
+        "shutdown-when-inactive", desiredState=true) :: Nil
+    }
+  }
+}
+

--- a/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
@@ -23,16 +23,6 @@ object SelfDeploy extends DeploymentType with S3AclParams {
     """.stripMargin
   )
 
-  val prefixStage = Param[Boolean]("prefixStage",
-    documentation = "Whether to prefix `stage` to the S3 location`"
-  ).default(true)
-  val prefixPackage = Param[Boolean]("prefixPackage",
-    documentation = "Whether to prefix `package` to the S3 location"
-  ).default(true)
-  val prefixStack = Param[Boolean]("prefixStack",
-    documentation = "Whether to prefix `stack` to the S3 location"
-  ).default(true)
-
   val managementPort = Param[Int]("managementPort",
     "For deferred deployment only: The port of the management pages containing the location of the switchboard"
   ).default(18080)
@@ -52,10 +42,7 @@ object SelfDeploy extends DeploymentType with S3AclParams {
           parameters.stage,
           bucket.get(pkg).orElse(stack.nameOption.map(stackName => s"$stackName-dist")).get,
           new File(pkg.srcDir.getPath + "/"),
-          prefixStage = prefixStage(pkg),
-          prefixStack = prefixStack(pkg),
-          prefixPackage = prefixPackage(pkg),
-          publicReadAcl = publicReadAcl(pkg)
+          publicReadAcl = false
         )
       )
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,3 +21,5 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.6")
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.5.0")

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -181,10 +181,7 @@ class Configuration(val application: String, val webappConfDirectory: String = "
     lazy val publicPrefix: String = configuration.getStringProperty("urls.publicPrefix", "http://localhost:9000")
   }
 
-  val version:String = Seq(
-    Manifest.asKeyValuePairs.get("Branch"),
-    Manifest.asKeyValuePairs.get("Build").orElse(Some("UNKNOWN"))
-  ).flatten.map(_.trim).mkString("/")
+  val version:String = Manifest.asKeyValuePairs.getOrElse("Build", "UNKNOWN")
 
   override def toString(): String = configuration.toString
 }

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -181,6 +181,11 @@ class Configuration(val application: String, val webappConfDirectory: String = "
     lazy val publicPrefix: String = configuration.getStringProperty("urls.publicPrefix", "http://localhost:9000")
   }
 
+  val version:String = Seq(
+    Manifest.asKeyValuePairs.get("Branch"),
+    Manifest.asKeyValuePairs.get("Build").orElse(Some("UNKNOWN"))
+  ).flatten.map(_.trim).mkString("/")
+
   override def toString(): String = configuration.toString
 }
 

--- a/riff-raff/app/views/page.scala.html
+++ b/riff-raff/app/views/page.scala.html
@@ -53,8 +53,7 @@
                 <a href="https://github.com/guardian/deploy">
                     <i>Riff Raff</i>
                 </a> is part of <a href="http://www.grauniad.co.uk">The Grauniad's</a> deployment toolset.
-                <br><small>I would like, if I may, to take you on a strange journey.</small>
-                <br><small>Build @conf.Configuration.version</small>
+                <br><small>I would like, if I may, to take you on a strange journey.</small><small class="pull-right">Build @conf.Configuration.version</small>
             </p>
         </footer>
     </div>

--- a/riff-raff/app/views/page.scala.html
+++ b/riff-raff/app/views/page.scala.html
@@ -54,7 +54,7 @@
                     <i>Riff Raff</i>
                 </a> is part of <a href="http://www.grauniad.co.uk">The Grauniad's</a> deployment toolset.
                 <br><small>I would like, if I may, to take you on a strange journey.</small>
-                <br><small>@conf.Configuration.version</small>
+                <br><small>Build @conf.Configuration.version</small>
             </p>
         </footer>
     </div>

--- a/riff-raff/app/views/page.scala.html
+++ b/riff-raff/app/views/page.scala.html
@@ -54,6 +54,7 @@
                     <i>Riff Raff</i>
                 </a> is part of <a href="http://www.grauniad.co.uk">The Grauniad's</a> deployment toolset.
                 <br><small>I would like, if I may, to take you on a strange journey.</small>
+                <br><small>@conf.Configuration.version</small>
             </p>
         </footer>
     </div>

--- a/riff-raff/conf/deploy.json
+++ b/riff-raff/conf/deploy.json
@@ -2,7 +2,7 @@
     "defaultStacks": ["deploy"],
     "packages":{
         "riff-raff":{
-            "type":"autoscaling",
+            "type":"self-deploy",
             "data":{
                 "bucket": "deploy-tools-dist",
                 "publicReadAcl": false
@@ -11,10 +11,13 @@
     },
     "recipes":{
       "default": {
-          "depends": ["deploy"]
+          "depends": ["uploadStep", "restartStep"]
       },
-      "deploy": {
+      "uploadStep": {
           "actionsPerHost": ["riff-raff.uploadArtifacts"]
+      },
+      "restartStep": {
+          "actionsPerHost": ["riff-raff.selfDeploy"]
       }
     }
 }


### PR DESCRIPTION
Make self deployment work inside the AWS environment.

This is connected with two other PRs: https://github.com/guardian/machine-images/pull/95 and https://github.com/guardian/deploy-tools-platform/pull/10. 

This PR also makes the build ID visible again at the bottom right of each page:
![image](https://cloud.githubusercontent.com/assets/1236466/13511956/993fa326-e18f-11e5-9e80-21987d1603be.png)
