### PR TITLE
Return an HSTS header if we are behind an HTTPS proxy (ie. an ELB)

### DIFF
--- a/riff-raff/app/Global.scala
+++ b/riff-raff/app/Global.scala
@@ -9,12 +9,12 @@ import play.api.Application
 import play.api.mvc.Results.InternalServerError
 import play.api.mvc.{RequestHeader, Result, WithFilters}
 import play.filters.gzip.GzipFilter
-import utils.ScheduledAgent
+import utils.{HstsFilter, ScheduledAgent}
 
 import scala.collection.mutable
 import scala.concurrent.Future
 
-object Global extends WithFilters(new GzipFilter() :: PlayRequestMetrics.asFilters: _*) with Logging {
+object Global extends WithFilters(new GzipFilter() :: new HstsFilter() :: PlayRequestMetrics.asFilters: _*) with Logging {
 
   val lifecycleSingletons = mutable.Buffer[Lifecycle]()
 

--- a/riff-raff/app/utils/HstsFilter.scala
+++ b/riff-raff/app/utils/HstsFilter.scala
@@ -1,0 +1,15 @@
+package utils
+
+import play.api.mvc.{RequestHeader, EssentialAction, EssentialFilter}
+import play.api.libs.concurrent.Execution.Implicits._
+
+class HstsFilter extends EssentialFilter {
+  def apply(next: EssentialAction) = new EssentialAction {
+    def apply(request: RequestHeader) = {
+      if (request.headers.get("X-Forwarded-Proto").contains("https"))
+        next(request).map(_.withHeaders("Strict-Transport-Security" -> "max-age=31536000"))
+      else
+        next(request)
+    }
+  }
+}


### PR DESCRIPTION
I'm somewhat bored forgetting to type https at the start of the Riff-Raff URL. This should fix that, after the first visit and I think a smarter than forwarding from HTTP.