### PR TITLE
Simplify HSTS header

### DIFF
--- a/riff-raff/app/utils/HstsFilter.scala
+++ b/riff-raff/app/utils/HstsFilter.scala
@@ -5,11 +5,6 @@ import play.api.libs.concurrent.Execution.Implicits._
 
 class HstsFilter extends EssentialFilter {
   def apply(next: EssentialAction) = new EssentialAction {
-    def apply(request: RequestHeader) = {
-      if (request.headers.get("X-Forwarded-Proto").contains("https"))
-        next(request).map(_.withHeaders("Strict-Transport-Security" -> "max-age=31536000"))
-      else
-        next(request)
-    }
+    def apply(request: RequestHeader) = next(request).map(_.withHeaders("Strict-Transport-Security" -> "max-age=31536000"))
   }
 }


### PR DESCRIPTION
The spec ignores HSTS headers when not on TLS connections so we can send the header with impunity.