### PR TITLE
Replace the S3Upload task with a new S3UploadV2 task

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -98,6 +98,8 @@ trait CompressedFilename {
   def compressedName = sourceFile.getName + ".tar.bz2"
 }
 
+@deprecated("The S3Upload task has now been replaced by the simpler S3UploadV2 task that has less of an opinion on S3 key generation", "2015/05/18")
+object S3Upload
 
 case class S3Upload( stack: Stack,
                      stage: Stage,

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -6,6 +6,7 @@ import scala.io.Source
 import java.net.Socket
 import java.io.{IOException, FileNotFoundException, File}
 import java.net.URL
+import com.amazonaws.services.s3.model.PutObjectRequest
 import magenta.deployment_type.PatternValue
 import dispatch.classic._
 
@@ -147,16 +148,60 @@ case class S3Upload( stack: Stack,
     s"$stackName$stageName${toRelative(file)}"
   }
 
-  def contentTypeLookup(fileName: String) =
-    fileExtension(fileName).flatMap(mimeTypeMap.get)
-
+  def contentTypeLookup(fileName: String) = fileExtension(fileName).flatMap(mimeTypeMap.get)
   def cacheControlLookup(fileName:String) = cacheControlPatterns.find(_.regex.findFirstMatchIn(fileName).isDefined).map(_.value)
+  private def fileExtension(fileName: String) = fileName.split('.').drop(1).lastOption
+  private def resolveFiles(file: File): Seq[File] = Option(file.listFiles).map { _.toSeq.flatMap(resolveFiles) } getOrElse (Seq(file)).distinct
+}
 
-  private def fileExtension(fileName: String) =
-    fileName.split('.').drop(1).lastOption
+case class S3UploadV2(
+  bucket: String,
+  files: Seq[(File, String)],
+  cacheControlPatterns: List[PatternValue] = Nil,
+  extensionToMimeType: Map[String,String] = Map.empty,
+  publicReadAcl: Boolean = false,
+  detailedLoggingThreshold: Int = 10
+)(implicit val keyRing: KeyRing) extends Task with S3 {
 
-  private def resolveFiles(file: File): Seq[File] =
-    Option(file.listFiles).map { _.toSeq.flatMap(resolveFiles) } getOrElse (Seq(file)).distinct
+  lazy val totalSize = files.map{ case (file, key) => file.length}.sum
+
+  lazy val flattenedFiles = files flatMap {
+    case (file, key) => resolveFiles(file, key)
+  }
+
+  lazy val requests = flattenedFiles map {
+    case (file, key) => S3.putObjectRequest(bucket, key, file, cacheControlLookup(key), contentTypeLookup(key), publicReadAcl)
+  }
+
+  // A verbose description of this task. For command line tasks,
+  def verbose: String = s"$description using file mapping $files"
+
+  // end-user friendly description of this task
+  def description: String = s"Upload ${requests.size} files to S3 bucket $bucket"
+
+  def requestToString(request: PutObjectRequest): String =
+    s"${request.getFile.getPath} to s3://${request.getBucketName}/${request.getKey} with "+
+      s"CacheControl:${request.getMetadata.getCacheControl} ContentType:${request.getMetadata.getContentType} ACL:${request.getCannedAcl}"
+
+  // execute this task (should throw on failure)
+  def execute(stopFlag: =>  Boolean)  {
+    val client = s3client(keyRing)
+    MessageBroker.verbose(s"Starting upload of ${files.size} files ($totalSize bytes) to S3")
+    requests.par foreach { request =>
+      client.putObject(request)
+      if (requests.length <= detailedLoggingThreshold) MessageBroker.verbose(s"Uploaded ${requestToString(request)}")
+    }
+    MessageBroker.verbose(s"Finished upload of ${files.size} files to S3")
+  }
+
+  private def resolveFiles(file: File, key: String): Seq[(File, String)] = {
+    if (!file.isDirectory) Seq((file, key))
+    else file.listFiles.toSeq.flatMap(f => resolveFiles(f, s"$key/${f.getName}")).distinct
+  }
+
+  private def contentTypeLookup(fileName: String) = fileExtension(fileName).flatMap(extensionToMimeType.get)
+  private def cacheControlLookup(fileName:String) = cacheControlPatterns.find(_.regex.findFirstMatchIn(fileName).isDefined).map(_.value)
+  private def fileExtension(fileName: String) = fileName.split('.').drop(1).lastOption
 }
 
 case class BlockFirewall(host: Host)(implicit val keyRing: KeyRing) extends RemoteShellTask {

--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
@@ -7,7 +7,7 @@ import org.json4s.JsonAST.JValue
 import org.json4s.JsonDSL._
 import org.scalatest.{FlatSpec, Matchers}
 import magenta.fixtures._
-import magenta.tasks.{S3Upload, UpdateS3Lambda}
+import magenta.tasks.{S3UploadV2, UpdateS3Lambda}
 
 class LambdaTest extends FlatSpec with Matchers {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
@@ -26,13 +26,9 @@ class LambdaTest extends FlatSpec with Matchers {
   it should "produce an S3 upload task" in {
     val tasks = Lambda.perAppActions("uploadLambda")(pkg)(lookupEmpty, parameters(PROD), NamedStack("test"))
     tasks should be (List(
-      S3Upload(
-        stack = NamedStack("test"),
-        stage = PROD,
+      S3UploadV2(
         bucket = "lambda-bucket",
-        file = new File(pkg.srcDir, "test-file.zip"),
-        prefixPackage = false,
-        publicReadAcl = false
+        files = Seq((new File(pkg.srcDir, "test-file.zip") -> s"test/PROD/lambda/test-file.zip"))
       )
     ))
   }
@@ -43,7 +39,7 @@ class LambdaTest extends FlatSpec with Matchers {
       UpdateS3Lambda(
         functionName = "MyFunction-PROD",
         s3Bucket = "lambda-bucket",
-        s3Key = "test/PROD/test-file.zip"
+        s3Key = "test/PROD/lambda/test-file.zip"
       )
     ))
   }

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -376,9 +376,115 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
     fileTwo.createNewFile()
 
     val mimeTypes = Map("xpi" -> "application/x-xpinstall")
-    val task = new S3Upload(UnnamedStack, Stage("CODE"), "bucket", baseDir, mimeTypeMap = mimeTypes) with StubS3 {
-      override val bucket = "bucket"
+    val task = new S3Upload(UnnamedStack, Stage("CODE"), "bucket", baseDir, mimeTypeMap = mimeTypes) with StubS3
+
+    Option(task.requests.find(_.getFile == fileOne).get.getMetadata.getContentType) should be(None)
+    Option(task.requests.find(_.getFile == fileTwo).get.getMetadata.getContentType) should be(Some("application/x-xpinstall"))
+  }
+
+  "S3UploadV2" should "upload a single file to S3" in {
+    val fileToUpload = new File("/foo/bar/the-jar.jar")
+    val task = new S3UploadV2("bucket", Seq((fileToUpload -> "keyPrefix/the-jar.jar"))) with StubS3
+
+    val requests = task.requests
+    requests.size should be (1)
+    val request = requests.head
+    request.getBucketName should be ("bucket")
+    request.getFile should be(fileToUpload)
+    request.getKey should be (s"keyPrefix/the-jar.jar")
+
+    task.execute()
+    val s3Client = task.s3client(fakeKeyRing)
+
+    verify(s3Client).putObject(request)
+    verifyNoMoreInteractions(s3Client)
+  }
+
+  it should "create an upload request with correct permissions" in {
+    val baseDir = createTempDir()
+    val artifact = new File(baseDir, "artifact")
+    artifact.createNewFile()
+
+    val task = new S3UploadV2("bucket", Seq((baseDir -> "bucket")))
+
+    task.requests should not be ('empty)
+    for (request <- task.requests) {
+      request.getBucketName should be ("bucket")
+      request.getCannedAcl should be (null)
+      request.getFile should be (artifact)
+      request.getKey should be ("bucket/artifact")
     }
+
+    val taskWithoutAcl = task.copy(publicReadAcl = true)
+
+    taskWithoutAcl.requests should not be ('empty)
+    for (request <- taskWithoutAcl.requests) {
+      request.getCannedAcl should be (CannedAccessControlList.PublicRead)
+    }
+  }
+
+  it should "upload a directory to S3" in {
+
+    val baseDir = createTempDir()
+
+    val fileOne = new File(baseDir, "one.txt")
+    fileOne.createNewFile()
+    val fileTwo = new File(baseDir, "two.txt")
+    fileTwo.createNewFile()
+    val subDir = new File(baseDir, "sub")
+    subDir.mkdir()
+    val fileThree = new File(subDir, "three.txt")
+    fileThree.createNewFile()
+
+    val task = new S3UploadV2("bucket", Seq((baseDir -> "myStack/CODE/myApp"))) with StubS3
+    task.execute()
+    val s3Client = task.s3client(fakeKeyRing)
+
+    val files = task.flattenedFiles
+    files.size should be (3)
+    files should contain ((fileOne,"myStack/CODE/myApp/one.txt"))
+    files should contain ((fileTwo,"myStack/CODE/myApp/two.txt"))
+    files should contain ((fileThree,"myStack/CODE/myApp/sub/three.txt"))
+
+    verify(s3Client, times(3)).putObject(any(classOf[PutObjectRequest]))
+
+    verifyNoMoreInteractions(s3Client)
+  }
+
+  it should "use different cache control" in {
+    val tempDir = createTempDir()
+    val baseDir = new File(tempDir, "package")
+    baseDir.mkdir()
+
+    val fileOne = new File(baseDir, "one.txt")
+    fileOne.createNewFile()
+    val fileTwo = new File(baseDir, "two.txt")
+    fileTwo.createNewFile()
+    val subDir = new File(baseDir, "sub")
+    subDir.mkdir()
+    val fileThree = new File(subDir, "three.txt")
+    fileThree.createNewFile()
+
+    val patternValues = List(PatternValue("^keyPrefix/sub/", "public; max-age=3600"), PatternValue(".*", "no-cache"))
+    val task = new S3UploadV2("bucket", Seq((baseDir -> "keyPrefix")), cacheControlPatterns = patternValues) with StubS3
+
+    task.requests.find(_.getFile == fileOne).get.getMetadata.getCacheControl should be("no-cache")
+    task.requests.find(_.getFile == fileTwo).get.getMetadata.getCacheControl should be("no-cache")
+    task.requests.find(_.getFile == fileThree).get.getMetadata.getCacheControl should be("public; max-age=3600")
+  }
+
+  it should "use overridden mime type" in {
+    val tempDir = createTempDir()
+    val baseDir = new File(tempDir, "package")
+    baseDir.mkdir()
+
+    val fileOne = new File(baseDir, "one.test.txt")
+    fileOne.createNewFile()
+    val fileTwo = new File(baseDir, "two.test.xpi")
+    fileTwo.createNewFile()
+
+    val mimeTypes = Map("xpi" -> "application/x-xpinstall")
+    val task = new S3UploadV2("bucket", Seq((baseDir -> "")), extensionToMimeType = mimeTypes) with StubS3
 
     Option(task.requests.find(_.getFile == fileOne).get.getMetadata.getContentType) should be(None)
     Option(task.requests.find(_.getFile == fileTwo).get.getMetadata.getContentType) should be(Some("application/x-xpinstall"))


### PR DESCRIPTION
The `S3Upload` task does a little too much internally which makes it hard to reason about and hard to use when you want to reliably work out where it has uploaded files. The replacement V2 doesn't do as much magic and moves the responsibility of mapping files to keys (or directories to key prefixes) to the callee.

At the moment I've only replaced the use of it in the lambda upload action, but would like to completely replace and remove `S3Upload`.