### PR TITLE
Logging without thread local

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,1 @@
 organization := "com.gu"
-
-scalaVersion in ThisBuild := "2.11.7"

--- a/magenta-cli/src/main/scala/magenta/cli/Main.scala
+++ b/magenta-cli/src/main/scala/magenta/cli/Main.scala
@@ -21,7 +21,7 @@ import scalax.file.Path
 object Main extends scala.App {
 
   var taskList: List[TaskDetail] = _
-  MessageBroker.messages.subscribe(wrapper => {
+  DeployLogger.messages.subscribe(wrapper => {
     val indent = "  " * (wrapper.stack.messages.size - 1)
     wrapper.stack.top match {
       case Verbose(message) => if (Config.verbose) Console.out.println(indent + message)
@@ -80,7 +80,7 @@ object Main extends scala.App {
     def localArtifactDir_=(dir: Option[File]) {
       dir.foreach { f =>
         if (!f.exists() || !f.isDirectory) sys.error("Directory not found.")
-        MessageBroker.info("WARN: Ignoring <project> and <build>; using local artifact directory of " + f.getAbsolutePath)
+        System.err.println("WARN: Ignoring <project> and <build>; using local artifact directory of " + f.getAbsolutePath)
       }
 
       _localArtifactDir = dir
@@ -169,48 +169,47 @@ object Main extends scala.App {
       withTemporaryDirectory { tmpDir =>
         val build = Build(Config.project.get, Config.build.get)
         val parameters = DeployParameters(Config.deployer, build, Stage(Config.stage), Config.recipe, Nil, Config.host.toList)
-        MessageBroker.deployContext(UUID.randomUUID(), parameters) {
+        val deployId = UUID.randomUUID()
+        implicit val rootLogger = DeployLogger.rootLoggerFor(deployId, parameters)
+        rootLogger.info("[using %s build %s]" format (programName, programVersion))
 
-          MessageBroker.info("[using %s build %s]" format (programName, programVersion))
+        rootLogger.info("Locating artifact...")
 
-          MessageBroker.info("Locating artifact...")
+        Config.localArtifactDir.map{ file =>
+          rootLogger.info("Making temporary copy of local artifact: %s" format file)
+          file.copyTo(Path(tmpDir))
+        } getOrElse {
+          S3Artifact.download(build, tmpDir)(Config.bucketName, new AmazonS3Client(
+            new AWSCredentialsProviderChain(new AWSCredentialsProvider {
+              override def getCredentials: AWSCredentials = (for {
+                key <- Config.accessKey
+                secret <- Config.secretKey
+              } yield new BasicAWSCredentials(key, secret)).getOrElse(null)
 
-          Config.localArtifactDir.map{ file =>
-            MessageBroker.info("Making temporary copy of local artifact: %s" format file)
-            file.copyTo(Path(tmpDir))
-          } getOrElse {
-            S3Artifact.download(build, tmpDir)(Config.bucketName, new AmazonS3Client(
-              new AWSCredentialsProviderChain(new AWSCredentialsProvider {
-                override def getCredentials: AWSCredentials = (for {
-                  key <- Config.accessKey
-                  secret <- Config.secretKey
-                } yield new BasicAWSCredentials(key, secret)).getOrElse(null)
-
-                override def refresh(): Unit = {}
-              }, new DefaultAWSCredentialsProviderChain())
-            ))
-          }
-
-          MessageBroker.info("Loading project file...")
-          val project = JsonReader.parse(new File(tmpDir, "deploy.json"))
-
-          MessageBroker.verbose("Loaded: " + project)
-
-          val context = DeployContext(parameters,project,Config.lookup)
-
-          if (Config.dryRun) {
-
-            val tasks = context.tasks
-            MessageBroker.info("Dry run requested. Not executing %d tasks." format tasks.size)
-
-          } else {
-
-            context.execute()
-          }
+              override def refresh(): Unit = {}
+            }, new DefaultAWSCredentialsProviderChain())
+          ), rootLogger)
         }
+
+        rootLogger.info("Loading project file...")
+        val project = JsonReader.parse(new File(tmpDir, "deploy.json"))
+
+        rootLogger.verbose("Loaded: " + project)
+
+        val context = DeployContext(deployId, parameters, project, Config.lookup, rootLogger)
+
+        if (Config.dryRun) {
+
+          val tasks = context.tasks
+          rootLogger.info("Dry run requested. Not executing %d tasks." format tasks.size)
+
+        } else {
+
+          context.execute()
+        }
+        rootLogger.info("Done")
       }
 
-      MessageBroker.info("Done")
 
     } catch {
       case e: UsageError =>

--- a/magenta-cli/src/main/scala/magenta/cli/Main.scala
+++ b/magenta-cli/src/main/scala/magenta/cli/Main.scala
@@ -21,7 +21,7 @@ import scalax.file.Path
 object Main extends scala.App {
 
   var taskList: List[TaskDetail] = _
-  DeployLogger.messages.subscribe(wrapper => {
+  DeployReporter.messages.subscribe(wrapper => {
     val indent = "  " * (wrapper.stack.messages.size - 1)
     wrapper.stack.top match {
       case Verbose(message) => if (Config.verbose) Console.out.println(indent + message)
@@ -170,7 +170,7 @@ object Main extends scala.App {
         val build = Build(Config.project.get, Config.build.get)
         val parameters = DeployParameters(Config.deployer, build, Stage(Config.stage), Config.recipe, Nil, Config.host.toList)
         val deployId = UUID.randomUUID()
-        implicit val rootLogger = DeployLogger.rootLoggerFor(deployId, parameters)
+        implicit val rootLogger = DeployReporter.rootReporterFor(deployId, parameters)
         rootLogger.info("[using %s build %s]" format (programName, programVersion))
 
         rootLogger.info("Locating artifact...")

--- a/magenta-lib/src/main/scala/magenta/DeployContext.scala
+++ b/magenta-lib/src/main/scala/magenta/DeployContext.scala
@@ -4,23 +4,21 @@ import tasks.Task
 import java.util.UUID
 
 object DeployContext {
-  def apply(parameters: DeployParameters, project: Project, resourceLookup: Lookup): DeployContext = {
-    val uuid = MessageBroker.deployID.getOrElse(UUID.randomUUID())
-    DeployContext(parameters, project, resourceLookup, uuid)
-  }
+  def apply(deployId: UUID, parameters: DeployParameters, project: Project,
+    resourceLookup: Lookup, rootLogger: DeployLogger): DeployContext = {
 
-  def apply(parameters: DeployParameters, project: Project, resourceLookup: Lookup, uuid: UUID): DeployContext = {
     val tasks = {
-      MessageBroker.info("Resolving tasks...")
-      val taskList = Resolver.resolve(project, resourceLookup, parameters)
-      MessageBroker.taskList(taskList)
+      rootLogger.info("Resolving tasks...")
+      val taskList = Resolver.resolve(project, resourceLookup, parameters, rootLogger)
+      rootLogger.taskList(taskList)
       taskList
     }
-    DeployContext(uuid, parameters, project, tasks)
+    DeployContext(deployId, parameters, project, tasks, rootLogger)
   }
 }
 
-case class DeployContext(uuid: UUID, parameters: DeployParameters, project: Project, tasks: List[Task]) {
+case class DeployContext(uuid: UUID, parameters: DeployParameters, project: Project,
+  tasks: List[Task], rootLogger: DeployLogger) {
   val deployer = parameters.deployer
   val buildName = parameters.build.projectName
   val buildId = parameters.build.id
@@ -28,13 +26,11 @@ case class DeployContext(uuid: UUID, parameters: DeployParameters, project: Proj
   val stage = parameters.stage
 
   def execute() {
-    MessageBroker.deployContext(uuid, parameters) {
-      if (tasks.isEmpty) MessageBroker.fail("No tasks were found to execute. Ensure the app(s) are in the list supported by this stage/host.")
+    if (tasks.isEmpty) rootLogger.fail("No tasks were found to execute. Ensure the app(s) are in the list supported by this stage/host.")
 
-      tasks.foreach { task =>
-        MessageBroker.taskContext(task) {
-          task.execute()
-        }
+    tasks.foreach { task =>
+      rootLogger.taskContext(task) { taskLogger =>
+        task.execute(taskLogger)
       }
     }
   }

--- a/magenta-lib/src/main/scala/magenta/DeployContext.scala
+++ b/magenta-lib/src/main/scala/magenta/DeployContext.scala
@@ -5,20 +5,20 @@ import java.util.UUID
 
 object DeployContext {
   def apply(deployId: UUID, parameters: DeployParameters, project: Project,
-    resourceLookup: Lookup, rootLogger: DeployLogger): DeployContext = {
+    resourceLookup: Lookup, rootReporter: DeployReporter): DeployContext = {
 
     val tasks = {
-      rootLogger.info("Resolving tasks...")
-      val taskList = Resolver.resolve(project, resourceLookup, parameters, rootLogger)
-      rootLogger.taskList(taskList)
+      rootReporter.info("Resolving tasks...")
+      val taskList = Resolver.resolve(project, resourceLookup, parameters, rootReporter)
+      rootReporter.taskList(taskList)
       taskList
     }
-    DeployContext(deployId, parameters, project, tasks, rootLogger)
+    DeployContext(deployId, parameters, project, tasks, rootReporter)
   }
 }
 
 case class DeployContext(uuid: UUID, parameters: DeployParameters, project: Project,
-  tasks: List[Task], rootLogger: DeployLogger) {
+  tasks: List[Task], rootReporter: DeployReporter) {
   val deployer = parameters.deployer
   val buildName = parameters.build.projectName
   val buildId = parameters.build.id
@@ -26,10 +26,10 @@ case class DeployContext(uuid: UUID, parameters: DeployParameters, project: Proj
   val stage = parameters.stage
 
   def execute() {
-    if (tasks.isEmpty) rootLogger.fail("No tasks were found to execute. Ensure the app(s) are in the list supported by this stage/host.")
+    if (tasks.isEmpty) rootReporter.fail("No tasks were found to execute. Ensure the app(s) are in the list supported by this stage/host.")
 
     tasks.foreach { task =>
-      rootLogger.taskContext(task) { taskLogger =>
+      rootReporter.taskContext(task) { taskLogger =>
         task.execute(taskLogger)
       }
     }

--- a/magenta-lib/src/main/scala/magenta/DeployContext.scala
+++ b/magenta-lib/src/main/scala/magenta/DeployContext.scala
@@ -18,7 +18,7 @@ object DeployContext {
 }
 
 case class DeployContext(uuid: UUID, parameters: DeployParameters, project: Project,
-  tasks: List[Task], rootReporter: DeployReporter) {
+  tasks: List[Task], reporter: DeployReporter) {
   val deployer = parameters.deployer
   val buildName = parameters.build.projectName
   val buildId = parameters.build.id
@@ -26,10 +26,10 @@ case class DeployContext(uuid: UUID, parameters: DeployParameters, project: Proj
   val stage = parameters.stage
 
   def execute() {
-    if (tasks.isEmpty) rootReporter.fail("No tasks were found to execute. Ensure the app(s) are in the list supported by this stage/host.")
+    if (tasks.isEmpty) reporter.fail("No tasks were found to execute. Ensure the app(s) are in the list supported by this stage/host.")
 
     tasks.foreach { task =>
-      rootReporter.taskContext(task) { taskLogger =>
+      reporter.taskContext(task) { taskLogger =>
         task.execute(taskLogger)
       }
     }

--- a/magenta-lib/src/main/scala/magenta/Project.scala
+++ b/magenta-lib/src/main/scala/magenta/Project.scala
@@ -137,7 +137,7 @@ object HostList {
 trait Action {
   def apps: Seq[App]
   def description: String
-  def resolve(resourceLookup: Lookup, params: DeployParameters, stack: Stack, deployLogger: DeployLogger): List[Task]
+  def resolve(resourceLookup: Lookup, params: DeployParameters, stack: Stack, deployReporter: DeployReporter): List[Task]
 }
 
 case class App (name: String)
@@ -185,8 +185,8 @@ case class DeployParameters(
                              hostList: List[String] = Nil
                              ) {
 
-  def toDeployContext(uuid: UUID, project: Project, resourceLookup: Lookup, logger: DeployLogger): DeployContext = {
-    DeployContext(uuid, this, project, resourceLookup, logger)
+  def toDeployContext(uuid: UUID, project: Project, resourceLookup: Lookup, reporter: DeployReporter): DeployContext = {
+    DeployContext(uuid, this, project, resourceLookup, reporter)
   }
 
   def matchingHost(hostName:String) = hostList.isEmpty || hostList.contains(hostName)

--- a/magenta-lib/src/main/scala/magenta/Project.scala
+++ b/magenta-lib/src/main/scala/magenta/Project.scala
@@ -137,7 +137,7 @@ object HostList {
 trait Action {
   def apps: Seq[App]
   def description: String
-  def resolve(resourceLookup: Lookup, params: DeployParameters, stack: Stack): List[Task]
+  def resolve(resourceLookup: Lookup, params: DeployParameters, stack: Stack, deployLogger: DeployLogger): List[Task]
 }
 
 case class App (name: String)
@@ -185,10 +185,9 @@ case class DeployParameters(
                              hostList: List[String] = Nil
                              ) {
 
-  def toDeployContext(uuid: UUID, project: Project, resourceLookup: Lookup): DeployContext = {
-
-    DeployContext(this,project, resourceLookup, uuid)
+  def toDeployContext(uuid: UUID, project: Project, resourceLookup: Lookup, logger: DeployLogger): DeployContext = {
+    DeployContext(uuid, this, project, resourceLookup, logger)
   }
-  def toDeployContext(project: Project, resourceLookup: Lookup): DeployContext = DeployContext(this,project, resourceLookup)
+
   def matchingHost(hostName:String) = hostList.isEmpty || hostList.contains(hostName)
 }

--- a/magenta-lib/src/main/scala/magenta/Resolver.scala
+++ b/magenta-lib/src/main/scala/magenta/Resolver.scala
@@ -21,25 +21,25 @@ case class RecipeTasksNode(recipeTasks: RecipeTasks, children: List[RecipeTasksN
 
 object Resolver {
 
-  def resolve( project: Project, resourceLookup: Lookup, parameters: DeployParameters, deployLogger: DeployLogger): List[Task] =
-    resolveDetail(project, resourceLookup, parameters, deployLogger).flatMap(_.tasks)
+  def resolve( project: Project, resourceLookup: Lookup, parameters: DeployParameters, deployReporter: DeployReporter): List[Task] =
+    resolveDetail(project, resourceLookup, parameters, deployReporter).flatMap(_.tasks)
 
-  def resolveDetail( project: Project, resourceLookup: Lookup, parameters: DeployParameters, deployLogger: DeployLogger): List[RecipeTasks] = {
+  def resolveDetail( project: Project, resourceLookup: Lookup, parameters: DeployParameters, deployReporter: DeployReporter): List[RecipeTasks] = {
 
-    def resolveTree(recipeName: String, stack: Stack, deployLogger: DeployLogger): RecipeTasksNode = {
+    def resolveTree(recipeName: String, stack: Stack, deployReporter: DeployReporter): RecipeTasksNode = {
       val recipe = project.recipes.getOrElse(recipeName, sys.error(s"Recipe '$recipeName' doesn't exist in your deploy.json file"))
-      val recipeTasks = resolveRecipe(recipe, stack, deployLogger)
-      val children = recipe.dependsOn.map(resolveTree(_, stack, deployLogger: DeployLogger))
+      val recipeTasks = resolveRecipe(recipe, stack, deployReporter)
+      val children = recipe.dependsOn.map(resolveTree(_, stack, deployReporter: DeployReporter))
       RecipeTasksNode(recipeTasks, children)
     }
 
-    def resolveRecipe(recipe: Recipe, stack: Stack, deployLogger: DeployLogger): RecipeTasks = {
-      val tasksToRunBeforeApp = recipe.actionsBeforeApp.toList flatMap { _.resolve(resourceLookup, parameters, stack, deployLogger) }
+    def resolveRecipe(recipe: Recipe, stack: Stack, deployReporter: DeployReporter): RecipeTasks = {
+      val tasksToRunBeforeApp = recipe.actionsBeforeApp.toList flatMap { _.resolve(resourceLookup, parameters, stack, deployReporter) }
 
       val perHostTasks = {
         for {
           action <- recipe.actionsPerHost
-          tasks <- action.resolve(resourceLookup, parameters, stack, deployLogger)
+          tasks <- action.resolve(resourceLookup, parameters, stack, deployReporter)
         } yield {
           tasks
         }
@@ -60,7 +60,7 @@ object Resolver {
     for {
       stack <- stacks.toList
       tasks <- {
-        val resolvedTree = resolveTree(parameters.recipe.name, stack, deployLogger)
+        val resolvedTree = resolveTree(parameters.recipe.name, stack, deployReporter)
         val filteredTree = resolvedTree.disable(rt => !rt.recipe.actionsPerHost.isEmpty && rt.hostTasks.isEmpty)
         filteredTree.toList.distinct
       }

--- a/magenta-lib/src/main/scala/magenta/Resolver.scala
+++ b/magenta-lib/src/main/scala/magenta/Resolver.scala
@@ -21,25 +21,25 @@ case class RecipeTasksNode(recipeTasks: RecipeTasks, children: List[RecipeTasksN
 
 object Resolver {
 
-  def resolve( project: Project, resourceLookup: Lookup, parameters: DeployParameters): List[Task] =
-    resolveDetail(project, resourceLookup, parameters).flatMap(_.tasks)
+  def resolve( project: Project, resourceLookup: Lookup, parameters: DeployParameters, deployLogger: DeployLogger): List[Task] =
+    resolveDetail(project, resourceLookup, parameters, deployLogger).flatMap(_.tasks)
 
-  def resolveDetail( project: Project, resourceLookup: Lookup, parameters: DeployParameters): List[RecipeTasks] = {
+  def resolveDetail( project: Project, resourceLookup: Lookup, parameters: DeployParameters, deployLogger: DeployLogger): List[RecipeTasks] = {
 
-    def resolveTree(recipeName: String, stack: Stack): RecipeTasksNode = {
+    def resolveTree(recipeName: String, stack: Stack, deployLogger: DeployLogger): RecipeTasksNode = {
       val recipe = project.recipes.getOrElse(recipeName, sys.error(s"Recipe '$recipeName' doesn't exist in your deploy.json file"))
-      val recipeTasks = resolveRecipe(recipe, stack)
-      val children = recipe.dependsOn.map(resolveTree(_, stack))
+      val recipeTasks = resolveRecipe(recipe, stack, deployLogger)
+      val children = recipe.dependsOn.map(resolveTree(_, stack, deployLogger: DeployLogger))
       RecipeTasksNode(recipeTasks, children)
     }
 
-    def resolveRecipe(recipe: Recipe, stack: Stack): RecipeTasks = {
-      val tasksToRunBeforeApp = recipe.actionsBeforeApp.toList flatMap { _.resolve(resourceLookup, parameters, stack) }
+    def resolveRecipe(recipe: Recipe, stack: Stack, deployLogger: DeployLogger): RecipeTasks = {
+      val tasksToRunBeforeApp = recipe.actionsBeforeApp.toList flatMap { _.resolve(resourceLookup, parameters, stack, deployLogger) }
 
       val perHostTasks = {
         for {
           action <- recipe.actionsPerHost
-          tasks <- action.resolve(resourceLookup, parameters, stack)
+          tasks <- action.resolve(resourceLookup, parameters, stack, deployLogger)
         } yield {
           tasks
         }
@@ -60,7 +60,7 @@ object Resolver {
     for {
       stack <- stacks.toList
       tasks <- {
-        val resolvedTree = resolveTree(parameters.recipe.name, stack)
+        val resolvedTree = resolveTree(parameters.recipe.name, stack, deployLogger)
         val filteredTree = resolvedTree.disable(rt => !rt.recipe.actionsPerHost.isEmpty && rt.hostTasks.isEmpty)
         filteredTree.toList.distinct
       }

--- a/magenta-lib/src/main/scala/magenta/artifact/S3Artifact.scala
+++ b/magenta-lib/src/main/scala/magenta/artifact/S3Artifact.scala
@@ -5,7 +5,7 @@ import java.io.File
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
 import magenta.tasks.CommandLine
-import magenta.{Build, DeployLogger}
+import magenta.{Build, DeployReporter}
 
 import scala.util.Try
 import scalax.file.ImplicitConversions.defaultPath2jfile
@@ -16,20 +16,20 @@ object S3Artifact {
 
   lazy val client = new AmazonS3Client()
 
-  def download(build: Build)(implicit bucket: Option[String], client: AmazonS3, logger: DeployLogger): File = {
+  def download(build: Build)(implicit bucket: Option[String], client: AmazonS3, reporter: DeployReporter): File = {
     val dir = Path.createTempDirectory(prefix="riffraff-", suffix="")
-    download(build, dir)(bucket, client, logger)
+    download(build, dir)(bucket, client, reporter)
     dir
   }
 
-  def download(build: Build, dir: File)(implicit bucket: Option[String], client: AmazonS3, logger: DeployLogger) {
-    logger.info("Downloading artifact")
+  def download(build: Build, dir: File)(implicit bucket: Option[String], client: AmazonS3, reporter: DeployReporter) {
+    reporter.info("Downloading artifact")
 
-    if (bucket.isEmpty) logger.fail("Don't know where to get artifact - no bucket set")
+    if (bucket.isEmpty) reporter.fail("Don't know where to get artifact - no bucket set")
 
     val path = s"${build.projectName}/${build.id}/artifacts.zip"
 
-    logger.verbose(s"Downloading from $path to ${dir.getAbsolutePath}...")
+    reporter.verbose(s"Downloading from $path to ${dir.getAbsolutePath}...")
 
     try {
       val artifactPath = Path.createTempFile(prefix = "riffraff-artifact-", suffix = ".zip")
@@ -38,20 +38,20 @@ object S3Artifact {
 
       artifactPath.write(blob.bytes)
 
-      CommandLine("unzip" :: "-q" :: "-d" :: dir.getAbsolutePath :: artifactPath.getAbsolutePath :: Nil).run(logger)
+      CommandLine("unzip" :: "-q" :: "-d" :: dir.getAbsolutePath :: artifactPath.getAbsolutePath :: Nil).run(reporter)
       artifactPath.delete()
-      logger.verbose("Extracted files")
+      reporter.verbose("Extracted files")
     } catch {
       case e: ScalaIOException => e.getCause match {
         case e: AmazonS3Exception if e.getStatusCode == 404 =>
-          logger.fail(s"404 downloading s3://${bucket.get}/$path\n - have you got the project name and build number correct?")
+          reporter.fail(s"404 downloading s3://${bucket.get}/$path\n - have you got the project name and build number correct?")
       }
     }
   }
 
   def withDownload[T](build: Build)(block: File => T)
-    (implicit bucket: Option[String], client: AmazonS3, logger: DeployLogger): T = {
-    val tempDir = Try { download(build)(bucket, client, logger) }
+    (implicit bucket: Option[String], client: AmazonS3, reporter: DeployReporter): T = {
+    val tempDir = Try { download(build)(bucket, client, reporter) }
     val result = tempDir.map(block)
     tempDir.map(dir => Path(dir).deleteRecursively(continueOnFailure = true))
     result.get

--- a/magenta-lib/src/main/scala/magenta/artifact/S3Artifact.scala
+++ b/magenta-lib/src/main/scala/magenta/artifact/S3Artifact.scala
@@ -1,40 +1,35 @@
 package magenta.artifact
 
-import java.io.{File, FileOutputStream}
-import java.net.URL
+import java.io.File
 
-import com.amazonaws.auth.{AWSCredentials, AWSCredentialsProvider, DefaultAWSCredentialsProviderChain, AWSCredentialsProviderChain}
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
 import com.amazonaws.services.s3.model.AmazonS3Exception
-import dispatch.classic.Request._
-import dispatch.classic.{StatusCode, _}
-import magenta.{Build, MessageBroker}
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
 import magenta.tasks.CommandLine
+import magenta.{Build, DeployLogger}
 
-import scala.io.Source
 import scala.util.Try
 import scalax.file.ImplicitConversions.defaultPath2jfile
 import scalax.file.Path
-import scalax.io.{ScalaIOException, Resource}
+import scalax.io.{Resource, ScalaIOException}
 
 object S3Artifact {
 
   lazy val client = new AmazonS3Client()
 
-  def download(build: Build)(implicit bucket: Option[String], client: AmazonS3): File = {
+  def download(build: Build)(implicit bucket: Option[String], client: AmazonS3, logger: DeployLogger): File = {
     val dir = Path.createTempDirectory(prefix="riffraff-", suffix="")
-    download(build, dir)(bucket, client)
+    download(build, dir)(bucket, client, logger)
     dir
   }
 
-  def download(build: Build, dir: File)(implicit bucket: Option[String], client: AmazonS3) {
-    MessageBroker.info("Downloading artifact")
+  def download(build: Build, dir: File)(implicit bucket: Option[String], client: AmazonS3, logger: DeployLogger) {
+    logger.info("Downloading artifact")
 
-    if (bucket.isEmpty) MessageBroker.fail("Don't know where to get artifact - no bucket set")
+    if (bucket.isEmpty) logger.fail("Don't know where to get artifact - no bucket set")
 
     val path = s"${build.projectName}/${build.id}/artifacts.zip"
 
-    MessageBroker.verbose(s"Downloading from $path to ${dir.getAbsolutePath}...")
+    logger.verbose(s"Downloading from $path to ${dir.getAbsolutePath}...")
 
     try {
       val artifactPath = Path.createTempFile(prefix = "riffraff-artifact-", suffix = ".zip")
@@ -43,19 +38,20 @@ object S3Artifact {
 
       artifactPath.write(blob.bytes)
 
-      CommandLine("unzip" :: "-q" :: "-d" :: dir.getAbsolutePath :: artifactPath.getAbsolutePath :: Nil).run()
+      CommandLine("unzip" :: "-q" :: "-d" :: dir.getAbsolutePath :: artifactPath.getAbsolutePath :: Nil).run(logger)
       artifactPath.delete()
-      MessageBroker.verbose("Extracted files")
+      logger.verbose("Extracted files")
     } catch {
       case e: ScalaIOException => e.getCause match {
         case e: AmazonS3Exception if e.getStatusCode == 404 =>
-          MessageBroker.fail(s"404 downloading s3://${bucket.get}/$path\n - have you got the project name and build number correct?")
+          logger.fail(s"404 downloading s3://${bucket.get}/$path\n - have you got the project name and build number correct?")
       }
     }
   }
 
-  def withDownload[T](build: Build)(block: File => T)(implicit bucket: Option[String], client: AmazonS3): T = {
-    val tempDir = Try { download(build)(bucket, client) }
+  def withDownload[T](build: Build)(block: File => T)
+    (implicit bucket: Option[String], client: AmazonS3, logger: DeployLogger): T = {
+    val tempDir = Try { download(build)(bucket, client, logger) }
     val result = tempDir.map(block)
     tempDir.map(dir => Path(dir).deleteRecursively(continueOnFailure = true))
     result.get

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
@@ -28,7 +28,7 @@ object AmiCloudFormationParameter extends DeploymentType {
   ).default("AMI")
 
   override def perAppActions = {
-    case "update" => pkg => (logger, lookup, parameters, stack) => {
+    case "update" => pkg => (reporter, lookup, parameters, stack) => {
       implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
 
       val stackName = stack.nameOption.filter(_ => prependStackToCloudFormationStackName(pkg))

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
@@ -28,7 +28,7 @@ object AmiCloudFormationParameter extends DeploymentType {
   ).default("AMI")
 
   override def perAppActions = {
-    case "update" => pkg => (lookup, parameters, stack) => {
+    case "update" => pkg => (logger, lookup, parameters, stack) => {
       implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
 
       val stackName = stack.nameOption.filter(_ => prependStackToCloudFormationStackName(pkg))

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -85,7 +85,7 @@ object AutoScaling  extends DeploymentType with S3AclParams {
   ).default(true)
 
   def perAppActions = {
-    case "deploy" => (pkg) => (logger, lookup, parameters, stack) => {
+    case "deploy" => (pkg) => (reporter, lookup, parameters, stack) => {
       implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
       List(
         CheckForStabilization(pkg, parameters.stage, stack),
@@ -101,7 +101,7 @@ object AutoScaling  extends DeploymentType with S3AclParams {
         ResumeAlarmNotifications(pkg, parameters.stage, stack)
       )
     }
-    case "uploadArtifacts" => (pkg) => (logger, lookup, parameters, stack) =>
+    case "uploadArtifacts" => (pkg) => (reporter, lookup, parameters, stack) =>
       implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
       val prefix = S3Upload.prefixGenerator(
         stack = if (prefixStack(pkg)) Some(stack) else None,

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -85,7 +85,7 @@ object AutoScaling  extends DeploymentType with S3AclParams {
   ).default(true)
 
   def perAppActions = {
-    case "deploy" => (pkg) => (lookup, parameters, stack) => {
+    case "deploy" => (pkg) => (logger, lookup, parameters, stack) => {
       implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
       List(
         CheckForStabilization(pkg, parameters.stage, stack),
@@ -101,7 +101,7 @@ object AutoScaling  extends DeploymentType with S3AclParams {
         ResumeAlarmNotifications(pkg, parameters.stage, stack)
       )
     }
-    case "uploadArtifacts" => (pkg) => (lookup, parameters, stack) =>
+    case "uploadArtifacts" => (pkg) => (logger, lookup, parameters, stack) =>
       implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
       val prefix = S3Upload.prefixGenerator(
         stack = if (prefixStack(pkg)) Some(stack) else None,

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -62,7 +62,7 @@ object CloudFormation extends DeploymentType {
   ).default("AMI")
 
   override def perAppActions = {
-    case "updateStack" => pkg => (lookup, parameters, stack) => {
+    case "updateStack" => pkg => (logger, lookup, parameters, stack) => {
       implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
 
       val stackName = stack.nameOption.filter(_ => prependStackToCloudFormationStackName(pkg))

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -62,7 +62,7 @@ object CloudFormation extends DeploymentType {
   ).default("AMI")
 
   override def perAppActions = {
-    case "updateStack" => pkg => (logger, lookup, parameters, stack) => {
+    case "updateStack" => pkg => (reporter, lookup, parameters, stack) => {
       implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
 
       val stackName = stack.nameOption.filter(_ => prependStackToCloudFormationStackName(pkg))

--- a/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
@@ -17,27 +17,27 @@ trait DeploymentType {
   val paramsList = mutable.Map.empty[String, Param[_]]
   lazy val params = paramsList.values.toSeq
   def perAppActions: PartialFunction[String, DeploymentPackage =>
-    (Lookup, DeployParameters, Stack) => List[Task]]
+    (DeployLogger, Lookup, DeployParameters, Stack) => List[Task]]
   def perHostActions: PartialFunction[String, DeploymentPackage =>
-    (Host, KeyRing) => List[Task]] = PartialFunction.empty
+    (DeployLogger, Host, KeyRing) => List[Task]] = PartialFunction.empty
 
   def mkAction(actionName: String)(pkg: DeploymentPackage): Action = {
     perHostActions.lift(actionName).map { action =>
       new PackageAction(pkg, actionName)  {
-        def resolve(resourceLookup: Lookup, parameters: DeployParameters, stack: Stack) = {
+        def resolve(resourceLookup: Lookup, parameters: DeployParameters, stack: Stack, deployLogger: DeployLogger) = {
           val hostsForApps = apps.toList.flatMap { app =>
             resourceLookup.hosts.get(pkg, app, parameters, stack)
           } filter { instance =>
             parameters.matchingHost(instance.name)
           }
-          hostsForApps flatMap (action(pkg)(_,
+          hostsForApps flatMap (action(pkg)(deployLogger, _,
             resourceLookup.keyRing(parameters.stage, pkg.apps.toSet, stack)))
         }
       }
     } orElse perAppActions.lift(actionName).map { action =>
       new PackageAction(pkg, actionName) {
-        def resolve(resourceLookup: Lookup, parameters: DeployParameters, stack: Stack) =
-          action(pkg)(resourceLookup, parameters, stack)
+        def resolve(resourceLookup: Lookup, parameters: DeployParameters, stack: Stack, deployLogger: DeployLogger) =
+          action(pkg)(deployLogger, resourceLookup, parameters, stack)
       }
     } getOrElse sys.error(s"Action $actionName is not supported on package ${pkg.name} of type $name")
   }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Django.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Django.scala
@@ -35,7 +35,7 @@ object Django extends DeploymentType {
     "The prefix of the deploy artifact, used to find directories to cleanup").defaultFromPackage( _.name )
 
   override def perHostActions = {
-    case "deploy" => pkg => (logger, host, keyRing) => {
+    case "deploy" => pkg => (reporter, host, keyRing) => {
       implicit val key = keyRing
       val destDir = "/django-apps/"
       // During preview the pkg.srcDir is not available, so we have to be a bit funky with options

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Django.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Django.scala
@@ -35,7 +35,7 @@ object Django extends DeploymentType {
     "The prefix of the deploy artifact, used to find directories to cleanup").defaultFromPackage( _.name )
 
   override def perHostActions = {
-    case "deploy" => pkg => (host, keyRing) => {
+    case "deploy" => pkg => (logger, host, keyRing) => {
       implicit val key = keyRing
       val destDir = "/django-apps/"
       // During preview the pkg.srcDir is not available, so we have to be a bit funky with options

--- a/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
@@ -18,7 +18,7 @@ object ElasticSearch extends DeploymentType with S3AclParams {
   ).default(15 * 60)
 
   def perAppActions = {
-    case "deploy" => (pkg) => (lookup, parameters, stack) => {
+    case "deploy" => (pkg) => (logger, lookup, parameters, stack) => {
       implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
       List(
         CheckGroupSize(pkg, parameters.stage, stack),
@@ -31,7 +31,7 @@ object ElasticSearch extends DeploymentType with S3AclParams {
         ResumeAlarmNotifications(pkg, parameters.stage, stack)
       )
     }
-    case "uploadArtifacts" => (pkg) => (lookup, parameters, stack) =>
+    case "uploadArtifacts" => (pkg) => (logger, lookup, parameters, stack) =>
       implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
       val prefix: String = S3Upload.prefixGenerator(stack, parameters.stage, pkg.name)
       List(

--- a/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
@@ -18,7 +18,7 @@ object ElasticSearch extends DeploymentType with S3AclParams {
   ).default(15 * 60)
 
   def perAppActions = {
-    case "deploy" => (pkg) => (logger, lookup, parameters, stack) => {
+    case "deploy" => (pkg) => (reporter, lookup, parameters, stack) => {
       implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
       List(
         CheckGroupSize(pkg, parameters.stage, stack),
@@ -31,7 +31,7 @@ object ElasticSearch extends DeploymentType with S3AclParams {
         ResumeAlarmNotifications(pkg, parameters.stage, stack)
       )
     }
-    case "uploadArtifacts" => (pkg) => (logger, lookup, parameters, stack) =>
+    case "uploadArtifacts" => (pkg) => (reporter, lookup, parameters, stack) =>
       implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
       val prefix: String = S3Upload.prefixGenerator(stack, parameters.stage, pkg.name)
       List(

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Fastly.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Fastly.scala
@@ -1,6 +1,6 @@
 package magenta.deployment_type
 
-import magenta.MessageBroker
+import magenta.DeployLogger$
 import magenta.tasks.UpdateFastlyConfig
 
 object Fastly  extends DeploymentType {
@@ -11,9 +11,9 @@ object Fastly  extends DeploymentType {
     """.stripMargin
 
   def perAppActions = {
-    case "deploy" => pkg => (lookup, parameters, stack) => {
+    case "deploy" => pkg => (logger, lookup, parameters, stack) => {
       implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
-      MessageBroker.verbose(s"Keyring is $keyRing")
+      logger.verbose(s"Keyring is $keyRing")
       List(UpdateFastlyConfig(pkg))
     }
   }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Fastly.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Fastly.scala
@@ -1,6 +1,5 @@
 package magenta.deployment_type
 
-import magenta.DeployLogger$
 import magenta.tasks.UpdateFastlyConfig
 
 object Fastly  extends DeploymentType {
@@ -11,9 +10,9 @@ object Fastly  extends DeploymentType {
     """.stripMargin
 
   def perAppActions = {
-    case "deploy" => pkg => (logger, lookup, parameters, stack) => {
+    case "deploy" => pkg => (reporter, lookup, parameters, stack) => {
       implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
-      logger.verbose(s"Keyring is $keyRing")
+      reporter.verbose(s"Keyring is $keyRing")
       List(UpdateFastlyConfig(pkg))
     }
   }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/FileCopy.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/FileCopy.scala
@@ -10,7 +10,7 @@ object FileCopy extends DeploymentType {
     """.stripMargin
 
   override def perHostActions = {
-    case "deploy" => pkg => (host, keyRing) => {
+    case "deploy" => pkg => (logger, host, keyRing) => {
       implicit val key = keyRing
       List(CopyFile(host, pkg.srcDir.getPath, "/"))
     }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/FileCopy.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/FileCopy.scala
@@ -10,7 +10,7 @@ object FileCopy extends DeploymentType {
     """.stripMargin
 
   override def perHostActions = {
-    case "deploy" => pkg => (logger, host, keyRing) => {
+    case "deploy" => pkg => (reporter, host, keyRing) => {
       implicit val key = keyRing
       List(CopyFile(host, pkg.srcDir.getPath, "/"))
     }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -2,7 +2,7 @@ package magenta.deployment_type
 
 import java.io.File
 
-import magenta.{DeployLogger, DeployParameters, DeploymentPackage, KeyRing, Stack, Stage}
+import magenta.{DeployReporter, DeployParameters, DeploymentPackage, KeyRing, Stack, Stage}
 import magenta.tasks.{S3Upload, UpdateLambda, UpdateS3Lambda}
 
 object Lambda extends DeploymentType  {
@@ -60,17 +60,17 @@ object Lambda extends DeploymentType  {
       """.stripMargin
   )
 
-  def lambdaToProcess(pkg: DeploymentPackage, stage: String)(logger: DeployLogger): List[LambdaFunction] = {
+  def lambdaToProcess(pkg: DeploymentPackage, stage: String)(reporter: DeployReporter): List[LambdaFunction] = {
     val bucketOption = bucketParam.get(pkg)
     (functionNamesParam.get(pkg), functionsParam.get(pkg)) match {
       case (Some(functionNames), None) =>
         functionNames.map(name => LambdaFunction(s"$name$stage", fileNameParam(pkg), bucketOption))
       case (None, Some(functionsMap)) =>
-        val functionDefinition = functionsMap.getOrElse(stage, logger.fail(s"Function not defined for stage $stage"))
-        val functionName = functionDefinition.getOrElse("name", logger.fail(s"Function name not defined for stage $stage"))
+        val functionDefinition = functionsMap.getOrElse(stage, reporter.fail(s"Function not defined for stage $stage"))
+        val functionName = functionDefinition.getOrElse("name", reporter.fail(s"Function name not defined for stage $stage"))
         val fileName = functionDefinition.getOrElse("filename", "lambda.zip")
         List(LambdaFunction(functionName, fileName, bucketOption))
-      case _ => logger.fail("Must specify one of 'functions' or 'functionNames' parameters")
+      case _ => reporter.fail("Must specify one of 'functions' or 'functionNames' parameters")
     }
   }
 

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -2,7 +2,7 @@ package magenta.deployment_type
 
 import java.io.File
 
-import magenta.{DeployParameters, DeploymentPackage, KeyRing, MessageBroker, Stack, Stage}
+import magenta.{DeployLogger, DeployParameters, DeploymentPackage, KeyRing, Stack, Stage}
 import magenta.tasks.{S3Upload, UpdateLambda, UpdateS3Lambda}
 
 object Lambda extends DeploymentType  {
@@ -60,17 +60,17 @@ object Lambda extends DeploymentType  {
       """.stripMargin
   )
 
-  def lambdaToProcess(pkg: DeploymentPackage, stage: String): List[LambdaFunction] = {
+  def lambdaToProcess(pkg: DeploymentPackage, stage: String)(logger: DeployLogger): List[LambdaFunction] = {
     val bucketOption = bucketParam.get(pkg)
     (functionNamesParam.get(pkg), functionsParam.get(pkg)) match {
       case (Some(functionNames), None) =>
         functionNames.map(name => LambdaFunction(s"$name$stage", fileNameParam(pkg), bucketOption))
       case (None, Some(functionsMap)) =>
-        val functionDefinition = functionsMap.getOrElse(stage, MessageBroker.fail(s"Function not defined for stage $stage"))
-        val functionName = functionDefinition.getOrElse("name", MessageBroker.fail(s"Function name not defined for stage $stage"))
+        val functionDefinition = functionsMap.getOrElse(stage, logger.fail(s"Function not defined for stage $stage"))
+        val functionName = functionDefinition.getOrElse("name", logger.fail(s"Function name not defined for stage $stage"))
         val fileName = functionDefinition.getOrElse("filename", "lambda.zip")
         List(LambdaFunction(functionName, fileName, bucketOption))
-      case _ => MessageBroker.fail("Must specify one of 'functions' or 'functionNames' parameters")
+      case _ => logger.fail("Must specify one of 'functions' or 'functionNames' parameters")
     }
   }
 
@@ -79,9 +79,9 @@ object Lambda extends DeploymentType  {
   }
 
   def perAppActions = {
-    case "uploadLambda" => (pkg) => (resourceLookup, parameters, stack) => {
+    case "uploadLambda" => (pkg) => (deployLogger, resourceLookup, parameters, stack) => {
       implicit val keyRing = resourceLookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
-      lambdaToProcess(pkg, parameters.stage.name).flatMap {
+      lambdaToProcess(pkg, parameters.stage.name)(deployLogger).flatMap {
         case LambdaFunctionFromZip(_,_) => None
 
         case LambdaFunctionFromS3(functionName, fileName, s3Bucket) =>
@@ -92,9 +92,9 @@ object Lambda extends DeploymentType  {
           ))
       }.distinct
     }
-    case "updateLambda" => (pkg) => (resourceLookup, parameters, stack) => {
+    case "updateLambda" => (pkg) => (deployLogger, resourceLookup, parameters, stack) => {
       implicit val keyRing = resourceLookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
-      lambdaToProcess(pkg, parameters.stage.name).flatMap {
+      lambdaToProcess(pkg, parameters.stage.name)(deployLogger).flatMap {
         case LambdaFunctionFromZip(functionName, fileName) =>
           Some(UpdateLambda(new File(s"${pkg.srcDir.getPath}/$fileName"), functionName))
 

--- a/magenta-lib/src/main/scala/magenta/deployment_type/NativePackagerWebapp.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/NativePackagerWebapp.scala
@@ -45,7 +45,7 @@ object NativePackagerWebapp extends WebApp {
   ).defaultFromPackage{ pkg => s"${applicationName(pkg)}.tar.gz" }
 
   override def perHostActions = {
-    case "deploy" => pkg => (logger, host, keyRing) => {
+    case "deploy" => pkg => (reporter, host, keyRing) => {
       implicit val key = keyRing
       val applicationRoot = s"/$containerName-apps/${servicename(pkg)}"
       val remoteTarballLocation = s"$applicationRoot/readyToDeploy.tar.gz"

--- a/magenta-lib/src/main/scala/magenta/deployment_type/NativePackagerWebapp.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/NativePackagerWebapp.scala
@@ -45,7 +45,7 @@ object NativePackagerWebapp extends WebApp {
   ).defaultFromPackage{ pkg => s"${applicationName(pkg)}.tar.gz" }
 
   override def perHostActions = {
-    case "deploy" => pkg => (host, keyRing) => {
+    case "deploy" => pkg => (logger, host, keyRing) => {
       implicit val key = keyRing
       val applicationRoot = s"/$containerName-apps/${servicename(pkg)}"
       val remoteTarballLocation = s"$applicationRoot/readyToDeploy.tar.gz"

--- a/magenta-lib/src/main/scala/magenta/deployment_type/RPM.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/RPM.scala
@@ -46,7 +46,7 @@ object RPM extends DeploymentType {
   }
 
   override def perHostActions = {
-    case "deploy" => pkg => (logger, host, keyRing) => {
+    case "deploy" => pkg => (reporter, host, keyRing) => {
       implicit val key = keyRing
       // During preview the pkg.srcDir is not available, so we have to be a bit funky with options
       lazy val rpmFilePath = Option(pkg.srcDir.listFiles()).flatMap(_.headOption).map(_.toString).getOrElse("UnknownDuringPreview")

--- a/magenta-lib/src/main/scala/magenta/deployment_type/RPM.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/RPM.scala
@@ -46,7 +46,7 @@ object RPM extends DeploymentType {
   }
 
   override def perHostActions = {
-    case "deploy" => pkg => (host, keyRing) => {
+    case "deploy" => pkg => (logger, host, keyRing) => {
       implicit val key = keyRing
       // During preview the pkg.srcDir is not available, so we have to be a bit funky with options
       lazy val rpmFilePath = Option(pkg.srcDir.listFiles()).flatMap(_.headOption).map(_.toString).getOrElse("UnknownDuringPreview")

--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
@@ -98,7 +98,7 @@ object S3 extends DeploymentType with S3AclParams {
   }
 
   def perAppActions = {
-    case "uploadStaticFiles" => (pkg) => (logger, resourceLookup, parameters, stack) => {
+    case "uploadStaticFiles" => (pkg) => (reporter, resourceLookup, parameters, stack) => {
       implicit val keyRing = resourceLookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
       assert(bucket.get(pkg).isDefined != bucketResource.get(pkg).isDefined, "One, and only one, of bucket or bucketResource must be specified")
       val bucketName = bucket.get(pkg) getOrElse {

--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
@@ -98,7 +98,7 @@ object S3 extends DeploymentType with S3AclParams {
   }
 
   def perAppActions = {
-    case "uploadStaticFiles" => (pkg) => (resourceLookup, parameters, stack) => {
+    case "uploadStaticFiles" => (pkg) => (logger, resourceLookup, parameters, stack) => {
       implicit val keyRing = resourceLookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
       assert(bucket.get(pkg).isDefined != bucketResource.get(pkg).isDefined, "One, and only one, of bucket or bucketResource must be specified")
       val bucketName = bucket.get(pkg) getOrElse {

--- a/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
@@ -34,7 +34,7 @@ object SelfDeploy extends DeploymentType with S3AclParams {
   ).default("/management/switchboard")
 
   def perAppActions = {
-    case "uploadArtifacts" => (pkg) => (logger, lookup, parameters, stack) =>
+    case "uploadArtifacts" => (pkg) => (reporter, lookup, parameters, stack) =>
       implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
       val prefix = S3Upload.prefixGenerator(stack, parameters.stage, pkg.name)
       List(
@@ -46,7 +46,7 @@ object SelfDeploy extends DeploymentType with S3AclParams {
   }
 
   override def perHostActions = {
-    case "selfDeploy" => pkg => (logger, host, keyRing) => {
+    case "selfDeploy" => pkg => (reporter, host, keyRing) => {
       implicit val key = keyRing
       ChangeSwitch(host, managementProtocol(pkg), managementPort(pkg), switchboardPath(pkg),
         "shutdown-when-inactive", desiredState=true) :: Nil

--- a/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
@@ -34,7 +34,7 @@ object SelfDeploy extends DeploymentType with S3AclParams {
   ).default("/management/switchboard")
 
   def perAppActions = {
-    case "uploadArtifacts" => (pkg) => (lookup, parameters, stack) =>
+    case "uploadArtifacts" => (pkg) => (logger, lookup, parameters, stack) =>
       implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
       val prefix = S3Upload.prefixGenerator(stack, parameters.stage, pkg.name)
       List(
@@ -46,7 +46,7 @@ object SelfDeploy extends DeploymentType with S3AclParams {
   }
 
   override def perHostActions = {
-    case "selfDeploy" => pkg => (host, keyRing) => {
+    case "selfDeploy" => pkg => (logger, host, keyRing) => {
       implicit val key = keyRing
       ChangeSwitch(host, managementProtocol(pkg), managementPort(pkg), switchboardPath(pkg),
         "shutdown-when-inactive", desiredState=true) :: Nil

--- a/magenta-lib/src/main/scala/magenta/deployment_type/WebApp.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/WebApp.scala
@@ -89,7 +89,7 @@ trait WebApp extends DeploymentType with S3AclParams {
   ).default("/management/switchboard")
 
   override def perHostActions = {
-    case "deploy" => pkg => (host, keyRing) => {
+    case "deploy" => pkg => (logger, host, keyRing) => {
       implicit val key = keyRing
 
       BlockFirewall(host as user(pkg)) ::
@@ -100,7 +100,7 @@ trait WebApp extends DeploymentType with S3AclParams {
       UnblockFirewall(host as user(pkg)) ::
       Nil
     }
-    case "restart" => pkg => (host, keyRing) => {
+    case "restart" => pkg => (logger, host, keyRing) => {
       implicit val key = keyRing
       List(
         BlockFirewall(host as user(pkg)),
@@ -110,7 +110,7 @@ trait WebApp extends DeploymentType with S3AclParams {
         UnblockFirewall(host as user(pkg))
       )
     }
-    case "selfDeploy" => pkg => (host, keyRing) => {
+    case "selfDeploy" => pkg => (logger, host, keyRing) => {
       implicit val key = keyRing
       rootCopies(pkg, host) :::
         ChangeSwitch(host, managementProtocol(pkg), managementPort(pkg), switchboardPath(pkg),
@@ -120,7 +120,7 @@ trait WebApp extends DeploymentType with S3AclParams {
   }
 
   def perAppActions = {
-    case "uploadArtifacts" => pkg => (lookup, parameters, stack) =>
+    case "uploadArtifacts" => pkg => (logger, lookup, parameters, stack) =>
       implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
       val prefix = S3Upload.prefixGenerator(stack, parameters.stage, pkg.name)
       List(

--- a/magenta-lib/src/main/scala/magenta/deployment_type/WebApp.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/WebApp.scala
@@ -89,7 +89,7 @@ trait WebApp extends DeploymentType with S3AclParams {
   ).default("/management/switchboard")
 
   override def perHostActions = {
-    case "deploy" => pkg => (logger, host, keyRing) => {
+    case "deploy" => pkg => (reporter, host, keyRing) => {
       implicit val key = keyRing
 
       BlockFirewall(host as user(pkg)) ::
@@ -100,7 +100,7 @@ trait WebApp extends DeploymentType with S3AclParams {
       UnblockFirewall(host as user(pkg)) ::
       Nil
     }
-    case "restart" => pkg => (logger, host, keyRing) => {
+    case "restart" => pkg => (reporter, host, keyRing) => {
       implicit val key = keyRing
       List(
         BlockFirewall(host as user(pkg)),
@@ -110,7 +110,7 @@ trait WebApp extends DeploymentType with S3AclParams {
         UnblockFirewall(host as user(pkg))
       )
     }
-    case "selfDeploy" => pkg => (logger, host, keyRing) => {
+    case "selfDeploy" => pkg => (reporter, host, keyRing) => {
       implicit val key = keyRing
       rootCopies(pkg, host) :::
         ChangeSwitch(host, managementProtocol(pkg), managementPort(pkg), switchboardPath(pkg),
@@ -120,7 +120,7 @@ trait WebApp extends DeploymentType with S3AclParams {
   }
 
   def perAppActions = {
-    case "uploadArtifacts" => pkg => (logger, lookup, parameters, stack) =>
+    case "uploadArtifacts" => pkg => (reporter, lookup, parameters, stack) =>
       implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
       val prefix = S3Upload.prefixGenerator(stack, parameters.stage, pkg.name)
       List(

--- a/magenta-lib/src/main/scala/magenta/json/JsonInputFile.scala
+++ b/magenta-lib/src/main/scala/magenta/json/JsonInputFile.scala
@@ -38,12 +38,12 @@ case class JsonRecipe(
 object JsonReader {
   private implicit val formats = DefaultFormats
 
-  def parse(f: File)(implicit logger: DeployLogger): Project = {
+  def parse(f: File)(implicit reporter: DeployReporter): Project = {
     try {
       parse(Source.fromFile(f).mkString, f.getAbsoluteFile.getParentFile)
     } catch {
       case e:FileNotFoundException =>
-        logger.fail("Artifact cannot be deployed: deploy.json file doesn't exist")
+        reporter.fail("Artifact cannot be deployed: deploy.json file doesn't exist")
     }
   }
 

--- a/magenta-lib/src/main/scala/magenta/json/JsonInputFile.scala
+++ b/magenta-lib/src/main/scala/magenta/json/JsonInputFile.scala
@@ -4,7 +4,7 @@ package json
 import org.json4s._
 import org.json4s.native.JsonMethods._
 import org.json4s.native.JsonParser
-import io.Source
+import scala.io.Source
 import java.io.{FileNotFoundException, File}
 
 
@@ -38,12 +38,12 @@ case class JsonRecipe(
 object JsonReader {
   private implicit val formats = DefaultFormats
 
-  def parse(f: File): Project = {
+  def parse(f: File)(implicit logger: DeployLogger): Project = {
     try {
       parse(Source.fromFile(f).mkString, f.getAbsoluteFile.getParentFile)
     } catch {
       case e:FileNotFoundException =>
-        MessageBroker.fail("Artifact cannot be deployed: deploy.json file doesn't exist")
+        logger.fail("Artifact cannot be deployed: deploy.json file doesn't exist")
     }
   }
 

--- a/magenta-lib/src/main/scala/magenta/logging.scala
+++ b/magenta-lib/src/main/scala/magenta/logging.scala
@@ -59,9 +59,10 @@ object DeployLogger {
 
   // get the genesis context that will be the root of all others
   def rootLoggerFor(uuid: UUID, parameters: DeployParameters, publishMessages: Boolean = true): DeployLogger = {
-    val initialContext = DeployLogger(Nil, MessageContext(uuid, parameters, None), publishMessages = publishMessages)
-    pushContext(Deploy(parameters), initialContext)
+    DeployLogger(Nil, MessageContext(uuid, parameters, None), publishMessages = publishMessages)
   }
+
+  def startDeployContext(logger: DeployLogger) = pushContext(Deploy(logger.messageContext.parameters), logger)
 
   // create a new context with the given message at the top of the stack - sends the StartContext event
   def pushContext(message: Message, currentContext: DeployLogger): DeployLogger = {

--- a/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
@@ -8,10 +8,10 @@ import magenta.KeyRing
 import magenta.Stage
 
 case class CheckGroupSize(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
-  def execute(asg: AutoScalingGroup, stopFlag: => Boolean) {
+  override def execute(asg: AutoScalingGroup, logger: DeployLogger, stopFlag: => Boolean) {
     val doubleCapacity = asg.getDesiredCapacity * 2
     if (asg.getMaxSize < doubleCapacity || doubleCapacity == 0) {
-      MessageBroker.fail(
+      logger.fail(
         s"Autoscaling group does not have the capacity to deploy current max = ${asg.getMaxSize} - desired max = $doubleCapacity"
       )
     }
@@ -21,7 +21,7 @@ case class CheckGroupSize(pkg: DeploymentPackage, stage: Stage, stack: Stack)(im
 }
 
 case class TagCurrentInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
-  def execute(asg: AutoScalingGroup, stopFlag: => Boolean) {
+  override def execute(asg: AutoScalingGroup, logger: DeployLogger, stopFlag: => Boolean) {
     EC2.setTag(asg.getInstances.toList, "Magenta", "Terminate")(keyRing)
   }
 
@@ -30,7 +30,7 @@ case class TagCurrentInstancesWithTerminationTag(pkg: DeploymentPackage, stage: 
 
 case class DoubleSize(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
 
-  def execute(asg: AutoScalingGroup, stopFlag: => Boolean) {
+  override def execute(asg: AutoScalingGroup, logger: DeployLogger, stopFlag: => Boolean) {
     desiredCapacity(asg.getAutoScalingGroupName, asg.getDesiredCapacity * 2)(keyRing)
   }
 
@@ -39,7 +39,7 @@ case class DoubleSize(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implic
 
 sealed abstract class Pause(durationMillis: Long)(implicit val keyRing: KeyRing) extends Task {
 
-  def execute(stopFlag: => Boolean) {
+  override def execute(logger: DeployLogger, stopFlag: => Boolean) {
     Thread.sleep(durationMillis)
   }
 
@@ -55,7 +55,7 @@ case class WarmupGrace(durationMillis: Long)(implicit keyRing: KeyRing) extends 
 }
 
 case class CheckForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
-  def execute(asg: AutoScalingGroup, stopFlag: => Boolean) {
+  override def execute(asg: AutoScalingGroup, logger: DeployLogger, stopFlag: => Boolean) {
     isStabilized(asg)
   }
   lazy val description: String = "Check the desired number of hosts in both the ASG and ELB are up and that the number of hosts match"
@@ -64,13 +64,13 @@ case class CheckForStabilization(pkg: DeploymentPackage, stage: Stage, stack: St
 case class WaitForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Stack, duration: Long)(implicit val keyRing: KeyRing) extends ASGTask
     with SlowRepeatedPollingCheck {
 
-  def execute(asg: AutoScalingGroup, stopFlag: => Boolean) {
-    check(stopFlag) {
+  override def execute(asg: AutoScalingGroup, logger: DeployLogger, stopFlag: => Boolean) {
+    check(logger, stopFlag) {
       try {
         isStabilized(refresh(asg))
       } catch {
         case e: AmazonServiceException if isRateExceeded(e) => {
-          MessageBroker.info(e.getMessage)
+          logger.info(e.getMessage)
           false
         }
       }
@@ -84,7 +84,7 @@ case class WaitForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Sta
 }
 
 case class CullInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
-  def execute(asg: AutoScalingGroup, stopFlag: => Boolean) {
+  override def execute(asg: AutoScalingGroup, logger: DeployLogger, stopFlag: => Boolean) {
     val instancesToKill = asg.getInstances.filter(instance => EC2.hasTag(instance, "Magenta", "Terminate")(keyRing))
     val orderedInstancesToKill = instancesToKill.transposeBy(_.getAvailabilityZone)
     orderedInstancesToKill.foreach(instance => cull(asg, instance)(keyRing))
@@ -95,7 +95,7 @@ case class CullInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage,
 
 case class SuspendAlarmNotifications(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
 
-  def execute(asg: AutoScalingGroup, stopFlag: => Boolean) {
+  override def execute(asg: AutoScalingGroup, logger: DeployLogger, stopFlag: => Boolean) {
     suspendAlarmNotifications(asg.getAutoScalingGroupName)(keyRing)
   }
 
@@ -104,7 +104,7 @@ case class SuspendAlarmNotifications(pkg: DeploymentPackage, stage: Stage, stack
 
 case class ResumeAlarmNotifications(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
 
-  def execute(asg: AutoScalingGroup, stopFlag: => Boolean) {
+  override def execute(asg: AutoScalingGroup, logger: DeployLogger, stopFlag: => Boolean) {
     resumeAlarmNotifications(asg.getAutoScalingGroupName)(keyRing)
   }
 
@@ -116,13 +116,14 @@ trait ASGTask extends Task with ASG {
   def stage: Stage
   def stack: Stack
 
-  def execute(asg: AutoScalingGroup, stopFlag: => Boolean)
+  def execute(asg: AutoScalingGroup, logger: DeployLogger, stopFlag: => Boolean)
 
-  override def execute(stopFlag: => Boolean) {
+  override def execute(logger: DeployLogger, stopFlag: => Boolean) {
     implicit val key = keyRing
+    implicit val dl = logger
 
     val group = groupForAppAndStage(pkg, stage, stack)
-    execute(group, stopFlag)
+    execute(group, logger, stopFlag)
   }
 
   def verbose = description

--- a/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
@@ -8,10 +8,10 @@ import magenta.KeyRing
 import magenta.Stage
 
 case class CheckGroupSize(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
-  override def execute(asg: AutoScalingGroup, logger: DeployLogger, stopFlag: => Boolean) {
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean) {
     val doubleCapacity = asg.getDesiredCapacity * 2
     if (asg.getMaxSize < doubleCapacity || doubleCapacity == 0) {
-      logger.fail(
+      reporter.fail(
         s"Autoscaling group does not have the capacity to deploy current max = ${asg.getMaxSize} - desired max = $doubleCapacity"
       )
     }
@@ -21,7 +21,7 @@ case class CheckGroupSize(pkg: DeploymentPackage, stage: Stage, stack: Stack)(im
 }
 
 case class TagCurrentInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
-  override def execute(asg: AutoScalingGroup, logger: DeployLogger, stopFlag: => Boolean) {
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean) {
     EC2.setTag(asg.getInstances.toList, "Magenta", "Terminate")(keyRing)
   }
 
@@ -30,7 +30,7 @@ case class TagCurrentInstancesWithTerminationTag(pkg: DeploymentPackage, stage: 
 
 case class DoubleSize(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
 
-  override def execute(asg: AutoScalingGroup, logger: DeployLogger, stopFlag: => Boolean) {
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean) {
     desiredCapacity(asg.getAutoScalingGroupName, asg.getDesiredCapacity * 2)(keyRing)
   }
 
@@ -39,7 +39,7 @@ case class DoubleSize(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implic
 
 sealed abstract class Pause(durationMillis: Long)(implicit val keyRing: KeyRing) extends Task {
 
-  override def execute(logger: DeployLogger, stopFlag: => Boolean) {
+  override def execute(reporter: DeployReporter, stopFlag: => Boolean) {
     Thread.sleep(durationMillis)
   }
 
@@ -55,7 +55,7 @@ case class WarmupGrace(durationMillis: Long)(implicit keyRing: KeyRing) extends 
 }
 
 case class CheckForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
-  override def execute(asg: AutoScalingGroup, logger: DeployLogger, stopFlag: => Boolean) {
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean) {
     isStabilized(asg)
   }
   lazy val description: String = "Check the desired number of hosts in both the ASG and ELB are up and that the number of hosts match"
@@ -64,13 +64,13 @@ case class CheckForStabilization(pkg: DeploymentPackage, stage: Stage, stack: St
 case class WaitForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Stack, duration: Long)(implicit val keyRing: KeyRing) extends ASGTask
     with SlowRepeatedPollingCheck {
 
-  override def execute(asg: AutoScalingGroup, logger: DeployLogger, stopFlag: => Boolean) {
-    check(logger, stopFlag) {
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean) {
+    check(reporter, stopFlag) {
       try {
         isStabilized(refresh(asg))
       } catch {
         case e: AmazonServiceException if isRateExceeded(e) => {
-          logger.info(e.getMessage)
+          reporter.info(e.getMessage)
           false
         }
       }
@@ -84,7 +84,7 @@ case class WaitForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Sta
 }
 
 case class CullInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
-  override def execute(asg: AutoScalingGroup, logger: DeployLogger, stopFlag: => Boolean) {
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean) {
     val instancesToKill = asg.getInstances.filter(instance => EC2.hasTag(instance, "Magenta", "Terminate")(keyRing))
     val orderedInstancesToKill = instancesToKill.transposeBy(_.getAvailabilityZone)
     orderedInstancesToKill.foreach(instance => cull(asg, instance)(keyRing))
@@ -95,7 +95,7 @@ case class CullInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage,
 
 case class SuspendAlarmNotifications(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
 
-  override def execute(asg: AutoScalingGroup, logger: DeployLogger, stopFlag: => Boolean) {
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean) {
     suspendAlarmNotifications(asg.getAutoScalingGroupName)(keyRing)
   }
 
@@ -104,7 +104,7 @@ case class SuspendAlarmNotifications(pkg: DeploymentPackage, stage: Stage, stack
 
 case class ResumeAlarmNotifications(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
 
-  override def execute(asg: AutoScalingGroup, logger: DeployLogger, stopFlag: => Boolean) {
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean) {
     resumeAlarmNotifications(asg.getAutoScalingGroupName)(keyRing)
   }
 
@@ -116,14 +116,14 @@ trait ASGTask extends Task with ASG {
   def stage: Stage
   def stack: Stack
 
-  def execute(asg: AutoScalingGroup, logger: DeployLogger, stopFlag: => Boolean)
+  def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean)
 
-  override def execute(logger: DeployLogger, stopFlag: => Boolean) {
+  override def execute(reporter: DeployReporter, stopFlag: => Boolean) {
     implicit val key = keyRing
-    implicit val dl = logger
+    implicit val dl = reporter
 
     val group = groupForAppAndStage(pkg, stage, stack)
-    execute(group, logger, stopFlag)
+    execute(group, reporter, stopFlag)
   }
 
   def verbose = description

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -115,7 +115,8 @@ trait ASG extends AWS {
     new ResumeProcessesRequest().withAutoScalingGroupName(name).withScalingProcesses("AlarmNotification")
   )
 
-  def groupForAppAndStage(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit keyRing: KeyRing): AutoScalingGroup = {
+  def groupForAppAndStage(pkg: DeploymentPackage, stage: Stage, stack: Stack)
+    (implicit keyRing: KeyRing, logger: DeployLogger): AutoScalingGroup = {
     case class ASGMatch(app:App, matches:List[AutoScalingGroup])
 
     implicit def autoscalingGroup2tagAndApp(asg: AutoScalingGroup) = new {
@@ -150,19 +151,19 @@ trait ASG extends AWS {
 
     val appMatch:ASGMatch = appToMatchingGroups match {
       case Seq() =>
-        MessageBroker.fail(s"No autoscaling group found in ${stage.name} with tags matching package ${pkg.name}")
+        logger.fail(s"No autoscaling group found in ${stage.name} with tags matching package ${pkg.name}")
       case Seq(onlyMatch) => onlyMatch
       case firstMatch +: otherMatches =>
-        MessageBroker.info(s"More than one app matches an autoscaling group, the first in the list will be used")
+        logger.info(s"More than one app matches an autoscaling group, the first in the list will be used")
         firstMatch
     }
 
     appMatch match {
       case ASGMatch(_, List(singleGroup)) =>
-        MessageBroker.verbose(s"Using group ${singleGroup.getAutoScalingGroupName}")
+        logger.verbose(s"Using group ${singleGroup.getAutoScalingGroupName}")
         singleGroup
       case ASGMatch(app, groupList) =>
-        MessageBroker.fail(s"More than one autoscaling group match for $app in ${stage.name} (${groupList.map(_.getAutoScalingGroupName).mkString(", ")}). Failing fast since this may be non-deterministic.")
+        logger.fail(s"More than one autoscaling group match for $app in ${stage.name} (${groupList.map(_.getAutoScalingGroupName).mkString(", ")}). Failing fast since this may be non-deterministic.")
     }
   }
 }

--- a/magenta-lib/src/main/scala/magenta/tasks/CommandLine.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/CommandLine.scala
@@ -13,9 +13,9 @@ case class CommandLine(commandLine: List[String], successCodes: List[Int] = List
         filteredOut(line)
   }
 
-  def run(logger: DeployLogger) {
+  def run(reporter: DeployReporter) {
     import sys.process._
-    logger.infoContext(s"$$ $quoted") { infoContext =>
+    reporter.infoContext(s"$$ $quoted") { infoContext =>
       val returnValue = commandLine ! ProcessLogger(infoContext.commandOutput(_), suppressor(infoContext.commandError(_)))
       infoContext.verbose("return value " + returnValue)
       if (!successCodes.contains(returnValue)) {

--- a/magenta-lib/src/main/scala/magenta/tasks/CommandLine.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/CommandLine.scala
@@ -13,13 +13,13 @@ case class CommandLine(commandLine: List[String], successCodes: List[Int] = List
         filteredOut(line)
   }
 
-  def run() {
+  def run(logger: DeployLogger) {
     import sys.process._
-    MessageBroker.infoContext("$ " + quoted) {
-      val returnValue = commandLine ! ProcessLogger(MessageBroker.commandOutput(_), suppressor(MessageBroker.commandError(_)))
-      MessageBroker.verbose("return value " + returnValue)
+    logger.infoContext(s"$$ $quoted") { infoContext =>
+      val returnValue = commandLine ! ProcessLogger(infoContext.commandOutput(_), suppressor(infoContext.commandError(_)))
+      infoContext.verbose("return value " + returnValue)
       if (!successCodes.contains(returnValue)) {
-        MessageBroker.fail("Exit code %d from command: %s" format (returnValue, quoted))
+        infoContext.fail("Exit code %d from command: %s" format (returnValue, quoted))
       }
     }
   }

--- a/magenta-lib/src/main/scala/magenta/tasks/FastlyTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/FastlyTasks.scala
@@ -2,8 +2,9 @@ package magenta.tasks
 
 import java.util.concurrent.Executors
 
-import magenta.{DeployStoppedException, MessageBroker, KeyRing, DeploymentPackage}
+import magenta.{DeployLogger, DeployStoppedException, DeploymentPackage, KeyRing}
 import java.io.File
+
 import org.json4s._
 import org.json4s.native.JsonMethods._
 import com.gu.fastly.api.FastlyApiClient
@@ -21,20 +22,17 @@ case class UpdateFastlyConfig(pkg: DeploymentPackage)(implicit val keyRing: KeyR
   // No, I'm not happy about this, but it gets things working until we can make a larger change
   def block[T](f: => Future[T]) = Await.result(f, 1.minute)
 
-  override def execute(stopFlag: => Boolean) {
+  override def execute(logger: DeployLogger, stopFlag: => Boolean) {
+    FastlyApiClientProvider.get(keyRing).foreach { client =>
+      val activeVersionNumber = getActiveVersionNumber(client, logger, stopFlag)
+      val nextVersionNumber = clone(activeVersionNumber, client, logger, stopFlag)
 
-    FastlyApiClientProvider.get(keyRing).map {
-      client => {
-        val activeVersionNumber = getActiveVersionNumber(client, stopFlag)
-        val nextVersionNumber = clone(activeVersionNumber, client, stopFlag)
+      deleteAllVclFilesFrom(nextVersionNumber, client, logger, stopFlag)
 
-        deleteAllVclFilesFrom(nextVersionNumber, client, stopFlag)
+      uploadNewVclFilesTo(nextVersionNumber, pkg.srcDir, client, logger, stopFlag)
+      activateVersion(nextVersionNumber, client, logger, stopFlag)
 
-        uploadNewVclFilesTo(nextVersionNumber, pkg.srcDir, client, stopFlag)
-        activateVersion(nextVersionNumber, client, stopFlag)
-
-        MessageBroker.info(s"Fastly version $nextVersionNumber is now active")
-      }
+      logger.info(s"Fastly version $nextVersionNumber is now active")
     }
   }
 
@@ -42,42 +40,42 @@ case class UpdateFastlyConfig(pkg: DeploymentPackage)(implicit val keyRing: KeyR
   def stopOnFlag[T](stopFlag: => Boolean)(block: => T): T =
     if (!stopFlag) block else throw new DeployStoppedException("Deploy manually stopped during UpdateFastlyConfig")
 
-  private def getActiveVersionNumber(client: FastlyApiClient, stopFlag: => Boolean): Int = {
+  private def getActiveVersionNumber(client: FastlyApiClient, logger: DeployLogger, stopFlag: => Boolean): Int = {
     stopOnFlag(stopFlag) {
       val versionList = block(client.versionList())
       val versions = parse(versionList.getResponseBody).extract[List[Version]]
       val activeVersion = versions.filter(x => x.active.getOrElse(false))(0)
-      MessageBroker.info(s"Current active version ${activeVersion.number}")
+      logger.info(s"Current active version ${activeVersion.number}")
       activeVersion.number
     }
   }
 
-  private def clone(versionNumber: Int, client: FastlyApiClient, stopFlag: => Boolean): Int = {
+  private def clone(versionNumber: Int, client: FastlyApiClient, logger: DeployLogger, stopFlag: => Boolean): Int = {
     stopOnFlag(stopFlag) {
       val cloned = block(client.versionClone(versionNumber))
       val clonedVersion = parse(cloned.getResponseBody).extract[Version]
-      MessageBroker.info(s"Cloned version ${clonedVersion.number}")
+      logger.info(s"Cloned version ${clonedVersion.number}")
       clonedVersion.number
     }
   }
 
-  private def deleteAllVclFilesFrom(versionNumber: Int, client: FastlyApiClient, stopFlag: => Boolean): Unit = {
+  private def deleteAllVclFilesFrom(versionNumber: Int, client: FastlyApiClient, logger: DeployLogger, stopFlag: => Boolean): Unit = {
     stopOnFlag(stopFlag) {
       val vclListResponse = block(client.vclList(versionNumber))
       val vclFilesToDelete = parse(vclListResponse.getResponseBody).extract[List[Vcl]]
       vclFilesToDelete.foreach { file =>
-        MessageBroker.info(s"Deleting ${file.name}")
+        logger.info(s"Deleting ${file.name}")
         block(client.vclDelete(versionNumber, file.name).map(_.getResponseBody))
       }
     }
   }
 
-  private def uploadNewVclFilesTo(versionNumber: Int, srcDir: File, client: FastlyApiClient, stopFlag: => Boolean): Unit = {
+  private def uploadNewVclFilesTo(versionNumber: Int, srcDir: File, client: FastlyApiClient, logger: DeployLogger, stopFlag: => Boolean): Unit = {
     stopOnFlag(stopFlag) {
       val vclFilesToUpload = srcDir.listFiles().toList
       vclFilesToUpload.foreach { file =>
         if (file.getName.endsWith(".vcl")) {
-          MessageBroker.info(s"Uploading ${file.getName}")
+          logger.info(s"Uploading ${file.getName}")
           val vcl = scala.io.Source.fromFile(file.getAbsolutePath).mkString
           block(client.vclUpload(versionNumber, vcl, file.getName, file.getName))
         }
@@ -86,21 +84,21 @@ case class UpdateFastlyConfig(pkg: DeploymentPackage)(implicit val keyRing: KeyR
     }
   }
 
-  private def activateVersion(versionNumber: Int, client: FastlyApiClient, stopFlag: => Boolean): Unit = {
-    val configIsValid = validateNewConfigFor(versionNumber, client, stopFlag)
+  private def activateVersion(versionNumber: Int, client: FastlyApiClient, logger: DeployLogger, stopFlag: => Boolean): Unit = {
+    val configIsValid = validateNewConfigFor(versionNumber, client, logger, stopFlag)
     if (configIsValid) {
       block(client.versionActivate(versionNumber))
     } else {
-      MessageBroker.fail(s"Error validating Fastly version $versionNumber")
+      logger.fail(s"Error validating Fastly version $versionNumber")
     }
   }
 
-  private def validateNewConfigFor(versionNumber: Int, client: FastlyApiClient, stopFlag: => Boolean): Boolean = {
+  private def validateNewConfigFor(versionNumber: Int, client: FastlyApiClient, logger: DeployLogger, stopFlag: => Boolean): Boolean = {
     stopOnFlag(stopFlag) {
-      MessageBroker.info("Waiting 5 seconds for the VCL to compile")
+      logger.info("Waiting 5 seconds for the VCL to compile")
       Thread.sleep(5000)
 
-      MessageBroker.info(s"Validating new config $versionNumber")
+      logger.info(s"Validating new config $versionNumber")
       val response = block(client.versionValidate(versionNumber))
       val validationResponse = parse(response.getResponseBody) \\ "status"
       validationResponse == JString("ok")

--- a/magenta-lib/src/main/scala/magenta/tasks/RemoteShellTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/RemoteShellTask.scala
@@ -21,7 +21,7 @@ trait RemoteShellTask extends ShellTask {
     )
   }
 
-  override def execute(stopFlag: =>  Boolean) { keyRing.sshCredentials match {
+  override def execute(logger: DeployLogger, stopFlag: =>  Boolean) { keyRing.sshCredentials match {
     case PassphraseProvided(user, pass, keyFile) =>
       val publicKeyLogin =
         PublicKeyLogin(user, SimplePasswordProducer(pass), keyFile map (_.getPath :: Nil) getOrElse DefaultKeyLocations)
@@ -30,7 +30,7 @@ trait RemoteShellTask extends ShellTask {
         case None => publicKeyLogin
       }
       SSH(host.name, credentialsForHost)(_.exec(commandLine.quoted))
-    case SystemUser(keyFile) => remoteCommandLine(keyRing.sshCredentials).run()
+    case SystemUser(keyFile) => remoteCommandLine(keyRing.sshCredentials).run(logger)
   }}
 
   lazy val description = "on " + host.name

--- a/magenta-lib/src/main/scala/magenta/tasks/RemoteShellTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/RemoteShellTask.scala
@@ -21,7 +21,7 @@ trait RemoteShellTask extends ShellTask {
     )
   }
 
-  override def execute(logger: DeployLogger, stopFlag: =>  Boolean) { keyRing.sshCredentials match {
+  override def execute(reporter: DeployReporter, stopFlag: => Boolean) { keyRing.sshCredentials match {
     case PassphraseProvided(user, pass, keyFile) =>
       val publicKeyLogin =
         PublicKeyLogin(user, SimplePasswordProducer(pass), keyFile map (_.getPath :: Nil) getOrElse DefaultKeyLocations)
@@ -30,7 +30,7 @@ trait RemoteShellTask extends ShellTask {
         case None => publicKeyLogin
       }
       SSH(host.name, credentialsForHost)(_.exec(commandLine.quoted))
-    case SystemUser(keyFile) => remoteCommandLine(keyRing.sshCredentials).run(logger)
+    case SystemUser(keyFile) => remoteCommandLine(keyRing.sshCredentials).run(reporter)
   }}
 
   lazy val description = "on " + host.name

--- a/magenta-lib/src/main/scala/magenta/tasks/ShellTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ShellTask.scala
@@ -4,7 +4,7 @@ package tasks
 trait ShellTask extends Task {
   def commandLine: CommandLine
 
-  override def execute(context: DeployLogger, stopFlag: =>  Boolean) { commandLine.run(context) }
+  override def execute(reporter: DeployReporter, stopFlag: => Boolean) { commandLine.run(reporter) }
 
   lazy val verbose = "$ " + commandLine.quoted
 }

--- a/magenta-lib/src/main/scala/magenta/tasks/ShellTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ShellTask.scala
@@ -4,7 +4,7 @@ package tasks
 trait ShellTask extends Task {
   def commandLine: CommandLine
 
-  def execute(stopFlag: =>  Boolean) { commandLine.run() }
+  override def execute(context: DeployLogger, stopFlag: =>  Boolean) { commandLine.run(context) }
 
   lazy val verbose = "$ " + commandLine.quoted
 }

--- a/magenta-lib/src/main/scala/magenta/tasks/Task.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/Task.scala
@@ -3,8 +3,8 @@ package tasks
 
 trait Task {
   // execute this task (should throw on failure)
-  def execute(context: DeployLogger, stopFlag: => Boolean)
-  def execute(context: DeployLogger) { execute(context, stopFlag = false) }
+  def execute(reporter: DeployReporter, stopFlag: => Boolean)
+  def execute(reporter: DeployReporter) { execute(reporter, stopFlag = false) }
 
   def keyRing: KeyRing
 

--- a/magenta-lib/src/main/scala/magenta/tasks/Task.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/Task.scala
@@ -3,8 +3,8 @@ package tasks
 
 trait Task {
   // execute this task (should throw on failure)
-  def execute(stopFlag: => Boolean)
-  def execute() { execute(false) }
+  def execute(context: DeployLogger, stopFlag: => Boolean)
+  def execute(context: DeployLogger) { execute(context, stopFlag = false) }
 
   def keyRing: KeyRing
 

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -42,7 +42,7 @@ object JsonConverter {
     * Return the template's content as JSON,
     * converting it from YAML if necessary.
     */
-  def convert(template: Path)(logger: DeployLogger): String = template.extension match {
+  def convert(template: Path)(implicit logger: DeployLogger): String = template.extension match {
     case Some("yml") | Some("yaml") =>
       logger.info(s"Converting ${template.name} from YAML to JSON")
       val tree = new ObjectMapper(new YAMLFactory()).readTree(template.string)

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -4,11 +4,12 @@ import com.amazonaws.AmazonServiceException
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import magenta.{MessageBroker, Stage, Stack, KeyRing}
+import magenta.{DeployLogger, KeyRing, Stack, Stage}
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.cloudformation.AmazonCloudFormationAsyncClient
 import com.amazonaws.services.cloudformation.model._
-import org.joda.time.{Duration, DateTime}
+import org.joda.time.{DateTime, Duration}
+
 import scalax.file.Path
 import collection.convert.wrapAsScala._
 
@@ -41,9 +42,9 @@ object JsonConverter {
     * Return the template's content as JSON,
     * converting it from YAML if necessary.
     */
-  def convert(template: Path): String = template.extension match {
+  def convert(template: Path)(logger: DeployLogger): String = template.extension match {
     case Some("yml") | Some("yaml") =>
-      MessageBroker.info(s"Converting ${template.name} from YAML to JSON")
+      logger.info(s"Converting ${template.name} from YAML to JSON")
       val tree = new ObjectMapper(new YAMLFactory()).readTree(template.string)
       new ObjectMapper()
         .writer(new DefaultPrettyPrinter().withoutSpacesInObjectEntries())
@@ -68,8 +69,8 @@ case class UpdateCloudFormationTask(
 
   import UpdateCloudFormationTask._
 
-  def execute(stopFlag: => Boolean) = if (!stopFlag) {
-    val templateJson = JsonConverter.convert(template)
+  override def execute(logger: DeployLogger, stopFlag: => Boolean) = if (!stopFlag) {
+    val templateJson = JsonConverter.convert(template)(logger)
     val templateParameters = CloudFormation.validateTemplate(templateJson).getParameters
       .map(tp => TemplateParameter(tp.getParameterKey, Option(tp.getDefaultValue).isDefined))
 
@@ -79,23 +80,23 @@ case class UpdateCloudFormationTask(
 
     val parameters: Map[String, ParameterValue] = combineParameters(stack, stage, templateParameters, userParameters, amiParam)
 
-    MessageBroker.info(s"Parameters: $parameters")
+    logger.info(s"Parameters: $parameters")
 
     if (CloudFormation.describeStack(cloudFormationStackName).isDefined)
       try {
         CloudFormation.updateStack(cloudFormationStackName, templateJson, parameters)
       } catch {
         case ase:AmazonServiceException if ase.getMessage contains "No updates are to be performed." =>
-          MessageBroker.info("Cloudformation update has no changes to template or parameters")
+          logger.info("Cloudformation update has no changes to template or parameters")
         case ase:AmazonServiceException if ase.getMessage contains "Template format error: JSON not well-formed" =>
-          MessageBroker.info(s"Cloudformation update failed with the following template content:\n$templateJson")
+          logger.info(s"Cloudformation update failed with the following template content:\n$templateJson")
           throw ase
       }
     else if (createStackIfAbsent) {
-      MessageBroker.info(s"Stack $cloudFormationStackName doesn't exist. Creating stack.")
-      CloudFormation.createStack(cloudFormationStackName, templateJson, parameters)
+      logger.info(s"Stack $cloudFormationStackName doesn't exist. Creating stack.")
+      CloudFormation.createStack(logger, cloudFormationStackName, templateJson, parameters)
     } else {
-      MessageBroker.fail(s"Stack $cloudFormationStackName doesn't exist and createStackIfAbsent is false")
+      logger.fail(s"Stack $cloudFormationStackName doesn't exist and createStackIfAbsent is false")
     }
   }
 
@@ -113,27 +114,27 @@ case class UpdateAmiCloudFormationParameterTask(
 
   import UpdateCloudFormationTask._
 
-  def execute(stopFlag: => Boolean) = if (!stopFlag) {
+  override def execute(logger: DeployLogger, stopFlag: => Boolean) = if (!stopFlag) {
     val (existingParameters, currentAmi) = CloudFormation.describeStack(cloudFormationStackName) match {
       case Some(cfStack) if cfStack.getParameters.exists(_.getParameterKey == amiParameter) =>
         (cfStack.getParameters.map(_.getParameterKey -> UseExistingValue).toMap, cfStack.getParameters.find(_.getParameterKey == amiParameter).get.getParameterValue)
       case Some(_) =>
-        MessageBroker.fail(s"stack $cloudFormationStackName does not have an $amiParameter parameter to update")
+        logger.fail(s"stack $cloudFormationStackName does not have an $amiParameter parameter to update")
       case None =>
-        MessageBroker.fail(s"Could not find CloudFormation stack $cloudFormationStackName")
+        logger.fail(s"Could not find CloudFormation stack $cloudFormationStackName")
     }
 
     latestImage(CloudFormation.region.name)(amiTags) match {
       case Some(sameAmi) if currentAmi == sameAmi =>
-        MessageBroker.info(s"Current AMI is the same as the resolved AMI ($sameAmi). No update to perform.")
+        logger.info(s"Current AMI is the same as the resolved AMI ($sameAmi). No update to perform.")
       case Some(ami) =>
-        MessageBroker.info(s"Resolved AMI: $ami")
+        logger.info(s"Resolved AMI: $ami")
         val parameters = existingParameters + (amiParameter -> SpecifiedValue(ami))
-        MessageBroker.info(s"Updating cloudformation stack params: $parameters")
+        logger.info(s"Updating cloudformation stack params: $parameters")
         CloudFormation.updateStackParams(cloudFormationStackName, parameters)
       case None =>
         val tagsStr = amiTags.map { case (k, v) => s"$k: $v" }.mkString(", ")
-        MessageBroker.fail(s"Failed to resolve AMI for $cloudFormationStackName with tags: $tagsStr")
+        logger.fail(s"Failed to resolve AMI for $cloudFormationStackName with tags: $tagsStr")
     }
   }
 
@@ -143,7 +144,7 @@ case class UpdateAmiCloudFormationParameterTask(
 
 case class CheckUpdateEventsTask(stackName: String)(implicit val keyRing: KeyRing) extends Task {
 
-  def execute(stopFlag: => Boolean): Unit = {
+  override def execute(logger: DeployLogger, stopFlag: => Boolean): Unit = {
     import StackEvent._
 
     def check(lastSeenEvent: Option[StackEvent]): Unit = {
@@ -154,21 +155,21 @@ case class CheckUpdateEventsTask(stackName: String)(implicit val keyRing: KeyRin
         case None => events.find(updateStart) foreach (e => {
           val age = new Duration(new DateTime(e.getTimestamp), new DateTime()).getStandardSeconds
           if (age > 30) {
-            MessageBroker.verbose("No recent IN_PROGRESS events found (nothing within last 30 seconds)")
+            logger.verbose("No recent IN_PROGRESS events found (nothing within last 30 seconds)")
           } else {
-            reportEvent(e)
+            reportEvent(logger, e)
             check(Some(e))
           }
         })
         case Some(event) => {
           val newEvents = events.takeWhile(_.getTimestamp.after(event.getTimestamp))
-          newEvents.reverse.foreach(reportEvent)
+          newEvents.reverse.foreach(reportEvent(logger, _))
 
           if (!newEvents.exists(e => updateComplete(e) || failed(e)) && !stopFlag) {
             Thread.sleep(5000)
             check(Some(newEvents.headOption.getOrElse(event)))
           }
-          newEvents.filter(failed).foreach(fail)
+          newEvents.filter(failed).foreach(fail(logger, _))
         }
       }
     }
@@ -176,9 +177,9 @@ case class CheckUpdateEventsTask(stackName: String)(implicit val keyRing: KeyRin
   }
 
   object StackEvent {
-    def reportEvent(e: StackEvent): Unit = {
-      MessageBroker.info(s"${e.getLogicalResourceId} (${e.getResourceType}): ${e.getResourceStatus}")
-      if (e.getResourceStatusReason != null) MessageBroker.verbose(e.getResourceStatusReason)
+    def reportEvent(logger: DeployLogger, e: StackEvent): Unit = {
+      logger.info(s"${e.getLogicalResourceId} (${e.getResourceType}): ${e.getResourceStatus}")
+      if (e.getResourceStatusReason != null) logger.verbose(e.getResourceStatusReason)
     }
     def isStackEvent(e: StackEvent): Boolean =
       e.getResourceType == "AWS::CloudFormation::Stack" && e.getLogicalResourceId == stackName
@@ -189,7 +190,7 @@ case class CheckUpdateEventsTask(stackName: String)(implicit val keyRing: KeyRin
 
     def failed(e: StackEvent): Boolean = e.getResourceStatus.contains("FAILED")
 
-    def fail(e: StackEvent): Unit = MessageBroker.fail(
+    def fail(logger: DeployLogger, e: StackEvent): Unit = logger.fail(
       s"""${e.getLogicalResourceId}(${e.getResourceType}}: ${e.getResourceStatus}
             |${e.getResourceStatusReason}""".stripMargin)
   }
@@ -236,12 +237,12 @@ trait CloudFormation extends AWS {
       )
     )
 
-  def createStack(name: String, templateBody: String, parameters: Map[String, ParameterValue])(implicit keyRing: KeyRing) =
+  def createStack(logger: DeployLogger, name: String, templateBody: String, parameters: Map[String, ParameterValue])(implicit keyRing: KeyRing) =
     client.createStack(
       new CreateStackRequest().withStackName(name).withTemplateBody(templateBody).withCapabilities(CAPABILITY_IAM).withParameters(
         parameters map {
           case (k, SpecifiedValue(v)) => new Parameter().withParameterKey(k).withParameterValue(v)
-          case (k, UseExistingValue) => MessageBroker.fail(s"Missing parameter value for parameter $k: all must be specified when creating a stack. Subsequent updates will reuse existing parameter values where possible.")
+          case (k, UseExistingValue) => logger.fail(s"Missing parameter value for parameter $k: all must be specified when creating a stack. Subsequent updates will reuse existing parameter values where possible.")
          } toSeq: _*
       )
     )

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -41,8 +41,8 @@ case class CopyFile(host: Host, source: String, dest: String, copyMode: String =
 
   lazy val description = "%s -> %s:%s" format (source, host.connectStr, dest)
 
-  override def execute(logger: DeployLogger, stopFlag: =>  Boolean) {
-    commandLine(keyRing).run(logger)
+  override def execute(reporter: DeployReporter, stopFlag: => Boolean) {
+    commandLine(keyRing).run(reporter)
   }
 }
 
@@ -65,8 +65,8 @@ case class CompressedCopy(host: Host, source: Option[File], dest: String)(implic
 
 trait CompositeTask extends Task {
   def tasks: Seq[Task]
-  override def execute(logger: DeployLogger, stopFlag: => Boolean) {
-    for (task <- tasks) { if (!stopFlag) task.execute(logger, stopFlag) }
+  override def execute(reporter: DeployReporter, stopFlag: => Boolean) {
+    for (task <- tasks) { if (!stopFlag) task.execute(reporter, stopFlag) }
   }
 }
 
@@ -130,12 +130,12 @@ case class S3Upload(
       s"CacheControl:${request.getMetadata.getCacheControl} ContentType:${request.getMetadata.getContentType} ACL:${request.getCannedAcl}"
 
   // execute this task (should throw on failure)
-  override def execute(logger: DeployLogger, stopFlag: =>  Boolean)  {
+  override def execute(reporter: DeployReporter, stopFlag: => Boolean) {
     val client = s3client(keyRing)
-    logger.verbose(s"Starting upload of ${fileString(files.size)} ($totalSize bytes) to S3")
-    requests.take(detailedLoggingThreshold).foreach(r => logger.verbose(s"Uploading ${requestToString(r)}"))
+    reporter.verbose(s"Starting upload of ${fileString(files.size)} ($totalSize bytes) to S3")
+    requests.take(detailedLoggingThreshold).foreach(r => reporter.verbose(s"Uploading ${requestToString(r)}"))
     requests.par foreach { request => client.putObject(request) }
-    logger.verbose(s"Finished upload of ${fileString(files.size)} to S3")
+    reporter.verbose(s"Finished upload of ${fileString(files.size)} to S3")
   }
 
   private def subDirectoryPrefix(key: String, file:File): String = if (key.isEmpty) file.getName else s"$key/${file.getName}"
@@ -176,8 +176,8 @@ case class WaitForPort(host: Host, port: Int, duration: Long)(implicit val keyRi
   def description = "to %s on %s" format(host.name, port)
   def verbose = "Wail until a socket connection can be made to %s:%s" format(host.name, port)
 
-  override def execute(logger: DeployLogger, stopFlag: =>  Boolean) {
-    check(logger, stopFlag) {
+  override def execute(reporter: DeployReporter, stopFlag: => Boolean) {
+    check(reporter, stopFlag) {
       try {
         new Socket(host.name, port).close()
         true
@@ -194,11 +194,11 @@ case class CheckUrls(host: Host, port: Int, paths: List[String], duration: Long,
   def description = "check [%s] on %s" format(paths, host)
   def verbose = "Check that [%s] returns a 200" format(paths)
 
-  def execute(logger: DeployLogger, stopFlag: =>  Boolean) {
+  def execute(reporter: DeployReporter, stopFlag: => Boolean) {
     for (path <- paths) {
       val url = new URL( "http://%s:%s%s" format (host.connectStr, port, path) )
-      logger.verbose("Checking %s" format url)
-      check(logger, stopFlag) {
+      reporter.verbose("Checking %s" format url)
+      check(reporter, stopFlag) {
         try {
           val connection = url.openConnection()
           connection.setConnectTimeout( 2000 )
@@ -206,7 +206,7 @@ case class CheckUrls(host: Host, port: Int, paths: List[String], duration: Long,
           Source.fromInputStream( connection.getInputStream )
           true
         } catch {
-          case e: FileNotFoundException => logger.fail("404 Not Found", e)
+          case e: FileNotFoundException => reporter.fail("404 Not Found", e)
           case e:Throwable => false
         }
       }
@@ -217,22 +217,22 @@ case class CheckUrls(host: Host, port: Int, paths: List[String], duration: Long,
 trait PollingCheck {
   def duration: Long
 
-  def check(logger:DeployLogger, stopFlag: => Boolean)(theCheck: => Boolean) {
+  def check(reporter: DeployReporter, stopFlag: => Boolean)(theCheck: => Boolean) {
     val expiry = System.currentTimeMillis() + duration
 
     def checkAttempt(currentAttempt: Int) {
       if (!theCheck) {
         if (stopFlag) {
-          logger.info("Abandoning remaining checks as stop flag has been set")
+          reporter.info("Abandoning remaining checks as stop flag has been set")
         } else {
           val remainingTime = expiry - System.currentTimeMillis()
           if (remainingTime > 0) {
             val sleepyTime = calculateSleepTime(currentAttempt)
-            logger.verbose("Check failed on attempt #%d (Will wait for a further %.1f seconds, retrying again after %.1fs)" format (currentAttempt, (remainingTime.toFloat/1000), (sleepyTime.toFloat/1000)))
+            reporter.verbose("Check failed on attempt #%d (Will wait for a further %.1f seconds, retrying again after %.1fs)" format (currentAttempt, (remainingTime.toFloat/1000), (sleepyTime.toFloat/1000)))
             Thread.sleep(sleepyTime)
             checkAttempt(currentAttempt + 1)
           } else {
-            logger.fail("Check failed to pass within %d milliseconds (tried %d times) - aborting" format (duration,currentAttempt))
+            reporter.fail("Check failed to pass within %d milliseconds (tried %d times) - aborting" format (duration,currentAttempt))
           }
         }
       }
@@ -259,8 +259,8 @@ trait SlowRepeatedPollingCheck extends PollingCheck {
 
 case class SayHello(host: Host)(implicit val keyRing: KeyRing) extends Task {
   override def taskHost = Some(host)
-  override def execute(logger: DeployLogger, stopFlag: => Boolean) {
-    logger.info("Hello to " + host.name + "!")
+  override def execute(reporter: DeployReporter, stopFlag: => Boolean) {
+    reporter.info("Hello to " + host.name + "!")
   }
 
   def description = "to " + host.name
@@ -320,8 +320,8 @@ case class ChangeSwitch(host: Host, protocol:String, port: Int, path: String, sw
   val switchboardUrl = s"$protocol://${host.name}:$port$path"
 
   // execute this task (should throw on failure)
-  override def execute(logger: DeployLogger, stopFlag: => Boolean) = {
-    logger.verbose(s"Changing $switchName to $desiredStateName using $switchboardUrl")
+  override def execute(reporter: DeployReporter, stopFlag: => Boolean) = {
+    reporter.verbose(s"Changing $switchName to $desiredStateName using $switchboardUrl")
     Http(url(switchboardUrl) << Map(switchName -> desiredStateName) >|)
   }
 
@@ -342,12 +342,12 @@ case class UpdateLambda(
   def description = s"Updating $functionName Lambda"
   def verbose = description
 
-  override def execute(logger: DeployLogger, stopFlag: =>  Boolean) {
+  override def execute(reporter: DeployReporter, stopFlag: => Boolean) {
 
     val client = lambdaClient(keyRing)
-    logger.verbose(s"Starting update $functionName Lambda")
+    reporter.verbose(s"Starting update $functionName Lambda")
     client.updateFunctionCode(lambdaUpdateFunctionCodeRequest(functionName, file))
-    logger.verbose(s"Finished update $functionName Lambda")
+    reporter.verbose(s"Finished update $functionName Lambda")
   }
 
 }
@@ -356,11 +356,11 @@ case class UpdateS3Lambda(functionName: String, s3Bucket: String, s3Key: String)
   def description = s"Updating $functionName Lambda using S3 $s3Bucket:$s3Key"
   def verbose = description
 
-  override def execute(logger: DeployLogger, stopFlag: =>  Boolean) {
+  override def execute(reporter: DeployReporter, stopFlag: => Boolean) {
     val client = lambdaClient(keyRing)
-    logger.verbose(s"Starting update $functionName Lambda")
+    reporter.verbose(s"Starting update $functionName Lambda")
     client.updateFunctionCode(lambdaUpdateFunctionCodeRequest(functionName, s3Bucket, s3Key))
-    logger.verbose(s"Finished update $functionName Lambda")
+    reporter.verbose(s"Finished update $functionName Lambda")
   }
 
 }

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -8,7 +8,6 @@ import java.io.{File, FileNotFoundException, IOException}
 import java.net.URL
 
 import com.amazonaws.services.s3.model.PutObjectRequest
-import com.gu.management.Loggable
 import magenta.deployment_type.PatternValue
 import dispatch.classic._
 

--- a/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
+++ b/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
@@ -15,7 +15,7 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
   it should ("resolve a set of tasks") in {
     val parameters = DeployParameters(Deployer("tester"), Build("project","1"), CODE, oneRecipeName)
     val context = DeployContext(parameters, project(baseRecipe), lookupSingleHost)
-    MessageBroker.deployContext(UUID.randomUUID(), parameters) {
+    DeployLogger.deployContext(UUID.randomUUID(), parameters) {
       context.tasks should be(List(
         StubTask("init_action_one per app task"),
         StubTask("action_one per host task on the_host", lookupSingleHost.hosts.all.headOption)
@@ -27,9 +27,9 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
     val parameters = DeployParameters(Deployer("tester1"), Build("project","1"), CODE, oneRecipeName)
 
     val messages = Buffer[Message]()
-    MessageBroker.messages.filter(_.stack.deployParameters == Some(parameters)).subscribe(messages += _.stack.top)
+    DeployLogger.messages.filter(_.stack.deployParameters == Some(parameters)).subscribe(messages += _.stack.top)
 
-    MessageBroker.deployContext(UUID.randomUUID(), parameters) {
+    DeployLogger.deployContext(UUID.randomUUID(), parameters) {
       val context = DeployContext(parameters, project(baseRecipe), lookupSingleHost)
     }
 
@@ -52,7 +52,7 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
 
     val start = Buffer[Message]()
     val finished = Buffer[Message]()
-    MessageBroker.messages.filter(_.stack.deployParameters == Some(parameters)).subscribe(wrapper =>
+    DeployLogger.messages.filter(_.stack.deployParameters == Some(parameters)).subscribe(wrapper =>
       wrapper.stack.top match {
         case FinishContext(finishMessage) => finished += finishMessage
         case StartContext(startMessage) => start += startMessage
@@ -74,7 +74,7 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
 
     val start = Buffer[Message]()
     val finished = Buffer[Message]()
-    MessageBroker.messages.filter(_.stack.deployParameters == Some(parameters)).subscribe(wrapper =>
+    DeployLogger.messages.filter(_.stack.deployParameters == Some(parameters)).subscribe(wrapper =>
       wrapper.stack.top match {
         case FinishContext(finishMessage) => finished += finishMessage
         case StartContext(startMessage) => start += startMessage

--- a/magenta-lib/src/test/scala/magenta/LoggingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/LoggingTest.scala
@@ -8,11 +8,11 @@ class LoggingTest extends FlatSpec with Matchers {
 
   def getWrapperBuffer(uuid: UUID): ListBuffer[MessageWrapper] = {
     val wrappers = ListBuffer.empty[MessageWrapper]
-    DeployLogger.messages.filter(_.context.deployId == uuid).subscribe(wrappers += _)
+    DeployReporter.messages.filter(_.context.deployId == uuid).subscribe(wrappers += _)
     wrappers
   }
 
-  def getRandomLogger = DeployLogger.rootLoggerFor(UUID.randomUUID(), parameters)
+  def getRandomLogger = DeployReporter.rootReporterFor(UUID.randomUUID(), parameters)
 
   val parameters = DeployParameters(Deployer("Tester"), Build("test-app", "test-build"), Stage("TEST"))
 
@@ -31,9 +31,9 @@ class LoggingTest extends FlatSpec with Matchers {
     val logger = getRandomLogger
     val wrappers = getWrapperBuffer(logger.messageContext.deployId)
 
-    val deployLogger = DeployLogger.startDeployContext(logger)
+    val deployLogger = DeployReporter.startDeployContext(logger)
     deployLogger.info("this should work")
-    DeployLogger.finishContext(deployLogger)
+    DeployReporter.finishContext(deployLogger)
 
     wrappers.size should be(3)
     wrappers(0).context should be(logger.messageContext)

--- a/magenta-lib/src/test/scala/magenta/ResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/ResolverTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class ResolverTest extends FlatSpec with Matchers {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
-  implicit val logger = DeployLogger.rootLoggerFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val logger = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
 
   val simpleExample = """
   {

--- a/magenta-lib/src/test/scala/magenta/ResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/ResolverTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class ResolverTest extends FlatSpec with Matchers {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
-  implicit val logger = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
 
   val simpleExample = """
   {
@@ -39,7 +39,7 @@ class ResolverTest extends FlatSpec with Matchers {
     val host = Host("host1", stage = CODE.name, tags=Map("group" -> "")).app(App("apache"))
     val lookup = stubLookup(host :: Nil)
 
-    val tasks = Resolver.resolve(project(deployRecipe), lookup, parameters(deployRecipe), logger)
+    val tasks = Resolver.resolve(project(deployRecipe), lookup, parameters(deployRecipe), reporter)
 
     tasks.size should be (1)
     tasks should be (List(
@@ -57,7 +57,7 @@ class ResolverTest extends FlatSpec with Matchers {
   val lookupTwoHosts = stubLookup(List(host1, host2))
 
   it should "generate the tasks from the actions supplied" in {
-    Resolver.resolve(project(baseRecipe), lookupSingleHost, parameters(baseRecipe), logger) should be (List(
+    Resolver.resolve(project(baseRecipe), lookupSingleHost, parameters(baseRecipe), reporter) should be (List(
       StubTask("init_action_one per app task"),
       StubTask("action_one per host task on the_host", Some(host))
     ))
@@ -65,14 +65,14 @@ class ResolverTest extends FlatSpec with Matchers {
 
   it should "only generate tasks for hosts that have apps" in {
     Resolver.resolve(project(baseRecipe),
-      stubLookup(Host("other_host").app(App("other_app")) +: lookupSingleHost.hosts.all), parameters(baseRecipe), logger) should be (List(
+      stubLookup(Host("other_host").app(App("other_app")) +: lookupSingleHost.hosts.all), parameters(baseRecipe), reporter) should be (List(
         StubTask("init_action_one per app task"),
         StubTask("action_one per host task on the_host", Some(host))
     ))
   }
 
   it should "generate tasks for all hosts with app" in {
-    Resolver.resolve(project(baseRecipe), lookupTwoHosts, parameters(baseRecipe), logger) should be (List(
+    Resolver.resolve(project(baseRecipe), lookupTwoHosts, parameters(baseRecipe), reporter) should be (List(
       StubTask("init_action_one per app task"),
       StubTask("action_one per host task on host1", Some(host1)),
       StubTask("action_one per host task on host2", Some(host2))
@@ -97,7 +97,7 @@ class ResolverTest extends FlatSpec with Matchers {
     val host2WithApp2 = Host("host2", stage = CODE.name, tags = Map("group" -> "")).app(app2)
     val lookupMultiHost = stubLookup(List(host1, host2WithApp2))
 
-    Resolver.resolve(project(multiRoleRecipe), lookupMultiHost, parameters(multiRoleRecipe), logger) should be (List(
+    Resolver.resolve(project(multiRoleRecipe), lookupMultiHost, parameters(multiRoleRecipe), reporter) should be (List(
       StubTask("init_action_one per app task"),
       StubTask("action_one per host task on host1", Some(host1)),
       StubTask("action_two per host task on host1", Some(host1)),
@@ -114,7 +114,7 @@ class ResolverTest extends FlatSpec with Matchers {
         allOnAllPackageType.mkAction("action_two")(stubPackage) :: Nil
     )
 
-    Resolver.resolve(project(recipe), lookupTwoHosts, parameters(recipe), logger) should be (List(
+    Resolver.resolve(project(recipe), lookupTwoHosts, parameters(recipe), reporter) should be (List(
       StubTask("init_action_one per app task"),
       StubTask("action_one per host task on host1", Some(host1)),
       StubTask("action_two per host task on host1", Some(host1)),
@@ -131,7 +131,7 @@ class ResolverTest extends FlatSpec with Matchers {
       actionsPerHost = basePackageType.mkAction("main_action")(stubPackage) :: Nil,
       dependsOn = List("one"))
 
-    Resolver.resolve(project(mainRecipe, baseRecipe), lookupSingleHost, parameters(mainRecipe), logger) should be (List(
+    Resolver.resolve(project(mainRecipe, baseRecipe), lookupSingleHost, parameters(mainRecipe), reporter) should be (List(
       StubTask("init_action_one per app task"),
       StubTask("action_one per host task on the_host", Some(host)),
       StubTask("main_init_action per app task"),
@@ -152,7 +152,7 @@ class ResolverTest extends FlatSpec with Matchers {
       actionsPerHost = basePackageType.mkAction("main_action")(stubPackage) :: Nil,
       dependsOn = List("two", "one"))
 
-    Resolver.resolve(project(mainRecipe, indirectDependencyRecipe, baseRecipe), lookupSingleHost, parameters(mainRecipe), logger) should be (List(
+    Resolver.resolve(project(mainRecipe, indirectDependencyRecipe, baseRecipe), lookupSingleHost, parameters(mainRecipe), reporter) should be (List(
       StubTask("init_action_one per app task"),
       StubTask("action_one per host task on the_host", Some(host)),
       StubTask("init_action_two per app task"),
@@ -161,9 +161,9 @@ class ResolverTest extends FlatSpec with Matchers {
       StubTask("main_action per host task on the_host", Some(host))
     ))
   }
-  
+
   it should "disable the recipe if no hosts found and actions require some" in {
-    val recipeTasks = Resolver.resolveDetail(project(baseRecipe), stubLookup(List()), parameters(baseRecipe), logger)
+    val recipeTasks = Resolver.resolveDetail(project(baseRecipe), stubLookup(List()), parameters(baseRecipe), reporter)
     recipeTasks.length should be(1)
     recipeTasks.head.disabled should be(true)
   }
@@ -173,7 +173,7 @@ class ResolverTest extends FlatSpec with Matchers {
       actionsBeforeApp =  basePackageType.mkAction("init_action_one")(stubPackage) :: Nil,
       dependsOn = Nil)
 
-    Resolver.resolve(project(nonHostRecipe), stubLookup(List()), parameters(nonHostRecipe), logger)
+    Resolver.resolve(project(nonHostRecipe), stubLookup(List()), parameters(nonHostRecipe), reporter)
   }
 
   it should "only resolve tasks on hosts in the correct stage" in {
@@ -181,7 +181,7 @@ class ResolverTest extends FlatSpec with Matchers {
       project(baseRecipe),
       stubLookup(List(host, Host("host_in_other_stage", Set(app1), "other_stage"))),
       parameters(baseRecipe),
-      logger
+      reporter
     ) should be (List(
       StubTask("init_action_one per app task"),
       StubTask("action_one per host task on the_host", Some(host))
@@ -189,7 +189,7 @@ class ResolverTest extends FlatSpec with Matchers {
   }
 
   it should "observe ordering of hosts in deployInfo" in {
-    Resolver.resolve(project(baseRecipe), stubLookup(List(host2, host1)), parameters(baseRecipe), logger) should be (List(
+    Resolver.resolve(project(baseRecipe), stubLookup(List(host2, host1)), parameters(baseRecipe), reporter) should be (List(
       StubTask("init_action_one per app task"),
       StubTask("action_one per host task on host2", Some(host2)),
       StubTask("action_one per host task on host1", Some(host1))
@@ -199,7 +199,7 @@ class ResolverTest extends FlatSpec with Matchers {
   it should "observe ordering of hosts in deployInfo irrespective of connection user" in {
     val pkgTypeWithUser = StubDeploymentType(
       perHostActions = {
-        case "deploy" => pkg => (logger, host, keyRing) =>
+        case "deploy" => pkg => (reporter, host, keyRing) =>
           List(StubTask("with conn", Some(host as "user")), StubTask("without conn", Some(host)))
       }
     )
@@ -207,7 +207,7 @@ class ResolverTest extends FlatSpec with Matchers {
     val recipe = Recipe("with-user",
       actionsPerHost = List(pkgTypeWithUser.mkAction("deploy")(pkg)))
 
-    Resolver.resolve(project(recipe), stubLookup(List(host2, host1)), parameters(recipe), logger) should be (List(
+    Resolver.resolve(project(recipe), stubLookup(List(host2, host1)), parameters(recipe), reporter) should be (List(
       StubTask("with conn", Some(host2 as "user")),
       StubTask("without conn", Some(host2)),
       StubTask("with conn", Some(host1 as "user")),
@@ -218,14 +218,14 @@ class ResolverTest extends FlatSpec with Matchers {
   it should "resolve tasks from multiple stacks" in {
     val pkgType = StubDeploymentType(
       perAppActions = {
-        case "deploy" => pkg => (logger, lookup, params, stack) =>
+        case "deploy" => pkg => (reporter, lookup, params, stack) =>
           List(StubTask("stacked", stack = Some(stack)))
       }
     )
     val recipe = Recipe("stacked",
       actionsPerHost = List(pkgType.mkAction("deploy")(stubPackage)))
 
-    Resolver.resolve(project(recipe, NamedStack("foo"), NamedStack("bar")), stubLookup(), parameters(recipe), logger) should be (List(
+    Resolver.resolve(project(recipe, NamedStack("foo"), NamedStack("bar")), stubLookup(), parameters(recipe), reporter) should be (List(
       StubTask("stacked", stack = Some(NamedStack("foo"))),
       StubTask("stacked", stack = Some(NamedStack("bar")))
     ))

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -1,16 +1,19 @@
 package magenta
 
 import java.io.File
+import java.util.UUID
+
 import org.json4s.JsonAST.JValue
 import tasks._
 import fixtures._
 import org.json4s._
 import org.json4s.JsonDSL._
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.{FlatSpec, Matchers}
 import magenta.deployment_type.AutoScaling
 
 class AutoScalingTest extends FlatSpec with Matchers {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
+  implicit val logger = DeployLogger.rootLoggerFor(UUID.randomUUID(), fixtures.parameters())
 
   "auto-scaling with ELB package type" should "have a deploy action" in {
     val data: Map[String, JValue] = Map(
@@ -21,7 +24,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
 
     val p = DeploymentPackage("app", app, data, "asg-elb", new File("/tmp/packages/webapp"))
 
-    AutoScaling.perAppActions("deploy")(p)(lookupEmpty, parameters(), UnnamedStack) should be (List(
+    AutoScaling.perAppActions("deploy")(p)(logger, lookupEmpty, parameters(), UnnamedStack) should be (List(
       CheckForStabilization(p, PROD, UnnamedStack),
       CheckGroupSize(p, PROD, UnnamedStack),
       SuspendAlarmNotifications(p, PROD, UnnamedStack),
@@ -48,7 +51,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
 
     val p = DeploymentPackage("app", app, data, "asg-elb", new File("/tmp/packages/webapp"))
 
-    AutoScaling.perAppActions("deploy")(p)(lookupEmpty, parameters(), UnnamedStack) should be (List(
+    AutoScaling.perAppActions("deploy")(p)(logger, lookupEmpty, parameters(), UnnamedStack) should be (List(
       CheckForStabilization(p, PROD, UnnamedStack),
       CheckGroupSize(p, PROD, UnnamedStack),
       SuspendAlarmNotifications(p, PROD, UnnamedStack),

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -13,7 +13,7 @@ import magenta.deployment_type.AutoScaling
 
 class AutoScalingTest extends FlatSpec with Matchers {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
-  implicit val logger = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
 
   "auto-scaling with ELB package type" should "have a deploy action" in {
     val data: Map[String, JValue] = Map(
@@ -24,7 +24,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
 
     val p = DeploymentPackage("app", app, data, "asg-elb", new File("/tmp/packages/webapp"))
 
-    AutoScaling.perAppActions("deploy")(p)(logger, lookupEmpty, parameters(), UnnamedStack) should be (List(
+    AutoScaling.perAppActions("deploy")(p)(reporter, lookupEmpty, parameters(), UnnamedStack) should be (List(
       CheckForStabilization(p, PROD, UnnamedStack),
       CheckGroupSize(p, PROD, UnnamedStack),
       SuspendAlarmNotifications(p, PROD, UnnamedStack),
@@ -51,7 +51,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
 
     val p = DeploymentPackage("app", app, data, "asg-elb", new File("/tmp/packages/webapp"))
 
-    AutoScaling.perAppActions("deploy")(p)(logger, lookupEmpty, parameters(), UnnamedStack) should be (List(
+    AutoScaling.perAppActions("deploy")(p)(reporter, lookupEmpty, parameters(), UnnamedStack) should be (List(
       CheckForStabilization(p, PROD, UnnamedStack),
       CheckGroupSize(p, PROD, UnnamedStack),
       SuspendAlarmNotifications(p, PROD, UnnamedStack),

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -13,7 +13,7 @@ import magenta.deployment_type.AutoScaling
 
 class AutoScalingTest extends FlatSpec with Matchers {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
-  implicit val logger = DeployLogger.rootLoggerFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val logger = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
 
   "auto-scaling with ELB package type" should "have a deploy action" in {
     val data: Map[String, JValue] = Map(

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -14,7 +14,7 @@ import scalax.file.Path
 
 class CloudFormationTest extends FlatSpec with Matchers with Inside {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
-  implicit val logger = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
 
   "cloudformation deployment type" should "have an updateStack action" in {
     val data: Map[String, JValue] = Map()
@@ -23,7 +23,7 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
     val cfnStackName = s"cfn-app-PROD"
     val p = DeploymentPackage("app", app, data, "cloudformation", new File("/tmp/packages/webapp"))
 
-    inside(CloudFormation.perAppActions("updateStack")(p)(logger, lookupEmpty, parameters(), stack)) {
+    inside(CloudFormation.perAppActions("updateStack")(p)(reporter, lookupEmpty, parameters(), stack)) {
       case List(updateTask, checkTask) =>
         inside(updateTask) {
           case UpdateCloudFormationTask(stackName, path, userParams, amiParam, amiTags, _, stage, stack, ifAbsent) =>

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -14,7 +14,7 @@ import scalax.file.Path
 
 class CloudFormationTest extends FlatSpec with Matchers with Inside {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
-  implicit val logger = DeployLogger.rootLoggerFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val logger = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
 
   "cloudformation deployment type" should "have an updateStack action" in {
     val data: Map[String, JValue] = Map()

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -1,18 +1,20 @@
 package magenta.deployment_type
 
 import java.io.File
+import java.util.UUID
 
 import magenta._
 import magenta.tasks._
 import magenta.tasks.UpdateCloudFormationTask._
 import org.json4s.JsonAST.JValue
-import org.scalatest.{Inside, FlatSpec, Matchers}
+import org.scalatest.{FlatSpec, Inside, Matchers}
 import fixtures._
 
 import scalax.file.Path
 
 class CloudFormationTest extends FlatSpec with Matchers with Inside {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
+  implicit val logger = DeployLogger.rootLoggerFor(UUID.randomUUID(), fixtures.parameters())
 
   "cloudformation deployment type" should "have an updateStack action" in {
     val data: Map[String, JValue] = Map()
@@ -21,7 +23,7 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
     val cfnStackName = s"cfn-app-PROD"
     val p = DeploymentPackage("app", app, data, "cloudformation", new File("/tmp/packages/webapp"))
 
-    inside(CloudFormation.perAppActions("updateStack")(p)(lookupEmpty, parameters(), stack)) {
+    inside(CloudFormation.perAppActions("updateStack")(p)(logger, lookupEmpty, parameters(), stack)) {
       case List(updateTask, checkTask) =>
         inside(updateTask) {
           case UpdateCloudFormationTask(stackName, path, userParams, amiParam, amiTags, _, stage, stack, ifAbsent) =>

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -13,7 +13,7 @@ import magenta.tasks._
 
 class DeploymentTypeTest extends FlatSpec with Matchers {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
-  implicit val logger = DeployLogger.rootLoggerFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val logger = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
 
   "Deployment types" should "automatically register params in the params Seq" in {
     S3.params should have size 8

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -13,7 +13,7 @@ import magenta.tasks._
 
 class DeploymentTypeTest extends FlatSpec with Matchers {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
-  implicit val logger = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
 
   "Deployment types" should "automatically register params in the params Seq" in {
     S3.params should have size 8
@@ -28,7 +28,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers {
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", new File("/tmp/packages/static-files"))
 
     val thrown = the[NoSuchElementException] thrownBy {
-      S3.perAppActions("uploadStaticFiles")(p)(logger, lookupSingleHost, parameters(Stage("CODE")), UnnamedStack) should be (
+      S3.perAppActions("uploadStaticFiles")(p)(reporter, lookupSingleHost, parameters(Stage("CODE")), UnnamedStack) should be (
         List(S3Upload(
           "bucket-1234",
           Seq(new File("/tmp/packages/static-files") -> "CODE/myapp"),
@@ -49,7 +49,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers {
 
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", new File("/tmp/packages/static-files"))
 
-    S3.perAppActions("uploadStaticFiles")(p)(logger, lookupSingleHost, parameters(Stage("CODE")), UnnamedStack) should be (
+    S3.perAppActions("uploadStaticFiles")(p)(reporter, lookupSingleHost, parameters(Stage("CODE")), UnnamedStack) should be (
       List(S3Upload(
         "bucket-1234",
         Seq(new File("/tmp/packages/static-files") -> "CODE/myapp"),
@@ -70,7 +70,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers {
 
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", new File("/tmp/packages/static-files"))
 
-    S3.perAppActions("uploadStaticFiles")(p)(logger, lookupSingleHost, parameters(Stage("CODE")), UnnamedStack) should be(
+    S3.perAppActions("uploadStaticFiles")(p)(reporter, lookupSingleHost, parameters(Stage("CODE")), UnnamedStack) should be(
       List(S3Upload(
         "bucket-1234",
         Seq(new File("/tmp/packages/static-files") -> "CODE/myapp"),
@@ -92,7 +92,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers {
 
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-lambda", new File("/tmp/packages"))
 
-    Lambda.perAppActions("updateLambda")(p)(logger, lookupSingleHost, parameters(Stage("CODE")), UnnamedStack) should be (
+    Lambda.perAppActions("updateLambda")(p)(reporter, lookupSingleHost, parameters(Stage("CODE")), UnnamedStack) should be (
       List(UpdateLambda(new File("/tmp/packages/lambda.zip"), "myLambda")
       ))
   }
@@ -109,7 +109,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers {
     val p = DeploymentPackage("myapp", Seq.empty, badData, "aws-lambda", new File("/tmp/packages"))
 
     val thrown = the[FailException] thrownBy {
-      Lambda.perAppActions("updateLambda")(p)(logger, lookupSingleHost, parameters(Stage("CODE")), UnnamedStack) should be (
+      Lambda.perAppActions("updateLambda")(p)(reporter, lookupSingleHost, parameters(Stage("CODE")), UnnamedStack) should be (
         List(UpdateLambda(new File("/tmp/packages/lambda.zip"), "myLambda")
         ))
     }
@@ -118,12 +118,12 @@ class DeploymentTypeTest extends FlatSpec with Matchers {
   }
 
   "executable web app package type" should "have a default user of jvmuser" in {
-    
+
     val webappPackage =  DeploymentPackage("foo", Seq.empty, Map.empty, "executable-jar-webapp", new File("."))
 
     ExecutableJarWebapp.user(webappPackage) should be ("jvmuser")
   }
-  
+
   it should "inherit defaults from base webapp" in {
     val webappPackage = DeploymentPackage("foo", Seq.empty, Map.empty, "executable-jar-webapp", new File("."))
 
@@ -142,7 +142,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers {
     val p = DeploymentPackage("webapp", Seq.empty, Map.empty, "django-webapp", webappDirectory)
     val host = Host("host_name")
 
-    Django.perHostActions("deploy")(p)(logger, host, fakeKeyRing) should be (List(
+    Django.perHostActions("deploy")(p)(reporter, host, fakeKeyRing) should be (List(
       BlockFirewall(host as "django"),
       CompressedCopy(host as "django", Some(specificBuildFile), "/django-apps/"),
       Link(host as "django", Some("/django-apps/" + specificBuildFile.getName), "/django-apps/webapp"),

--- a/magenta-lib/src/test/scala/magenta/deployment_type/JettyWebappTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/JettyWebappTest.scala
@@ -19,7 +19,7 @@ import magenta.deployment_type.JettyWebapp
 
 class JettyWebappTest  extends FlatSpec with Matchers {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
-  implicit val logger = DeployLogger.rootLoggerFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val logger = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
 
   "jetty web app package type" should "have a deploy action" in {
     val p = DeploymentPackage("webapp", Seq.empty, Map.empty, "jetty-webapp", new File("/tmp/packages/webapp"))

--- a/magenta-lib/src/test/scala/magenta/deployment_type/JettyWebappTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/JettyWebappTest.scala
@@ -19,14 +19,14 @@ import magenta.deployment_type.JettyWebapp
 
 class JettyWebappTest  extends FlatSpec with Matchers {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
-  implicit val logger = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
 
   "jetty web app package type" should "have a deploy action" in {
     val p = DeploymentPackage("webapp", Seq.empty, Map.empty, "jetty-webapp", new File("/tmp/packages/webapp"))
 
     val host = Host("host_name")
 
-    JettyWebapp.perHostActions("deploy")(p)(logger, host, fakeKeyRing) should be (List(
+    JettyWebapp.perHostActions("deploy")(p)(reporter, host, fakeKeyRing) should be (List(
       BlockFirewall(host as "jetty"),
       CopyFile(host as "jetty", "/tmp/packages/webapp/", "/jetty-apps/webapp/"),
       Service(host as "jetty", "webapp"),
@@ -51,7 +51,7 @@ class JettyWebappTest  extends FlatSpec with Matchers {
     val p = DeploymentPackage("webapp", Seq.empty, Map("healthcheck_paths" -> urls_json), "jetty-webapp", new File("/tmp/packages/webapp"))
     val host = Host("host_name")
 
-    JettyWebapp.perHostActions("deploy")(p)(logger, host, fakeKeyRing) should be (List(
+    JettyWebapp.perHostActions("deploy")(p)(reporter, host, fakeKeyRing) should be (List(
       BlockFirewall(host as "jetty"),
       CopyFile(host as "jetty", "/tmp/packages/webapp/", "/jetty-apps/webapp/"),
       Service(host as "jetty", "webapp"),
@@ -68,13 +68,13 @@ class JettyWebappTest  extends FlatSpec with Matchers {
 
     val host = Host("host_name")
 
-    JettyWebapp.perHostActions("deploy")(p)(logger, host, fakeKeyRing) should (contain (
+    JettyWebapp.perHostActions("deploy")(p)(reporter, host, fakeKeyRing) should (contain (
       CopyFile(host as "jetty", "/tmp/packages/webapp/", "/jetty-apps/webapp/")
     ) and contain (
       Service(host as "jetty", "webapp")
     ))
 
-    JettyWebapp.perHostActions("deploy")(p2)(logger, host, fakeKeyRing) should (contain (
+    JettyWebapp.perHostActions("deploy")(p2)(reporter, host, fakeKeyRing) should (contain (
       CopyFile(host as "jetty", "/tmp/packages/webapp/", "/jetty-apps/microapps/")
     ) and contain (
       Service(host as "jetty", "microapps")
@@ -89,7 +89,7 @@ class JettyWebappTest  extends FlatSpec with Matchers {
   it should "add missing slashes" in {
     val p = DeploymentPackage("webapp", Seq.empty, Map("copyRoots" -> JArray(List("solr/conf/", "app"))), "jetty-webapp", new File("/tmp/packages/webapp"))
     val host = Host("host_name")
-    JettyWebapp.perHostActions("deploy")(p)(logger, host, fakeKeyRing) should (contain (
+    JettyWebapp.perHostActions("deploy")(p)(reporter, host, fakeKeyRing) should (contain (
       CopyFile(host as "jetty", "/tmp/packages/webapp/solr/conf/", "/jetty-apps/webapp/solr/conf/")
     ) and contain (
       CopyFile(host as "jetty", "/tmp/packages/webapp/app/", "/jetty-apps/webapp/app/")
@@ -100,7 +100,7 @@ class JettyWebappTest  extends FlatSpec with Matchers {
     val p = DeploymentPackage("d2index", Seq.empty, Map("copyRoots" -> JArray(List("solr/conf/", "webapp")), "copyMode" -> CopyFile.MIRROR_MODE), "jetty-webapp", new File("/tmp/packages/d2index"))
     val host = Host("host_name")
 
-    JettyWebapp.perHostActions("deploy")(p)(logger, host, fakeKeyRing) should be (List(
+    JettyWebapp.perHostActions("deploy")(p)(reporter, host, fakeKeyRing) should be (List(
       BlockFirewall(host as "jetty"),
       CopyFile(host as "jetty", "/tmp/packages/d2index/solr/conf/", "/jetty-apps/d2index/solr/conf/", CopyFile.MIRROR_MODE),
       CopyFile(host as "jetty", "/tmp/packages/d2index/webapp/", "/jetty-apps/d2index/webapp/", CopyFile.MIRROR_MODE),

--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
@@ -12,7 +12,7 @@ import magenta.tasks.{S3Upload, UpdateS3Lambda}
 
 class LambdaTest extends FlatSpec with Matchers {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
-  implicit val logger = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
 
   behavior of "Lambda deployment action uploadLambda"
 
@@ -26,7 +26,7 @@ class LambdaTest extends FlatSpec with Matchers {
   val pkg = DeploymentPackage("lambda", app, data, "aws-s3-lambda", new File("/tmp/packages/webapp"))
 
   it should "produce an S3 upload task" in {
-    val tasks = Lambda.perAppActions("uploadLambda")(pkg)(logger, lookupEmpty, parameters(PROD), NamedStack("test"))
+    val tasks = Lambda.perAppActions("uploadLambda")(pkg)(reporter, lookupEmpty, parameters(PROD), NamedStack("test"))
     tasks should be (List(
       S3Upload(
         bucket = "lambda-bucket",
@@ -36,7 +36,7 @@ class LambdaTest extends FlatSpec with Matchers {
   }
 
   it should "produce a lambda update task" in {
-    val tasks = Lambda.perAppActions("updateLambda")(pkg)(logger, lookupEmpty, parameters(PROD), NamedStack("test"))
+    val tasks = Lambda.perAppActions("updateLambda")(pkg)(reporter, lookupEmpty, parameters(PROD), NamedStack("test"))
     tasks should be (List(
       UpdateS3Lambda(
         functionName = "MyFunction-PROD",

--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
@@ -3,7 +3,7 @@ package magenta.deployment_type
 import java.io.File
 import java.util.UUID
 
-import magenta.{App, DeployLogger, DeploymentPackage, KeyRing, NamedStack, SystemUser, fixtures}
+import magenta.{App, DeployReporter, DeploymentPackage, KeyRing, NamedStack, SystemUser, fixtures}
 import org.json4s.JsonAST.JValue
 import org.json4s.JsonDSL._
 import org.scalatest.{FlatSpec, Matchers}
@@ -12,7 +12,7 @@ import magenta.tasks.{S3Upload, UpdateS3Lambda}
 
 class LambdaTest extends FlatSpec with Matchers {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
-  implicit val logger = DeployLogger.rootLoggerFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val logger = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
 
   behavior of "Lambda deployment action uploadLambda"
 

--- a/magenta-lib/src/test/scala/magenta/fixtures/fixtures.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/fixtures.scala
@@ -6,23 +6,24 @@ import magenta.deployment_type.DeploymentType
 import magenta.Lookup
 
 case class StubTask(description: String, override val taskHost: Option[Host] = None, stack: Option[Stack] = None) extends Task {
-  def execute(stopFlag: =>  Boolean) { }
+  def execute(logger: DeployLogger, stopFlag: =>  Boolean) { }
   def verbose = "stub(%s)" format description
   def keyRing = KeyRing(SystemUser(None))
 }
 
 case class StubPerHostAction(description: String, apps: Seq[App]) extends Action {
-  def resolve(resourceLookup: Lookup, params: DeployParameters, stack: Stack) = ???
+  def resolve(resourceLookup: Lookup, params: DeployParameters, stack: Stack, logger: DeployLogger) = ???
 }
 
 case class StubPerAppAction(description: String, apps: Seq[App]) extends Action {
-  def resolve(resourceLookup: Lookup, params: DeployParameters, stack: Stack) = ???
+  def resolve(resourceLookup: Lookup, params: DeployParameters, stack: Stack, logger: DeployLogger) = ???
 }
 
-case class StubDeploymentType(override val perHostActions:
-                            PartialFunction[String, DeploymentPackage => (Host, KeyRing) => List[Task]] = Map.empty,
-                           override val perAppActions:
-                            PartialFunction[String, DeploymentPackage => (Lookup, DeployParameters, Stack) => List[Task]] = Map.empty
+case class StubDeploymentType(
+  override val perHostActions:
+    PartialFunction[String, DeploymentPackage => (DeployLogger, Host, KeyRing) => List[Task]] = Map.empty,
+  override val perAppActions:
+    PartialFunction[String, DeploymentPackage => (DeployLogger, Lookup, DeployParameters, Stack) => List[Task]] = Map.empty
                             ) extends DeploymentType {
   def name = "stub-package-type"
 

--- a/magenta-lib/src/test/scala/magenta/fixtures/fixtures.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/fixtures.scala
@@ -6,24 +6,24 @@ import magenta.deployment_type.DeploymentType
 import magenta.Lookup
 
 case class StubTask(description: String, override val taskHost: Option[Host] = None, stack: Option[Stack] = None) extends Task {
-  def execute(logger: DeployLogger, stopFlag: =>  Boolean) { }
+  def execute(reporter: DeployReporter, stopFlag: => Boolean) { }
   def verbose = "stub(%s)" format description
   def keyRing = KeyRing(SystemUser(None))
 }
 
 case class StubPerHostAction(description: String, apps: Seq[App]) extends Action {
-  def resolve(resourceLookup: Lookup, params: DeployParameters, stack: Stack, logger: DeployLogger) = ???
+  def resolve(resourceLookup: Lookup, params: DeployParameters, stack: Stack, reporter: DeployReporter) = ???
 }
 
 case class StubPerAppAction(description: String, apps: Seq[App]) extends Action {
-  def resolve(resourceLookup: Lookup, params: DeployParameters, stack: Stack, logger: DeployLogger) = ???
+  def resolve(resourceLookup: Lookup, params: DeployParameters, stack: Stack, reporter: DeployReporter) = ???
 }
 
 case class StubDeploymentType(
   override val perHostActions:
-    PartialFunction[String, DeploymentPackage => (DeployLogger, Host, KeyRing) => List[Task]] = Map.empty,
+    PartialFunction[String, DeploymentPackage => (DeployReporter, Host, KeyRing) => List[Task]] = Map.empty,
   override val perAppActions:
-    PartialFunction[String, DeploymentPackage => (DeployLogger, Lookup, DeployParameters, Stack) => List[Task]] = Map.empty
+    PartialFunction[String, DeploymentPackage => (DeployReporter, Lookup, DeployParameters, Stack) => List[Task]] = Map.empty
                             ) extends DeploymentType {
   def name = "stub-package-type"
 

--- a/magenta-lib/src/test/scala/magenta/fixtures/package.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/package.scala
@@ -28,10 +28,10 @@ package object fixtures {
 
   def stubPackageType(perAppActionNames: Seq[String], perHostActionNames: Seq[String]) = StubDeploymentType(
     perAppActions = {
-      case name if perAppActionNames.contains(name) => pkg => (_,_, _) => List(StubTask(name + " per app task"))
+      case name if perAppActionNames.contains(name) => pkg => (_,_,_, _) => List(StubTask(name + " per app task"))
     },
     perHostActions = {
-      case name if perHostActionNames.contains(name) => pkg => (host, _) =>
+      case name if perHostActionNames.contains(name) => pkg => (_, host, _) =>
         List(StubTask(name + " per host task on " + host.name, Some(host)))
     }
   )

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
@@ -13,7 +13,7 @@ import java.util.UUID
 
 class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
-  implicit val logger = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
 
   it should "double the size of the autoscaling group" in {
     val asg = new AutoScalingGroup().withDesiredCapacity(3).withAutoScalingGroupName("test").withMaxSize(10)
@@ -27,7 +27,7 @@ class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
                                       (implicit keyRing: KeyRing, reporter: DeployReporter) = asg
     }
 
-    task.execute(logger)
+    task.execute(reporter)
 
     verify(asgClientMock).setDesiredCapacity(
       new SetDesiredCapacityRequest().withAutoScalingGroupName("test").withDesiredCapacity(6)
@@ -48,7 +48,7 @@ class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
                                       (implicit keyRing: KeyRing, reporter: DeployReporter) = asg
     }
 
-    val thrown = intercept[FailException](task.execute(logger))
+    val thrown = intercept[FailException](task.execute(reporter))
 
     thrown.getMessage should startWith ("Autoscaling group does not have the capacity")
 

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
@@ -13,7 +13,7 @@ import java.util.UUID
 
 class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
-  implicit val logger = DeployLogger.rootLoggerFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val logger = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
 
   it should "double the size of the autoscaling group" in {
     val asg = new AutoScalingGroup().withDesiredCapacity(3).withAutoScalingGroupName("test").withMaxSize(10)
@@ -24,7 +24,7 @@ class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
     val task = new DoubleSize(p, Stage("PROD"), UnnamedStack) {
       override def client(implicit keyRing: KeyRing) = asgClientMock
       override def groupForAppAndStage(pkg: DeploymentPackage,  stage: Stage, stack: Stack)
-                                      (implicit keyRing: KeyRing, logger: DeployLogger) = asg
+                                      (implicit keyRing: KeyRing, reporter: DeployReporter) = asg
     }
 
     task.execute(logger)
@@ -45,7 +45,7 @@ class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
     val task = new CheckGroupSize(p, Stage("PROD"), UnnamedStack) {
       override def client(implicit keyRing: KeyRing) = asgClientMock
       override def groupForAppAndStage(pkg: DeploymentPackage, stage: Stage, stack: Stack)
-                                      (implicit keyRing: KeyRing, logger: DeployLogger) = asg
+                                      (implicit keyRing: KeyRing, reporter: DeployReporter) = asg
     }
 
     val thrown = intercept[FailException](task.execute(logger))

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
@@ -1,21 +1,23 @@
 package magenta.tasks
 
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.{FlatSpec, Matchers}
 import magenta._
 import org.scalatest.mock.MockitoSugar
 import com.amazonaws.services.autoscaling.AmazonAutoScalingClient
 import com.amazonaws.services.autoscaling.model.{Instance => ASGInstance, _}
-
 import org.mockito.Mockito._
 import org.mockito.Matchers._
+
 import collection.JavaConversions._
 import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClient
-import com.amazonaws.services.elasticloadbalancing.model.{Instance => ELBInstance, InstanceState, DescribeInstanceHealthResult, DescribeInstanceHealthRequest}
-import magenta.{App, SystemUser, KeyRing, Stage}
+import com.amazonaws.services.elasticloadbalancing.model.{DescribeInstanceHealthRequest, DescribeInstanceHealthResult, InstanceState, Instance => ELBInstance}
+import magenta.{App, KeyRing, Stage, SystemUser}
 import java.io.File
+import java.util.UUID
 
 class ASGTest extends FlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
+  implicit val logger = DeployLogger.rootLoggerFor(UUID.randomUUID(), fixtures.parameters())
 
   it should "find the matching auto-scaling group with App tagging" in {
     val asgClientMock = mock[AmazonAutoScalingClient]

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
@@ -17,7 +17,7 @@ import java.util.UUID
 
 class ASGTest extends FlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
-  implicit val logger = DeployLogger.rootLoggerFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val logger = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
 
   it should "find the matching auto-scaling group with App tagging" in {
     val asgClientMock = mock[AmazonAutoScalingClient]

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
@@ -17,7 +17,7 @@ import java.util.UUID
 
 class ASGTest extends FlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
-  implicit val logger = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
 
   it should "find the matching auto-scaling group with App tagging" in {
     val asgClientMock = mock[AmazonAutoScalingClient]

--- a/magenta-lib/src/test/scala/magenta/tasks/CommandLineTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/CommandLineTest.scala
@@ -21,14 +21,14 @@ class CommandLineTest extends FlatSpec with Matchers {
       be ("echo \"this needs to be quoted\"")
   }
 
-  it should "execute command and pipe progress results to Logger" in {
+  it should "execute command and pipe progress results to reporter" in {
     val recordedMessages = new ListBuffer[List[Message]]()
     DeployReporter.messages.filter(_.stack.deployParameters == Some(parameters)).subscribe(recordedMessages += _.stack.messages)
 
-    val logger = DeployReporter.startDeployContext(DeployReporter.rootReporterFor(UUID.randomUUID(), parameters))
+    val reporter = DeployReporter.startDeployContext(DeployReporter.rootReporterFor(UUID.randomUUID(), parameters))
     val c = CommandLine(List("echo", "hello"))
-    c.run(logger)
-    DeployReporter.finishContext(logger)
+    c.run(reporter)
+    DeployReporter.finishContext(reporter)
 
     recordedMessages.toList should be (
       List(StartContext(Deploy(parameters))) ::
@@ -43,15 +43,15 @@ class CommandLineTest extends FlatSpec with Matchers {
 
   it should "throw when command is not found" in {
     a[FailException] should be thrownBy {
-      val logger = DeployReporter.startDeployContext(DeployReporter.rootReporterFor(UUID.randomUUID(), parameters))
-      CommandLine(List("unknown_command")).run(logger)
+      val reporter = DeployReporter.startDeployContext(DeployReporter.rootReporterFor(UUID.randomUUID(), parameters))
+      CommandLine(List("unknown_command")).run(reporter)
     }
   }
 
   it should "throw when command returns non zero exit code" in {
     a[FailException] should be thrownBy {
-      val logger = DeployReporter.startDeployContext(DeployReporter.rootReporterFor(UUID.randomUUID(), parameters))
-      CommandLine(List("false")).run(logger)
+      val reporter = DeployReporter.startDeployContext(DeployReporter.rootReporterFor(UUID.randomUUID(), parameters))
+      CommandLine(List("false")).run(reporter)
     }
   }
 

--- a/magenta-lib/src/test/scala/magenta/tasks/CommandLineTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/CommandLineTest.scala
@@ -23,9 +23,9 @@ class CommandLineTest extends FlatSpec with Matchers {
 
   it should "execute command and pipe progress results to Logger" in {
     val recordedMessages = new ListBuffer[List[Message]]()
-    MessageBroker.messages.filter(_.stack.deployParameters == Some(parameters)).subscribe(recordedMessages += _.stack.messages)
+    DeployLogger.messages.filter(_.stack.deployParameters == Some(parameters)).subscribe(recordedMessages += _.stack.messages)
 
-    MessageBroker.deployContext(UUID.randomUUID(), parameters) {
+    DeployLogger.deployContext(UUID.randomUUID(), parameters) {
       val c = CommandLine(List("echo", "hello"))
       c.run()
     }
@@ -43,7 +43,7 @@ class CommandLineTest extends FlatSpec with Matchers {
 
   it should "throw when command is not found" in {
     an[IOException] should be thrownBy {
-      MessageBroker.deployContext(UUID.randomUUID(), parameters) {
+      DeployLogger.deployContext(UUID.randomUUID(), parameters) {
         CommandLine(List("unknown_command")).run()
       }
     }
@@ -51,7 +51,7 @@ class CommandLineTest extends FlatSpec with Matchers {
 
   it should "throw when command returns non zero exit code" in {
     a[FailException] should be thrownBy {
-      MessageBroker.deployContext(UUID.randomUUID(), parameters) {
+      DeployLogger.deployContext(UUID.randomUUID(), parameters) {
         CommandLine(List("false")).run()
       }
     }

--- a/magenta-lib/src/test/scala/magenta/tasks/CommandLineTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/CommandLineTest.scala
@@ -23,12 +23,12 @@ class CommandLineTest extends FlatSpec with Matchers {
 
   it should "execute command and pipe progress results to Logger" in {
     val recordedMessages = new ListBuffer[List[Message]]()
-    DeployLogger.messages.filter(_.stack.deployParameters == Some(parameters)).subscribe(recordedMessages += _.stack.messages)
+    DeployReporter.messages.filter(_.stack.deployParameters == Some(parameters)).subscribe(recordedMessages += _.stack.messages)
 
-    val logger = DeployLogger.startDeployContext(DeployLogger.rootLoggerFor(UUID.randomUUID(), parameters))
+    val logger = DeployReporter.startDeployContext(DeployReporter.rootReporterFor(UUID.randomUUID(), parameters))
     val c = CommandLine(List("echo", "hello"))
     c.run(logger)
-    DeployLogger.finishContext(logger)
+    DeployReporter.finishContext(logger)
 
     recordedMessages.toList should be (
       List(StartContext(Deploy(parameters))) ::
@@ -43,14 +43,14 @@ class CommandLineTest extends FlatSpec with Matchers {
 
   it should "throw when command is not found" in {
     a[FailException] should be thrownBy {
-      val logger = DeployLogger.startDeployContext(DeployLogger.rootLoggerFor(UUID.randomUUID(), parameters))
+      val logger = DeployReporter.startDeployContext(DeployReporter.rootReporterFor(UUID.randomUUID(), parameters))
       CommandLine(List("unknown_command")).run(logger)
     }
   }
 
   it should "throw when command returns non zero exit code" in {
     a[FailException] should be thrownBy {
-      val logger = DeployLogger.startDeployContext(DeployLogger.rootLoggerFor(UUID.randomUUID(), parameters))
+      val logger = DeployReporter.startDeployContext(DeployReporter.rootReporterFor(UUID.randomUUID(), parameters))
       CommandLine(List("false")).run(logger)
     }
   }

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -81,7 +81,7 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
       server.accept().close()
       server.close()
     }
-    MessageBroker.deployContext(UUID.randomUUID(), parameters) { task.execute() }
+    DeployLogger.deployContext(UUID.randomUUID(), parameters) { task.execute() }
   }
 
   it should "connect to an open port after a short time" in {

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -19,7 +19,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class TasksTest extends FlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing = KeyRing(SystemUser(None))
-  implicit val logger = DeployLogger.rootLoggerFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val logger = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
 
   "block firewall task" should "use configurable path" in {
     val host = Host("some-host") as ("some-user")
@@ -160,7 +160,7 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
       def host = Host("some-host")
 
       override def remoteCommandLine(credentials: Option[SshCredentials]) = new CommandLine(""::Nil) {
-        override def run(logger: DeployLogger) { passed = true }
+        override def run(reporter: DeployReporter) { passed = true }
       }
 
       def commandLine = null
@@ -299,7 +299,7 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
     fileThree.createNewFile()
 
     val task = new S3Upload("bucket", Seq(baseDir -> "")) with StubS3
-    task.execute()
+    task.execute(logger)
     val s3Client = task.s3client(fakeKeyRing)
 
     val files = task.flattenedFiles

--- a/project/MagentaBuild.scala
+++ b/project/MagentaBuild.scala
@@ -44,6 +44,7 @@ object MagentaBuild extends Build {
     )
 
   val magentaSettings: Seq[Setting[_]] = Seq(
+    scalaVersion in ThisBuild := "2.11.8",
     scalacOptions ++= Seq("-deprecation", "-feature", "-language:postfixOps,reflectiveCalls,implicitConversions"),
     version := magentaVersion,
     resolvers += "Guardian Github Releases" at "http://guardian.github.com/maven/repo-releases",

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -235,7 +235,7 @@ object DeployMetrics extends LifecycleWithoutApp {
 
   val all = Seq(DeployStart, DeployComplete, DeployFail, DeployRunning)
 
-  val messageSub = MessageBroker.messages.subscribe(message => {
+  val messageSub = DeployLogger.messages.subscribe(message => {
     message.stack.top match {
       case StartContext(Deploy(parameters)) =>
         DeployStart.recordCount(1)

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -235,7 +235,7 @@ object DeployMetrics extends LifecycleWithoutApp {
 
   val all = Seq(DeployStart, DeployComplete, DeployFail, DeployRunning)
 
-  val messageSub = DeployLogger.messages.subscribe(message => {
+  val messageSub = DeployReporter.messages.subscribe(message => {
     message.stack.top match {
       case StartContext(Deploy(parameters)) =>
         DeployStart.recordCount(1)

--- a/riff-raff/app/controllers/Testing.scala
+++ b/riff-raff/app/controllers/Testing.scala
@@ -21,14 +21,14 @@ object Testing extends Controller with Logging with LoginActions {
     val parameters = DeployParameters(Deployer("Simon Hildrew"), Build("tools::deploy", "131"), Stage("DEV"), DefaultRecipe())
 
     val testTask1 = new Task {
-      override def execute(logger: DeployLogger, stopFlag: => Boolean) {}
+      override def execute(reporter: DeployReporter, stopFlag: => Boolean) {}
       def description = "Test task that does stuff, the first time"
       def verbose = "A particularly verbose task description that lists some stuff, innit"
 
       def keyRing = ???
     }
     val testTask2 = new Task {
-      override def execute(logger: DeployLogger, stopFlag: => Boolean) {}
+      override def execute(reporter: DeployReporter, stopFlag: => Boolean) {}
       def description = "Test task that does stuff"
       def verbose = "A particularly verbose task description that lists some stuff, innit"
 

--- a/riff-raff/app/controllers/Testing.scala
+++ b/riff-raff/app/controllers/Testing.scala
@@ -21,14 +21,14 @@ object Testing extends Controller with Logging with LoginActions {
     val parameters = DeployParameters(Deployer("Simon Hildrew"), Build("tools::deploy", "131"), Stage("DEV"), DefaultRecipe())
 
     val testTask1 = new Task {
-      def execute(stopFlag: => Boolean) {}
+      override def execute(logger: DeployLogger, stopFlag: => Boolean) {}
       def description = "Test task that does stuff, the first time"
       def verbose = "A particularly verbose task description that lists some stuff, innit"
 
       def keyRing = ???
     }
     val testTask2 = new Task {
-      def execute(stopFlag: => Boolean) {}
+      override def execute(logger: DeployLogger, stopFlag: => Boolean) {}
       def description = "Test task that does stuff"
       def verbose = "A particularly verbose task description that lists some stuff, innit"
 

--- a/riff-raff/app/deployment/Deployments.scala
+++ b/riff-raff/app/deployment/Deployments.scala
@@ -23,7 +23,7 @@ object Deployments extends Logging with LifecycleWithoutApp {
   private lazy val deployCompleteSubject = Subject[UUID]()
 
   private val messagesSubscription: Subscription =
-    DeployLogger.messages.subscribe{ wrapper =>
+    DeployReporter.messages.subscribe{ wrapper =>
       try {
         update(wrapper)
       } catch {

--- a/riff-raff/app/deployment/Deployments.scala
+++ b/riff-raff/app/deployment/Deployments.scala
@@ -23,7 +23,7 @@ object Deployments extends Logging with LifecycleWithoutApp {
   private lazy val deployCompleteSubject = Subject[UUID]()
 
   private val messagesSubscription: Subscription =
-    MessageBroker.messages.subscribe{ wrapper =>
+    DeployLogger.messages.subscribe{ wrapper =>
       try {
         update(wrapper)
       } catch {

--- a/riff-raff/app/deployment/actors.scala
+++ b/riff-raff/app/deployment/actors.scala
@@ -170,7 +170,7 @@ class DeployCoordinator extends Actor with Logging {
 
     case StartDeploy(record) if schedulable(record) =>
       log.debug("Scheduling deploy")
-      val rootLogger = DeployLogger.rootLoggerFor(record.uuid, record.parameters)
+      val rootLogger = DeployLogger.startDeployContext(DeployLogger.rootLoggerFor(record.uuid, record.parameters))
       val state = DeployRunState(record, rootLogger)
       ifStopFlagClear(state) {
         deployStateMap += (record.uuid -> state)

--- a/riff-raff/app/deployment/actors.scala
+++ b/riff-raff/app/deployment/actors.scala
@@ -49,7 +49,7 @@ object DeployControlActor extends Logging {
   import deployment.DeployCoordinator.{StopDeploy, StartDeploy, CheckStopFlag}
 
   def interruptibleDeploy(record: Record) {
-    log.debug("Sending start deploy mesage to co-ordinator")
+    log.debug("Sending start deploy message to co-ordinator")
     deployCoordinator ! StartDeploy(record)
   }
 
@@ -106,7 +106,7 @@ case class UniqueTask(id: Int, task: Task)
 
 case class DeployRunState(
   record: Record,
-  loggingContext: MessageBrokerContext,
+  rootLogger: DeployLogger,
   artifactDir: Option[File] = None,
   context: Option[DeployContext] = None
 ) {
@@ -153,7 +153,7 @@ class DeployCoordinator extends Actor with Logging {
       case true =>
         log.debug("Stop flag set")
         val stopMessage = "Deploy has been stopped by %s" format stopFlagMap(state.record.uuid).getOrElse("an unknown user")
-        MessageBroker.failAllContexts(state.loggingContext, stopMessage, DeployStoppedException(stopMessage))
+        DeployLogger.failAllContexts(state.rootLogger, stopMessage, DeployStoppedException(stopMessage))
         log.debug("Cleaning up")
         cleanup(state)
         None
@@ -170,11 +170,11 @@ class DeployCoordinator extends Actor with Logging {
 
     case StartDeploy(record) if schedulable(record) =>
       log.debug("Scheduling deploy")
-      val loggingContext = MessageBroker.startDeployContext(record.uuid, record.parameters)
-      val state = DeployRunState(record, loggingContext)
+      val rootLogger = DeployLogger.rootLoggerFor(record.uuid, record.parameters)
+      val state = DeployRunState(record, rootLogger)
       ifStopFlagClear(state) {
         deployStateMap += (record.uuid -> state)
-        runners ! PrepareDeploy(record, loggingContext)
+        runners ! PrepareDeploy(record, rootLogger)
       }
 
     case StopDeploy(uuid, userName) =>
@@ -191,11 +191,11 @@ class DeployCoordinator extends Actor with Logging {
         ifStopFlagClear(newState) {
           newState.firstTask.foreach { task =>
             log.debug("Starting first task")
-            runners ! RunTask(newState.record, task, newState.loggingContext, new DateTime())
+            runners ! RunTask(newState.record, task, newState.rootLogger, new DateTime())
           }
         }
       }
-      
+
     case TaskCompleted(record, task) =>
       log.debug("Task completed")
       deployStateMap.get(record.uuid).foreach { state =>
@@ -205,9 +205,9 @@ class DeployCoordinator extends Actor with Logging {
           state.nextTask(task) match {
             case Some(nextTask) =>
               log.debug("Running next task")
-              runners ! RunTask(state.record, state.nextTask(task).get, state.loggingContext, new DateTime())
+              runners ! RunTask(state.record, state.nextTask(task).get, state.rootLogger, new DateTime())
             case None =>
-              MessageBroker.finishContext(state.loggingContext)
+              DeployLogger.finishContext(state.rootLogger)
               log.debug("Cleaning up")
               cleanup(state)
           }
@@ -251,11 +251,11 @@ class DeployCoordinator extends Actor with Logging {
 
 object TaskRunner {
   trait Message
-  case class RunTask(record: Record, task: UniqueTask, loggingContext:MessageBrokerContext, queueTime: DateTime) extends Message
+  case class RunTask(record: Record, task: UniqueTask, loggingContext:DeployLogger, queueTime: DateTime) extends Message
   case class TaskCompleted(record: Record, task: UniqueTask) extends Message
   case class TaskFailed(record: Record, exception: Throwable) extends Message
 
-  case class PrepareDeploy(record: Record, loggingContext: MessageBrokerContext) extends Message
+  case class PrepareDeploy(record: Record, rootLogger: DeployLogger) extends Message
   case class DeployReady(record: Record, artifactDir: File, context: DeployContext) extends Message
   case class RemoveArtifact(artifactDir: File) extends Message
 }
@@ -264,19 +264,18 @@ class TaskRunner extends Actor with Logging {
   import TaskRunner._
 
   def receive = {
-    case PrepareDeploy(record, loggingContext) =>
+    case PrepareDeploy(record, rootLogger) =>
+      implicit val logger = rootLogger
       try {
-        MessageBroker.withContext(loggingContext) {
-          import Configuration.artifact.aws._
-          val artifactDir = S3Artifact.download(record.parameters.build)
-          MessageBroker.info("Reading deploy.json")
-          val project = JsonReader.parse(new File(artifactDir, "deploy.json"))
-          val context = record.parameters.toDeployContext(record.uuid, project, LookupSelector())
-          if (context.tasks.isEmpty)
-            MessageBroker.fail("No tasks were found to execute. Ensure the app(s) are in the list supported by this stage/host.")
+        import Configuration.artifact.aws._
+        val artifactDir = S3Artifact.download(record.parameters.build)
+        rootLogger.info("Reading deploy.json")
+        val project = JsonReader.parse(new File(artifactDir, "deploy.json"))
+        val context = record.parameters.toDeployContext(record.uuid, project, LookupSelector(), rootLogger)
+        if (context.tasks.isEmpty)
+          rootLogger.fail("No tasks were found to execute. Ensure the app(s) are in the list supported by this stage/host.")
 
-          sender ! DeployReady(record, artifactDir, context)
-        }
+        sender ! DeployReady(record, artifactDir, context)
       } catch {
         case t:Throwable =>
           log.debug("Preparing deploy failed")
@@ -284,7 +283,7 @@ class TaskRunner extends Actor with Logging {
       }
 
 
-    case RunTask(record, task, loggingContext, queueTime) => {
+    case RunTask(record, task, rootLogger, queueTime) => {
       import DeployMetricsActor._
       deployMetricsProcessor ! TaskStart(record.uuid, task.id, queueTime, new DateTime())
       log.debug("Running task %d" format task.id)
@@ -299,10 +298,8 @@ class TaskRunner extends Actor with Logging {
             case t:Throwable => false
           }
         }
-        MessageBroker.withContext(loggingContext) {
-          MessageBroker.taskContext(task.task) {
-            task.task.execute(stopFlagAsker)
-          }
+        rootLogger.taskContext(task.task) { taskLogger =>
+          task.task.execute(taskLogger, stopFlagAsker)
         }
         log.debug("Sending completed message")
         sender ! TaskCompleted(record, task)

--- a/riff-raff/app/deployment/model.scala
+++ b/riff-raff/app/deployment/model.scala
@@ -76,10 +76,6 @@ trait Record {
 
   def isSummarised: Boolean
 
-  def loggingContext[T](block: => T): T = {
-    MessageBroker.deployContext(uuid, parameters) { block }
-  }
-
   lazy val hoursAgo: Long = new Interval(time, new DateTime()).toDuration.getStandardHours
 
   lazy val allMetaData = metaData ++ computedMetaData

--- a/riff-raff/app/deployment/preview.scala
+++ b/riff-raff/app/deployment/preview.scala
@@ -1,26 +1,24 @@
 package deployment
 
-import _root_.resources.LookupSelector
-import ci.S3Build
-import magenta._
-import magenta.artifact.S3Artifact
-import persistence.Persistence
 import java.io.File
-import io.Source
-import magenta.json.JsonReader
-import controllers.routes
-import magenta.DeployParameters
-import magenta.Project
-import magenta.Build
-import tasks.{ Task => MagentaTask }
 import java.util.UUID
-import akka.agent.Agent
-import org.joda.time.DateTime
-import conf.Configuration
-import scala.concurrent._
+
+import _root_.resources.LookupSelector
 import akka.actor.ActorSystem
-import ExecutionContext.Implicits.global
-import duration._
+import akka.agent.Agent
+import conf.Configuration
+import controllers.routes
+import magenta.{Build, DeployParameters, Project, _}
+import magenta.artifact.S3Artifact
+import magenta.json.JsonReader
+import magenta.tasks.{Task => MagentaTask}
+import org.joda.time.DateTime
+import persistence.Persistence
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent._
+import scala.concurrent.duration._
+import scala.io.Source
 
 case class PreviewResult(future: Future[Preview], startTime: DateTime = new DateTime()) {
   def completed = future.isCompleted
@@ -42,7 +40,8 @@ object PreviewController {
   def startPreview(parameters: DeployParameters): UUID = {
     cleanupPreviews()
     val previewId = UUID.randomUUID()
-    val previewFuture = future { Preview(parameters) }
+    val muteLogger = DeployLogger.rootLoggerFor(previewId, parameters, publishMessages = false)
+    val previewFuture = Future { Preview(parameters, muteLogger) }
     Await.ready(agent.alter{ _ + (previewId -> PreviewResult(previewFuture)) }, 30.second)
     previewId
   }
@@ -54,9 +53,10 @@ object Preview {
   import Configuration.artifact.aws._
 
   def getJsonFromStore(build: Build): Option[String] = Persistence.store.getDeployJson(build)
-  def getJsonFromArtifact(build: Build): String = S3Artifact.withDownload(build) { artifactDir =>
-    Source.fromFile(new File(artifactDir, "deploy.json")).getLines().mkString
-  }
+  def getJsonFromArtifact(build: Build)(implicit logger: DeployLogger): String =
+    S3Artifact.withDownload(build) { artifactDir =>
+      Source.fromFile(new File(artifactDir, "deploy.json")).getLines().mkString
+    }
   def parseJson(json:String) = JsonReader.parse(json, new File(System.getProperty("java.io.tmpdir")))
 
   /**
@@ -64,9 +64,9 @@ object Preview {
    * cannot be used for an actual deploy.
    * This is cached in the database so future previews are faster.
    */
-  def getProject(build: Build): Project = {
+  def getProject(build: Build, logger: DeployLogger): Project = {
     val json = getJsonFromStore(build).getOrElse {
-      val json = getJsonFromArtifact(build)
+      val json = getJsonFromArtifact(build)(logger)
       Persistence.store.writeDeployJson(build, json)
       json
     }
@@ -76,13 +76,13 @@ object Preview {
   /**
    * Get the preview, extracting the artifact if necessary - this may take a long time to run
    */
-  def apply(parameters: DeployParameters): Preview = {
-    val project = Preview.getProject(parameters.build)
-    Preview(project, parameters)
+  def apply(parameters: DeployParameters, logger: DeployLogger): Preview = {
+    val project = Preview.getProject(parameters.build, logger)
+    Preview(project, parameters, logger)
   }
 }
 
-case class Preview(project: Project, parameters: DeployParameters) {
+case class Preview(project: Project, parameters: DeployParameters, logger: DeployLogger) {
   lazy val lookup = LookupSelector()
   lazy val stacks = Resolver.resolveStacks(project, parameters) collect {
     case NamedStack(s) => s
@@ -93,18 +93,18 @@ case class Preview(project: Project, parameters: DeployParameters) {
   def isDependantRecipe(r: String) = r != recipe && recipeNames.contains(r)
   def dependsOn(r: String) = project.recipes(r).dependsOn
 
-  lazy val recipeTasks = Resolver.resolveDetail(project, lookup, parameters)
+  lazy val recipeTasks = Resolver.resolveDetail(project, lookup, parameters, logger)
   lazy val tasks = recipeTasks.flatMap(_.tasks)
 
   def taskHosts(taskList:List[MagentaTask]) = taskList.flatMap(_.taskHost).filter(lookup.hosts.all.contains).distinct
 
   lazy val hosts = taskHosts(tasks)
   lazy val allHosts = {
-    val allTasks = Resolver.resolve(project, lookup, parameters.copy(recipe = RecipeName(recipe), hostList=Nil)).distinct
+    val allTasks = Resolver.resolve(project, lookup, parameters.copy(recipe = RecipeName(recipe), hostList=Nil), logger).distinct
     taskHosts(allTasks)
   }
   lazy val allPossibleHosts = {
-    val allTasks = allRecipes.flatMap(recipe => Resolver.resolve(project, lookup, parameters.copy(recipe = RecipeName(recipe), hostList=Nil))).distinct
+    val allTasks = allRecipes.flatMap(recipe => Resolver.resolve(project, lookup, parameters.copy(recipe = RecipeName(recipe), hostList=Nil), logger)).distinct
     taskHosts(allTasks)
   }
 

--- a/riff-raff/app/notification/hooks.scala
+++ b/riff-raff/app/notification/hooks.scala
@@ -147,7 +147,7 @@ object HooksClient extends LifecycleWithoutApp with Logging {
     actor.foreach(_ ! Finished(uuid, parameters))
   }
 
-  val messageSub = MessageBroker.messages.subscribe(message => {
+  val messageSub = DeployLogger.messages.subscribe(message => {
     message.stack.top match {
       case FinishContext(Deploy(parameters)) =>
         finishedBuild(message.context.deployId, parameters)

--- a/riff-raff/app/notification/hooks.scala
+++ b/riff-raff/app/notification/hooks.scala
@@ -147,7 +147,7 @@ object HooksClient extends LifecycleWithoutApp with Logging {
     actor.foreach(_ ! Finished(uuid, parameters))
   }
 
-  val messageSub = DeployLogger.messages.subscribe(message => {
+  val messageSub = DeployReporter.messages.subscribe(message => {
     message.stack.top match {
       case FinishContext(Deploy(parameters)) =>
         finishedBuild(message.context.deployId, parameters)

--- a/riff-raff/app/notification/irc.scala
+++ b/riff-raff/app/notification/irc.scala
@@ -19,7 +19,7 @@ object IrcClient extends LifecycleWithoutApp {
     actor.foreach(_ ! Notify(message))
   }
 
-  val messageSub = MessageBroker.messages.subscribe(message => {
+  val messageSub = DeployLogger.messages.subscribe(message => {
     message.stack.top match {
       case StartContext(Deploy(parameters)) =>
         sendMessage("[%s] Starting deploy of %s build %s (using recipe %s) to %s" format

--- a/riff-raff/app/notification/irc.scala
+++ b/riff-raff/app/notification/irc.scala
@@ -19,7 +19,7 @@ object IrcClient extends LifecycleWithoutApp {
     actor.foreach(_ ! Notify(message))
   }
 
-  val messageSub = DeployLogger.messages.subscribe(message => {
+  val messageSub = DeployReporter.messages.subscribe(message => {
     message.stack.top match {
       case StartContext(Deploy(parameters)) =>
         sendMessage("[%s] Starting deploy of %s build %s (using recipe %s) to %s" format


### PR DESCRIPTION
This is a bash at removing the dependency on thread local logging. The approach is to pass around a `DeployLogger` (née `MessageBroker`) everywhere that needs it. This is largely used during task resolution and then task execution.

I've got as far as all of the test suites passing - but this has not been tested outside of that and if memory serves me right, logging has historically been somewhat brittle. Having said that, the changes made here feel generally good.