### PR TITLE
Cater for case with zero length prefix

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -140,9 +140,10 @@ case class S3Upload(
     MessageBroker.verbose(s"Finished upload of ${fileString(files.size)} to S3")
   }
 
+  private def subDirectoryPrefix(key: String, file:File): String = if (key.isEmpty) file.getName else s"$key/${file.getName}"
   private def resolveFiles(file: File, key: String): Seq[(File, String)] = {
     if (!file.isDirectory) Seq((file, key))
-    else file.listFiles.toSeq.flatMap(f => resolveFiles(f, s"$key/${f.getName}")).distinct
+    else file.listFiles.toSeq.flatMap(f => resolveFiles(f, subDirectoryPrefix(key, f))).distinct
   }
 
   private def contentTypeLookup(fileName: String) = fileExtension(fileName).flatMap(extensionToMimeType.get)


### PR DESCRIPTION
The restructured `S3Upload` task broke mobile's static file deploy as we inject a superfluous `/` into the key when a zero length prefix is provided (see https://riffraff.gutools.co.uk/deployment/view/1cbf487f-89c7-46c9-8cbe-2b5facc27eed?verbose=1).

This fix special cases the zero length key.