### PR TITLE
Deploy again feature

### DIFF
--- a/riff-raff/app/assets/stylesheets/magenta.less
+++ b/riff-raff/app/assets/stylesheets/magenta.less
@@ -128,10 +128,6 @@ ul.magenta-list {
   margin-bottom:0;
 }
 
-.checkbox-fix-right {
-  margin-right: 18px;
-}
-
 .checkbox-fix-top {
   margin-top: 20px;
 }

--- a/riff-raff/app/controllers/DeployController.scala
+++ b/riff-raff/app/controllers/DeployController.scala
@@ -193,12 +193,17 @@ object DeployController extends Controller with Logging with LoginActions {
 
   def deployConfirmation(deployFormJson: String) = AuthAction { implicit request =>
     val parametersJson = Json.parse(deployFormJson)
-    Ok(views.html.deploy.deployConfirmation(request, deployForm.bind(parametersJson)))
+    Ok(views.html.deploy.deployConfirmation(request, deployForm.bind(parametersJson), isExternal = true))
   }
 
-  def deployConfirmationWithParameters = AuthAction { implicit request =>
+  def deployConfirmationExternal = AuthAction { implicit request =>
     val form = deployForm.bindFromRequest()
-    Ok(views.html.deploy.deployConfirmation(request, form))
+    Ok(views.html.deploy.deployConfirmation(request, form, isExternal = true))
+  }
+
+  def deployAgain = AuthAction { implicit request =>
+    val form = deployForm.bindFromRequest()
+    Ok(views.html.deploy.deployConfirmation(request, form, isExternal = false))
   }
 
   def markAsFailed = AuthAction { implicit request =>

--- a/riff-raff/app/views/deploy/deployConfirmation.scala.html
+++ b/riff-raff/app/views/deploy/deployConfirmation.scala.html
@@ -1,17 +1,19 @@
-@(request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], deployForm: Form[controllers.DeployParameterForm])
+@(request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], deployForm: Form[controllers.DeployParameterForm], isExternal: Boolean)
 @import helper.twitterBootstrap._
 
 @main("Deploy confirmation", request) {
 
 <h2>Deploy confirmation</h2>
 
-<div class="alert alert-warning alert-block">
-    <h4 class="alert-heading">External deployment request</h4>
-    <p/>
-    <p>The deploy below has been requested, please confirm that this should go ahead.</p>
-    <p>(You are seeing this message as an external system has requested this build or you tried to deploy on a
-        different riff-raff node that wasn't in the correct location on the network to reach the required hosts).</p>
-</div>
+@if(isExternal) {
+    <div class="alert alert-warning alert-block">
+        <h4 class="alert-heading">External deployment request</h4>
+        <p/>
+        <p>The deploy below has been requested, please confirm that this should go ahead.</p>
+        <p>(You are seeing this message as an external system has requested this build or you tried to deploy on a
+            different riff-raff node that wasn't in the correct location on the network to reach the required hosts).</p>
+    </div>
+}
 
     @defining(deployForm.data.keys.toList.sorted) { fields =>
         <div class="col-md-6">

--- a/riff-raff/app/views/deploy/viewDeploy.scala.html
+++ b/riff-raff/app/views/deploy/viewDeploy.scala.html
@@ -37,13 +37,21 @@ to stacks (@{record.stacks.map { stack => stack.name }.mkString(", ")})
         </label>
     </div>
 }
+@helper.form(action=routes.DeployController.processForm) {
+    <input type="hidden" name="project" value="@record.buildName"/>
+    <input type="hidden" name="build" value="@record.buildId"/>
+    <input type="hidden" name="stage" value="@record.stage.name"/>
+    <input type="hidden" name="recipe" value="@record.recipe.name"/>
 
-<div class="actions">
-    <p>
-        <button id="modalConfirm" name="action" type="submit" value="deploy" class="btn btn-primary pull-right">Deploy Again</button>
-    </p>
-</div>
-
+    @record.stacks.zipWithIndex.map { stack =>
+        <input type="hidden" name="stacks[@stack._2]" value="@{stack._1.name}"/>
+    }
+    <div class="actions"><p>
+        <button id="modalConfirm" name="action" type="submit" value="deploy" class="btn btn-default pull-right">
+            Deploy Again
+        </button>
+    </p></div>
+}
 </div>
 </div>
 

--- a/riff-raff/app/views/deploy/viewDeploy.scala.html
+++ b/riff-raff/app/views/deploy/viewDeploy.scala.html
@@ -43,7 +43,7 @@ to stacks (@{record.stacks.map { stack => stack.name }.mkString(", ")})
     <input type="hidden" name="stage" value="@record.stage.name"/>
     <input type="hidden" name="recipe" value="@record.recipe.name"/>
 
-    @record.stacks.zipWithIndex.foreach { case (stack, index) =>
+    @record.stacks.zipWithIndex.map { case (stack, index) =>
         <input type="hidden" name="stacks[@index]" value="@{stack.name}"/>
     }
     <div class="actions"><p>

--- a/riff-raff/app/views/deploy/viewDeploy.scala.html
+++ b/riff-raff/app/views/deploy/viewDeploy.scala.html
@@ -37,7 +37,7 @@ to stacks (@{record.stacks.map { stack => stack.name }.mkString(", ")})
         </label>
     </div>
 }
-@helper.form(action=routes.DeployController.processForm) {
+@helper.form(action=routes.DeployController.deployAgain) {
     <input type="hidden" name="project" value="@record.buildName"/>
     <input type="hidden" name="build" value="@record.buildId"/>
     <input type="hidden" name="stage" value="@record.stage.name"/>

--- a/riff-raff/app/views/deploy/viewDeploy.scala.html
+++ b/riff-raff/app/views/deploy/viewDeploy.scala.html
@@ -32,7 +32,7 @@ to stacks (@{record.stacks.map { stack => stack.name }.mkString(", ")})
 }
 @if(!record.isSummarised){
     <div class="clearfix">
-        <label class="checkbox pull-right checkbox-fix-top checkbox-fix-right">
+        <label class="checkbox pull-right checkbox-fix-top">
             <input id="verbose-checkbox" @if(verbose){checked="checked"} type="checkbox"/> Show verbose log lines
         </label>
     </div>

--- a/riff-raff/app/views/deploy/viewDeploy.scala.html
+++ b/riff-raff/app/views/deploy/viewDeploy.scala.html
@@ -43,8 +43,8 @@ to stacks (@{record.stacks.map { stack => stack.name }.mkString(", ")})
     <input type="hidden" name="stage" value="@record.stage.name"/>
     <input type="hidden" name="recipe" value="@record.recipe.name"/>
 
-    @record.stacks.zipWithIndex.map { stack =>
-        <input type="hidden" name="stacks[@stack._2]" value="@{stack._1.name}"/>
+    @record.stacks.zipWithIndex.foreach { case (stack, index) =>
+        <input type="hidden" name="stacks[@index]" value="@{stack.name}"/>
     }
     <div class="actions"><p>
         <button id="modalConfirm" name="action" type="submit" value="deploy" class="btn btn-default pull-right">

--- a/riff-raff/app/views/deploy/viewDeploy.scala.html
+++ b/riff-raff/app/views/deploy/viewDeploy.scala.html
@@ -30,9 +30,20 @@ to stacks (@{record.stacks.map { stack => stack.name }.mkString(", ")})
     }
 </div>
 }
-@if(!record.isSummarised){<label class="checkbox pull-right checkbox-fix-top checkbox-fix-right">
-    <input id="verbose-checkbox" @if(verbose){checked="checked"} type="checkbox"/> Show verbose log lines
-</label>}
+@if(!record.isSummarised){
+    <div class="clearfix">
+        <label class="checkbox pull-right checkbox-fix-top checkbox-fix-right">
+            <input id="verbose-checkbox" @if(verbose){checked="checked"} type="checkbox"/> Show verbose log lines
+        </label>
+    </div>
+}
+
+<div class="actions">
+    <p>
+        <button id="modalConfirm" name="action" type="submit" value="deploy" class="btn btn-primary pull-right">Deploy Again</button>
+    </p>
+</div>
+
 </div>
 </div>
 

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -18,7 +18,8 @@ GET         /deployment/request                             controllers.DeployCo
 POST        /deployment/request                             controllers.DeployController.processForm
 POST        /deployment/:uuid/stop                          controllers.DeployController.stop(uuid)
 GET         /deployment/confirm                             controllers.DeployController.deployConfirmation(parametersJson:String)
-GET         /deployment/externalRequest                     controllers.DeployController.deployConfirmationWithParameters
+GET         /deployment/externalRequest                     controllers.DeployController.deployConfirmationExternal
+GET         /deployment/deployAgain                         controllers.DeployController.deployAgain
 
 GET         /deployment/history                             controllers.DeployController.history
 GET         /deployment/history/update                      controllers.DeployController.historyContent


### PR DESCRIPTION
Adds a Deploy Again button to the /deploy/view/:uuid view (Fixes #168). This will add a new deploy (new uuid) with the same parameters as the deploy in view.

Some notes: 
* Button is present for both failed and successful builds
* As we don't seem to deploy to specific hosts anymore I haven't included this in parameters to pass to the form. @sihil should I?

![screen shot 2016-05-27 at 16 14 14](https://cloud.githubusercontent.com/assets/944375/15612374/70f5daf0-2426-11e6-8055-af89d03d9f63.png)


cc/ @sihil @alexduf 
