### PR TITLE
Support looking up CloudFormation stack by tags

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
@@ -1,5 +1,6 @@
 package magenta.deployment_type
 
+import magenta.tasks.UpdateCloudFormationTask.{LookupByName, LookupByTags}
 import magenta.tasks.{CheckUpdateEventsTask, UpdateAmiCloudFormationParameterTask}
 
 object AmiCloudFormationParameter extends DeploymentType {
@@ -20,6 +21,14 @@ object AmiCloudFormationParameter extends DeploymentType {
   val appendStageToCloudFormationStackName = Param[Boolean]("appendStageToCloudFormationStackName",
     documentation = "Whether to add '-`stage`' to the `cloudFormationStackName`, e.g. MyApp => MyApp-PROD"
   ).default(true)
+  val cloudFormationStackTags = Param[Map[String, String]]("cloudFormationStackTags",
+    documentation =
+      """
+        |The tags used to find the CloudFormation stack to update. The Stack and Stage tags will be automatically added.
+        |
+        |If this parameter is set, it will override any other parameters related to the CloudFormation stack name.
+      """.stripMargin
+  ).default(Map.empty)
   val amiTags = Param[Map[String,String]]("amiTags",
     documentation = "Specify the set of tags to use to find the latest AMI"
   )
@@ -31,21 +40,33 @@ object AmiCloudFormationParameter extends DeploymentType {
     case "update" => pkg => (reporter, lookup, parameters, stack) => {
       implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
 
-      val stackName = stack.nameOption.filter(_ => prependStackToCloudFormationStackName(pkg))
-      val stageName = Some(parameters.stage.name).filter(_ => appendStageToCloudFormationStackName(pkg))
-      val cloudFormationStackNameParts = Seq(stackName, Some(cloudFormationStackName(pkg)), stageName).flatten
-      val fullCloudFormationStackName = cloudFormationStackNameParts.mkString("-")
+      // Based on the supplied params, decide whether to look up the CF stack by name or by tags
+      val cloudFormationStackLookupStrategy = {
+        val tagsMap = cloudFormationStackTags(pkg)
+        if (tagsMap.nonEmpty) {
+          val withStackAndStageTags = tagsMap ++
+            stack.nameOption.map("Stack" -> _) ++
+            Map("Stage" -> parameters.stage.name)
+          LookupByTags(withStackAndStageTags)
+        } else {
+          val stackName = stack.nameOption.filter(_ => prependStackToCloudFormationStackName(pkg))
+          val stageName = Some(parameters.stage.name).filter(_ => appendStageToCloudFormationStackName(pkg))
+          val cloudFormationStackNameParts = Seq(stackName, Some(cloudFormationStackName(pkg)), stageName).flatten
+          val fullCloudFormationStackName = cloudFormationStackNameParts.mkString("-")
+          LookupByName(fullCloudFormationStackName)
+        }
+      }
 
       List(
         UpdateAmiCloudFormationParameterTask(
-          fullCloudFormationStackName,
+          cloudFormationStackLookupStrategy,
           amiParameter(pkg),
           amiTags(pkg),
           lookup.getLatestAmi,
           parameters.stage,
           stack
         ),
-        CheckUpdateEventsTask(fullCloudFormationStackName)
+        CheckUpdateEventsTask(cloudFormationStackLookupStrategy)
       )
     }
   }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -1,5 +1,6 @@
 package magenta.deployment_type
 
+import magenta.tasks.UpdateCloudFormationTask.LookupByName
 import magenta.tasks.{CheckUpdateEventsTask, UpdateCloudFormationTask}
 
 import scalax.file.Path
@@ -86,7 +87,7 @@ object CloudFormation extends DeploymentType {
           stack,
           createStackIfAbsent(pkg)
         ),
-        CheckUpdateEventsTask(fullCloudFormationStackName)
+        CheckUpdateEventsTask(LookupByName(fullCloudFormationStackName))
       )
     }
   }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -37,8 +37,8 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
             ifAbsent should be(true)
         }
         inside(checkTask) {
-          case CheckUpdateEventsTask(updateStackName) =>
-            updateStackName should be(cfnStackName)
+          case CheckUpdateEventsTask(lookupStrategy) =>
+            lookupStrategy should be(LookupByName(cfnStackName))
         }
     }
   }


### PR DESCRIPTION
Add a param to `UpdateAmiCloudFormationParameterTask` to specify tags for looking up the CF stack. `Stack` and `Stage` are automatically added to the list of tag filters if they are not already present, so usually only the `App` tag will need to be specified.

This more flexible way of looking up the CF stack is needed by CAPI because some of our stacks don't use the `<stack>-my-cf-stack-<stage>` naming scheme. In particular we have some nested CF stacks with auto-generated random IDs appended to their names.

@sihil @adamnfish @LATaylor-guardian
