### PR TITLE
Fix S3 deploy paths, removing double-slashes ('//')

### DIFF
--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -91,7 +91,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
     val lookup = stubLookup(List(Host("the_host", stage=CODE.name).app(app1)), Map("s3-path-prefix" -> Seq(Datum(None, app1.name, CODE.name, "testing/2016/05/brexit-companion", None))))
 
     inside(S3.perAppActions("uploadStaticFiles")(p)(reporter, lookup, parameters(CODE), UnnamedStack).head) {
-      case upload: S3Upload => upload.files should be(Seq(sourceFiles -> "testing/2016/05/brexit-companion/"))
+      case upload: S3Upload => upload.files should be(Seq(sourceFiles -> "testing/2016/05/brexit-companion"))
     }
   }
 


### PR DESCRIPTION
With this change, when a `pathPrefixResource` is found, the `prefixStage`, `prefixPackage` and `prefixStack` keys are ignored and only the looked-up prefix is used, ie:

`/<pathPrefix>/<filePathAndName>`

The old, broken paths had `//` in them (eg `s3://gdn-cdn/testing/2016/05/brexit-companion//embed/embed.html`):

![image](https://cloud.githubusercontent.com/assets/52038/16124415/c41b23be-33e6-11e6-9eeb-4f25e4df8c5f.png)



This follows on from #302, which introduced `pathPrefixResource` configuration.



cc @philwills @SiAdcock 