### PR TITLE
Prefix the lambda with stack name if prefixStack is set to true

### DIFF
--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
@@ -45,4 +45,24 @@ class LambdaTest extends FlatSpec with Matchers {
       )
     ))
   }
+
+  it should "prefix stack name to function name" in {
+    val dataWithStack: Map[String, JValue] = Map(
+      "bucket" -> "lambda-bucket",
+      "fileName" -> "test-file.zip",
+      "prefixStack" -> true,
+      "functionNames" -> List("MyFunction-")
+    )
+    val app = Seq(App("lambda"))
+    val pkg = DeploymentPackage("lambda", app, dataWithStack, "aws-s3-lambda", new File("/tmp/packages/webapp"))
+
+    val tasks = Lambda.perAppActions("updateLambda")(pkg)(reporter, lookupEmpty, parameters(PROD), NamedStack("some-stack"))
+    tasks should be (List(
+      UpdateS3Lambda(
+        functionName = "some-stackMyFunction-PROD",
+        s3Bucket = "lambda-bucket",
+        s3Key = "some-stack/PROD/lambda/test-file.zip"
+      )
+    ))
+  }
 }


### PR DESCRIPTION
To be able work with multiple stacks we need to be able to prepend the stack name to a lambda function name. This will only be set if `prefixStack` is set to true. 

@sihil I've added a test as per our discussion.