### PR TITLE
Make the project filter on deploy history page work reliably

### DIFF
--- a/riff-raff/app/assets/js/history-dropdown.coffee
+++ b/riff-raff/app/assets/js/history-dropdown.coffee
@@ -1,15 +1,17 @@
-updateOrAddParam = (url, param, value) ->
+updateOrAddParam = (location, param, value) ->
   re = new RegExp("([?|&])" + param + "=.*?(&|$)", "i")
-  separator = if url.indexOf('?') != -1 then "&" else "?"
+  separator = if location.search == "" then "?" else "&"
   encodedValue=encodeURIComponent(value)
-  if url.match(re)
-    url.replace(re,'$1'+param+'='+encodedValue+'$2')
-  else
-    url+separator+param+'='+encodedValue
+  queryString =
+    if location.search.match(re)
+      location.search.replace(re,'$1'+param+'='+encodedValue+'$2')
+    else
+      location.search + separator + param+'='+encodedValue
+  location.pathname + queryString + location.hash
 
 filterByProjectName = ->
   projectName = $('#projectInput').val()
-  newUrl = updateOrAddParam(document.URL, "projectName", projectName)
+  newUrl = updateOrAddParam(document.location, "projectName", projectName)
   pageResetUrl = updateOrAddParam(newUrl, "page", "1")
   window.location = pageResetUrl
 

--- a/riff-raff/app/assets/js/history-dropdown.coffee
+++ b/riff-raff/app/assets/js/history-dropdown.coffee
@@ -1,19 +1,17 @@
-updateOrAddParam = (location, param, value) ->
+updateOrAddParam = (queryString, param, value) ->
   re = new RegExp("([?|&])" + param + "=.*?(&|$)", "i")
-  separator = if location.search == "" then "?" else "&"
-  encodedValue=encodeURIComponent(value)
-  queryString =
-    if location.search.match(re)
-      location.search.replace(re,'$1'+param+'='+encodedValue+'$2')
-    else
-      location.search + separator + param+'='+encodedValue
-  location.origin + location.pathname + queryString + location.hash
+  separator = if queryString == "" then "?" else "&"
+  encodedValue = encodeURIComponent(value)
+  if queryString.match(re)
+    queryString.replace(re,'$1'+param+'='+encodedValue+'$2')
+  else
+    queryString + separator + param+'='+encodedValue
 
 filterByProjectName = ->
   projectName = $('#projectInput').val()
-  newUrl = updateOrAddParam(document.location, "projectName", projectName)
-  pageResetUrl = updateOrAddParam(newUrl, "page", "1")
-  window.location = pageResetUrl
+  newQueryString = updateOrAddParam(window.location.search, "projectName", projectName)
+  pageResetQueryString = updateOrAddParam(newQueryString, "page", "1")
+  window.location.search = pageResetQueryString
 
 $ ->
   $('.dropdown-toggle').dropdown()

--- a/riff-raff/app/assets/js/history-dropdown.coffee
+++ b/riff-raff/app/assets/js/history-dropdown.coffee
@@ -7,7 +7,7 @@ updateOrAddParam = (location, param, value) ->
       location.search.replace(re,'$1'+param+'='+encodedValue+'$2')
     else
       location.search + separator + param+'='+encodedValue
-  location.pathname + queryString + location.hash
+  location.origin + location.pathname + queryString + location.hash
 
 filterByProjectName = ->
   projectName = $('#projectInput').val()


### PR DESCRIPTION
i.e. prevent the Hash of Doom from breaking the project name filter.

![screen shot 2016-07-11 at 2 31 41 pm](https://cloud.githubusercontent.com/assets/106760/16732372/c231a540-4774-11e6-99bc-76ca21c2d55b.png)

I'm still not sure where that hash comes from, but this should make the URL manipulation resilient to its presence.

You're welcome, every Riff Raff user ever.