### PR TITLE
Consistently display timestamps in London time, UK locale

### DIFF
--- a/magenta-lib/src/main/scala/magenta/reporting.scala
+++ b/magenta-lib/src/main/scala/magenta/reporting.scala
@@ -1,8 +1,8 @@
 package magenta
 
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, DateTimeZone}
 import org.joda.time.format.DateTimeFormat
-import java.util.UUID
+import java.util.{UUID, Locale}
 
 object RunState extends Enumeration {
   type State = Value
@@ -33,9 +33,9 @@ object MessageState {
 }
 
 trait MessageState {
-  val timeOfDayFormatter=DateTimeFormat.mediumTime()
+  val timeOfDayFormatter = DateTimeFormat.mediumTime.withLocale(Locale.UK).withZone(DateTimeZone.forID("Europe/London"))
   def time:DateTime
-  def timeOfDay() = timeOfDayFormatter.print(time)
+  def timeOfDay = timeOfDayFormatter.print(time)
   def message:Message
   def startContext:StartContext
   def finished:Option[Message]

--- a/riff-raff/app/utils/DateFormats.scala
+++ b/riff-raff/app/utils/DateFormats.scala
@@ -1,0 +1,20 @@
+package utils
+
+import org.joda.time.DateTimeZone
+import org.joda.time.format.DateTimeFormat
+import java.util.Locale
+
+/**
+ * Date formats to print datetimes in English style and London time.
+ */
+object DateFormats {
+
+  val Medium = DateTimeFormat.mediumDateTime
+    .withLocale(Locale.UK)
+    .withZone(DateTimeZone.forID("Europe/London"))
+
+  val Short = DateTimeFormat.shortDateTime
+    .withLocale(Locale.UK)
+    .withZone(DateTimeZone.forID("Europe/London"))
+
+}

--- a/riff-raff/app/views/api/list.scala.html
+++ b/riff-raff/app/views/api/list.scala.html
@@ -24,11 +24,11 @@
             <tbody>
             @keyList.map { key =>
                 <tr>
-                    <td>@org.joda.time.format.DateTimeFormat.shortDateTime.print(key.created)</td>
+                    <td>@utils.DateFormats.Short.print(key.created)</td>
                     <td><span class="label label-default">@key.issuedBy</span></td>
                     <td>@key.application</td>
                     <td>@key.key</td>
-                    <td>@key.lastUsed.map(org.joda.time.format.DateTimeFormat.shortDateTime.print).getOrElse("never")</td>
+                    <td>@key.lastUsed.map(utils.DateFormats.Short.print).getOrElse("never")</td>
                     <td>@key.totalCalls</td>
                     <td>
                     @helper.form(routes.Api.delete(), 'class -> "modal-form") {

--- a/riff-raff/app/views/auth/list.scala.html
+++ b/riff-raff/app/views/auth/list.scala.html
@@ -20,7 +20,7 @@
             <tbody>
             @authList.map { auth =>
                 <tr>
-                    <td>@org.joda.time.format.DateTimeFormat.shortDateTime.print(auth.approvedDate)</td>
+                    <td>@utils.DateFormats.Short.print(auth.approvedDate)</td>
                     <td>@auth.email</td>
                     <td><span class="label label-default">@auth.approvedBy</span></td>
                     <td>

--- a/riff-raff/app/views/continuousDeployment/list.scala.html
+++ b/riff-raff/app/views/continuousDeployment/list.scala.html
@@ -34,7 +34,7 @@
         <tbody>
           @for(config <- configs) {
             <tr @if(config.trigger == Disabled){ class="danger" }>
-                <td>@shortDateTime.print(config.lastEdited) by <span class="label label-default">@config.user</span></td>
+                <td>@utils.DateFormats.Short.print(config.lastEdited) by <span class="label label-default">@config.user</span></td>
                 <td>@config.projectName</td>
                 <td>@config.branchRE.toString()</td>
                 <td>@config.stage</td>

--- a/riff-raff/app/views/deploy/buildInfo.scala.html
+++ b/riff-raff/app/views/deploy/buildInfo.scala.html
@@ -11,7 +11,7 @@
         </tr>
         <tr>
             <th>Start Time</th>
-            <td>@org.joda.time.format.DateTimeFormat.mediumDateTime.print(build.startTime)</td>
+            <td>@utils.DateFormats.Medium.print(build.startTime)</td>
         </tr>
         <tr>
             <th>Tags</th>

--- a/riff-raff/app/views/hooks/list.scala.html
+++ b/riff-raff/app/views/hooks/list.scala.html
@@ -26,7 +26,7 @@
         <tbody>
           @for(config <- hooks) {
             <tr @if(!config.enabled){ class="danger" }>
-                <td>@shortDateTime.print(config.lastEdited) by <span class="label label-default">@config.user</span></td>
+                <td>@utils.DateFormats.Short.print(config.lastEdited) by <span class="label label-default">@config.user</span></td>
                 <td>@config.projectName</td>
                 <td>@config.stage</td>
                 <td>@config.url</td>

--- a/riff-raff/app/views/snippets/pimpedBuildId.scala.html
+++ b/riff-raff/app/views/snippets/pimpedBuildId.scala.html
@@ -5,7 +5,7 @@
     <table>
         <tbody>
         <tr>
-    <td><strong>Deploy started:</strong></td><td>@org.joda.time.format.DateTimeFormat.shortDateTime.print(r.time)</td>
+    <td><strong>Deploy started:</strong></td><td>@utils.DateFormats.Short.print(r.time)</td>
         </tr><tr>
             <td><strong>Branch:</strong></td><td>@r.metaData.get("branch").getOrElse("unknown")</td>
         </tr><tr>

--- a/riff-raff/app/views/snippets/recordTable.scala.html
+++ b/riff-raff/app/views/snippets/recordTable.scala.html
@@ -23,7 +23,7 @@
     <tbody class="rowlink" data-provides="rowlink">
     @records.map{ record =>
     <tr class="rowlink">
-        <td><time class="makeRelativeDate" withinhours="24" datetime="@record.time">@org.joda.time.format.DateTimeFormat.mediumDateTime.print(record.time)</time></td>
+        <td><time class="makeRelativeDate" withinhours="24" datetime="@record.time">@utils.DateFormats.Medium.print(record.time)</time></td>
         <td><span class="label label-default">@record.deployerName</span></td>
         <td><a href="@routes.DeployController.viewUUID(record.uuid.toString)" class="rowlink">@record.buildName</a></td>
         <td>@record.stage.name</td>

--- a/riff-raff/app/views/test/s3Latencies.scala.html
+++ b/riff-raff/app/views/test/s3Latencies.scala.html
@@ -21,7 +21,7 @@
       <tbody>
           @deploys.map { case(deploy, duration) =>
             <tr>
-              <td>@org.joda.time.format.DateTimeFormat.mediumDateTime.print(deploy.time)</td>
+              <td>@utils.DateFormats.Medium.print(deploy.time)</td>
               <td>@deploy.parameters.build.projectName</td>
                 <td>@duration.map(_.getStandardSeconds).getOrElse("")</td>
               <td>


### PR DESCRIPTION
Date formatting was quite inconsistent across the app, e.g.:

* Deploy start time was in London time (actually browser locale's time, I think) on the history page, but the deploy logs were in UTC.
* API keys, etc. had their dates formatted in US style (mm/dd/yy)

There is an argument for displaying all timestamps in UTC, but given that nearly all users are in London, I think London time is more convenient. As long as we are consistent (which we now should be), it doesn't really matter which one we pick.