### PR TITLE
Refactor deployment type by introducing resources and target classes

### DIFF
--- a/magenta-lib/src/main/scala/magenta/Project.scala
+++ b/magenta-lib/src/main/scala/magenta/Project.scala
@@ -1,10 +1,11 @@
 package magenta
 
-import json.{DeployInfoHost, DeployInfoJsonInputFile}
-import tasks.Task
-import collection.SortedSet
 import java.util.UUID
+
+import magenta.json.{DeployInfoHost, DeployInfoJsonInputFile}
+import magenta.tasks.Task
 import org.joda.time.DateTime
+
 import scala.math.Ordering.OptionOrdering
 
 object DeployInfo {
@@ -130,6 +131,13 @@ object HostList {
   implicit def hostListAsListOfHosts(hostList: HostList) = hostList.hosts
 }
 
+case class DeploymentResources(reporter: DeployReporter, lookup: Lookup) {
+  def assembleKeyring(target: DeployTarget, pkg: DeploymentPackage): KeyRing =
+    lookup.keyRing(target.parameters.stage, pkg.apps.toSet, target.stack)
+}
+
+case class DeployTarget(parameters: DeployParameters, stack: Stack)
+
 /*
  An action represents a step within a recipe. It isn't executable
  until it's resolved against a particular host.
@@ -137,7 +145,7 @@ object HostList {
 trait Action {
   def apps: Seq[App]
   def description: String
-  def resolve(resourceLookup: Lookup, params: DeployParameters, stack: Stack, deployReporter: DeployReporter): List[Task]
+  def resolve(resources: DeploymentResources, target: DeployTarget): List[Task]
 }
 
 case class App (name: String)

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Fastly.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Fastly.scala
@@ -10,9 +10,9 @@ object Fastly  extends DeploymentType {
     """.stripMargin
 
   def perAppActions = {
-    case "deploy" => pkg => (reporter, lookup, parameters, stack) => {
-      implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
-      reporter.verbose(s"Keyring is $keyRing")
+    case "deploy" => pkg => (resources, target) => {
+      implicit val keyRing = resources.assembleKeyring(target, pkg)
+      resources.reporter.verbose(s"Keyring is $keyRing")
       List(UpdateFastlyConfig(pkg))
     }
   }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
@@ -34,12 +34,12 @@ object SelfDeploy extends DeploymentType with S3AclParams {
   ).default("/management/switchboard")
 
   def perAppActions = {
-    case "uploadArtifacts" => (pkg) => (reporter, lookup, parameters, stack) =>
-      implicit val keyRing = lookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
-      val prefix = S3Upload.prefixGenerator(stack, parameters.stage, pkg.name)
+    case "uploadArtifacts" => (pkg) => (resources, target) =>
+      implicit val keyRing = resources.assembleKeyring(target, pkg)
+      val prefix = S3Upload.prefixGenerator(target.stack, target.parameters.stage, pkg.name)
       List(
         S3Upload(
-          bucket.get(pkg).orElse(stack.nameOption.map(stackName => s"$stackName-dist")).get,
+          bucket.get(pkg).orElse(target.stack.nameOption.map(stackName => s"$stackName-dist")).get,
           files = Seq(new File(pkg.srcDir.getPath) -> prefix)
         )
       )

--- a/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
+++ b/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
@@ -99,15 +99,15 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
   val CODE = Stage("CODE")
 
   case class MockStubPerHostAction(description: String, apps: Seq[App]) extends Action {
-    def resolve(resourceLookup: Lookup, params: DeployParameters, stack: Stack, reporter: DeployReporter) = {
+    def resolve(resources: DeploymentResources, target: DeployTarget) = {
       val task = mock[Task]
-      when(task.taskHost).thenReturn(Some(resourceLookup.hosts.all.head))
+      when(task.taskHost).thenReturn(Some(resources.lookup.hosts.all.head))
       task :: Nil
     }
   }
 
   case class MockStubPerAppAction(description: String, apps: Seq[App]) extends Action {
-    def resolve(resourceLookup: Lookup, params: DeployParameters, stack: Stack, reporter: DeployReporter) = {
+    def resolve(resources: DeploymentResources, target: DeployTarget) = {
       val task = mock[Task]
       when(task.taskHost).thenReturn(None)
       task :: Nil

--- a/magenta-lib/src/test/scala/magenta/ResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/ResolverTest.scala
@@ -218,8 +218,7 @@ class ResolverTest extends FlatSpec with Matchers {
   it should "resolve tasks from multiple stacks" in {
     val pkgType = StubDeploymentType(
       perAppActions = {
-        case "deploy" => pkg => (reporter, lookup, params, stack) =>
-          List(StubTask("stacked", stack = Some(stack)))
+        case "deploy" => pkg => (resources, target) => List(StubTask("stacked", stack = Some(target.stack)))
       }
     )
     val recipe = Recipe("stacked",

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -23,7 +23,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
 
     val p = DeploymentPackage("app", app, data, "asg-elb", new File("/tmp/packages/webapp"))
 
-    AutoScaling.perAppActions("deploy")(p)(reporter, lookupEmpty, parameters(), UnnamedStack) should be (List(
+    AutoScaling.perAppActions("deploy")(p)(DeploymentResources(reporter, lookupEmpty), DeployTarget(parameters(), UnnamedStack)) should be (List(
       CheckForStabilization(p, PROD, UnnamedStack),
       CheckGroupSize(p, PROD, UnnamedStack),
       SuspendAlarmNotifications(p, PROD, UnnamedStack),
@@ -50,7 +50,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
 
     val p = DeploymentPackage("app", app, data, "asg-elb", new File("/tmp/packages/webapp"))
 
-    AutoScaling.perAppActions("deploy")(p)(reporter, lookupEmpty, parameters(), UnnamedStack) should be (List(
+    AutoScaling.perAppActions("deploy")(p)(DeploymentResources(reporter, lookupEmpty), DeployTarget(parameters(), UnnamedStack)) should be (List(
       CheckForStabilization(p, PROD, UnnamedStack),
       CheckGroupSize(p, PROD, UnnamedStack),
       SuspendAlarmNotifications(p, PROD, UnnamedStack),

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -23,7 +23,7 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
     val cfnStackName = s"cfn-app-PROD"
     val p = DeploymentPackage("app", app, data, "cloudformation", new File("/tmp/packages/webapp"))
 
-    inside(CloudFormation.perAppActions("updateStack")(p)(reporter, lookupEmpty, parameters(), stack)) {
+    inside(CloudFormation.perAppActions("updateStack")(p)(DeploymentResources(reporter, lookupEmpty), DeployTarget(parameters(), stack))) {
       case List(updateTask, checkTask) =>
         inside(updateTask) {
           case UpdateCloudFormationTask(stackName, path, userParams, amiParam, amiTags, _, stage, stack, ifAbsent) =>

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -29,7 +29,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceFiles)
 
     val thrown = the[NoSuchElementException] thrownBy {
-      S3.perAppActions("uploadStaticFiles")(p)(reporter, lookupSingleHost, parameters(CODE), UnnamedStack) should be (
+      S3.perAppActions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookupSingleHost), DeployTarget(parameters(CODE), UnnamedStack)) should be (
         List(S3Upload(
           "bucket-1234",
           Seq(sourceFiles -> "CODE/myapp"),
@@ -50,7 +50,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
 
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceFiles)
 
-    S3.perAppActions("uploadStaticFiles")(p)(reporter, lookupSingleHost, parameters(CODE), UnnamedStack) should be (
+    S3.perAppActions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookupSingleHost), DeployTarget(parameters(CODE), UnnamedStack)) should be (
       List(S3Upload(
         "bucket-1234",
         Seq(sourceFiles -> "CODE/myapp"),
@@ -71,7 +71,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
 
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceFiles)
 
-    inside(S3.perAppActions("uploadStaticFiles")(p)(reporter, lookupSingleHost, parameters(Stage("CODE")), UnnamedStack).head) {
+    inside(S3.perAppActions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookupSingleHost), DeployTarget(parameters(CODE), UnnamedStack)).head) {
       case upload: S3Upload => upload.cacheControlPatterns should be(List(PatternValue("^sub", "no-cache"), PatternValue(".*", "public; max-age:3600")))
     }
   }
@@ -89,7 +89,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
 
     val lookup = stubLookup(List(Host("the_host", stage=CODE.name).app(app1)), Map("s3-path-prefix" -> Seq(Datum(None, app1.name, CODE.name, "testing/2016/05/brexit-companion", None))))
 
-    inside(S3.perAppActions("uploadStaticFiles")(p)(reporter, lookup, parameters(CODE), UnnamedStack).head) {
+    inside(S3.perAppActions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookup), DeployTarget(parameters(CODE), UnnamedStack)).head) {
       case upload: S3Upload => upload.files should be(Seq(sourceFiles -> "testing/2016/05/brexit-companion"))
     }
   }
@@ -106,7 +106,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
 
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-lambda", new File("/tmp/packages"))
 
-    Lambda.perAppActions("updateLambda")(p)(reporter, lookupSingleHost, parameters(CODE), UnnamedStack) should be (
+    Lambda.perAppActions("updateLambda")(p)(DeploymentResources(reporter, lookupSingleHost), DeployTarget(parameters(CODE), UnnamedStack)) should be (
       List(UpdateLambda(new File("/tmp/packages/lambda.zip"), "myLambda")
       ))
   }
@@ -123,7 +123,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
     val p = DeploymentPackage("myapp", Seq.empty, badData, "aws-lambda", new File("/tmp/packages"))
 
     val thrown = the[FailException] thrownBy {
-      Lambda.perAppActions("updateLambda")(p)(reporter, lookupSingleHost, parameters(CODE), UnnamedStack) should be (
+      Lambda.perAppActions("updateLambda")(p)(DeploymentResources(reporter, lookupSingleHost), DeployTarget(parameters(CODE), UnnamedStack)) should be (
         List(UpdateLambda(new File("/tmp/packages/lambda.zip"), "myLambda")
         ))
     }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 
 import magenta.fixtures._
 import magenta.tasks.{S3Upload, UpdateS3Lambda}
-import magenta.{App, DeployReporter, DeploymentPackage, KeyRing, NamedStack, fixtures}
+import magenta.{App, DeployReporter, DeployTarget, DeploymentPackage, KeyRing, NamedStack, DeploymentResources, fixtures}
 import org.json4s.JsonAST.JValue
 import org.json4s.JsonDSL._
 import org.scalatest.{FlatSpec, Matchers}
@@ -26,7 +26,7 @@ class LambdaTest extends FlatSpec with Matchers {
   val pkg = DeploymentPackage("lambda", app, data, "aws-s3-lambda", new File("/tmp/packages/webapp"))
 
   it should "produce an S3 upload task" in {
-    val tasks = Lambda.perAppActions("uploadLambda")(pkg)(reporter, lookupEmpty, parameters(PROD), NamedStack("test"))
+    val tasks = Lambda.perAppActions("uploadLambda")(pkg)(DeploymentResources(reporter, lookupEmpty), DeployTarget(parameters(PROD), NamedStack("test")))
     tasks should be (List(
       S3Upload(
         bucket = "lambda-bucket",
@@ -36,7 +36,7 @@ class LambdaTest extends FlatSpec with Matchers {
   }
 
   it should "produce a lambda update task" in {
-    val tasks = Lambda.perAppActions("updateLambda")(pkg)(reporter, lookupEmpty, parameters(PROD), NamedStack("test"))
+    val tasks = Lambda.perAppActions("updateLambda")(pkg)(DeploymentResources(reporter, lookupEmpty), DeployTarget(parameters(PROD), NamedStack("test")))
     tasks should be (List(
       UpdateS3Lambda(
         functionName = "MyFunction-PROD",
@@ -56,7 +56,7 @@ class LambdaTest extends FlatSpec with Matchers {
     val app = Seq(App("lambda"))
     val pkg = DeploymentPackage("lambda", app, dataWithStack, "aws-s3-lambda", new File("/tmp/packages/webapp"))
 
-    val tasks = Lambda.perAppActions("updateLambda")(pkg)(reporter, lookupEmpty, parameters(PROD), NamedStack("some-stack"))
+    val tasks = Lambda.perAppActions("updateLambda")(pkg)(DeploymentResources(reporter, lookupEmpty), DeployTarget(parameters(PROD), NamedStack("some-stack")))
     tasks should be (List(
       UpdateS3Lambda(
         functionName = "some-stackMyFunction-PROD",

--- a/magenta-lib/src/test/scala/magenta/fixtures/fixtures.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/fixtures.scala
@@ -11,18 +11,18 @@ case class StubTask(description: String, override val taskHost: Option[Host] = N
 }
 
 case class StubPerHostAction(description: String, apps: Seq[App]) extends Action {
-  def resolve(resourceLookup: Lookup, params: DeployParameters, stack: Stack, reporter: DeployReporter) = ???
+  def resolve(resources: DeploymentResources, target: DeployTarget) = ???
 }
 
 case class StubPerAppAction(description: String, apps: Seq[App]) extends Action {
-  def resolve(resourceLookup: Lookup, params: DeployParameters, stack: Stack, reporter: DeployReporter) = ???
+  def resolve(resources: DeploymentResources, target: DeployTarget) = ???
 }
 
 case class StubDeploymentType(
   override val perHostActions:
     PartialFunction[String, DeploymentPackage => (DeployReporter, Host, KeyRing) => List[Task]] = Map.empty,
   override val perAppActions:
-    PartialFunction[String, DeploymentPackage => (DeployReporter, Lookup, DeployParameters, Stack) => List[Task]] = Map.empty
+    PartialFunction[String, DeploymentPackage => (DeploymentResources, DeployTarget) => List[Task]] = Map.empty
                             ) extends DeploymentType {
   def name = "stub-package-type"
 

--- a/magenta-lib/src/test/scala/magenta/fixtures/package.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/package.scala
@@ -27,7 +27,7 @@ package object fixtures {
 
   def stubPackageType(perAppActionNames: Seq[String], perHostActionNames: Seq[String]) = StubDeploymentType(
     perAppActions = {
-      case name if perAppActionNames.contains(name) => pkg => (_,_,_, _) => List(StubTask(name + " per app task"))
+      case name if perAppActionNames.contains(name) => pkg => (_, _) => List(StubTask(name + " per app task"))
     },
     perHostActions = {
       case name if perHostActionNames.contains(name) => pkg => (_, host, _) =>


### PR DESCRIPTION
This will make it less intrusive to make other more significant changes (adding more resources to this case class is easier than changing every deployment type).