### PR TITLE
Avoid buffering in memory when downloading and uploading files

### DIFF
--- a/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
+++ b/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
@@ -3,7 +3,7 @@ package magenta.artifact
 import java.io.File
 
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
-import com.amazonaws.services.s3.model.{AmazonS3Exception, ListObjectsV2Request, ListObjectsV2Result}
+import com.amazonaws.services.s3.model._
 import com.gu.management.Loggable
 import magenta.{Build, DeployReporter}
 
@@ -102,7 +102,10 @@ object S3Artifact extends Loggable {
       val filesToUpload = resolveFiles(dir, artifact.key)
       reporter.info(s"Uploading contents of artifact (${filesToUpload.size} files) to S3")
       filesToUpload.foreach{ case (file, key) =>
-          client.putObject(artifact.bucket, key, file)
+        val metadata = new ObjectMetadata()
+        metadata.setContentLength(file.length)
+        val req = new PutObjectRequest(artifact.bucket, key, file).withMetadata(metadata)
+        client.putObject(req)
       }
       reporter.info(s"Zip artifact converted")
     }(client, reporter)

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -98,6 +98,7 @@ case class PutReq(source: S3Object, target: S3Path, cacheControl: Option[String]
     val metaData = new ObjectMetadata
     cacheControl foreach metaData.setCacheControl
     metaData.setContentType(contentType.getOrElse(S3Upload.awsMimeTypeLookup(target.key)))
+    metaData.setContentLength(source.size)
     val req = new PutObjectRequest(target.bucket, target.key, inputStream, metaData)
     if (publicReadAcl) req.withCannedAcl(PublicRead) else req
   }


### PR DESCRIPTION
Magenta-lib was buffering the whole file in memory when downloading artifacts and uploading to S3. With the recent changes memory pressure will have increased somewhat - this removes the needless use of memory when handling streams.