### PR TITLE
Add parameter to set custom headers on S3 upload

### DIFF
--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -18,8 +18,8 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
   implicit val artifactClient: AmazonS3 = null
 
   "Deployment types" should "automatically register params in the params Seq" in {
-    S3.params should have size 9
-    S3.params.map(_.name).toSet should be(Set("prefixStage","prefixPackage","prefixStack", "pathPrefixResource","bucket","publicReadAcl","bucketResource","cacheControl","mimeTypes"))
+    S3.params should have size 10
+    S3.params.map(_.name).toSet should be(Set("prefixStage","prefixPackage","prefixStack", "pathPrefixResource","bucket","publicReadAcl","bucketResource","cacheControl","mimeTypes","headers"))
   }
 
   private val sourceS3Package = S3Package("artifact-bucket", "test/123/static-files")


### PR DESCRIPTION
Similarly to cacheControl, allow setting any custom header.

My use case it to set an [S3 redirect](http://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html) for discussion-frontend as @jamespamplin suggested.

@sihil @philwills forgive my scala skills, that's the best I could come up with.

I have absolutely no idea on how to run riff raff locally (and I'd like to avoid doing that), but at least it compiles, tests pass and I've added a test for that use case.