### PR TITLE
Add a way of instantly seeing the associated deploy.json

### DIFF
--- a/riff-raff/app/views/deploy/viewDeploy.scala.html
+++ b/riff-raff/app/views/deploy/viewDeploy.scala.html
@@ -48,10 +48,11 @@ to stacks (@{record.stacks.map { stack => stack.name }.mkString(", ")})
     @record.stacks.zipWithIndex.map { case (stack, index) =>
         <input type="hidden" name="stacks[@index]" value="@{stack.name}"/>
     }
-    <div class="actions"><p>
-        <button id="modalConfirm" name="action" type="submit" value="deploy" class="btn btn-default pull-right">
+    <div class="actions pull-right"><p>
+        <button id="modalConfirm" name="action" type="submit" value="deploy" class="btn btn-default">
             Deploy Again
         </button>
+        <a class="btn btn-default" href="@routes.DeployController.deployObject(record.buildName, record.buildId)" role="button">See deploy.json</a>
     </p></div>
 }
 </div>

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -40,6 +40,8 @@ GET         /deployment/preview/content                     controllers.DeployCo
 GET         /deployment/dashboard                           controllers.DeployController.dashboard(projects:String, search:Boolean?=false)
 GET         /deployment/dashboard/content                   controllers.DeployController.dashboardContent(projects:String, search:Boolean?=false)
 
+GET         /deployment/request/deployObject                controllers.DeployController.deployObject(projectName:String, id:String)
+
 # Continuous deployment
 GET         /deployment/continuous                          controllers.ContinuousDeployController.list
 GET         /deployment/continuous/new                      controllers.ContinuousDeployController.form


### PR DESCRIPTION
It's pretty difficult to view the deploy.json without accessing the S3 bucket. I'd like to expand this to a debug view for a build, but this is an easy starting point that only took a few minutes but will none the less be useful.

![screen shot 2016-08-12 at 17 29 37](https://cloud.githubusercontent.com/assets/1236466/17629464/61401742-60b2-11e6-980c-69da4d6f8f8e.png)
