### PR TITLE
Tests around the DeployCoordinator FSM

### DIFF
--- a/riff-raff/app/deployment/actors.scala
+++ b/riff-raff/app/deployment/actors.scala
@@ -3,7 +3,7 @@ package deployment
 import java.io.File
 import java.util.UUID
 
-import _root_.resources.LookupSelector
+import resources.LookupSelector
 import akka.actor.SupervisorStrategy.Restart
 import akka.actor._
 import akka.pattern.ask
@@ -46,7 +46,16 @@ object DeployControlActor extends Logging {
   )
   lazy val system = ActorSystem("deploy", dispatcherConfig.withFallback(ConfigFactory.load()))
 
-  lazy val deployCoordinator = system.actorOf(Props[DeployCoordinator])
+  lazy val taskRunnerFactory = { context:ActorRefFactory =>
+    context.actorOf(
+      props = RoundRobinPool(
+        concurrentDeploys,
+        supervisorStrategy = OneForOneStrategy(maxNrOfRetries = 3, withinTimeRange = 1 minute) { case _ => Restart }
+      ).props(Props[TaskRunner].withDispatcher("akka.task-dispatcher")),
+      name = "taskRunners"
+    )
+  }
+  lazy val deployCoordinator = system.actorOf(Props(classOf[DeployCoordinator], taskRunnerFactory))
 
   import deployment.DeployCoordinator.{CheckStopFlag, StartDeploy, StopDeploy}
 
@@ -123,7 +132,7 @@ object DeployCoordinator {
   case class CheckStopFlag(uuid: UUID) extends Message
 }
 
-class DeployCoordinator extends Actor with Logging {
+class DeployCoordinator(val runnerFactory: ActorRefFactory => ActorRef) extends Actor with Logging {
   import DeployCoordinator._
   import TaskRunner._
 
@@ -131,11 +140,7 @@ class DeployCoordinator extends Actor with Logging {
     case _ => Restart
   }
 
-  val taskStrategy = OneForOneStrategy(maxNrOfRetries = 3, withinTimeRange = 1 minute) { case _ => Restart }
-  val runners = context.actorOf(
-    RoundRobinPool(conf.Configuration.concurrency.maxDeploys, supervisorStrategy = taskStrategy)
-      .props(Props[TaskRunner].withDispatcher("akka.task-dispatcher")), "taskRunners"
-  )
+  val runners = runnerFactory(context)
 
   var deployStateMap = Map.empty[UUID, DeployRunState]
   var deferredDeployQueue = ListBuffer[DeployCoordinator.Message]()
@@ -143,10 +148,9 @@ class DeployCoordinator extends Actor with Logging {
 
   def schedulable(record: Record): Boolean = {
     deployStateMap.size < conf.Configuration.concurrency.maxDeploys &&
-      deployStateMap.values.find(state =>
+      !deployStateMap.values.exists(state =>
         state.record.parameters.build.projectName == record.parameters.build.projectName &&
-          state.record.parameters.stage == record.parameters.stage
-      ).isEmpty
+          state.record.parameters.stage == record.parameters.stage)
   }
 
   def ifStopFlagClear[T](state: DeployRunState)(block: => T): Option[T] = {
@@ -280,7 +284,7 @@ class TaskRunner extends Actor with Logging {
       }
 
 
-    case RunTask(record, task, deployReporter, queueTime) => {
+    case RunTask(record, task, deployReporter, queueTime) =>
       import DeployMetricsActor._
       deployMetricsProcessor ! TaskStart(record.uuid, task.id, queueTime, new DateTime())
       log.debug("Running task %d" format task.id)
@@ -309,11 +313,9 @@ class TaskRunner extends Actor with Logging {
       } finally {
         deployMetricsProcessor ! TaskComplete(record.uuid, task.id, new DateTime())
       }
-    }
 
-    case RemoveArtifact(artifactDir) => {
+    case RemoveArtifact(artifactDir) =>
       log.debug("Delete artifact dir")
       Path(artifactDir).delete()
-    }
   }
 }

--- a/riff-raff/build.sbt
+++ b/riff-raff/build.sbt
@@ -25,7 +25,8 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
   filters,
   ws,
-  "org.scalatestplus" %% "play" % "1.2.0" % "test"
+  "org.scalatestplus" %% "play" % "1.2.0" % "test",
+  "com.typesafe.akka" %% "akka-testkit" % "2.3.8" % "test"
 )
 
 riffRaffPackageType := (packageZipTarball in Universal).value

--- a/riff-raff/test/deployment/DeployCoordinatorTest.scala
+++ b/riff-raff/test/deployment/DeployCoordinatorTest.scala
@@ -1,0 +1,231 @@
+package deployment
+
+import java.util.UUID
+
+import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
+import akka.testkit.{TestActorRef, TestKit, TestProbe}
+import akka.util.Timeout
+import com.amazonaws.services.s3.AmazonS3Client
+import com.typesafe.config.ConfigFactory
+import deployment.DeployCoordinator.{CheckStopFlag, StartDeploy, StopDeploy}
+import deployment.TaskRunner._
+import magenta.tasks.{HealthcheckGrace, S3Upload, SayHello, SuspendAlarmNotifications}
+import magenta.{Build, DeployContext, DeployParameters, Deployer, DeploymentPackage, Host, KeyRing, Project, Stage}
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.util.Success
+
+object DeployCoordinatorTest {
+  lazy val testConfig = ConfigFactory.parseMap(
+    Map("akka.test.single-expect-default" -> "500").asJava
+  ).withFallback(ConfigFactory.load())
+}
+
+class DeployCoordinatorTest extends TestKit(ActorSystem("DeployCoordinatorTest", DeployCoordinatorTest.testConfig))
+  with FlatSpecLike with Matchers with BeforeAndAfterAll with MockitoSugar {
+
+  implicit val fakeKeyRing = KeyRing()
+  implicit val artifactClient = mock[AmazonS3Client]
+
+  override def afterAll {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  "DeployCoordinator" should "respond to StartDeploy with PrepareDeploy to runner" in {
+    val dc = createDeployCoordinatorWithUnderlying
+    val record = DeployRecord(
+      UUID.fromString("967c5ca9-36cb-4e1c-b317-983792cdf622"),
+      DeployParameters(Deployer("Tester"), Build("test", "1"), Stage("TEST"))
+    )
+    dc.actor ! StartDeploy(record)
+
+    dc.probe.expectMsgPF(){
+      case PrepareDeploy(pdRecord, reporter) =>
+        pdRecord should be(record)
+        reporter.messageContext.deployId should be(record.uuid)
+        reporter.messageContext.parameters should be(record.parameters)
+    }
+
+    dc.ul.deployStateMap.keys should contain(record.uuid)
+  }
+
+  it should "queue a StartDeploy message if the deploy is already running" in {
+    val dc = createDeployCoordinatorWithUnderlying
+    val record = DeployRecord(
+      UUID.fromString("967c5ca9-36cb-4e1c-b317-983792cdf622"),
+      DeployParameters(Deployer("Tester"), Build("test", "1"), Stage("TEST"))
+    )
+    val recordTwo = DeployRecord(
+      UUID.fromString("60efc45c-8441-4abb-81cf-e7d84e3469c6"),
+      DeployParameters(Deployer("TesterTwo"), Build("test", "6"), Stage("TEST"))
+    )
+
+    dc.actor ! StartDeploy(record)
+    dc.probe.expectMsgClass(classOf[PrepareDeploy])
+
+    dc.actor ! StartDeploy(recordTwo)
+    dc.probe.expectNoMsg()
+    dc.ul.deferredDeployQueue.size should be(1)
+    dc.ul.deferredDeployQueue.head should be(StartDeploy(recordTwo))
+  }
+
+  it should "respond to a DeployReady message with the appropriate first task" in {
+    val dc = createDeployCoordinator
+    val record = DeployRecord(
+      UUID.fromString("967c5ca9-36cb-4e1c-b317-983792cdf622"),
+      DeployParameters(Deployer("Tester"), Build("test", "1"), Stage("TEST"))
+    )
+
+    dc.actor ! StartDeploy(record)
+    val prepareDeploy = dc.probe.expectMsgClass(classOf[PrepareDeploy])
+    val context = DeployContext(record.uuid, record.parameters, Project(), List(S3Upload("test-bucket", Seq())), prepareDeploy.reporter)
+    dc.probe.reply(DeployReady(record, context))
+    dc.probe.expectMsgPF(){
+      case RunTask(r, t, _, _) =>
+        t.task should be(S3Upload("test-bucket", Seq()))
+        r should be(record)
+    }
+  }
+
+  it should "respond to a final TaskCompleted message with cleanup" in {
+    val dc = createDeployCoordinatorWithUnderlying
+    val record = DeployRecord(
+      UUID.fromString("967c5ca9-36cb-4e1c-b317-983792cdf622"),
+      DeployParameters(Deployer("Tester"), Build("test", "1"), Stage("TEST"))
+    )
+
+    dc.actor ! StartDeploy(record)
+    val prepareDeploy = dc.probe.expectMsgClass(classOf[PrepareDeploy])
+    val context = DeployContext(record.uuid, record.parameters, Project(), List(S3Upload("test-bucket", Seq())), prepareDeploy.reporter)
+    dc.probe.reply(DeployReady(record, context))
+    val runTask = dc.probe.expectMsgClass(classOf[RunTask])
+    dc.probe.reply(TaskCompleted(record, runTask.task))
+    dc.probe.expectNoMsg()
+
+    dc.ul.deployStateMap.keys shouldNot contain(record.uuid)
+  }
+
+  it should "dequeue StartDeploy messages when deploys complete" in {
+    val dc = createDeployCoordinator
+    val record = DeployRecord(
+      UUID.fromString("967c5ca9-36cb-4e1c-b317-983792cdf622"),
+      DeployParameters(Deployer("Tester"), Build("test", "1"), Stage("TEST"))
+    )
+    val recordTwo = DeployRecord(
+      UUID.fromString("60efc45c-8441-4abb-81cf-e7d84e3469c6"),
+      DeployParameters(Deployer("TesterTwo"), Build("test", "6"), Stage("TEST"))
+    )
+
+    dc.actor ! StartDeploy(record)
+    dc.actor ! StartDeploy(recordTwo)
+    val prepareDeploy = dc.probe.expectMsgClass(classOf[PrepareDeploy])
+    val context = DeployContext(record.uuid, record.parameters, Project(), List(S3Upload("test-bucket", Seq())), prepareDeploy.reporter)
+    dc.probe.reply(DeployReady(record, context))
+    val runTask = dc.probe.expectMsgClass(classOf[RunTask])
+    dc.probe.reply(TaskCompleted(record, runTask.task))
+
+    val prepareDeployTwo = dc.probe.expectMsgClass(classOf[PrepareDeploy])
+    prepareDeployTwo.record should be(recordTwo)
+  }
+
+  it should "process a list of tasks" in {
+    val dc = createDeployCoordinator
+    val record = DeployRecord(
+      UUID.fromString("967c5ca9-36cb-4e1c-b317-983792cdf622"),
+      DeployParameters(Deployer("Tester"), Build("test", "1"), Stage("TEST"))
+    )
+
+    dc.actor ! StartDeploy(record)
+    val prepareDeploy = dc.probe.expectMsgClass(classOf[PrepareDeploy])
+    val tasks = List(
+      S3Upload("test-bucket", Seq()),
+      SayHello(Host("testHost")),
+      HealthcheckGrace(1000)
+    )
+    val context = DeployContext(record.uuid, record.parameters, Project(), tasks, prepareDeploy.reporter)
+
+    dc.probe.reply(DeployReady(record, context))
+    val runS3Upload = dc.probe.expectMsgClass(classOf[RunTask])
+    runS3Upload.task.task should be(S3Upload("test-bucket", Seq()))
+
+    dc.probe.reply(TaskCompleted(runS3Upload.record, runS3Upload.task))
+    val runSayHello = dc.probe.expectMsgClass(classOf[RunTask])
+    runSayHello.task.task should be(SayHello(Host("testHost")))
+
+    dc.probe.reply(TaskCompleted(runSayHello.record, runSayHello.task))
+    val runGrace = dc.probe.expectMsgClass(classOf[RunTask])
+    runGrace.task.task should be(HealthcheckGrace(1000))
+
+    dc.probe.reply(TaskCompleted(runGrace.record, runGrace.task))
+    dc.probe.expectNoMsg()
+  }
+
+  it should "process a task failure" in {
+    val dc = createDeployCoordinatorWithUnderlying
+    val record = DeployRecord(
+      UUID.fromString("967c5ca9-36cb-4e1c-b317-983792cdf622"),
+      DeployParameters(Deployer("Tester"), Build("test", "1"), Stage("TEST"))
+    )
+
+    dc.actor ! StartDeploy(record)
+    val prepareDeploy = dc.probe.expectMsgClass(classOf[PrepareDeploy])
+    val tasks = List(
+      S3Upload("test-bucket", Seq()),
+      SayHello(Host("testHost")),
+      HealthcheckGrace(1000)
+    )
+    val context = DeployContext(record.uuid, record.parameters, Project(), tasks, prepareDeploy.reporter)
+
+    dc.probe.reply(DeployReady(record, context))
+    val runS3Upload = dc.probe.expectMsgClass(classOf[RunTask])
+    runS3Upload.task.task should be(S3Upload("test-bucket", Seq()))
+
+    dc.probe.reply(TaskFailed(runS3Upload.record, new RuntimeException("Something bad happened")))
+    dc.probe.expectNoMsg()
+    dc.ul.deployStateMap.keySet shouldNot contain(record.uuid)
+  }
+
+  it should "set the stop flag" in {
+    val dc = createDeployCoordinatorWithUnderlying
+    dc.actor ! StopDeploy(UUID.fromString("967c5ca9-36cb-4e1c-b317-983792cdf622"), "testUser")
+    dc.probe.expectNoMsg()
+    dc.ul.stopFlagMap should contain(UUID.fromString("967c5ca9-36cb-4e1c-b317-983792cdf622") -> Some("testUser"))
+  }
+
+  it should "correctly report the stop flag status" in {
+    import akka.pattern.ask
+    implicit val timeout = Timeout(1 second)
+
+    val dc = createDeployCoordinator
+    val stopFlagResult = dc.actor ? CheckStopFlag(UUID.fromString("967c5ca9-36cb-4e1c-b317-983792cdf622")) mapTo manifest[Boolean]
+    Await.result(stopFlagResult, timeout.duration) should be(false)
+
+    dc.actor ! StopDeploy(UUID.fromString("967c5ca9-36cb-4e1c-b317-983792cdf622"), "testUser")
+    expectNoMsg()
+
+    val stopFlagResult2 = dc.actor ? CheckStopFlag(UUID.fromString("967c5ca9-36cb-4e1c-b317-983792cdf622")) mapTo manifest[Boolean]
+    Await.result(stopFlagResult2, timeout.duration) should be(true)
+  }
+
+  case class DC(probe: TestProbe, actor: ActorRef)
+
+  def createDeployCoordinator = {
+    val runnerProbe = TestProbe()
+    val taskRunnerFactory = (_: ActorRefFactory) => runnerProbe.ref
+    val ref = system.actorOf(Props(classOf[DeployCoordinator], taskRunnerFactory))
+    DC(runnerProbe, ref)
+  }
+
+  case class DCwithUnderlying(probe: TestProbe, actor: ActorRef, ul: DeployCoordinator)
+
+  def createDeployCoordinatorWithUnderlying = {
+    val runnerProbe = TestProbe()
+    val taskRunnerFactory = (_: ActorRefFactory) => runnerProbe.ref
+    val ref = TestActorRef(new DeployCoordinator(taskRunnerFactory))
+    DCwithUnderlying(runnerProbe, ref, ref.underlyingActor)
+  }
+}


### PR DESCRIPTION
A brittle part of the Riff-Raff codebase is the `DeployCoordinator` Finite State Machine. This adds some tests around it to test some of the basic functionality. A couple of minor tweaks to the codebase have been made in order to make it possible to get a test harness around it easily.