### PR TITLE
Update riffraff.template

### DIFF
--- a/cloudformation/riffraff.template
+++ b/cloudformation/riffraff.template
@@ -11,7 +11,8 @@
           "arn:aws:iam::865473395570:root",
           "arn:aws:iam::021353022223:root",
           "arn:aws:iam::942464564246:root",
-          "arn:aws:iam::563563610310:root"
+          "arn:aws:iam::563563610310:root",
+          "arn:aws:iam::855023211239:root"
         ]
       }
     }


### PR DESCRIPTION
@akash1810  @gidsg  - Requesting access to RiffRaff for the Multimedia AWS account.  Main reason is to be able to deploy the in-development live stream tool and content delivery for atoms.