### PR TITLE
Make graph implementation generic and add new methods

### DIFF
--- a/magenta-lib/src/main/scala/magenta/Resolver.scala
+++ b/magenta-lib/src/main/scala/magenta/Resolver.scala
@@ -1,7 +1,7 @@
 package magenta
 
 import com.amazonaws.services.s3.AmazonS3
-import magenta.graph.DeploymentGraph
+import magenta.graph.{Deployment, DeploymentGraph, Graph}
 import magenta.tasks._
 
 case class RecipeTasks(recipe: Recipe, preTasks: List[Task], hostTasks: List[Task], disabled: Boolean = false) {
@@ -23,7 +23,7 @@ case class RecipeTasksNode(recipeTasks: RecipeTasks, children: List[RecipeTasksN
 
 object Resolver {
 
-  def resolve( project: Project, resourceLookup: Lookup, parameters: DeployParameters, deployReporter: DeployReporter, artifactClient: AmazonS3): DeploymentGraph = {
+  def resolve( project: Project, resourceLookup: Lookup, parameters: DeployParameters, deployReporter: DeployReporter, artifactClient: AmazonS3): Graph[Deployment] = {
     resolveStacks(project, parameters).map { stack =>
       val stackTasks = resolveStack(project, resourceLookup, parameters, deployReporter, artifactClient, stack).flatMap(_.tasks)
       DeploymentGraph(stackTasks, s"${parameters.build.projectName}${stack.nameOption.map(" -> "+_).getOrElse("")}")

--- a/magenta-lib/src/main/scala/magenta/graph/DeploymentGraph.scala
+++ b/magenta-lib/src/main/scala/magenta/graph/DeploymentGraph.scala
@@ -6,7 +6,7 @@ case class Deployment(tasks: List[Task], pathName: String)
 
 object DeploymentGraph {
   def apply(tasks: List[Task], pathName: String, priority: Int = 1): Graph[Deployment] = {
-    val deploymentNode = MidNode(Deployment(tasks, pathName), priority)
+    val deploymentNode = MidNode(Deployment(tasks, pathName))
     Graph(StartNode ~> deploymentNode, deploymentNode ~> EndNode)
   }
 

--- a/magenta-lib/src/main/scala/magenta/graph/DeploymentGraph.scala
+++ b/magenta-lib/src/main/scala/magenta/graph/DeploymentGraph.scala
@@ -2,89 +2,13 @@ package magenta.graph
 
 import magenta.tasks.Task
 
-sealed trait Node {
-  def ~>(to: Node) = Edge(this, to)
-  def maybePriority: Option[Int] = None
-}
-case object StartNode extends Node
-case class DeploymentNode(tasks: List[Task], pathName: String, priority: Int = 1) extends Node {
-  override def maybePriority: Option[Int] = Some(priority)
-  def incPriority(n: Int): DeploymentNode = this.copy(priority = priority + n)
-}
-case object EndNode extends Node
+case class Deployment(tasks: List[Task], pathName: String)
 
-case class Edge(from: Node, to: Node)
-
-/**
-  * This graph is specialised for deployment. It consists of a start node, an end node and any number of
-  * deployment nodes. The graph structure represents which deployments must be run in series and which can be run in
-  * parallel.
-  */
 object DeploymentGraph {
-  def apply(tasks: List[Task], pathName: String, priority: Int = 1): DeploymentGraph = {
-    val deploymentNode = DeploymentNode(tasks, pathName, priority)
-    DeploymentGraph(StartNode ~> deploymentNode, deploymentNode ~> EndNode)
+  def apply(tasks: List[Task], pathName: String, priority: Int = 1): Graph[Deployment] = {
+    val deploymentNode = MidNode(Deployment(tasks, pathName), priority)
+    Graph(StartNode ~> deploymentNode, deploymentNode ~> EndNode)
   }
 
-  def apply(edges: Edge*): DeploymentGraph = DeploymentGraph(edges.toSet)
-
-  val empty = DeploymentGraph(StartNode ~> EndNode)
-}
-
-case class DeploymentGraph(edges: Set[Edge]) {
-  val nodes = edges.map(_.from) ++ edges.map(_.to)
-
-  val isValid: Either[List[String], Boolean] = {
-    val errors =
-      ((if (!nodes.contains(StartNode)) Some("No start node") else None) ::
-        (if (!nodes.contains(EndNode)) Some("No end node") else None) :: Nil).flatten
-    if (errors.isEmpty) Right(true) else Left(errors)
-  }
-  assert(isValid.isRight, s"Graph isn't valid: ${isValid.left.get.mkString(", ")}")
-
-  def successors(node: Node): Set[Node] = edges.filter(_.from == node).map(_.to)
-  def predecessors(node: Node): Set[Node] = edges.filter(_.to == node).map(_.from)
-  def successorDeploymentNodes(node: Node): List[DeploymentNode] = {
-    successors(node).filterDeploymentNodes.toList.sortBy(_.priority)
-  }
-
-  def replace(node: Node, withNode: Node): DeploymentGraph = {
-    assert(nodes.contains(node), "Node to replace not found in graph")
-    val newEdges = edges.map {
-      case Edge(from, to) if from == node => Edge(withNode, to)
-      case Edge(from, to) if to == node => Edge(from, withNode)
-      case other => other
-    }
-    DeploymentGraph(newEdges)
-  }
-
-  def joinParallel(other: DeploymentGraph): DeploymentGraph = {
-    val maxPriority = successorDeploymentNodes(StartNode).map(_.priority).max
-    val otherEdges = other.successorDeploymentNodes(StartNode).foldLeft(other){ case(g, node) =>
-      g.replace(node, node.incPriority(maxPriority))
-    }.edges
-    DeploymentGraph(edges ++ otherEdges)
-  }
-
-  def toList: List[Node] = {
-    def traverseFrom(node: Node, visited: Set[Node]): List[Node] = {
-      val predecessors: Set[Node] = this.predecessors(node)
-      if ((predecessors -- visited).nonEmpty) {
-        // if there are some predecessors of this node that we haven't yet visited then return empty list - we'll be back
-        Nil
-      } else {
-        // if we've visited all the predecessors then follow all the successors
-        val successors = this.successors(node).toList.sortBy{ node =>
-          // order by the priority of the node
-          node.maybePriority
-        }
-        successors.foldLeft(List(node)){ case (acc, successor) =>
-          acc ::: traverseFrom(successor, visited ++ acc)
-        }
-      }
-    }
-    traverseFrom(StartNode, Set.empty)
-  }
-
-  def toTaskList = toList.filterDeploymentNodes.flatMap(_.tasks)
+  def toTaskList(taskGraph: Graph[Deployment]) = taskGraph.toList.flatMap(_.tasks)
 }

--- a/magenta-lib/src/main/scala/magenta/graph/Graph.scala
+++ b/magenta-lib/src/main/scala/magenta/graph/Graph.scala
@@ -1,0 +1,101 @@
+package magenta.graph
+
+sealed trait Node[+T] {
+  def ~>[R >: T](to: Node[R]): Edge[R] = Edge(this, to)
+  def maybePriority: Option[Int] = None
+  def maybeValue: Option[T] = None
+}
+case object StartNode extends Node[Nothing]
+case class MidNode[T](value: T, priority: Int = 1) extends Node[T] {
+  override def maybePriority: Option[Int] = Some(priority)
+  def incPriority(n: Int): MidNode[T] = this.copy(priority = priority + n)
+  override def maybeValue: Option[T] = Some(value)
+}
+case object EndNode extends Node[Nothing]
+
+case class Edge[+T](from: Node[T], to: Node[T])
+
+object Graph {
+  def apply[T](edges: Edge[T]*): Graph[T] = Graph(edges.toSet)
+
+  def empty[T] = Graph[T](StartNode ~> EndNode)
+}
+
+case class Graph[T](edges: Set[Edge[T]]) {
+  val nodes = edges.map(_.from) ++ edges.map(_.to)
+  val dataNodes = nodes.filterMidNodes
+
+  val isValid: Either[List[String], Boolean] = {
+    val errors =
+      ((if (!nodes.contains(StartNode)) Some("No start node") else None) ::
+        (if (!nodes.contains(EndNode)) Some("No end node") else None) :: Nil).flatten
+    if (errors.isEmpty) Right(true) else Left(errors)
+  }
+  assert(isValid.isRight, s"Graph isn't valid: ${isValid.left.get.mkString(", ")}")
+
+  def get(node: T): MidNode[T] = dataNodes.find(_.value == node).get
+  def successors(node: Node[T]): Set[Node[T]] = edges.filter(_.from == node).map(_.to)
+  def predecessors(node: Node[T]): Set[Node[T]] = edges.filter(_.to == node).map(_.from)
+  def successorNodes(node: Node[T]): List[MidNode[T]] = {
+    successors(node).filterMidNodes.toList.sortBy(_.priority)
+  }
+
+  def replace(node: Node[T], withNode: Node[T]): Graph[T] = {
+    assert(nodes.contains(node), "Node to replace not found in graph")
+    val newEdges = edges.map {
+      case Edge(from, to) if from == node => Edge(withNode, to)
+      case Edge(from, to) if to == node => Edge(from, withNode)
+      case other => other
+    }
+    Graph(newEdges)
+  }
+
+  def map[R](f: MidNode[T] => MidNode[R]): Graph[R] = {
+    val newNodeMap: Map[Node[T], Node[R]] = dataNodes.map { currentNode =>
+      currentNode -> f(currentNode)
+    }.toMap ++ Map(StartNode -> StartNode, EndNode -> EndNode)
+    assert(newNodeMap.size == newNodeMap.values.toSet.size, "Source nodes must be mapped onto unique target nodes")
+    val newEdges = edges.map { oldEdge =>
+      Edge(newNodeMap(oldEdge.from), newNodeMap(oldEdge.to))
+    }
+    Graph(newEdges)
+  }
+
+  def joinParallel(other: Graph[T]): Graph[T] = {
+    val maxPriority = successorNodes(StartNode).map(_.priority).max
+    val otherEdges = other.successorNodes(StartNode).foldLeft(other){ case(g, node) =>
+      g.replace(node, node.incPriority(maxPriority))
+    }.edges
+    Graph(edges ++ otherEdges)
+  }
+
+  def joinSeries(other: Graph[T]): Graph[T] = {
+    val ourEndEdges = edges.filter(_.to == EndNode)
+    val otherStartEdges = other.edges.filter(_.from == StartNode)
+    val joiningEdges = ourEndEdges.map(_.from).flatMap { endNode =>
+      otherStartEdges.map(_.to).map(startNode => Edge(endNode, startNode))
+    }
+    val mergedEdges = (edges -- ourEndEdges) ++ (other.edges -- otherStartEdges) ++ joiningEdges
+    Graph(mergedEdges)
+  }
+
+  def toList: List[T] = {
+    def traverseFrom(node: Node[T], visited: Set[Node[T]]): List[Node[T]] = {
+      val predecessors: Set[Node[T]] = this.predecessors(node)
+      if ((predecessors -- visited).nonEmpty) {
+        // if there are some predecessors of this node that we haven't yet visited then return empty list - we'll be back
+        Nil
+      } else {
+        // if we've visited all the predecessors then follow all the successors
+        val successors = this.successors(node).toList.sortBy{ node =>
+          // order by the priority of the node
+          node.maybePriority
+        }
+        successors.foldLeft(List(node)){ case (acc, successor) =>
+          acc ::: traverseFrom(successor, visited ++ acc)
+        }
+      }
+    }
+    traverseFrom(StartNode, Set.empty).flatMap(_.maybeValue)
+  }
+}

--- a/magenta-lib/src/main/scala/magenta/graph/package.scala
+++ b/magenta-lib/src/main/scala/magenta/graph/package.scala
@@ -1,15 +1,15 @@
 package magenta
 
 package object graph {
-  implicit class RichNodeSet(nodes: Set[Node]) {
-    def filterDeploymentNodes: Set[DeploymentNode] = nodes.flatMap{
-      case deploymentNode:DeploymentNode => Some(deploymentNode)
+  implicit class RichNodeSet[T](nodes: Set[Node[T]]) {
+    def filterMidNodes: Set[MidNode[T]] = nodes.flatMap{
+      case deploymentNode:MidNode[T] => Some(deploymentNode)
       case _ => None
     }
   }
-  implicit class RichNodeList(nodes: List[Node]) {
-    def filterDeploymentNodes: List[DeploymentNode] = nodes.flatMap{
-      case deploymentNode:DeploymentNode => Some(deploymentNode)
+  implicit class RichNodeList[T](nodes: List[Node[T]]) {
+    def filterMidNodes: List[MidNode[T]] = nodes.flatMap{
+      case deploymentNode:MidNode[T] => Some(deploymentNode)
       case _ => None
     }
   }

--- a/magenta-lib/src/main/scala/magenta/graph/package.scala
+++ b/magenta-lib/src/main/scala/magenta/graph/package.scala
@@ -2,15 +2,9 @@ package magenta
 
 package object graph {
   implicit class RichNodeSet[T](nodes: Set[Node[T]]) {
-    def filterMidNodes: Set[MidNode[T]] = nodes.flatMap{
-      case deploymentNode:MidNode[T] => Some(deploymentNode)
-      case _ => None
-    }
+    def filterMidNodes: Set[MidNode[T]] = nodes.collect{ case mn:MidNode[T] => mn }
   }
   implicit class RichNodeList[T](nodes: List[Node[T]]) {
-    def filterMidNodes: List[MidNode[T]] = nodes.flatMap{
-      case deploymentNode:MidNode[T] => Some(deploymentNode)
-      case _ => None
-    }
+    def filterMidNodes: List[MidNode[T]] = nodes.collect{ case mn:MidNode[T] => mn }
   }
 }

--- a/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
+++ b/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
@@ -4,6 +4,7 @@ import java.util.UUID
 
 import com.amazonaws.services.s3.AmazonS3Client
 import magenta.fixtures.{StubTask, _}
+import magenta.graph.DeploymentGraph
 import magenta.tasks.Task
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
@@ -19,7 +20,7 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
     val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
     val parameters = DeployParameters(Deployer("tester"), Build("project","1"), CODE, oneRecipeName)
     val context = DeployContext(UUID.randomUUID(), parameters, project(baseRecipe), lookupSingleHost, reporter, artifactClient)
-    context.tasks.toTaskList should be(List(
+    DeploymentGraph.toTaskList(context.tasks) should be(List(
       StubTask("init_action_one per app task"),
       StubTask("action_one per host task on the_host", lookupSingleHost.hosts.all.headOption)
     ))
@@ -43,7 +44,7 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
     val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), parameters)
     val context = DeployContext(reporter.messageContext.deployId, parameters, project(baseMockRecipe), lookupSingleHost, reporter, artifactClient)
     context.execute(reporter)
-    val task = context.tasks.toTaskList.head
+    val task = DeploymentGraph.toTaskList(context.tasks).head
 
     verify(task, times(1)).execute(any[DeployReporter])
   }

--- a/magenta-lib/src/test/scala/magenta/ResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/ResolverTest.scala
@@ -265,13 +265,15 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
 
     val proj = project(recipe, NamedStack("foo"), NamedStack("bar"), NamedStack("monkey"), NamedStack("litre"))
     val taskGraph = Resolver.resolve(proj, stubLookup(), parameters(recipe), reporter, artifactClient)
-    val successors = taskGraph.successors(StartNode)
+    val successors = taskGraph.orderedSuccessors(StartNode)
     successors.size should be(4)
 
-    successors should contain(MidNode(Deployment(List(StubTask("stacked", stack = Some(NamedStack("foo")))), "project -> foo"), 1))
-    successors should contain(MidNode(Deployment(List(StubTask("stacked", stack = Some(NamedStack("bar")))), "project -> bar"), 2))
-    successors should contain(MidNode(Deployment(List(StubTask("stacked", stack = Some(NamedStack("monkey")))), "project -> monkey"), 3))
-    successors should contain(MidNode(Deployment(List(StubTask("stacked", stack = Some(NamedStack("litre")))), "project -> litre"), 4))
+    successors should be(List(
+      MidNode(Deployment(List(StubTask("stacked", stack = Some(NamedStack("foo")))), "project -> foo")),
+      MidNode(Deployment(List(StubTask("stacked", stack = Some(NamedStack("bar")))), "project -> bar")),
+      MidNode(Deployment(List(StubTask("stacked", stack = Some(NamedStack("monkey")))), "project -> monkey")),
+      MidNode(Deployment(List(StubTask("stacked", stack = Some(NamedStack("litre")))), "project -> litre"))
+    ))
   }
 
   def parameters(recipe: Recipe) =

--- a/magenta-lib/src/test/scala/magenta/ResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/ResolverTest.scala
@@ -6,7 +6,7 @@ import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.{ListObjectsV2Request, ListObjectsV2Result}
 import magenta.artifact.{S3Artifact, S3Package}
 import magenta.fixtures.{StubDeploymentType, StubTask, _}
-import magenta.graph.{DeploymentNode, StartNode}
+import magenta.graph.{Deployment, DeploymentGraph, MidNode, StartNode}
 import magenta.json._
 import magenta.tasks.{S3Upload, Task}
 import org.mockito.Matchers._
@@ -49,7 +49,7 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
 
     val tasks = Resolver.resolve(project(deployRecipe), lookup, parameters(deployRecipe), reporter, artifactClient)
 
-    val taskList: List[Task] = tasks.toTaskList
+    val taskList: List[Task] = DeploymentGraph.toTaskList(tasks)
     taskList.size should be (1)
     taskList should be (List(
       S3Upload("test", Seq((new S3Package("artifact-bucket","tmp/123/packages/htmlapp"), "CODE/htmlapp")), publicReadAcl = true)
@@ -67,7 +67,7 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
 
   it should "generate the tasks from the actions supplied" in {
     val taskGraph = Resolver.resolve(project(baseRecipe), lookupSingleHost, parameters(baseRecipe), reporter, artifactClient)
-    taskGraph.toTaskList should be (List(
+    DeploymentGraph.toTaskList(taskGraph) should be (List(
       StubTask("init_action_one per app task"),
       StubTask("action_one per host task on the_host", Some(host))
     ))
@@ -76,7 +76,7 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
   it should "only generate tasks for hosts that have apps" in {
     val taskGraph = Resolver.resolve(project(baseRecipe),
       stubLookup(Host("other_host").app(App("other_app")) +: lookupSingleHost.hosts.all), parameters(baseRecipe), reporter, artifactClient)
-    taskGraph.toTaskList should be (List(
+    DeploymentGraph.toTaskList(taskGraph) should be (List(
         StubTask("init_action_one per app task"),
         StubTask("action_one per host task on the_host", Some(host))
     ))
@@ -84,7 +84,7 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
 
   it should "generate tasks for all hosts with app" in {
     val taskGraph = Resolver.resolve(project(baseRecipe), lookupTwoHosts, parameters(baseRecipe), reporter, artifactClient)
-    taskGraph.toTaskList should be (List(
+    DeploymentGraph.toTaskList(taskGraph) should be (List(
       StubTask("init_action_one per app task"),
       StubTask("action_one per host task on host1", Some(host1)),
       StubTask("action_one per host task on host2", Some(host2))
@@ -110,7 +110,7 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
     val lookupMultiHost = stubLookup(List(host1, host2WithApp2))
 
     val taskGraph = Resolver.resolve(project(multiRoleRecipe), lookupMultiHost, parameters(multiRoleRecipe), reporter, artifactClient)
-    taskGraph.toTaskList should be (List(
+    DeploymentGraph.toTaskList(taskGraph) should be (List(
       StubTask("init_action_one per app task"),
       StubTask("action_one per host task on host1", Some(host1)),
       StubTask("action_two per host task on host1", Some(host1)),
@@ -128,7 +128,7 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
     )
 
     val taskGraph = Resolver.resolve(project(recipe), lookupTwoHosts, parameters(recipe), reporter, artifactClient)
-    taskGraph.toTaskList should be (List(
+    DeploymentGraph.toTaskList(taskGraph) should be (List(
       StubTask("init_action_one per app task"),
       StubTask("action_one per host task on host1", Some(host1)),
       StubTask("action_two per host task on host1", Some(host1)),
@@ -146,7 +146,7 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
       dependsOn = List("one"))
 
     val taskGraph = Resolver.resolve(project(mainRecipe, baseRecipe), lookupSingleHost, parameters(mainRecipe), reporter, artifactClient)
-    taskGraph.toTaskList should be (List(
+    DeploymentGraph.toTaskList(taskGraph) should be (List(
       StubTask("init_action_one per app task"),
       StubTask("action_one per host task on the_host", Some(host)),
       StubTask("main_init_action per app task"),
@@ -168,7 +168,7 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
       dependsOn = List("two", "one"))
 
     val taskGraph = Resolver.resolve(project(mainRecipe, indirectDependencyRecipe, baseRecipe), lookupSingleHost, parameters(mainRecipe), reporter, artifactClient)
-    taskGraph.toTaskList should be (List(
+    DeploymentGraph.toTaskList(taskGraph) should be (List(
       StubTask("init_action_one per app task"),
       StubTask("action_one per host task on the_host", Some(host)),
       StubTask("init_action_two per app task"),
@@ -200,7 +200,7 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
       reporter,
       artifactClient
     )
-    taskGraph.toTaskList should be (List(
+    DeploymentGraph.toTaskList(taskGraph) should be (List(
       StubTask("init_action_one per app task"),
       StubTask("action_one per host task on the_host", Some(host))
     ))
@@ -208,7 +208,7 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
 
   it should "observe ordering of hosts in deployInfo" in {
     val taskGraph = Resolver.resolve(project(baseRecipe), stubLookup(List(host2, host1)), parameters(baseRecipe), reporter, artifactClient)
-    taskGraph.toTaskList should be (List(
+    DeploymentGraph.toTaskList(taskGraph) should be (List(
       StubTask("init_action_one per app task"),
       StubTask("action_one per host task on host2", Some(host2)),
       StubTask("action_one per host task on host1", Some(host1))
@@ -227,7 +227,7 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
       actionsPerHost = List(pkgTypeWithUser.mkAction("deploy")(pkg)))
 
     val taskGraph = Resolver.resolve(project(recipe), stubLookup(List(host2, host1)), parameters(recipe), reporter, artifactClient)
-    taskGraph.toTaskList should be (List(
+    DeploymentGraph.toTaskList(taskGraph) should be (List(
       StubTask("with conn", Some(host2 as "user")),
       StubTask("without conn", Some(host2)),
       StubTask("with conn", Some(host1 as "user")),
@@ -246,7 +246,7 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
 
     val proj = project(recipe, NamedStack("foo"), NamedStack("bar"), NamedStack("monkey"), NamedStack("litre"))
     val taskGraph = Resolver.resolve(proj, stubLookup(), parameters(recipe), reporter, artifactClient)
-    taskGraph.toTaskList should be (List(
+    DeploymentGraph.toTaskList(taskGraph) should be (List(
       StubTask("stacked", stack = Some(NamedStack("foo"))),
       StubTask("stacked", stack = Some(NamedStack("bar"))),
       StubTask("stacked", stack = Some(NamedStack("monkey"))),
@@ -268,10 +268,10 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
     val successors = taskGraph.successors(StartNode)
     successors.size should be(4)
 
-    successors should contain(DeploymentNode(List(StubTask("stacked", stack = Some(NamedStack("foo")))), "project -> foo", 1))
-    successors should contain(DeploymentNode(List(StubTask("stacked", stack = Some(NamedStack("bar")))), "project -> bar", 2))
-    successors should contain(DeploymentNode(List(StubTask("stacked", stack = Some(NamedStack("monkey")))), "project -> monkey", 3))
-    successors should contain(DeploymentNode(List(StubTask("stacked", stack = Some(NamedStack("litre")))), "project -> litre", 4))
+    successors should contain(MidNode(Deployment(List(StubTask("stacked", stack = Some(NamedStack("foo")))), "project -> foo"), 1))
+    successors should contain(MidNode(Deployment(List(StubTask("stacked", stack = Some(NamedStack("bar")))), "project -> bar"), 2))
+    successors should contain(MidNode(Deployment(List(StubTask("stacked", stack = Some(NamedStack("monkey")))), "project -> monkey"), 3))
+    successors should contain(MidNode(Deployment(List(StubTask("stacked", stack = Some(NamedStack("litre")))), "project -> litre"), 4))
   }
 
   def parameters(recipe: Recipe) =

--- a/magenta-lib/src/test/scala/magenta/graph/DeploymentGraphTest.scala
+++ b/magenta-lib/src/test/scala/magenta/graph/DeploymentGraphTest.scala
@@ -14,32 +14,8 @@ class DeploymentGraphTest extends FlatSpec with ShouldMatchers with MockitoSugar
     val graph = DeploymentGraph(threeSimpleTasks, "unnamed")
     graph.nodes.size should be(3)
     graph.edges.size should be(2)
-    graph.nodes.filterDeploymentNodes.head.tasks should be(threeSimpleTasks)
-    graph.toTaskList should be(threeSimpleTasks)
-  }
-
-  it should "merge two graphs together" in {
-    val graph = DeploymentGraph(threeSimpleTasks, "bobbins")
-    val graph2 = DeploymentGraph(threeSimpleTasks, "bobbins-the-second")
-    val mergedGraph = graph.joinParallel(graph2)
-    val successors = mergedGraph.successors(StartNode)
-    successors.size should be(2)
-    val deploymentNodes = successors.filterDeploymentNodes.toList.sortBy(_.priority)
-    deploymentNodes.head should matchPattern{case DeploymentNode(_, "bobbins", 1) =>}
-    deploymentNodes(1) should matchPattern{case DeploymentNode(_, "bobbins-the-second", 2) =>}
-  }
-
-  it should "merge two complex graphs together" in {
-    val graph = DeploymentGraph(threeSimpleTasks, "bobbins")
-    val graph2 = DeploymentGraph(threeSimpleTasks, "bobbins-the-second")
-    val joinedGraph = graph.joinParallel(graph2)
-    val graph3 = DeploymentGraph(threeSimpleTasks, "bobbins-the-third")
-    val graph4 = DeploymentGraph(threeSimpleTasks, "bobbins-the-fourth")
-    val joinedGraph2 = graph3.joinParallel(graph4)
-    val mergedGraph = joinedGraph.joinParallel(joinedGraph2)
-    val outgoing = mergedGraph.successors(StartNode)
-    outgoing.size should be(4)
-    joinedGraph.joinParallel(graph3).joinParallel(graph4) should be(mergedGraph)
+    graph.nodes.filterMidNodes.head.value.tasks should be(threeSimpleTasks)
+    DeploymentGraph.toTaskList(graph) should be(threeSimpleTasks)
   }
 
   val threeSimpleTasks = List(

--- a/magenta-lib/src/test/scala/magenta/graph/GraphTest.scala
+++ b/magenta-lib/src/test/scala/magenta/graph/GraphTest.scala
@@ -2,7 +2,7 @@ package magenta.graph
 
 import org.scalatest._
 
-class SimpleGraphTest extends FlatSpec with ShouldMatchers {
+class GraphTest extends FlatSpec with ShouldMatchers {
 
   val start = StartNode
   val one = MidNode("one")
@@ -15,11 +15,11 @@ class SimpleGraphTest extends FlatSpec with ShouldMatchers {
     val graph = Graph(start ~> one, one ~> end)
     val graph2 = Graph(start ~> two, two ~> end)
     val mergedGraph = graph.joinParallel(graph2)
-    val successors = mergedGraph.successors(StartNode)
+    val successors = mergedGraph.orderedSuccessors(StartNode)
     successors.size should be(2)
-    val nodes = successors.filterMidNodes.toList.sortBy(_.priority)
-    nodes.head should matchPattern{case MidNode("one", 1) =>}
-    nodes(1) should matchPattern{case MidNode("two", 2) =>}
+    val nodes = successors.filterMidNodes
+    nodes.head should matchPattern{case MidNode("one") =>}
+    nodes(1) should matchPattern{case MidNode("two") =>}
   }
 
   it should "parallel join two complex graphs together" in {
@@ -33,6 +33,25 @@ class SimpleGraphTest extends FlatSpec with ShouldMatchers {
     val outgoing = mergedGraph.successors(StartNode)
     outgoing.size should be(4)
     joinedGraph.joinParallel(graph3).joinParallel(graph4) should be(mergedGraph)
+  }
+
+  it should "parallel join two graphs with shared nodes together" in {
+    val graph = Graph(start ~> one, one ~> end)
+    val graph2 = Graph(start ~> one, one ~> end)
+    val joinedGraph = graph.joinParallel(graph2)
+    joinedGraph should be(graph)
+  }
+
+  it should "parallel join two different graphs with shared nodes together" in {
+    val graph = Graph(start ~> one, one ~> two, two ~> end)
+    val graph2 = Graph(start ~> two, two ~> three, three ~> end)
+    val joinedGraph = graph.joinParallel(graph2)
+    joinedGraph should be(Graph(
+      start ~> one, (start ~> two).incPriority(1),
+      one ~> two,
+      two ~> end, (two ~> three).incPriority(1),
+      three ~> end
+    ))
   }
 
   it should "join two graphs together in series" in {
@@ -55,11 +74,29 @@ class SimpleGraphTest extends FlatSpec with ShouldMatchers {
     mergedGraph.nodes.size should be(6)
     mergedGraph.edges should contain(one ~> three)
     mergedGraph should be(Graph(
-      start ~> one, start ~> two.incPriority(1),
-      one ~> three, one ~> four.incPriority(1),
-      two.incPriority(1) ~> three, two.incPriority(1) ~> four.incPriority(1),
-      three ~> end, four.incPriority(1) ~> end
+      start ~> one, (start ~> two).incPriority(1),
+      one ~> three, (one ~> four).incPriority(1),
+      two ~> three, (two ~> four).incPriority(1),
+      three ~> end, four ~> end
     ))
+  }
+
+  it should "noop when parallel joining to an empty graph" in {
+    val graph = Graph(start ~> one, one ~> end)
+    val mergedGraph = graph.joinParallel(Graph.empty)
+    mergedGraph should be(graph)
+
+    val mergedGraph2 = Graph.empty[String].joinParallel(graph)
+    mergedGraph2 should be(graph)
+  }
+
+  it should "noop when series joining to an empty graph" in {
+    val graph = Graph(start ~> one, one ~> end)
+    val mergedGraph = graph.joinSeries(Graph.empty)
+    mergedGraph should be(graph)
+
+    val mergedGraph2 = Graph.empty[String].joinSeries(graph)
+    mergedGraph2 should be(graph)
   }
 
   it should "allow nodes to be mapped" in {
@@ -70,8 +107,8 @@ class SimpleGraphTest extends FlatSpec with ShouldMatchers {
     val graph4 = Graph(start ~> four, four ~> end)
     val joinedGraph2 = graph3.joinParallel(graph4)
     val mergedGraph = joinedGraph.joinSeries(joinedGraph2)
-    val transformedGraph = mergedGraph.map { case MidNode(s, priority) =>
-        MidNode(List(s, s), priority)
+    val transformedGraph = mergedGraph.map { case MidNode(s) =>
+        MidNode(List(s, s))
     }
     transformedGraph.nodes.size should be(6)
     transformedGraph.edges.size should be(mergedGraph.edges.size)

--- a/magenta-lib/src/test/scala/magenta/graph/SimpleGraphTest.scala
+++ b/magenta-lib/src/test/scala/magenta/graph/SimpleGraphTest.scala
@@ -1,0 +1,79 @@
+package magenta.graph
+
+import org.scalatest._
+
+class SimpleGraphTest extends FlatSpec with ShouldMatchers {
+
+  val start = StartNode
+  val one = MidNode("one")
+  val two = MidNode("two")
+  val three = MidNode("three")
+  val four = MidNode("four")
+  val end = EndNode
+
+  "SimpleGraph" should "parallel join two graphs together" in {
+    val graph = Graph(start ~> one, one ~> end)
+    val graph2 = Graph(start ~> two, two ~> end)
+    val mergedGraph = graph.joinParallel(graph2)
+    val successors = mergedGraph.successors(StartNode)
+    successors.size should be(2)
+    val nodes = successors.filterMidNodes.toList.sortBy(_.priority)
+    nodes.head should matchPattern{case MidNode("one", 1) =>}
+    nodes(1) should matchPattern{case MidNode("two", 2) =>}
+  }
+
+  it should "parallel join two complex graphs together" in {
+    val graph = Graph(start ~> one, one ~> end)
+    val graph2 = Graph(start ~> two, two ~> end)
+    val joinedGraph = graph.joinParallel(graph2)
+    val graph3 = Graph(start ~> three, three ~> end)
+    val graph4 = Graph(start ~> four, four ~> end)
+    val joinedGraph2 = graph3.joinParallel(graph4)
+    val mergedGraph = joinedGraph.joinParallel(joinedGraph2)
+    val outgoing = mergedGraph.successors(StartNode)
+    outgoing.size should be(4)
+    joinedGraph.joinParallel(graph3).joinParallel(graph4) should be(mergedGraph)
+  }
+
+  it should "join two graphs together in series" in {
+    val graph = Graph(start ~> one, one ~> end)
+    val graph2 = Graph(start ~> two, two ~> end)
+    val mergedGraph = graph.joinSeries(graph2)
+    mergedGraph.nodes.size should be(4)
+    mergedGraph.successors(StartNode).size should be(1)
+    mergedGraph should be(Graph(start ~> one, one ~> two, two ~> end))
+  }
+
+  it should "join two complex graphs together in series" in {
+    val graph = Graph(start ~> one, one ~> end)
+    val graph2 = Graph(start ~> two, two ~> end)
+    val joinedGraph = graph.joinParallel(graph2)
+    val graph3 = Graph(start ~> three, three ~> end)
+    val graph4 = Graph(start ~> four, four ~> end)
+    val joinedGraph2 = graph3.joinParallel(graph4)
+    val mergedGraph = joinedGraph.joinSeries(joinedGraph2)
+    mergedGraph.nodes.size should be(6)
+    mergedGraph.edges should contain(one ~> three)
+    mergedGraph should be(Graph(
+      start ~> one, start ~> two.incPriority(1),
+      one ~> three, one ~> four.incPriority(1),
+      two.incPriority(1) ~> three, two.incPriority(1) ~> four.incPriority(1),
+      three ~> end, four.incPriority(1) ~> end
+    ))
+  }
+
+  it should "allow nodes to be mapped" in {
+    val graph = Graph(start ~> one, one ~> end)
+    val graph2 = Graph(start ~> two, two ~> end)
+    val joinedGraph = graph.joinParallel(graph2)
+    val graph3 = Graph(start ~> three, three ~> end)
+    val graph4 = Graph(start ~> four, four ~> end)
+    val joinedGraph2 = graph3.joinParallel(graph4)
+    val mergedGraph = joinedGraph.joinSeries(joinedGraph2)
+    val transformedGraph = mergedGraph.map { case MidNode(s, priority) =>
+        MidNode(List(s, s), priority)
+    }
+    transformedGraph.nodes.size should be(6)
+    transformedGraph.edges.size should be(mergedGraph.edges.size)
+  }
+}

--- a/riff-raff/app/deployment/actors.scala
+++ b/riff-raff/app/deployment/actors.scala
@@ -12,7 +12,7 @@ import conf.{Configuration, TaskMetrics}
 import controllers.Logging
 import magenta._
 import magenta.artifact.S3Artifact
-import magenta.graph.{DeploymentGraph, DeploymentNode, StartNode}
+import magenta.graph.{Deployment, DeploymentGraph, MidNode, Graph, StartNode}
 import magenta.json.JsonReader
 import org.joda.time.DateTime
 import resources.LookupSelector
@@ -110,7 +110,7 @@ class DeployMetricsActor extends Actor with Logging {
 
 object DeployGroupRunner {
   sealed trait NextResult
-  case class Deployments(deployments: List[DeploymentNode]) extends NextResult
+  case class Deployments(deployments: List[MidNode[Deployment]]) extends NextResult
   case object FinishPath extends NextResult
   case object FinishDeploy extends NextResult
 
@@ -118,8 +118,8 @@ object DeployGroupRunner {
   case object Start extends Message
   case class ContextCreated(context: DeployContext) extends Message
   case object StartDeployment extends Message
-  case class DeploymentCompleted(deploymentNode: DeploymentNode) extends Message
-  case class DeploymentFailed(deploymentNode: DeploymentNode, exception: Throwable) extends Message
+  case class DeploymentCompleted(deployment: Deployment) extends Message
+  case class DeploymentFailed(deployment: Deployment, exception: Throwable) extends Message
 }
 
 case class DeployGroupRunner(
@@ -141,29 +141,29 @@ case class DeployGroupRunner(
 
   var deployContext: Option[DeployContext] = None
 
-  var executing: Set[DeploymentNode] = Set.empty
-  var completed: Set[DeploymentNode] = Set.empty
-  var failed: Set[DeploymentNode] = Set.empty
+  var executing: Set[MidNode[Deployment]] = Set.empty
+  var completed: Set[MidNode[Deployment]] = Set.empty
+  var failed: Set[MidNode[Deployment]] = Set.empty
 
-  def deploymentGraph: DeploymentGraph = deployContext.map(_.tasks).getOrElse(DeploymentGraph.empty)
-  def allDeployments = deploymentGraph.nodes.filterDeploymentNodes
+  def deploymentGraph: Graph[Deployment] = deployContext.map(_.tasks).getOrElse(Graph.empty[Deployment])
+  def allDeployments = deploymentGraph.nodes.filterMidNodes
 
   def isFinished: Boolean = allDeployments == completed ++ failed
   def isExecuting: Boolean = executing.nonEmpty
 
-  def firstDeployments: List[DeploymentNode] = deploymentGraph.successorDeploymentNodes(StartNode)
+  def firstDeployments: List[MidNode[Deployment]] = deploymentGraph.successorNodes(StartNode)
   /* these two functions can return a number of things
       - Deployments: list of deployments
       - FinishPath: indicator there are no more tasks on this path
       - FinishDeploy: indicator that there are no more tasks for this deploy
       first will actually only ever return the first of these.  */
-  def nextDeployments(deployment: DeploymentNode): NextResult = {
+  def nextDeployments(deployment: Deployment): NextResult = {
     // if this was a last node and there is no other nodes executing then there is nothing left to do
     if (isFinished) FinishDeploy
     // otherwise let's see what children are valid to return
     else {
       // candidates are all successors not already executing or completing
-      val nextDeploymentCandidates = deploymentGraph.successorDeploymentNodes(deployment)
+      val nextDeploymentCandidates = deploymentGraph.successorNodes(deploymentGraph.get(deployment))
       // now filter for only tasks whose predecessors are all completed
       val nextDeployments = nextDeploymentCandidates.filter { deployment => (deploymentGraph.predecessors(deployment) -- completed).isEmpty }
       if (nextDeployments.nonEmpty) {
@@ -173,16 +173,18 @@ case class DeployGroupRunner(
       }
     }
   }
-  protected[deployment] def markExecuting(deployment: DeploymentNode) = {
-    executing += deployment
+  protected[deployment] def markExecuting(deployment: Deployment) = {
+    executing += deploymentGraph.get(deployment)
   }
-  protected[deployment] def markComplete(deployment: DeploymentNode) = {
-    executing -= deployment
-    completed += deployment
+  protected[deployment] def markComplete(deployment: Deployment) = {
+    val node = deploymentGraph.get(deployment)
+    executing -= node
+    completed += node
   }
-  protected[deployment] def markFailed(deployment: DeploymentNode) = {
-    executing -= deployment
-    failed += deployment
+  protected[deployment] def markFailed(deployment: Deployment) = {
+    val node = deploymentGraph.get(deployment)
+    executing -= node
+    failed += node
   }
   def finishRootContext() = {
     rootContextClosed = true
@@ -220,7 +222,7 @@ case class DeployGroupRunner(
       } catch {
         case NonFatal(t) =>
           if (!rootContextClosed) failRootContext("Preparing deploy failed", t)
-          cleanup
+          cleanup()
       }
 
     case ContextCreated(preparedContext) =>
@@ -237,7 +239,7 @@ case class DeployGroupRunner(
           runDeployments(deployments)
         case FinishPath =>
         case FinishDeploy =>
-          cleanup
+          cleanup()
       }
 
     case DeploymentFailed(deployment, exception) =>
@@ -246,7 +248,7 @@ case class DeployGroupRunner(
       if (isExecuting) {
         log.debug("Failed during deployment but others still running - deferring clean up")
       } else {
-        cleanup
+        cleanup()
       }
 
     case Terminated(actor) =>
@@ -264,18 +266,18 @@ case class DeployGroupRunner(
       }(client, safeReporter)
       val project = JsonReader.parse(json, s3Artifact)
       val context = record.parameters.toDeployContext(record.uuid, project, LookupSelector(), safeReporter, client)
-      if (context.tasks.toTaskList.isEmpty)
+      if (DeploymentGraph.toTaskList(context.tasks).isEmpty)
         safeReporter.fail("No tasks were found to execute. Ensure the app(s) are in the list supported by this stage/host.")
       context
     }
   }
 
-  private def runDeployments(deployments: List[DeploymentNode]) = {
+  private def runDeployments(deployments: List[MidNode[Deployment]]) = {
     try {
       honourStopFlag(rootReporter) {
-        deployments.foreach { deployment =>
+        deployments.foreach { case MidNode(deployment, priority) =>
           val actorName = s"${record.uuid}-${context.children.size}"
-          log.debug(s"Running next deployment (${deployment.pathName}/${deployment.priority}) on actor $actorName")
+          log.debug(s"Running next deployment (${deployment.pathName}/$priority) on actor $actorName")
           val deploymentRunner = context.watch(deploymentRunnerFactory(context, actorName))
           deploymentRunner ! DeploymentRunner.RunDeployment(record.uuid, deployment, rootReporter, new DateTime())
           markExecuting(deployment)
@@ -294,7 +296,7 @@ case class DeployGroupRunner(
         if (!isExecuting) {
           DeployReporter.failContext(rootReporter, stopMessage, DeployStoppedException(stopMessage))
           log.debug("Cleaning up")
-          cleanup
+          cleanup()
         }
 
       case None =>
@@ -379,7 +381,7 @@ class DeployCoordinator(
 
 object DeploymentRunner {
   trait Message
-  case class RunDeployment(uuid: UUID, deployment: DeploymentNode, rootReporter: DeployReporter, queueTime: DateTime) extends Message
+  case class RunDeployment(uuid: UUID, deployment: Deployment, rootReporter: DeployReporter, queueTime: DateTime) extends Message
 }
 
 class DeploymentRunner(stopFlagAgent: Agent[Map[UUID, String]]) extends Actor with Logging {

--- a/riff-raff/test/deployment/DeployGroupRunnerTest.scala
+++ b/riff-raff/test/deployment/DeployGroupRunnerTest.scala
@@ -13,7 +13,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")) with FlatSpecLike with ShouldMatchers {
   import Fixtures._
-  "DeployRunState" should "initalise the state from a set of tasks" in {
+  "DeployGroupRunnerTest" should "initalise the state from a set of tasks" in {
     val dr = createDeployRunnerWithUnderlying()
     prepare(dr, threeSimpleTasks)
     dr.ul.allDeployments.size should be(1)
@@ -27,7 +27,7 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
     val runDeployment = dr.deploymentRunnerProbe.expectMsgClass(classOf[DeploymentRunner.RunDeployment])
     val firstDeployment = runDeployment.deployment
     firstDeployment should be(Deployment(threeSimpleTasks, "test"))
-    dr.ul.executing should contain(MidNode(firstDeployment, 1))
+    dr.ul.executing should contain(MidNode(firstDeployment))
   }
 
   it should "process a list of tasks and clean up" in {
@@ -47,8 +47,8 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
     prepare(dr, simpleGraph)
     val firstDeployments = dr.ul.firstDeployments
     firstDeployments.size should be(2)
-    firstDeployments should contain(MidNode(Deployment(twoTasks, "branch one"), 1))
-    firstDeployments should contain(MidNode(Deployment(twoTasks, "branch two"), 2))
+    firstDeployments should contain(MidNode(Deployment(twoTasks, "branch one")))
+    firstDeployments should contain(MidNode(Deployment(twoTasks, "branch two")))
     dr.ul.markComplete(firstDeployments.head.value)
     val nextResult = dr.ul.nextDeployments(firstDeployments.head.value)
     nextResult should be(DeployGroupRunner.FinishPath)
@@ -76,7 +76,7 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
     dr.deploymentRunnerProbe.reply(DeployGroupRunner.DeploymentCompleted(runDeployment.deployment))
     dr.ul.isExecuting should be(false)
     dr.ul.executing should be(Set.empty)
-    dr.ul.completed should be(Set(MidNode(runDeployment.deployment, 1)))
+    dr.ul.completed should be(Set(MidNode(runDeployment.deployment)))
   }
 
   it should "mark a task as failed" in {
@@ -87,7 +87,7 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
     dr.deploymentRunnerProbe.reply(DeployGroupRunner.DeploymentFailed(runDeployment.deployment, new RuntimeException("test exception")))
     dr.ul.isExecuting should be(false)
     dr.ul.executing should be(Set.empty)
-    dr.ul.failed should be(Set(MidNode(runDeployment.deployment, 1)))
+    dr.ul.failed should be(Set(MidNode(runDeployment.deployment)))
     dr.deploymentRunnerProbe.expectNoMsg()
     dr.deployCoordinatorProbe.expectMsgClass(classOf[DeployCoordinator.CleanupDeploy])
   }

--- a/riff-raff/test/deployment/DeployGroupRunnerTest.scala
+++ b/riff-raff/test/deployment/DeployGroupRunnerTest.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
 import akka.agent.Agent
 import akka.testkit.{TestActorRef, TestKit, TestProbe}
-import magenta.graph.{DeploymentGraph, DeploymentNode}
+import magenta.graph.{Deployment, MidNode, Graph}
 import magenta.tasks.Task
 import org.scalatest.{FlatSpecLike, ShouldMatchers}
 
@@ -26,8 +26,8 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
     dr.ref ! DeployGroupRunner.StartDeployment
     val runDeployment = dr.deploymentRunnerProbe.expectMsgClass(classOf[DeploymentRunner.RunDeployment])
     val firstDeployment = runDeployment.deployment
-    firstDeployment should be(DeploymentNode(threeSimpleTasks, "test", 1))
-    dr.ul.executing should contain(firstDeployment)
+    firstDeployment should be(Deployment(threeSimpleTasks, "test"))
+    dr.ul.executing should contain(MidNode(firstDeployment, 1))
   }
 
   it should "process a list of tasks and clean up" in {
@@ -36,7 +36,7 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
     dr.ref ! DeployGroupRunner.StartDeployment
     val runDeployment = dr.deploymentRunnerProbe.expectMsgClass(classOf[DeploymentRunner.RunDeployment])
     val firstDeployment = runDeployment.deployment
-    firstDeployment should be(DeploymentNode(threeSimpleTasks, "test", 1))
+    firstDeployment should be(Deployment(threeSimpleTasks, "test"))
     dr.deploymentRunnerProbe.reply(DeployGroupRunner.DeploymentCompleted(firstDeployment))
     dr.deploymentRunnerProbe.expectNoMsg()
     dr.deployCoordinatorProbe.expectMsgClass(classOf[DeployCoordinator.CleanupDeploy])
@@ -47,13 +47,13 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
     prepare(dr, simpleGraph)
     val firstDeployments = dr.ul.firstDeployments
     firstDeployments.size should be(2)
-    firstDeployments should contain(DeploymentNode(twoTasks, "branch one", 1))
-    firstDeployments should contain(DeploymentNode(twoTasks, "branch two", 2))
-    dr.ul.markComplete(firstDeployments.head)
-    val nextResult = dr.ul.nextDeployments(firstDeployments.head)
+    firstDeployments should contain(MidNode(Deployment(twoTasks, "branch one"), 1))
+    firstDeployments should contain(MidNode(Deployment(twoTasks, "branch two"), 2))
+    dr.ul.markComplete(firstDeployments.head.value)
+    val nextResult = dr.ul.nextDeployments(firstDeployments.head.value)
     nextResult should be(DeployGroupRunner.FinishPath)
-    dr.ul.markComplete(firstDeployments.tail.head)
-    val nextResult2 = dr.ul.nextDeployments(firstDeployments.tail.head)
+    dr.ul.markComplete(firstDeployments.tail.head.value)
+    val nextResult2 = dr.ul.nextDeployments(firstDeployments.tail.head.value)
     nextResult2 should be(DeployGroupRunner.FinishDeploy)
   }
 
@@ -76,7 +76,7 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
     dr.deploymentRunnerProbe.reply(DeployGroupRunner.DeploymentCompleted(runDeployment.deployment))
     dr.ul.isExecuting should be(false)
     dr.ul.executing should be(Set.empty)
-    dr.ul.completed should be(Set(runDeployment.deployment))
+    dr.ul.completed should be(Set(MidNode(runDeployment.deployment, 1)))
   }
 
   it should "mark a task as failed" in {
@@ -87,7 +87,7 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
     dr.deploymentRunnerProbe.reply(DeployGroupRunner.DeploymentFailed(runDeployment.deployment, new RuntimeException("test exception")))
     dr.ul.isExecuting should be(false)
     dr.ul.executing should be(Set.empty)
-    dr.ul.failed should be(Set(runDeployment.deployment))
+    dr.ul.failed should be(Set(MidNode(runDeployment.deployment, 1)))
     dr.deploymentRunnerProbe.expectNoMsg()
     dr.deployCoordinatorProbe.expectMsgClass(classOf[DeployCoordinator.CleanupDeploy])
   }
@@ -136,7 +136,7 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
     dr.ref ! DeployGroupRunner.ContextCreated(context)
   }
 
-  def prepare(dr: DR, deployments: DeploymentGraph): Unit = {
+  def prepare(dr: DR, deployments: Graph[Deployment]): Unit = {
     val context = createContext(deployments, dr.record.uuid, dr.record.parameters)
     dr.ref ! DeployGroupRunner.ContextCreated(context)
   }

--- a/riff-raff/test/deployment/Fixtures.scala
+++ b/riff-raff/test/deployment/Fixtures.scala
@@ -3,7 +3,7 @@ package deployment
 import java.util.UUID
 
 import com.amazonaws.services.s3.AmazonS3Client
-import magenta.graph.DeploymentGraph
+import magenta.graph.{Deployment, DeploymentGraph, Graph}
 import magenta.{Build, DeployContext, DeployParameters, DeployReporter, Deployer, Host, KeyRing, NamedStack, Project, Stage}
 import magenta.tasks._
 import org.scalatest.mock.MockitoSugar
@@ -23,7 +23,7 @@ object Fixtures extends MockitoSugar {
     HealthcheckGrace(1000)
   )
 
-  val simpleGraph: DeploymentGraph = {
+  val simpleGraph: Graph[Deployment] = {
     DeploymentGraph(twoTasks, "branch one") joinParallel DeploymentGraph(twoTasks, "branch two")
   }
 
@@ -44,7 +44,7 @@ object Fixtures extends MockitoSugar {
 
   def createContext(tasks: List[Task], uuid: UUID, parameters: DeployParameters): DeployContext =
     createContext(DeploymentGraph(tasks, parameters.stacks.head.name), uuid, parameters)
-  def createContext(taskGraph: DeploymentGraph, uuid: UUID, parameters: DeployParameters): DeployContext =
+  def createContext(taskGraph: Graph[Deployment], uuid: UUID, parameters: DeployParameters): DeployContext =
     DeployContext(uuid, parameters, Project(), taskGraph)
 
   def createReporter(record: Record) = DeployReporter.rootReporterFor(record.uuid, record.parameters)


### PR DESCRIPTION
In preparation for overhauling the resolver I've made the new graph type I built generic and made it somewhat more fully featured. 

Making it generic makes it possible to map from a graph of one type to a graph of a different type - for example this makes it possible to resolve a graph of recipes as the first step and then map the recipes into deployments as a second step rather than doing everything at once.

I've also moved priority onto the edge instead of the node. Turns out that it makes merging graphs like the following much easier as nodes are easily discoverable within the edges and nodes without having to workaround priorities. Other methods are easier to implement too.

This was originally done to deal with cases like the below. Whilst this is contrived it does deal with cases where a deployment is duplicated and needs to be de-duplicated. Previously the join methods would effectively duplicate the nodes (with different priority).

```
S     S     +-+ S +-+
            |       |
+     +     |       |
|     |     v       |
|     |             |
v     v     1       |
                    |
1     2     +       |
            |       v
+     +     |
|  +  |  =  +-----> 2 +-----+
|     |                     |
v     v             +       |
                    |       v
2     3             |
                    |       3
+     +             |
|     |             |       +
|     |             |       |
v     v             |       |
                    +-> E <-+
E     E
```