### PR TITLE
Make the continous deployments Dynamo table name configurable

### DIFF
--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -65,7 +65,7 @@ class Configuration(val application: String, val webappConfDirectory: String = "
       credentialsProviderChain(None, None),
       new ClientConfiguration()
     )
-    val dynamoTableName = configuration.getStringProperty("continuousDeployment.dynamoTable").getOrException("Dynamo table name for continous deployment configs not configured")
+    val dynamoTableName = configuration.getStringProperty("continuousDeployment.dynamoTableName").getOrException("Dynamo table name for continous deployment configs not configured")
   }
 
   object credentials {

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -65,6 +65,7 @@ class Configuration(val application: String, val webappConfDirectory: String = "
       credentialsProviderChain(None, None),
       new ClientConfiguration()
     )
+    val dynamoTableName = configuration.getStringProperty("continuousDeployment.dynamoTable").getOrException("Dynamo table name for continous deployment configs not configured")
   }
 
   object credentials {

--- a/riff-raff/app/persistence/ContinuousDeploymentConfigRepository.scala
+++ b/riff-raff/app/persistence/ContinuousDeploymentConfigRepository.scala
@@ -11,6 +11,7 @@ import org.joda.time.DateTime
 
 object ContinuousDeploymentConfigRepository {
   val client = Configuration.continuousDeployment.dynamoClient
+  val tableName = Configuration.continuousDeployment.dynamoTableName
 
   implicit val uuidFormat =
     DynamoFormat.coercedXmap[UUID, String, IllegalArgumentException](UUID.fromString)(_.toString)
@@ -21,7 +22,7 @@ object ContinuousDeploymentConfigRepository {
   implicit val triggerModeFormat =
     DynamoFormat.coercedXmap[Trigger.Mode, String, NoSuchElementException](Trigger.withName)(_.toString)
 
-  val table = Table[ContinuousDeploymentConfig]("continuous-deployment-config")
+  val table = Table[ContinuousDeploymentConfig](tableName)
   def exec[A](ops: ScanamoOps[A]): A = Scanamo.exec(client)(ops)
 
   def getContinuousDeploymentList(): List[ContinuousDeploymentConfig] =

--- a/riff-raff/conf/env/global.properties
+++ b/riff-raff/conf/env/global.properties
@@ -18,3 +18,7 @@ auth.domain=guardian.co.uk
 # from https://console.developers.google.com
 auth.clientId=863070799113-9oefm3nnjf0hu4g9k3k1ue3fopfvrtpg.apps.googleusercontent.com
 auth.clientSecret=5uLmlI8afy5vufKFWXWS2GPw
+
+# The Dynamo table for storing the continous deployment configs.
+# This is the production table.
+continuousDeployment.dynamoTableName=continuous-deployment-config


### PR DESCRIPTION
Corresponding CloudFormation change: https://github.com/guardian/deploy-tools-platform/pull/38