### PR TITLE
Modify the resolver to create graphs more intelligently

### DIFF
--- a/magenta-lib/src/main/scala/magenta/Resolver.scala
+++ b/magenta-lib/src/main/scala/magenta/Resolver.scala
@@ -8,6 +8,8 @@ case class RecipeTasks(recipe: Recipe, preTasks: List[Task], hostTasks: List[Tas
   lazy val hosts = tasks.flatMap(_.taskHost).map(_.copy(connectAs=None)).distinct
   lazy val tasks = if (disabled) Nil else preTasks ++ hostTasks
   lazy val recipeName = recipe.name
+  // invalid if there are host-tasks but not any hosts to apply them to :(
+  lazy val invalid = recipe.actionsPerHost.nonEmpty && hostTasks.isEmpty
 }
 
 case class RecipeTasksNode(recipeTasks: RecipeTasks, children: List[RecipeTasksNode]) {
@@ -19,72 +21,94 @@ case class RecipeTasksNode(recipeTasks: RecipeTasks, children: List[RecipeTasksN
   }
 
   def toList: List[RecipeTasks] = children.flatMap(_.toList) ++ List(recipeTasks)
+
+  def toGraph(name: String): Graph[Deployment] = {
+    val thisGraph: Graph[Deployment] =
+      if (recipeTasks.invalid) Graph.empty
+      else DeploymentGraph(recipeTasks.tasks, s"$name (${recipeTasks.recipeName})")
+
+    val childGraph: Graph[Deployment] =
+      children.map(_.toGraph(name)).reduceLeftOption(_ joinParallel _).getOrElse(Graph.empty)
+
+    val graph = childGraph joinSeries thisGraph
+    graph
+  }
 }
 
 object Resolver {
-
-  def resolve( project: Project, resourceLookup: Lookup, parameters: DeployParameters, deployReporter: DeployReporter, artifactClient: AmazonS3): Graph[Deployment] = {
-    resolveStacks(project, parameters).map { stack =>
-      val stackTasks = resolveStack(project, resourceLookup, parameters, deployReporter, artifactClient, stack).flatMap(_.tasks)
-      DeploymentGraph(stackTasks, s"${parameters.build.projectName}${stack.nameOption.map(" -> "+_).getOrElse("")}")
-    }.reduce(_ joinParallel _)
-  }
-
-  def resolveDetail( project: Project, resourceLookup: Lookup, parameters: DeployParameters, deployReporter: DeployReporter, artifactClient: AmazonS3): List[RecipeTasks] = {
-    val stacks = resolveStacks(project, parameters)
-    for {
-      stack <- stacks.toList
-      tasks <- resolveStack(project, resourceLookup, parameters, deployReporter, artifactClient, stack)
-    } yield tasks
-  }
-
-  def resolveStack( project: Project, resourceLookup: Lookup, parameters: DeployParameters, deployReporter: DeployReporter, artifactClient: AmazonS3, stack: Stack): List[RecipeTasks] = {
-
-    def resolveTree(recipeName: String, resources: DeploymentResources, target: DeployTarget): RecipeTasksNode = {
-      val recipe = project.recipes.getOrElse(recipeName, sys.error(s"Recipe '$recipeName' doesn't exist in your deploy.json file"))
-      val recipeTasks = resolveRecipe(recipe, resources, target)
-      val children = recipe.dependsOn.map(resolveTree(_, resources, target))
-      RecipeTasksNode(recipeTasks, children)
-    }
-
-    def resolveRecipe(recipe: Recipe, resources: DeploymentResources, target: DeployTarget): RecipeTasks = {
-      val tasksToRunBeforeApp = recipe.actionsBeforeApp.toList flatMap { _.resolve(resources, target) }
-
-      val perHostTasks = {
-        for {
-          action <- recipe.actionsPerHost
-          tasks <- action.resolve(resources, target)
-        } yield {
-          tasks
-        }
-      }
-
-      val taskHosts = perHostTasks.flatMap(_.taskHost).toSet
-      val taskHostsInOriginalOrder = resourceLookup.hosts.all.filter(h => taskHosts.contains(h.copy(connectAs = None)))
-      val groupedHosts = taskHostsInOriginalOrder.transposeBy(_.tags.getOrElse("group",""))
-      val sortedPerHostTasks = perHostTasks.toList.sortBy(t =>
-        t.taskHost.map(h => groupedHosts.indexOf(h.copy(connectAs = None))).getOrElse(-1)
-      )
-
-      RecipeTasks(recipe, tasksToRunBeforeApp, sortedPerHostTasks)
-    }
-
-    for {
-      tasks <- {
-        val resources = DeploymentResources(deployReporter, resourceLookup, artifactClient)
-        val target = DeployTarget(parameters, stack)
-        val resolvedTree = resolveTree(parameters.recipe.name, resources, target)
-        val filteredTree = resolvedTree.disable(rt => rt.recipe.actionsPerHost.nonEmpty && rt.hostTasks.isEmpty)
-        filteredTree.toList.distinct
-      }
-    } yield tasks
-  }
 
   def resolveStacks(project: Project, parameters: DeployParameters): Seq[Stack] = {
     parameters.stacks match {
       case Nil => if (project.defaultStacks.nonEmpty) project.defaultStacks else Seq(UnnamedStack)
       case s => s
     }
+  }
+
+  def resolveRecipeTasks(recipe: Recipe, resources: DeploymentResources, target: DeployTarget): RecipeTasks = {
+    val tasksToRunBeforeApp = recipe.actionsBeforeApp.toList flatMap { _.resolve(resources, target) }
+
+    val perHostTasks = {
+      for {
+        action <- recipe.actionsPerHost
+        tasks <- action.resolve(resources, target)
+      } yield {
+        tasks
+      }
+    }
+
+    val taskHosts = perHostTasks.flatMap(_.taskHost).toSet
+    val taskHostsInOriginalOrder = resources.lookup.hosts.all.filter(h => taskHosts.contains(h.copy(connectAs = None)))
+    val groupedHosts = taskHostsInOriginalOrder.transposeBy(_.tags.getOrElse("group",""))
+    val sortedPerHostTasks = perHostTasks.toList.sortBy(t =>
+      t.taskHost.map(h => groupedHosts.indexOf(h.copy(connectAs = None))).getOrElse(-1)
+    )
+
+    RecipeTasks(recipe, tasksToRunBeforeApp, sortedPerHostTasks)
+  }
+
+  def resolveRecipeTree(project: Project, recipeName: String, resources: DeploymentResources,
+    target: DeployTarget): RecipeTasksNode = {
+    val recipe = project.recipes.getOrElse(recipeName, sys.error(s"Recipe '$recipeName' doesn't exist in your deploy.json file"))
+    val recipeTasks = resolveRecipeTasks(recipe, resources, target)
+    val children = recipe.dependsOn.map(resolveRecipeTree(project, _, resources, target))
+    RecipeTasksNode(recipeTasks, children)
+  }
+
+  def resolveFilteredTree(project: Project, resourceLookup: Lookup, parameters: DeployParameters, deployReporter: DeployReporter, artifactClient: AmazonS3, stack: Stack): RecipeTasksNode = {
+    val resources = DeploymentResources(deployReporter, resourceLookup, artifactClient)
+    val target = DeployTarget(parameters, stack)
+    val resolvedTree = resolveRecipeTree(project, parameters.recipe.name, resources, target)
+    val filteredTree = resolvedTree.disable(_.invalid)
+    filteredTree
+  }
+
+  def resolveStackTasks(project: Project, resourceLookup: Lookup, parameters: DeployParameters,
+    deployReporter: DeployReporter, artifactClient: AmazonS3, stack: Stack): List[RecipeTasks] = {
+    for {
+      tasks <- resolveFilteredTree(project, resourceLookup, parameters, deployReporter, artifactClient, stack).toList.distinct
+    } yield tasks
+  }
+
+  def resolveStackTaskGraph(project: Project, resourceLookup: Lookup, parameters: DeployParameters,
+    deployReporter: DeployReporter, artifactClient: AmazonS3, stack: Stack): Graph[Deployment] = {
+    val filteredTree = resolveFilteredTree(project, resourceLookup, parameters, deployReporter, artifactClient, stack)
+    filteredTree.toGraph(s"${parameters.build.projectName}${stack.nameOption.map(" -> "+_).getOrElse("")}")
+  }
+
+  def resolveDetail(project: Project, resourceLookup: Lookup, parameters: DeployParameters,
+    deployReporter: DeployReporter, artifactClient: AmazonS3): List[RecipeTasks] = {
+    val stacks = resolveStacks(project, parameters)
+    for {
+      stack <- stacks.toList
+      tasks <- resolveStackTasks(project, resourceLookup, parameters, deployReporter, artifactClient, stack)
+    } yield tasks
+  }
+
+  def resolve(project: Project, resourceLookup: Lookup, parameters: DeployParameters, deployReporter: DeployReporter,
+    artifactClient: AmazonS3): Graph[Deployment] = {
+    resolveStacks(project, parameters).map { stack =>
+      resolveStackTaskGraph(project, resourceLookup, parameters, deployReporter, artifactClient, stack)
+    }.reduce(_ joinParallel _)
   }
 }
 class NoHostsFoundException extends Exception("No hosts found")

--- a/magenta-lib/src/main/scala/magenta/graph/package.scala
+++ b/magenta-lib/src/main/scala/magenta/graph/package.scala
@@ -7,4 +7,16 @@ package object graph {
   implicit class RichNodeList[T](nodes: List[Node[T]]) {
     def filterMidNodes: List[MidNode[T]] = nodes.collect{ case mn:MidNode[T] => mn }
   }
+  implicit class RichEdgeList[T](edges: List[Edge[T]]) {
+    def replace(old: Edge[T], newEdges: List[Edge[T]]): List[Edge[T]] = {
+      val before = edges.takeWhile(old != _)
+      val after = edges.dropWhile(old != _).tail
+      before ::: newEdges ::: after
+    }
+    def reprioritise: List[Edge[T]] = {
+      edges.zipWithIndex.map {case (edge, index) =>
+        edge.copy(priority = index + 1)
+      }
+    }
+  }
 }


### PR DESCRIPTION
Start to more deeply leverage the fact that we can now run things in parallel. This now builds graphs of deployments based on the recipe dependencies in `deploy.json`. I've not (yet?) gone so far as to split out host groups - the need to do so has mostly gone (we rarely target hosts now). However if you have a static files recipe and also a number of applications that all depend on the static files then it will now do the expected thing of creating a graph of start ~> static and then static ~> app1, static ~> app2 etc. Once the static deployment is completed all of the appX deployments will kick off.

To do this I've:
 - added `toGraph` to the `RecipeTasksNode` to build a graph from tree of nodes
 - split the resolver methods down into smaller pieces
 - made various improvements to the graph library to behave correctly in a number of corner cases when merging or flattening graphs
 - added methods for gaining access to the graph edges
 - changed `map` to work with underlying types instead of the wrappers
 - added an easy to read toString method on graph class, which is helpful for troubleshooting and logging
 - added numerous tests to cover more corner cases

Todo:
 - [ ] Testing locally or in CODE (there are not so many config files that will make use of this yet, so might need to create one)