### PR TITLE
Retry failed S3 uploads when using InputStream

### DIFF
--- a/magenta-lib/src/main/scala/magenta/package.scala
+++ b/magenta-lib/src/main/scala/magenta/package.scala
@@ -2,6 +2,11 @@ package magenta
 
 import java.io.Closeable
 
+import com.amazonaws.{AmazonClientException, ClientConfiguration}
+
+import scala.annotation.tailrec
+import scala.util.{Failure, Success, Try}
+
 object `package` {
   def transpose[A](xs: Seq[Seq[A]]): Seq[Seq[A]] = xs.filter(_.nonEmpty) match {
     case Nil => Nil
@@ -20,6 +25,25 @@ object `package` {
       f(resource)
     } finally {
       resource.close()
+    }
+  }
+
+  @tailrec
+  def retryOnException[T](config: ClientConfiguration, currentAttempt: Int = 1)(f: => T): T = {
+    val policy = config.getRetryPolicy
+    val retries = policy.getMaxErrorRetry
+
+    // use the client config retry logic - we pass in null for the request as no SDK implementations actually use it
+    def shouldRetryFor(ace: AmazonClientException) = policy.getRetryCondition.shouldRetry(null, ace, currentAttempt)
+
+    Try(f) match {
+      case Success(result) => result
+      case Failure(exception:AmazonClientException) if currentAttempt <= retries && shouldRetryFor(exception) =>
+        // use client config to calculate delay - pass in null for request as no SDK implementations actually use it
+        val delay = policy.getBackoffStrategy.delayBeforeNextRetry(null, exception, currentAttempt)
+        Thread.sleep(delay)
+        retryOnException(config, currentAttempt + 1)(f)
+      case Failure(t) => throw t
     }
   }
 }

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -19,7 +19,8 @@ import magenta.{App, DeployReporter, DeploymentPackage, KeyRing, NamedStack, Sta
 import scala.collection.JavaConversions._
 
 trait S3 extends AWS {
-  def s3client(keyRing: KeyRing) = new AmazonS3Client(provider(keyRing), clientConfiguration)
+  def s3client(keyRing: KeyRing, config: ClientConfiguration = clientConfiguration) =
+    new AmazonS3Client(provider(keyRing), config)
 }
 
 trait Lambda extends AWS {
@@ -233,4 +234,6 @@ trait AWS {
       20,
       false
     ))
+
+  val clientConfigurationNoRetry = new ClientConfiguration().withRetryPolicy(PredefinedRetryPolicies.NO_RETRY_POLICY)
 }

--- a/magenta-lib/src/test/scala/magenta/PackageTest.scala
+++ b/magenta-lib/src/test/scala/magenta/PackageTest.scala
@@ -1,0 +1,69 @@
+package magenta
+
+import java.io.IOException
+
+import com.amazonaws.{AmazonClientException, ClientConfiguration}
+import com.amazonaws.retry.{PredefinedRetryPolicies, RetryPolicy}
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{FlatSpec, Matchers}
+
+class PackageTest extends FlatSpec with Matchers with MockitoSugar {
+  val clientConfiguration = new ClientConfiguration().
+    withRetryPolicy(new RetryPolicy(
+      PredefinedRetryPolicies.DEFAULT_RETRY_CONDITION,
+      PredefinedRetryPolicies.DEFAULT_BACKOFF_STRATEGY,
+      3,
+      false
+    ))
+
+  "retryOnException" should "work when no exception is thrown" in {
+    var calls = 0
+    def block:String = {
+      calls += 1
+      "banana"
+    }
+
+    val result = retryOnException(clientConfiguration)(block)
+    result should be("banana")
+    calls should be(1)
+  }
+
+  "retryOnException" should "work when an exception is thrown" in {
+    var calls = 0
+    def block:String = {
+      calls += 1
+      if (calls == 1)
+        throw new AmazonClientException("failure message", new IOException("IO cause"))
+      else
+        "banana"
+    }
+
+    val result = retryOnException(clientConfiguration)(block)
+    result should be("banana")
+    calls should be(2)
+  }
+
+  "retryOnException" should "throw an exception if it fails consistently" in {
+    var calls = 0
+    def block:String = {
+      calls += 1
+      throw new AmazonClientException("failure message", new IOException("IO cause"))
+    }
+
+    an [AmazonClientException] should be thrownBy retryOnException(clientConfiguration)(block)
+
+    calls should be(4)
+  }
+
+  "retryOnException" should "throw an exception immediately if not retryable" in {
+    var calls = 0
+    def block:String = {
+      calls += 1
+      throw new AmazonClientException("failure message")
+    }
+
+    an [AmazonClientException] should be thrownBy retryOnException(clientConfiguration)(block)
+
+    calls should be(1)
+  }
+}

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -6,6 +6,7 @@ import java.net.ServerSocket
 import java.util
 import java.util.UUID
 
+import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model._
@@ -239,7 +240,7 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
     override lazy val envCredentials = new BasicAWSCredentials(accessKey, secretAccessKey)
 
     lazy val s3Client = mock[AmazonS3Client]
-    override def s3client(keyRing: KeyRing) = s3Client
+    override def s3client(keyRing: KeyRing, config: ClientConfiguration) = s3Client
   }
 
   val parameters = DeployParameters(Deployer("tester"), Build("Project","1"), Stage("CODE"), RecipeName("baseRecipe.name"))


### PR DESCRIPTION
The retry logic in the AWS SDK is flawed when uploading an InputStream that cannot be reset. 

This moves the retry logic for this case outside of the SDK call so that the InputStream can also be reset. The internal retry logic is disabled by passing in a `ClientConfiguration` with a no retry policy. We continue to use the AWS retry and backoff logic from the client configuration - you'll note that the `originalRequest` is not passed in as we do not have it and neither is it actually used.