### PR TITLE
Add deprecation warnings for deploy.json configs

### DIFF
--- a/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
+++ b/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
@@ -96,6 +96,7 @@ object S3Artifact extends Loggable {
   }
 
   def convertFromZipBundle(artifact: S3Artifact)(implicit client: AmazonS3, reporter: DeployReporter): Unit = {
+    reporter.warning("DEPRECATED: The artifact.zip is now a legacy format - please switch to the new format (if you are using sbt-riffraff-artifact then simply upgrade to >= 0.9.1)")
     reporter.info("Converting artifact.zip to S3 layout")
     implicit val sourceBucket: Option[String] = Some(artifact.bucket)
     S3ZipArtifact.withDownload(artifact){ dir =>

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -111,11 +111,13 @@ object AutoScaling  extends DeploymentType with S3AclParams {
         stage = if (prefixStage(pkg)) Some(target.parameters.stage) else None,
         packageName = if (prefixPackage(pkg)) Some(pkg.name) else None
       )
+      val readAcl = publicReadAcl(pkg)
+      if (readAcl) resources.reporter.warning("DEPRECATED: publicReadAcl should be set to false when uploading an artifact for an autoscaling deploy (this is not currently the default but will be at some stage).")
       List(
         S3Upload(
           bucket.get(pkg).orElse(target.stack.nameOption.map(stackName => s"$stackName-dist")).get,
           Seq(pkg.s3Package -> prefix),
-          publicReadAcl = publicReadAcl(pkg)
+          publicReadAcl = readAcl
         )
       )
   }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -66,6 +66,7 @@ object Lambda extends DeploymentType  {
 
   def lambdaToProcess(pkg: DeploymentPackage, stage: String, stack: Stack)(reporter: DeployReporter): List[LambdaFunction] = {
     val bucketOption = bucketParam.get(pkg)
+    if (bucketOption.isEmpty) reporter.warning(s"DEPRECATED: Uploading directly to lambda is deprecated (it is dangerous for CloudFormed lambdas). Specify the bucket parameter and call both uploadLambda and updateLambda to upload via S3.")
     (functionNamesParam.get(pkg), functionsParam.get(pkg), prefixStackParam(pkg)) match {
       case (Some(functionNames), None, prefixStack) =>
         val stackNamePrefix = stack.nameOption.filter(_ => prefixStack).getOrElse("")

--- a/magenta-lib/src/main/scala/magenta/logging.scala
+++ b/magenta-lib/src/main/scala/magenta/logging.scala
@@ -40,6 +40,7 @@ case class DeployReporter(messageStack: List[Message], messageContext: MessageCo
   def commandOutput(message: String) { DeployReporter.send(this, CommandOutput(message)) }
   def commandError(message: String) { DeployReporter.send(this, CommandError(message)) }
   def verbose(message: String) { DeployReporter.send(this, Verbose(message)) }
+  def warning(message: String) { DeployReporter.send(this, Warning(message)) }
   def fail(message: String, e: Option[Throwable] = None): Nothing = {
     throw DeployReporter.failException(this, message, e)
   }
@@ -141,12 +142,12 @@ case class MessageStack(messages: List[Message], time:DateTime = new DateTime())
 
 class FailException(val message: String, val throwable: Throwable = null) extends Throwable(message, throwable)
 
-trait Message {
+sealed trait Message {
   def text: String
   def deployParameters: Option[DeployParameters] = None
 }
 
-trait ContextMessage extends Message {
+sealed trait ContextMessage extends Message {
   def originalMessage: Message
   override def deployParameters: Option[DeployParameters] = originalMessage.deployParameters
 }
@@ -165,6 +166,7 @@ case class CommandOutput(text: String) extends Message
 case class CommandError(text: String) extends Message
 case class Verbose(text: String) extends Message
 case class Fail(text: String, detail: ThrowableDetail) extends Message
+case class Warning(text: String) extends Message
 
 case class StartContext(originalMessage: Message) extends ContextMessage { lazy val text = s"Starting ${originalMessage.text}" }
 case class FailContext(originalMessage: Message) extends ContextMessage { lazy val text = s"Failed during ${originalMessage.text}" }

--- a/magenta-lib/src/main/scala/magenta/reporting.scala
+++ b/magenta-lib/src/main/scala/magenta/reporting.scala
@@ -28,6 +28,7 @@ object MessageState {
     end match {
       case finish:FinishContext => FinishMessageState(message, finish, time)
       case fail:FailContext => FailMessageState(message, fail, time)
+      case notValid => throw new IllegalArgumentException(s"Provided end message not a valid end: $notValid")
     }
   }
 }

--- a/riff-raff/app/assets/stylesheets/magenta.less
+++ b/riff-raff/app/assets/stylesheets/magenta.less
@@ -87,6 +87,11 @@ ul.magenta-list {
   font-weight: bold;
 }
 
+.message-warning {
+  color: #ff3333;
+  background-color: black;
+}
+
 .message-fail {
   font-weight: bold;
 }

--- a/riff-raff/app/controllers/Testing.scala
+++ b/riff-raff/app/controllers/Testing.scala
@@ -65,6 +65,7 @@ class Testing(prismLookup: PrismLookup)(implicit val messagesApi: MessagesApi, v
       /var/folders/ZO/ZOSa3fR3FsCiU3jxetWKQU+++TQ/-Tmp-/sbt_5489e15/deploy.json
     /var/folders/ZO/ZOSa3fR3FsCiU3jxetWKQU+++TQ/-Tmp-/sbt_5489e15/packages/riff-raff/riff-raff.jar"""), message.deploy),
       wrapper(Some(message.deployUUID), UUID.randomUUID(), Info("Reading deploy.json"), message.deploy),
+      wrapper(Some(message.deployUUID), UUID.randomUUID(), Warning("DEPRECATED: Something in your deploy.json is deprecated!"), message.deploy),
       wrapper(Some(message.deployUUID), message.task1UUID, StartContext(message.task1), message.deploy),
       wrapper(Some(message.task1UUID), UUID.randomUUID(), FinishContext(message.task1), message.task1, message.deploy),
       wrapper(Some(message.deployUUID), message.task2UUID, StartContext(message.task2), message.deploy),

--- a/riff-raff/app/deployment/preview.scala
+++ b/riff-raff/app/deployment/preview.scala
@@ -73,7 +73,7 @@ object Preview {
 }
 
 case class Preview(project: Project, parameters: DeployParameters, reporter: DeployReporter, artifactClient: AmazonS3, lookup: PrismLookup) {
-  lazy val stacks = Resolver.resolveStacks(project, parameters) collect {
+  lazy val stacks = Resolver.resolveStacks(project, parameters, reporter) collect {
     case NamedStack(s) => s
   }
   lazy val recipeNames = recipeTasks.map(_.recipe.name).distinct

--- a/riff-raff/app/persistence/package.scala
+++ b/riff-raff/app/persistence/package.scala
@@ -9,7 +9,7 @@ import com.mongodb.casbah.MongoCursor
 import org.joda.time.{LocalDate, DateMidnight}
 
 object `package` {
-  implicit def deployFilter2Criteria(filter: DeployFilter) = new {
+  implicit class deployFilter2Criteria(filter: DeployFilter) {
     def criteria: DBObject = {
       val criteriaList: List[(String, Any)] = Nil ++
         filter.projectName.map(p => ("parameters.projectName", s"(?i)$p".r)) ++
@@ -24,13 +24,13 @@ object `package` {
     }
   }
 
-  implicit def mongoCursor2pagination(cursor: MongoCursor) = new {
+  implicit class mongoCursor2pagination(cursor: MongoCursor) {
     def pagination(p: PaginationView): MongoCursor = {
       p.pageSize.map(l => cursor.skip(p.skip.get).limit(l)).getOrElse(cursor)
     }
   }
 
-  implicit def message2MessageDocument(message: Message) = new {
+  implicit class message2MessageDocument(message: Message) {
     def asMessageDocument: MessageDocument = MessageDocument(message)
   }
 }

--- a/riff-raff/test/RepresentationTest.scala
+++ b/riff-raff/test/RepresentationTest.scala
@@ -27,6 +27,7 @@ class RepresentationTest extends FlatSpec with Matchers with Utilities with Pers
     finishInfo.asMessageDocument should be(FinishContextDocument())
     failInfo.asMessageDocument should be(FailContextDocument())
     failDep.asMessageDocument should be(FailContextDocument())
+    warning.asMessageDocument should be(WarningDocument("deprecation"))
   }
 
   it should "not convert StartContext log messages" in {
@@ -59,7 +60,8 @@ class RepresentationTest extends FlatSpec with Matchers with Utilities with Pers
       finishDep -> """{ "deploy" : { "$uuid" : "90013e69-8afc-4ba2-80a8-d7b063183d13"} , "id" : { "$uuid" : "4ef18506-3b38-4235-9933-d7da831247a6"} , "parent" : { "$uuid" : "4236c133-be50-4169-8e0c-096eded5bfeb"} , "document" : { "_typeHint" : "persistence.FinishContextDocument"} , "time" : { "$date" : "2012-11-08T17:20:00.000Z"}}""",
       finishInfo -> """{ "deploy" : { "$uuid" : "90013e69-8afc-4ba2-80a8-d7b063183d13"} , "id" : { "$uuid" : "4ef18506-3b38-4235-9933-d7da831247a6"} , "parent" : { "$uuid" : "4236c133-be50-4169-8e0c-096eded5bfeb"} , "document" : { "_typeHint" : "persistence.FinishContextDocument"} , "time" : { "$date" : "2012-11-08T17:20:00.000Z"}}""",
       failInfo -> """{ "deploy" : { "$uuid" : "90013e69-8afc-4ba2-80a8-d7b063183d13"} , "id" : { "$uuid" : "4ef18506-3b38-4235-9933-d7da831247a6"} , "parent" : { "$uuid" : "4236c133-be50-4169-8e0c-096eded5bfeb"} , "document" : { "_typeHint" : "persistence.FailContextDocument"} , "time" : { "$date" : "2012-11-08T17:20:00.000Z"}}""",
-      failDep -> """{ "deploy" : { "$uuid" : "90013e69-8afc-4ba2-80a8-d7b063183d13"} , "id" : { "$uuid" : "4ef18506-3b38-4235-9933-d7da831247a6"} , "parent" : { "$uuid" : "4236c133-be50-4169-8e0c-096eded5bfeb"} , "document" : { "_typeHint" : "persistence.FailContextDocument"} , "time" : { "$date" : "2012-11-08T17:20:00.000Z"}}"""
+      failDep -> """{ "deploy" : { "$uuid" : "90013e69-8afc-4ba2-80a8-d7b063183d13"} , "id" : { "$uuid" : "4ef18506-3b38-4235-9933-d7da831247a6"} , "parent" : { "$uuid" : "4236c133-be50-4169-8e0c-096eded5bfeb"} , "document" : { "_typeHint" : "persistence.FailContextDocument"} , "time" : { "$date" : "2012-11-08T17:20:00.000Z"}}""",
+      warning -> """{ "deploy" : { "$uuid" : "90013e69-8afc-4ba2-80a8-d7b063183d13"} , "id" : { "$uuid" : "4ef18506-3b38-4235-9933-d7da831247a6"} , "parent" : { "$uuid" : "4236c133-be50-4169-8e0c-096eded5bfeb"} , "document" : { "_typeHint" : "persistence.WarningDocument" , "text" : "deprecation"} , "time" : { "$date" : "2012-11-08T17:20:00.000Z"}}"""
     )
     messageJsonMap.foreach { case (message, json) =>
       val logDocument = LogDocument(testUUID, id, Some(parentId), message, time)

--- a/riff-raff/test/Utilities.scala
+++ b/riff-raff/test/Utilities.scala
@@ -64,6 +64,7 @@ trait PersistenceTestInstances {
   val finishInfo = FinishContext(infoMsg)
   val failInfo = FailContext(infoMsg)
   val failDep = FailContext(deploy)
+  val warning = Warning("deprecation")
   val messageStacks: List[MessageStack] =
     stack(startDeploy) ::
       stack(startInfo, deploy) ::


### PR DESCRIPTION
It's been an aim of mine for a while to have a way of pushing people to migrate from deprecated configurations. I've added a reporter message type of warning which is highlighted beautifully and can be used to give deprecation warnings.

I've added a handful of things to highlight as deprecation warnings:
 - `publicReadAcl=true` on an autoscaling deploy
 - Not uploading via S3 when updating lambdas
 - Not having `defaultStacks` in a deploy.json
 - Using the artifacts.zip format

An example:
![screen shot 2016-09-14 at 11 29 34](https://cloud.githubusercontent.com/assets/1236466/18510735/8ccabd52-7a77-11e6-8304-69248d255051.png)