### PR TITLE
Bump sbt-riffraff-artifact plugin to use new format

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,6 +7,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.0")
 
 addSbtPlugin("com.gu" % "sbt-teamcity-test-reporting-plugin" % "1.5")
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.3")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.4")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")


### PR DESCRIPTION
We should really migrate ourselves onto the non-legacy artifact format.