### PR TITLE
Improve the deprecation messaging and also the publicReadAcl check

### DIFF
--- a/magenta-lib/src/main/scala/magenta/Resolver.scala
+++ b/magenta-lib/src/main/scala/magenta/Resolver.scala
@@ -74,7 +74,7 @@ object Resolver {
     parameters.stacks match {
       case Nil if project.defaultStacks.nonEmpty => project.defaultStacks
       case Nil =>
-        reporter.warning("DEPRECATED: Your deploy.json should always specify stacks using the top level defaultStacks parameter.")
+        reporter.warning("DEPRECATED: Your deploy.json should always specify stacks using the top level defaultStacks parameter. Not doing so means that stacks are not taken into account when determining which AWS credentials to use and therefore which AWS account to deploy to.")
         Seq(UnnamedStack)
       case s => s
     }

--- a/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
+++ b/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
@@ -96,7 +96,7 @@ object S3Artifact extends Loggable {
   }
 
   def convertFromZipBundle(artifact: S3Artifact)(implicit client: AmazonS3, reporter: DeployReporter): Unit = {
-    reporter.warning("DEPRECATED: The artifact.zip is now a legacy format - please switch to the new format (if you are using sbt-riffraff-artifact then simply upgrade to >= 0.9.2)")
+    reporter.warning("DEPRECATED: The artifact.zip is now a legacy format - please switch to the new format (if you are using sbt-riffraff-artifact then simply upgrade to >= 0.9.4, if you use the TeamCity upload plugin you'll need to use the riffRaffNotifyTeamcity task instead of the riffRaffArtifact task)")
     reporter.info("Converting artifact.zip to S3 layout")
     implicit val sourceBucket: Option[String] = Some(artifact.bucket)
     S3ZipArtifact.withDownload(artifact){ dir =>


### PR DESCRIPTION
This improves the publicReadAcl so that the deprecation warning only happens when it is not set at all. If a project explicitly sets it to true then we don't display the warning.

We make the message clearer as well.

This depends on https://github.com/guardian/sbt-riffraff-artifact/pull/27