### PR TITLE
Parser for riff-raff.yaml proposal

### DIFF
--- a/magenta-lib/src/main/scala/magenta/input/DeploymentResolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/DeploymentResolver.scala
@@ -1,0 +1,68 @@
+package magenta.input
+
+import play.api.libs.json.JsValue
+
+case class Deployment(
+  name: String,
+  `type`: String,
+  stacks: List[String],
+  regions: List[String],
+  dependencies: List[String],
+  app: String,
+  contentDirectory: String,
+  parameters: Map[String, JsValue]
+)
+
+object DeploymentResolver {
+  val DEFAULT_REGIONS = List("eu-west-1")
+
+  def resolveDeployment(name: String, deployment: DeploymentOrTemplate, yaml: RiffRaffYaml): Either[List[String], DeploymentOrTemplate] = {
+    val missingDeps = yaml.missingDependencies(deployment.dependencies.getOrElse(Nil))
+    if (missingDeps.nonEmpty)
+      Left(missingDeps.map(dep => s"Missing dependency $dep in $name"))
+    else {
+      deployment match {
+        case deployment @ DeploymentOrTemplate(Some(deploymentType), None, stacks, regions, _, _, _, _) =>
+          // terminating case - apply any default stacks and regions
+          val deploymentWithGlobalDefaults = deployment.copy(stacks = stacks.orElse(yaml.stacks), regions = regions.orElse(yaml.regions))
+          Right(deploymentWithGlobalDefaults)
+
+        case template @ DeploymentOrTemplate(None, Some(templateName), stacks, regions, app, contentDirectory, dependencies, parameters) =>
+          // template case - recursively resolve
+          for {
+            template <- yaml.templates.flatMap(_.get(templateName))
+              .toRight(List(s"Template with name $templateName (specified in $name) does not exist")).right
+            resolved <- resolveDeployment(templateName, template, yaml).right
+          } yield {
+            DeploymentOrTemplate(
+              resolved.`type`,
+              None,
+              stacks.orElse(resolved.stacks),
+              regions.orElse(resolved.regions),
+              app.orElse(resolved.app),
+              contentDirectory.orElse(resolved.contentDirectory),
+              dependencies.orElse(resolved.dependencies),
+              Some(resolved.parameters.getOrElse(Map.empty) ++ parameters.getOrElse(Map.empty))
+            )
+          }
+      }
+    }
+  }
+
+  def resolve(yaml: RiffRaffYaml): List[Either[List[String], Deployment]] = {
+    yaml.deployments.map { case (name, deployment) =>
+      resolveDeployment(name, deployment, yaml).right.map { resolved =>
+        Deployment(
+          name = name,
+          `type` = resolved.`type`.get,
+          stacks = resolved.stacks.get,
+          regions = resolved.regions.getOrElse(DEFAULT_REGIONS),
+          dependencies = resolved.dependencies.getOrElse(Nil),
+          app = resolved.app.getOrElse(name),
+          contentDirectory = resolved.contentDirectory.getOrElse(name),
+          parameters = resolved.parameters.getOrElse(Map.empty)
+        )
+      }
+    }.toList
+  }
+}

--- a/magenta-lib/src/main/scala/magenta/input/DeploymentResolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/DeploymentResolver.scala
@@ -68,7 +68,8 @@ object DeploymentResolver {
     * Ensures that when deployments have named dependencies, deployments with those names exists.
     */
   private[input] def validateDependencies(label: String, deployment: Deployment, allDeployments: List[(String, DeploymentOrTemplate)]): Either[(String, String), Deployment] = {
-    deployment.dependencies.filterNot(allDeployments.map(_._1).contains) match {
+    val allDeploymentNames = allDeployments.map { case (name, _) => name }
+    deployment.dependencies.filterNot(allDeploymentNames.contains) match {
       case Nil =>
         Right(deployment)
       case missingDependencies =>

--- a/magenta-lib/src/main/scala/magenta/input/DeploymentResolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/DeploymentResolver.scala
@@ -4,11 +4,11 @@ package magenta.input
 object DeploymentResolver {
   val DEFAULT_REGIONS = List("eu-west-1")
 
-  def resolve(yaml: RiffRaffDeployConfig): List[Either[(String, String), Deployment]] = {
-    yaml.deployments.toList.map { case (label, rawDeployment) =>
+  def resolve(config: RiffRaffDeployConfig): List[Either[(String, String), Deployment]] = {
+    config.deployments.map { case (label, rawDeployment) =>
       for {
-        templated <- applyTemplates(label, rawDeployment, yaml.templates).right
-        deployment <- resolveDeployment(label, templated, yaml.stacks, yaml.regions).right
+        templated <- applyTemplates(label, rawDeployment, config.templates).right
+        deployment <- resolveDeployment(label, templated, config.stacks, config.regions).right
       } yield deployment
     }
   }

--- a/magenta-lib/src/main/scala/magenta/input/RiffRaffYamlReader.scala
+++ b/magenta-lib/src/main/scala/magenta/input/RiffRaffYamlReader.scala
@@ -1,0 +1,45 @@
+package magenta.input
+
+import magenta.tasks.YamlToJsonConverter
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+
+case class DeploymentOrTemplate(
+  `type`: Option[String],
+  template: Option[String],
+  stacks: Option[List[String]],
+  regions: Option[List[String]],
+  app: Option[String],
+  contentDirectory: Option[String],
+  dependencies: Option[List[String]],
+  parameters: Option[Map[String, JsValue]]
+)
+object DeploymentOrTemplate {
+  implicit val reads: Reads[DeploymentOrTemplate] = Json.reads
+}
+
+case class RiffRaffYaml(
+  stacks: Option[List[String]],
+  regions: Option[List[String]],
+  templates: Option[Map[String, DeploymentOrTemplate]],
+  // TODO - we should extract this in order, using JsObject?
+  deployments: Map[String, DeploymentOrTemplate]
+) {
+  def missingDependencies(dependencies: List[String]): List[String] = dependencies.filterNot(deployments.keySet.contains)
+}
+object RiffRaffYaml {
+  implicit val reads: Reads[RiffRaffYaml] = Json.reads
+}
+
+object RiffRaffYamlReader {
+  def fromString(yaml: String) = {
+    // convert form YAML to JSON
+    val jsonString = YamlToJsonConverter.convert(yaml)
+
+    val json = Json.parse(jsonString)
+    Json.fromJson[RiffRaffYaml](json) match {
+      case JsSuccess(s, _) => s
+      case JsError(errors) => throw new RuntimeException(s"Errors parsing YAML: $errors")
+    }
+  }
+}

--- a/magenta-lib/src/main/scala/magenta/input/RiffRaffYamlReader.scala
+++ b/magenta-lib/src/main/scala/magenta/input/RiffRaffYamlReader.scala
@@ -4,32 +4,6 @@ import magenta.tasks.YamlToJsonConverter
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 
-case class DeploymentOrTemplate(
-  `type`: Option[String],
-  template: Option[String],
-  stacks: Option[List[String]],
-  regions: Option[List[String]],
-  app: Option[String],
-  contentDirectory: Option[String],
-  dependencies: Option[List[String]],
-  parameters: Option[Map[String, JsValue]]
-)
-object DeploymentOrTemplate {
-  implicit val reads: Reads[DeploymentOrTemplate] = Json.reads
-}
-
-case class RiffRaffYaml(
-  stacks: Option[List[String]],
-  regions: Option[List[String]],
-  templates: Option[Map[String, DeploymentOrTemplate]],
-  // TODO - we should extract this in order, using JsObject?
-  deployments: Map[String, DeploymentOrTemplate]
-) {
-  def missingDependencies(dependencies: List[String]): List[String] = dependencies.filterNot(deployments.keySet.contains)
-}
-object RiffRaffYaml {
-  implicit val reads: Reads[RiffRaffYaml] = Json.reads
-}
 
 object RiffRaffYamlReader {
   def fromString(yaml: String) = {
@@ -37,7 +11,7 @@ object RiffRaffYamlReader {
     val jsonString = YamlToJsonConverter.convert(yaml)
 
     val json = Json.parse(jsonString)
-    Json.fromJson[RiffRaffYaml](json) match {
+    Json.fromJson[RiffRaffDeployConfig](json) match {
       case JsSuccess(s, _) => s
       case JsError(errors) => throw new RuntimeException(s"Errors parsing YAML: $errors")
     }

--- a/magenta-lib/src/main/scala/magenta/input/models.scala
+++ b/magenta-lib/src/main/scala/magenta/input/models.scala
@@ -2,6 +2,7 @@ package magenta.input
 
 import play.api.libs.json._
 
+case class ConfigError(context: String, message: String)
 
 case class RiffRaffDeployConfig(
   stacks: Option[List[String]],

--- a/magenta-lib/src/main/scala/magenta/input/models.scala
+++ b/magenta-lib/src/main/scala/magenta/input/models.scala
@@ -1,15 +1,35 @@
 package magenta.input
 
-import play.api.libs.json.{JsValue, Json, Reads}
+import play.api.data.validation.ValidationError
+import play.api.libs.json._
 
 
 case class RiffRaffDeployConfig(
   stacks: Option[List[String]],
   regions: Option[List[String]],
   templates: Option[Map[String, DeploymentOrTemplate]],
-  deployments: Map[String, DeploymentOrTemplate]
+  deployments: List[(String, DeploymentOrTemplate)]
 )
 object RiffRaffDeployConfig {
+  implicit def readObjectAsList[V](implicit fmtv: Reads[V]) = new Reads[List[(String, V)]] {
+    // copied from the map implementation in play.api.libs.json.Reads but builds an ordered
+    // list instead of an unordered map
+    def reads(json: JsValue): JsResult[List[(String, V)]] = json match {
+      case JsObject(linkedMap) =>
+        type Errors = Seq[(JsPath, Seq[ValidationError])]
+        def locate(e: Errors, key: String) = e.map { case (p, valerr) => (JsPath \ key) ++ p -> valerr }
+
+        linkedMap.foldLeft(Right(Nil): Either[Errors, List[(String, V)]]) {
+          case (acc, (key, value)) => (acc, Json.fromJson[V](value)(fmtv)) match {
+            case (Right(vs), JsSuccess(v, _)) => Right(vs :+ (key -> v))
+            case (Right(_), JsError(e)) => Left(locate(e, key))
+            case (Left(e), _: JsSuccess[_]) => Left(e)
+            case (Left(e1), JsError(e2)) => Left(e1 ++ locate(e2, key))
+          }
+        }.fold(JsError.apply, res => JsSuccess(res))
+      case _ => JsError(Seq(JsPath() -> Seq(ValidationError("error.expected.jsobject"))))
+    }
+  }
   implicit val reads: Reads[RiffRaffDeployConfig] = Json.reads
 }
 

--- a/magenta-lib/src/main/scala/magenta/input/models.scala
+++ b/magenta-lib/src/main/scala/magenta/input/models.scala
@@ -1,0 +1,55 @@
+package magenta.input
+
+import play.api.libs.json.{JsValue, Json, Reads}
+
+
+case class RiffRaffDeployConfig(
+  stacks: Option[List[String]],
+  regions: Option[List[String]],
+  templates: Option[Map[String, DeploymentOrTemplate]],
+  deployments: Map[String, DeploymentOrTemplate]
+)
+object RiffRaffDeployConfig {
+  implicit val reads: Reads[RiffRaffDeployConfig] = Json.reads
+}
+
+/**
+  * Represents entries for deployments and templates in a riff-raff.yml.
+  * Deployments and deployment templates have the same structure so this class can represent both.
+  *
+  * @param `type`           The type of deployment to perform (e.g. autoscaling, s3).
+  * @param template         Name of the custom deploy template to use for this deployment.
+  * @param stacks           Stack tags to apply to this deployment. The deployment will be executed once for each stack.
+  * @param regions          A list of the regions in which this deploy will be executed. Defaults to just 'eu-west-1'
+  * @param app              The `app` tag to use for this deployment. By default the deployment's key is used.
+  * @param contentDirectory The path where this deployment is found in the build output. Defaults to app.
+  * @param dependencies     This deployment's execution will be delayed until all named dependencies have completed. (Default empty)
+  * @param parameters       Provides additional parameters to the deployment type. Refer to the deployment types to see what is required.
+  */
+case class DeploymentOrTemplate(
+  `type`: Option[String],
+  template: Option[String],
+  stacks: Option[List[String]],
+  regions: Option[List[String]],
+  app: Option[String],
+  contentDirectory: Option[String],
+  dependencies: Option[List[String]],
+  parameters: Option[Map[String, JsValue]]
+)
+object DeploymentOrTemplate {
+  implicit val reads: Reads[DeploymentOrTemplate] = Json.reads
+}
+
+/**
+  * A deployment that has been parsed and validated out of a riff-raff.yml file.
+  */
+case class Deployment(
+  name: String,
+  `type`: String,
+  stacks: List[String],
+  regions: List[String],
+  app: String,
+  contentDirectory: String,
+  dependencies: List[String],
+  parameters: Map[String, JsValue]
+)

--- a/magenta-lib/src/main/scala/magenta/input/models.scala
+++ b/magenta-lib/src/main/scala/magenta/input/models.scala
@@ -1,6 +1,5 @@
 package magenta.input
 
-import play.api.data.validation.ValidationError
 import play.api.libs.json._
 
 
@@ -11,25 +10,7 @@ case class RiffRaffDeployConfig(
   deployments: List[(String, DeploymentOrTemplate)]
 )
 object RiffRaffDeployConfig {
-  implicit def readObjectAsList[V](implicit fmtv: Reads[V]) = new Reads[List[(String, V)]] {
-    // copied from the map implementation in play.api.libs.json.Reads but builds an ordered
-    // list instead of an unordered map
-    def reads(json: JsValue): JsResult[List[(String, V)]] = json match {
-      case JsObject(linkedMap) =>
-        type Errors = Seq[(JsPath, Seq[ValidationError])]
-        def locate(e: Errors, key: String) = e.map { case (p, valerr) => (JsPath \ key) ++ p -> valerr }
-
-        linkedMap.foldLeft(Right(Nil): Either[Errors, List[(String, V)]]) {
-          case (acc, (key, value)) => (acc, Json.fromJson[V](value)(fmtv)) match {
-            case (Right(vs), JsSuccess(v, _)) => Right(vs :+ (key -> v))
-            case (Right(_), JsError(e)) => Left(locate(e, key))
-            case (Left(e), _: JsSuccess[_]) => Left(e)
-            case (Left(e1), JsError(e2)) => Left(e1 ++ locate(e2, key))
-          }
-        }.fold(JsError.apply, res => JsSuccess(res))
-      case _ => JsError(Seq(JsPath() -> Seq(ValidationError("error.expected.jsobject"))))
-    }
-  }
+  import RiffRaffYamlReader.readObjectAsList
   implicit val reads: Reads[RiffRaffDeployConfig] = Json.reads
 }
 

--- a/magenta-lib/src/test/scala/magenta/input/DeploymentResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/DeploymentResolverTest.scala
@@ -1,0 +1,302 @@
+package magenta.input
+
+import org.scalatest.{FlatSpec, ShouldMatchers}
+import play.api.libs.json.{JsNumber, JsString, JsValue}
+
+class DeploymentResolverTest extends FlatSpec with ShouldMatchers {
+  "DeploymentResolver" should "parse a simple deployment with defaults" in {
+    val yaml = RiffRaffYaml(None, None, None,
+      Map("test" -> deploymentType("testType").withParameters("testParam" -> JsString("testValue")).withStacks("testStack")))
+    val deployments = DeploymentResolver.resolve(yaml)
+    deployments.size should be (1)
+    deployments.head.isRight should be(true)
+    deployments.head.right.get should have (
+      'type ("testType"),
+      'stacks (List("testStack")),
+      'regions (List("eu-west-1")),
+      'app ("test"),
+      'contentDirectory ("test"),
+      'dependencies (Nil),
+      'parameters (Map("testParam" -> JsString("testValue")))
+    )
+  }
+
+  it should "fill in global defaults and regions when not specified in the deployment" in {
+    val yaml = RiffRaffYaml(Some(List("stack1", "stack2")), Some(List("oceania-south-1")), None,
+      Map("test" -> deploymentType("testType").withParameters("testParam" -> JsString("testValue"))))
+    val deployments = DeploymentResolver.resolve(yaml)
+    deployments.size should be (1)
+    deployments.head.isRight should be(true)
+    deployments.head.right.get should have (
+      'type ("testType"),
+      'stacks (List("stack1", "stack2")),
+      'regions (List("oceania-south-1")),
+      'app ("test"),
+      'contentDirectory ("test"),
+      'dependencies (Nil),
+      'parameters (Map("testParam" -> JsString("testValue")))
+    )
+  }
+
+  it should "override the global defaults when specified in the deployment" in {
+    val yaml = RiffRaffYaml(
+      Some(List("overriden-stack1")),
+      Some(List("oceania-south-1")), None,
+      Map("test" -> deploymentType("testType").withParameters("testParam" -> JsString("testValue")).withStacks("testStack").withRegions("eurasia-north-1"))
+    )
+    val deployments = DeploymentResolver.resolve(yaml)
+    deployments.size should be (1)
+    deployments.head.isRight should be(true)
+    deployments.head.right.get should have (
+      'type ("testType"),
+      'stacks (List("testStack")),
+      'regions (List("eurasia-north-1")),
+      'app ("test"),
+      'contentDirectory ("test"),
+      'dependencies (Nil),
+      'parameters (Map("testParam" -> JsString("testValue")))
+    )
+  }
+
+  it should "use values from a simple template" in {
+    val yaml = RiffRaffYaml(
+      None, None,
+      Some(Map("testTemplate" -> deploymentType("testType").withParameters("testParam" -> JsString("testValue")).withStacks("testStack"))),
+      Map("test" -> deploymentTemplate("testTemplate").withParameters("anotherParam" -> JsNumber(1984)))
+    )
+    val deployments = DeploymentResolver.resolve(yaml)
+    deployments.size should be (1)
+    deployments.head.isRight should be(true)
+    deployments.head.right.get should have (
+      'type ("testType"),
+      'stacks (List("testStack")),
+      'regions (List("eu-west-1")),
+      'app ("test"),
+      'contentDirectory ("test"),
+      'dependencies (Nil),
+      'parameters (Map("testParam" -> JsString("testValue"), "anotherParam" -> JsNumber(1984)))
+    )
+  }
+
+  it should "correctly prioritise stacks and regions from deployment when specified everywhere" in {
+    val yaml = RiffRaffYaml(
+      Some(List("global-stack")), Some(List("global-region")),
+      Some(Map("testTemplate" -> deploymentType("testType").withStacks("template-stack").withRegions("template-region"))),
+      Map("test" -> deploymentTemplate("testTemplate").withStacks("deployment-stack").withRegions("deployment-region"))
+    )
+    val deployments = DeploymentResolver.resolve(yaml)
+    deployments.size should be (1)
+    deployments.head.isRight should be(true)
+    deployments.head.right.get should have(
+      'stacks (List("deployment-stack")),
+      'regions (List("deployment-region"))
+    )
+  }
+
+  it should "correctly prioritise stacks and regions from template when not specified in deployment" in {
+    val yaml = RiffRaffYaml(
+      Some(List("global-stack")), Some(List("global-region")),
+      Some(Map("testTemplate" -> deploymentType("testType").withStacks("template-stack").withRegions("template-region"))),
+      Map("test" -> deploymentTemplate("testTemplate"))
+    )
+    val deployments = DeploymentResolver.resolve(yaml)
+    deployments.size should be (1)
+    deployments.head.isRight should be(true)
+    deployments.head.right.get should have(
+      'stacks (List("template-stack")),
+      'regions (List("template-region"))
+    )
+  }
+
+  it should "correctly prioritise stacks and regions from global when not specified in deployment or template" in {
+    val yaml = RiffRaffYaml(
+      Some(List("global-stack")), Some(List("global-region")),
+      Some(Map("testTemplate" -> deploymentType("testType"))),
+      Map("test" -> deploymentTemplate("testTemplate"))
+    )
+    val deployments = DeploymentResolver.resolve(yaml)
+    deployments.size should be (1)
+    deployments.head.isRight should be(true)
+    deployments.head.right.get should have(
+      'stacks (List("global-stack")),
+      'regions (List("global-region"))
+    )
+  }
+
+  it should "resolve nested templates" in {
+    val yaml = RiffRaffYaml(
+      Some(List("global-stack")), Some(List("global-region")),
+      Some(Map(
+        "nestedTemplate" -> deploymentType("testType").withStacks("nested-template-stack").withRegions("nested-template-region"),
+        "testTemplate" -> deploymentTemplate("nestedTemplate").withRegions("template-region")
+      )),
+      Map("test" -> deploymentTemplate("testTemplate"))
+    )
+    val deployments = DeploymentResolver.resolve(yaml)
+    deployments.size should be (1)
+    deployments.head.isRight should be(true)
+    deployments.head.right.get should have(
+      'stacks (List("nested-template-stack")),
+      'regions (List("template-region"))
+    )
+  }
+
+  it should "correctly merge parameters from templates deployments" in {
+    val yaml = RiffRaffYaml(
+      Some(List("global-stack")), Some(List("global-region")),
+      Some(Map(
+        "nestedTemplate" -> deploymentType("testType").withParameters(
+          "nestedParameter" -> JsNumber(1984),
+          "commonParameter" -> JsString("nested"),
+          "allParameter" -> JsString("nested"),
+          "sandwichParameter" -> JsString("nested")
+        ),
+        "testTemplate" -> deploymentTemplate("nestedTemplate").withParameters(
+          "templateParameter" -> JsNumber(2016),
+          "commonParameter" -> JsString("template"),
+          "allParameter" -> JsString("template")
+        )
+      )),
+      Map("test" -> deploymentTemplate("testTemplate").withParameters(
+        "deploymentParameter" -> JsNumber(1234),
+        "allParameter" -> JsString("deployment"),
+        "sandwichParameter" -> JsString("deployment")
+      ))
+    )
+    val deployments = DeploymentResolver.resolve(yaml)
+    deployments.size should be (1)
+    deployments.head.isRight should be(true)
+    val deployment = deployments.head.right.get
+    deployment.parameters.size should be(6)
+    deployment.parameters should contain("nestedParameter" -> JsNumber(1984))
+    deployment.parameters should contain("templateParameter" -> JsNumber(2016))
+    deployment.parameters should contain("deploymentParameter" -> JsNumber(1234))
+    deployment.parameters should contain("commonParameter" -> JsString("template"))
+    deployment.parameters should contain("allParameter" -> JsString("deployment"))
+    deployment.parameters should contain("sandwichParameter" -> JsString("deployment"))
+  }
+
+  it should "not default app and contentDirectory if specified in template" in {
+    val yaml = RiffRaffYaml(
+      Some(List("global-stack")), Some(List("global-region")),
+      Some(Map("testTemplate" -> deploymentType("testType").withApp("templateApp").withContentDirectory("templateContentDirectory"))),
+      Map("test" -> deploymentTemplate("testTemplate"))
+    )
+    val deployments = DeploymentResolver.resolve(yaml)
+    deployments.size should be (1)
+    deployments.head.isRight should be(true)
+    deployments.head.right.get should have(
+      'app ("templateApp"),
+      'contentDirectory ("templateContentDirectory")
+    )
+  }
+
+  it should "correctly prioritise dependencies from deployment when specified everywhere" in {
+    val yaml = RiffRaffYaml(
+      Some(List("global-stack")), None,
+      Some(Map(
+        "nestedTemplate" -> deploymentType("testType").withDependencies("nested-dep"),
+        "testTemplate" -> deploymentTemplate("nestedTemplate").withDependencies("template-dep")
+      )),
+      Map(
+        "nested-dep" -> deploymentType("autoscaling"),
+        "template-dep" -> deploymentType("autoscaling"),
+        "deployment-dep" -> deploymentType("autoscaling"),
+        "test" -> deploymentTemplate("testTemplate").withDependencies("deployment-dep")
+      )
+    )
+    val deployments = assertDeployments(DeploymentResolver.resolve(yaml))
+    deployments.size should be (4)
+    val deployment = deployments.find(_.name == "test").get
+    deployment.dependencies should be(List("deployment-dep"))
+  }
+
+  it should "correctly prioritise dependencies from template when not specified in deployment" in {
+    val yaml = RiffRaffYaml(
+      Some(List("global-stack")), None,
+      Some(Map(
+        "nestedTemplate" -> deploymentType("testType").withDependencies("nested-dep"),
+        "testTemplate" -> deploymentTemplate("nestedTemplate").withDependencies("template-dep")
+      )),
+      Map(
+        "nested-dep" -> deploymentType("autoscaling"),
+        "template-dep" -> deploymentType("autoscaling"),
+        "test" -> deploymentTemplate("testTemplate")
+      )
+    )
+    val deployments = assertDeployments(DeploymentResolver.resolve(yaml))
+    deployments.size should be (3)
+    val deployment = deployments.find(_.name == "test").get
+    deployment.dependencies should be(List("template-dep"))
+  }
+
+  it should "correctly prioritise dependencies from nested template when not specified in deployment or template" in {
+    val yaml = RiffRaffYaml(
+      Some(List("global-stack")), None,
+      Some(Map(
+        "nestedTemplate" -> deploymentType("testType").withDependencies("nested-dep"),
+        "testTemplate" -> deploymentTemplate("nestedTemplate")
+      )),
+      Map(
+        "nested-dep" -> deploymentType("autoscaling"),
+        "test" -> deploymentTemplate("testTemplate")
+      )
+    )
+    val deployments = assertDeployments(DeploymentResolver.resolve(yaml))
+    deployments.size should be (2)
+    val deployment = deployments.find(_.name == "test").get
+    deployment.dependencies should be(List("nested-dep"))
+  }
+
+  it should "report an error if a named template doesn't exist" in {
+    val yaml = RiffRaffYaml(
+      Some(List("global-stack")), None,
+      Some(Map(
+        "nestedTemplate" -> deploymentType("testType").withDependencies("nested-dep"),
+        "testTemplate" -> deploymentTemplate("nestedTemplate")
+      )),
+      Map("test" -> deploymentTemplate("nonExistentTemplate"))
+    )
+    val deployments = DeploymentResolver.resolve(yaml)
+    deployments.size should be (1)
+    deployments.head.isLeft should be(true)
+    val errors = deployments.head.left.get
+    errors should be(List("Template with name nonExistentTemplate (specified in test) does not exist"))
+  }
+
+  it should "report missing dependencies" in {
+    val yaml = RiffRaffYaml(
+      Some(List("global-stack")), None,
+      None,
+      Map(
+        "test" -> deploymentTemplate("testTemplate").withDependencies("missing-dep")
+      )
+    )
+    val deployments = DeploymentResolver.resolve(yaml)
+    deployments.size should be (1)
+    deployments.head.isLeft should be(true)
+    val errors = deployments.head.left.get
+    errors should be(List("Missing dependency missing-dep in test"))
+  }
+
+  def assertDeployments(maybeDeployments: List[Either[List[String], Deployment]]): List[Deployment] = {
+    maybeDeployments.flatMap{ either =>
+      either should matchPattern { case Right(_) => }
+      either.right.toOption
+    }
+  }
+
+  implicit class RichDeploymentOrTemplate(deploymentOrTemplate: DeploymentOrTemplate) {
+    def withType(`type`: String) = deploymentOrTemplate.copy(`type` = Some(`type`))
+    def withTemplate(template: String) = deploymentOrTemplate.copy(template = Some(template))
+    def withStacks(stacks: String*) = deploymentOrTemplate.copy(stacks = Some(stacks.toList))
+    def withRegions(regions: String*) = deploymentOrTemplate.copy(regions = Some(regions.toList))
+    def withApp(app: String) = deploymentOrTemplate.copy(app = Some(app))
+    def withContentDirectory(contentDirectory: String) = deploymentOrTemplate.copy(contentDirectory = Some(contentDirectory))
+    def withDependencies(dependencies: String*) = deploymentOrTemplate.copy(dependencies = Some(dependencies.toList))
+    def withParameters(parameters: (String, JsValue)*) = deploymentOrTemplate.copy(parameters = Some(parameters.toMap))
+  }
+
+  def deploymentType(`type`: String) = DeploymentOrTemplate(Some(`type`), None, None, None, None, None, None, None)
+  def deploymentTemplate(name: String) = DeploymentOrTemplate(None, Some(name), None, None, None, None, None, None)
+}

--- a/magenta-lib/src/test/scala/magenta/input/DeploymentResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/DeploymentResolverTest.scala
@@ -362,7 +362,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = DeploymentResolver.resolve(yaml)
     deployments.size should be (1)
-    deployments.head.left.value should be("test" -> "Template with name nonExistentTemplate does not exist")
+    deployments.head.left.value should be(ConfigError("test", "Template with name nonExistentTemplate does not exist"))
   }
 
   it should "report an error if a named dependency does not exist" in {
@@ -377,7 +377,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = DeploymentResolver.resolve(yaml)
     deployments.size should be (1)
-    deployments.head.left.value should be("test" -> "Missing deployment dependencies missing-dep")
+    deployments.head.left.value should be(ConfigError("test", "Missing deployment dependencies missing-dep"))
 
   }
 
@@ -390,10 +390,10 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = DeploymentResolver.resolve(yaml)
-    deployments.head.left.value should be("test" -> "No stacks provided")
+    deployments.head.left.value should be(ConfigError("test", "No stacks provided"))
   }
 
-  def assertDeployments(maybeDeployments: List[Either[(String, String), Deployment]]): List[Deployment] = {
+  def assertDeployments(maybeDeployments: List[Either[ConfigError, Deployment]]): List[Deployment] = {
     maybeDeployments.flatMap{ either =>
       either should matchPattern { case Right(_) => }
       either.right.toOption

--- a/magenta-lib/src/test/scala/magenta/input/DeploymentResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/DeploymentResolverTest.scala
@@ -6,7 +6,7 @@ import play.api.libs.json.{JsNumber, JsString, JsValue}
 class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherValues {
   "DeploymentResolver" should "parse a simple deployment with defaults" in {
     val yaml = RiffRaffDeployConfig(None, None, None,
-      Map("test" -> deploymentType("testType").withParameters("testParam" -> JsString("testValue")).withStacks("testStack")))
+      List("test" -> deploymentType("testType").withParameters("testParam" -> JsString("testValue")).withStacks("testStack")))
     val deployments = DeploymentResolver.resolve(yaml)
     deployments.size should be (1)
     deployments.head.right.value should have (
@@ -22,7 +22,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
 
   it should "fill in global defaults and regions when not specified in the deployment" in {
     val yaml = RiffRaffDeployConfig(Some(List("stack1", "stack2")), Some(List("oceania-south-1")), None,
-      Map("test" -> deploymentType("testType").withParameters("testParam" -> JsString("testValue"))))
+      List("test" -> deploymentType("testType").withParameters("testParam" -> JsString("testValue"))))
     val deployments = DeploymentResolver.resolve(yaml)
     deployments.size should be (1)
     deployments.head.right.value should have (
@@ -40,7 +40,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
     val yaml = RiffRaffDeployConfig(
       Some(List("overriden-stack1")),
       Some(List("oceania-south-1")), None,
-      Map("test" -> deploymentType("testType").withParameters("testParam" -> JsString("testValue")).withStacks("testStack").withRegions("eurasia-north-1"))
+      List("test" -> deploymentType("testType").withParameters("testParam" -> JsString("testValue")).withStacks("testStack").withRegions("eurasia-north-1"))
     )
     val deployments = DeploymentResolver.resolve(yaml)
     deployments.size should be (1)
@@ -59,7 +59,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
     val yaml = RiffRaffDeployConfig(
       None, None,
       Some(Map("testTemplate" -> deploymentType("testType").withParameters("testParam" -> JsString("testValue")).withStacks("testStack"))),
-      Map("test" -> deploymentTemplate("testTemplate").withParameters("anotherParam" -> JsNumber(1984)))
+      List("test" -> deploymentTemplate("testTemplate").withParameters("anotherParam" -> JsNumber(1984)))
     )
     val deployments = DeploymentResolver.resolve(yaml)
     deployments.size should be (1)
@@ -78,7 +78,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
     val yaml = RiffRaffDeployConfig(
       Some(List("global-stack")), Some(List("global-region")),
       Some(Map("testTemplate" -> deploymentType("testType").withStacks("template-stack").withRegions("template-region"))),
-      Map("test" -> deploymentTemplate("testTemplate").withStacks("deployment-stack").withRegions("deployment-region"))
+      List("test" -> deploymentTemplate("testTemplate").withStacks("deployment-stack").withRegions("deployment-region"))
     )
     val deployments = DeploymentResolver.resolve(yaml)
     deployments.size should be (1)
@@ -92,7 +92,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
     val yaml = RiffRaffDeployConfig(
       Some(List("global-stack")), Some(List("global-region")),
       Some(Map("testTemplate" -> deploymentType("testType").withStacks("template-stack").withRegions("template-region"))),
-      Map("test" -> deploymentTemplate("testTemplate"))
+      List("test" -> deploymentTemplate("testTemplate"))
     )
     val deployments = DeploymentResolver.resolve(yaml)
     deployments.size should be (1)
@@ -106,7 +106,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
     val yaml = RiffRaffDeployConfig(
       Some(List("global-stack")), Some(List("global-region")),
       Some(Map("testTemplate" -> deploymentType("testType"))),
-      Map("test" -> deploymentTemplate("testTemplate"))
+      List("test" -> deploymentTemplate("testTemplate"))
     )
     val deployments = DeploymentResolver.resolve(yaml)
     deployments.size should be (1)
@@ -123,7 +123,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         "nestedTemplate" -> deploymentType("testType").withStacks("nested-template-stack").withRegions("nested-template-region"),
         "testTemplate" -> deploymentTemplate("nestedTemplate").withRegions("template-region")
       )),
-      Map("test" -> deploymentTemplate("testTemplate"))
+      List("test" -> deploymentTemplate("testTemplate"))
     )
     val deployments = DeploymentResolver.resolve(yaml)
     deployments.size should be (1)
@@ -149,7 +149,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
           "allParameter" -> JsString("template")
         )
       )),
-      Map("test" -> deploymentTemplate("testTemplate").withParameters(
+      List("test" -> deploymentTemplate("testTemplate").withParameters(
         "deploymentParameter" -> JsNumber(1234),
         "allParameter" -> JsString("deployment"),
         "sandwichParameter" -> JsString("deployment")
@@ -171,7 +171,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
     val yaml = RiffRaffDeployConfig(
       Some(List("global-stack")), Some(List("global-region")),
       Some(Map("testTemplate" -> deploymentType("testType").withApp("templateApp").withContentDirectory("templateContentDirectory"))),
-      Map("test" -> deploymentTemplate("testTemplate"))
+      List("test" -> deploymentTemplate("testTemplate"))
     )
     val deployments = DeploymentResolver.resolve(yaml)
     deployments.size should be (1)
@@ -188,7 +188,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         "nestedTemplate" -> deploymentType("testType").withDependencies("nested-dep"),
         "testTemplate" -> deploymentTemplate("nestedTemplate").withDependencies("template-dep")
       )),
-      Map(
+      List(
         "nested-dep" -> deploymentType("autoscaling"),
         "template-dep" -> deploymentType("autoscaling"),
         "deployment-dep" -> deploymentType("autoscaling"),
@@ -208,7 +208,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         "nestedTemplate" -> deploymentType("testType").withDependencies("nested-dep"),
         "testTemplate" -> deploymentTemplate("nestedTemplate").withDependencies("template-dep")
       )),
-      Map(
+      List(
         "nested-dep" -> deploymentType("autoscaling"),
         "template-dep" -> deploymentType("autoscaling"),
         "test" -> deploymentTemplate("testTemplate")
@@ -227,7 +227,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         "nestedTemplate" -> deploymentType("testType").withDependencies("nested-dep"),
         "testTemplate" -> deploymentTemplate("nestedTemplate")
       )),
-      Map(
+      List(
         "nested-dep" -> deploymentType("autoscaling"),
         "test" -> deploymentTemplate("testTemplate")
       )
@@ -245,7 +245,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         "nestedTemplate" -> deploymentType("testType").withDependencies("nested-dep"),
         "testTemplate" -> deploymentTemplate("nestedTemplate")
       )),
-      Map("test" -> deploymentTemplate("nonExistentTemplate"))
+      List("test" -> deploymentTemplate("nonExistentTemplate"))
     )
     val deployments = DeploymentResolver.resolve(yaml)
     deployments.size should be (1)
@@ -256,7 +256,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
     val yaml = RiffRaffDeployConfig(
       None, None,
       None,
-      Map(
+      List(
         "test" -> deploymentType("autoscaling")
       )
     )

--- a/magenta-lib/src/test/scala/magenta/input/DeploymentResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/DeploymentResolverTest.scala
@@ -252,6 +252,18 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
     deployments.head.left.value should be("test" -> "Template with name nonExistentTemplate does not exist")
   }
 
+  it should "report an error if a named dependency does not exist" in {
+    val yaml = RiffRaffDeployConfig(
+      Some(List("global-stack")), None,
+      None,
+      List("test" -> deploymentType("autoscaling").withDependencies("missing-dep"))
+    )
+    val deployments = DeploymentResolver.resolve(yaml)
+    deployments.size should be (1)
+    deployments.head.left.value should be("test" -> "Missing deployment dependencies missing-dep")
+
+  }
+
   it should "report an error if no stacks are provided" in {
     val yaml = RiffRaffDeployConfig(
       None, None,

--- a/magenta-lib/src/test/scala/magenta/input/RiffRaffYamlReaderTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/RiffRaffYamlReaderTest.scala
@@ -68,5 +68,6 @@ class RiffRaffYamlReaderTest extends FlatSpec with ShouldMatchers{
       DeploymentOrTemplate(Some("autoscaling"), None, None, None, Some("ook"), None, Some(List("elephant")), None))
     input.deployments should contain("elephant" ->
       DeploymentOrTemplate(Some("dung"), None, None, None, None, None, None, None))
+    input.deployments.map(_._1) should be(List("human", "monkey", "elephant"))
   }
 }

--- a/magenta-lib/src/test/scala/magenta/input/RiffRaffYamlReaderTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/RiffRaffYamlReaderTest.scala
@@ -1,0 +1,72 @@
+package magenta.input
+
+import org.scalatest.{FlatSpec, ShouldMatchers}
+import play.api.libs.json.{JsArray, JsNumber, JsString, Json}
+
+class RiffRaffYamlReaderTest extends FlatSpec with ShouldMatchers{
+  "RiffRaffYamlReader" should "read a minimal file" in {
+    val yaml =
+      """
+        |---
+        |stacks: [banana]
+        |deployments:
+        |  monkey:
+        |    type: autoscaling
+      """.stripMargin
+    val input = RiffRaffYamlReader.fromString(yaml)
+    input.stacks.isDefined should be(true)
+    input.stacks.get.size should be(1)
+    input.stacks.get should be(List("banana"))
+    input.deployments.size should be(1)
+    input.deployments.head should be("monkey" -> DeploymentOrTemplate(Some("autoscaling"), None, None, None, None, None, None, None))
+  }
+
+  it should "parse a more complex yaml example" in {
+    val yaml =
+      """
+        |---
+        |stacks: [banana, cabbage]
+        |templates:
+        |  custom-auto:
+        |    type: autoscaling
+        |    parameters:
+        |      paramString: value1
+        |      paramNumber: 2000
+        |      paramList: [valueOne, valueTwo]
+        |      paramMap:
+        |        txt: text/plain
+        |        json: application/json
+        |deployments:
+        |  human:
+        |    template: custom-auto
+        |    dependencies: [elephant]
+        |    stacks: [carrot]
+        |    parameters:
+        |      paramString: value2
+        |  monkey:
+        |    type: autoscaling
+        |    app: ook
+        |    dependencies: [elephant]
+        |  elephant:
+        |    type: dung
+      """.stripMargin
+    val input = RiffRaffYamlReader.fromString(yaml)
+    input.stacks.isDefined should be(true)
+    input.stacks.get.size should be(2)
+    input.stacks.get should be(List("banana", "cabbage"))
+    input.templates.isDefined should be(true)
+    input.templates.get should be(Map("custom-auto" -> DeploymentOrTemplate(Some("autoscaling"),None, None, None, None, None, None, Some(Map(
+      "paramString" -> JsString("value1"),
+      "paramNumber" -> JsNumber(2000),
+      "paramList" -> JsArray(Seq(JsString("valueOne"), JsString("valueTwo"))),
+      "paramMap" -> Json.obj("txt" -> "text/plain", "json" -> "application/json")
+    )))))
+    input.deployments.size should be(3)
+    input.deployments should contain("human" ->
+      DeploymentOrTemplate(None, Some("custom-auto"), Some(List("carrot")), None, None, None, Some(List("elephant")), Some(Map("paramString" -> JsString("value2")))))
+    input.deployments should contain("monkey" ->
+      DeploymentOrTemplate(Some("autoscaling"), None, None, None, Some("ook"), None, Some(List("elephant")), None))
+    input.deployments should contain("elephant" ->
+      DeploymentOrTemplate(Some("dung"), None, None, None, None, None, None, None))
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,6 +8,9 @@ object Dependencies {
     val aws = "1.11.32"
     val guardianManagement = "5.35"
     val guardianManagementPlay = "8.0"
+    val jackson = "2.8.2"
+    // keep in sync with plugin
+    val play = "2.5.6"
   }
 
   val commonDeps = Seq(
@@ -35,8 +38,9 @@ object Dependencies {
     "com.github.scala-incubator.io" %% "scala-io-file" % "0.4.3",
     "com.gu" %% "management" % Versions.guardianManagement,
     "com.gu" %% "fastly-api-client" % "0.2.5",
-    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % "2.7.1",
-    "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.1"
+    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % Versions.jackson,
+    "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jackson,
+    "com.typesafe.play" %% "play-json" % Versions.play
   ).map((m: ModuleID) =>
     // don't even ask why I need to do this
     m.excludeAll(ExclusionRule(organization = "com.google.code.findbugs", name = "jsr305"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,6 @@
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
+// keep in sync with the play version in Dependencies
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.6")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.0")


### PR DESCRIPTION
This implements a parser for the `riff-raff.yaml` [proposal](https://docs.google.com/document/d/1zUQz8cHj8WbcZ-JgbFhtWteFgYtiTCmW771SELxZ5S8/edit).

It consists of two parts, a RiffRaffYamlReader and a DeploymentResolver. The reader turns the YAML in to a set of case classes that map directly from the YAML format. The resolver takes the representation provided by the first and produces a list of deployments by applying the templates and defaults.

None of this is actually hooked up to anything else, but I think makes sense to review on its own.

Reader
-------
The reader converts the YAML to JSON and then uses the Play JSON library. I tried using some YAML libraries to no avail. Someone is welcome to try again if they so desire, but this works well given that the format is a subset of JSON.

Resolver
---------
The resolver deals with applying templates and correctly populating the fields of a deployment according the prioritisation rules for values that come from application defaults, global values, templates and deployments. The resolver returns a list of either of errors or deployments. Errors are returned for missing templates and missing dependencies. This could be extended in time.