### PR TITLE
Update to the riff-raff.yaml proposal

### DIFF
--- a/magenta-lib/src/main/scala/magenta/input/RiffRaffYamlReader.scala
+++ b/magenta-lib/src/main/scala/magenta/input/RiffRaffYamlReader.scala
@@ -4,32 +4,6 @@ import magenta.tasks.YamlToJsonConverter
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 
-case class DeploymentOrTemplate(
-  `type`: Option[String],
-  template: Option[String],
-  stacks: Option[List[String]],
-  regions: Option[List[String]],
-  app: Option[String],
-  contentDirectory: Option[String],
-  dependencies: Option[List[String]],
-  parameters: Option[Map[String, JsValue]]
-)
-object DeploymentOrTemplate {
-  implicit val reads: Reads[DeploymentOrTemplate] = Json.reads
-}
-
-case class RiffRaffYaml(
-  stacks: Option[List[String]],
-  regions: Option[List[String]],
-  templates: Option[Map[String, DeploymentOrTemplate]],
-  // TODO - we should extract this in order, using JsObject?
-  deployments: Map[String, DeploymentOrTemplate]
-) {
-  def missingDependencies(dependencies: List[String]): List[String] = dependencies.filterNot(deployments.keySet.contains)
-}
-object RiffRaffYaml {
-  implicit val reads: Reads[RiffRaffYaml] = Json.reads
-}
 
 object RiffRaffYamlReader {
   def fromString(yaml: String) = {
@@ -37,7 +11,7 @@ object RiffRaffYamlReader {
     val jsonString = YamlToJsonConverter.convert(yaml)
 
     val json = Json.parse(jsonString)
-    Json.fromJson[RiffRaffYaml](json) match {
+    Json.fromJson[RiffRaffDeployConfig](json) match {
       case JsSuccess(s, _) => s
       case JsError(errors) => throw new RuntimeException(s"Errors parsing YAML: $errors")
     }

--- a/magenta-lib/src/main/scala/magenta/input/models.scala
+++ b/magenta-lib/src/main/scala/magenta/input/models.scala
@@ -1,0 +1,55 @@
+package magenta.input
+
+import play.api.libs.json.{JsValue, Json, Reads}
+
+
+case class RiffRaffDeployConfig(
+  stacks: Option[List[String]],
+  regions: Option[List[String]],
+  templates: Option[Map[String, DeploymentOrTemplate]],
+  deployments: Map[String, DeploymentOrTemplate]
+)
+object RiffRaff {
+  implicit val reads: Reads[RiffRaffDeployConfig] = Json.reads
+}
+
+/**
+  * Represents entries for deployments and templates in a riff-raff.yml.
+  * Deployments and deployment templates have the same structure so this class can represent both.
+  *
+  * @param `type`           The type of deployment to perform (e.g. autoscaling, s3).
+  * @param template         Name of the custom deploy template to use for this deployment.
+  * @param stacks           Stack tags to apply to this deployment. The deployment will be executed once for each stack.
+  * @param regions          A list of the regions in which this deploy will be executed. Defaults to just 'eu-west-1'
+  * @param app              The `app` tag to use for this deployment. By default the deployment's key is used.
+  * @param contentDirectory The path where this deployment is found in the build output. Defaults to app.
+  * @param dependencies     This deployment's execution will be delayed until all named dependencies have completed. (Default empty)
+  * @param parameters       Provides additional parameters to the deployment type. Refer to the deployment types to see what is required.
+  */
+case class DeploymentOrTemplate(
+  `type`: Option[String],
+  template: Option[String],
+  stacks: Option[List[String]],
+  regions: Option[List[String]],
+  app: Option[String],
+  contentDirectory: Option[String],
+  dependencies: Option[List[String]],
+  parameters: Option[Map[String, JsValue]]
+)
+object DeploymentOrTemplate {
+  implicit val reads: Reads[DeploymentOrTemplate] = Json.reads
+}
+
+/**
+  * A deployment that has been parsed and validated out of a riff-raff.yml file.
+  */
+case class Deployment(
+  name: String,
+  `type`: String,
+  stacks: List[String],
+  regions: List[String],
+  app: String,
+  contentDirectory: String,
+  dependencies: List[String],
+  parameters: Map[String, JsValue]
+)

--- a/magenta-lib/src/main/scala/magenta/input/models.scala
+++ b/magenta-lib/src/main/scala/magenta/input/models.scala
@@ -9,7 +9,7 @@ case class RiffRaffDeployConfig(
   templates: Option[Map[String, DeploymentOrTemplate]],
   deployments: Map[String, DeploymentOrTemplate]
 )
-object RiffRaff {
+object RiffRaffDeployConfig {
   implicit val reads: Reads[RiffRaffDeployConfig] = Json.reads
 }
 


### PR DESCRIPTION
This commit addresses the points I raised in my review of [the `riff-raff.yaml` proposal PR](https://github.com/guardian/riff-raff/pull/342).
* handles missing required fields in deployments
* makes use of scalatest's EitherValues trait
* passes a context in the Left of the Either to enable display of which block the error refers to

It also:
* simplifies the DeploymentResolver logic
* separates the models from the business logic
* documents the DeploymentOrTemplate model