### PR TITLE
Remove per-host actions concept

### DIFF
--- a/magenta-lib/src/main/scala/magenta/Project.scala
+++ b/magenta-lib/src/main/scala/magenta/Project.scala
@@ -88,8 +88,7 @@ case class App (name: String)
 
 case class Recipe(
   name: String,
-  actionsBeforeApp: Iterable[Action] = Nil, //executed once per app (before the host actions are executed)
-  actionsPerHost: Iterable[Action] = Nil,  //executed once per host in the application
+  actions: Iterable[Action] = Nil, //executed once per app (before the host actions are executed)
   dependsOn: List[String] = Nil
 )
 

--- a/magenta-lib/src/main/scala/magenta/Resolver.scala
+++ b/magenta-lib/src/main/scala/magenta/Resolver.scala
@@ -4,28 +4,16 @@ import com.amazonaws.services.s3.AmazonS3
 import magenta.graph.{Deployment, DeploymentGraph, Graph}
 import magenta.tasks._
 
-case class RecipeTasks(recipe: Recipe, preTasks: List[Task], hostTasks: List[Task], disabled: Boolean = false) {
+case class RecipeTasks(recipe: Recipe, tasks: List[Task]) {
   lazy val hosts = tasks.flatMap(_.taskHost).map(_.copy(connectAs=None)).distinct
-  lazy val tasks = if (disabled) Nil else preTasks ++ hostTasks
   lazy val recipeName = recipe.name
-  // invalid if there are host-tasks but not any hosts to apply them to :(
-  lazy val invalid = recipe.actionsPerHost.nonEmpty && hostTasks.isEmpty
 }
 
 case class RecipeTasksNode(recipeTasks: RecipeTasks, children: List[RecipeTasksNode]) {
-  def disable(f: RecipeTasks => Boolean): RecipeTasksNode = {
-    if (f(recipeTasks))
-      copy(recipeTasks = recipeTasks.copy(disabled=true), children = children.map(_.disable(_ => true)))
-    else
-      copy(children = children.map(_.disable(f)))
-  }
-
   def toList: List[RecipeTasks] = children.flatMap(_.toList) ++ List(recipeTasks)
 
   def toGraph(name: String): Graph[Deployment] = {
-    val thisGraph: Graph[Deployment] =
-      if (recipeTasks.invalid) Graph.empty
-      else DeploymentGraph(recipeTasks.tasks, s"$name (${recipeTasks.recipeName})")
+    val thisGraph: Graph[Deployment] = DeploymentGraph(recipeTasks.tasks, s"$name (${recipeTasks.recipeName})")
 
     val childGraph: Graph[Deployment] =
       children.map(_.toGraph(name)).reduceLeftOption(_ joinParallel _).getOrElse(Graph.empty)
@@ -62,34 +50,22 @@ object Resolver {
     }
 
     def resolveRecipe(recipe: Recipe, resources: DeploymentResources, target: DeployTarget): RecipeTasks = {
-    val tasksToRunBeforeApp = recipe.actionsBeforeApp.toList flatMap { _.resolve(resources, target) }
+      val tasks = for {
+          action <- recipe.actions
+          tasks <- action.resolve(resources, target)
+        } yield {
+          tasks
+        }
 
-    val perHostTasks = {
-      for {
-        action <- recipe.actionsPerHost
-        tasks <- action.resolve(resources, target)
-      } yield {
-        tasks
-      }
+      RecipeTasks(recipe, tasks.toList)
     }
-
-    val taskHosts = perHostTasks.flatMap(_.taskHost).toSet
-      val taskHostsInOriginalOrder = resourceLookup.hosts.all.filter(h => taskHosts.contains(h.copy(connectAs = None)))
-    val groupedHosts = taskHostsInOriginalOrder.transposeBy(_.tags.getOrElse("group",""))
-    val sortedPerHostTasks = perHostTasks.toList.sortBy(t =>
-      t.taskHost.map(h => groupedHosts.indexOf(h.copy(connectAs = None))).getOrElse(-1)
-    )
-
-    RecipeTasks(recipe, tasksToRunBeforeApp, sortedPerHostTasks)
-  }
 
     for {
       tasks <- {
     val resources = DeploymentResources(deployReporter, resourceLookup, artifactClient)
     val target = DeployTarget(parameters, stack)
         val resolvedTree = resolveTree(parameters.recipe.name, resources, target)
-        val filteredTree = resolvedTree.disable(_.invalid)
-        filteredTree.toList.distinct
+        resolvedTree.toList.distinct
   }
     } yield tasks
   }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
@@ -27,7 +27,7 @@ object AmiCloudFormationParameter extends DeploymentType {
     documentation = "The CloudFormation parameter name for the AMI"
   ).default("AMI")
 
-  override def perAppActions = {
+  override def actions = {
     case "update" => pkg => (resources, target) => {
       implicit val keyRing = resources.assembleKeyring(target, pkg)
 

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -84,7 +84,7 @@ object AutoScaling  extends DeploymentType with S3AclParams {
     documentation = "Whether to prefix `stack` to the S3 location"
   ).default(true)
 
-  def perAppActions = {
+  def actions = {
     case "deploy" => (pkg) => (resources, target) => {
       implicit val keyRing = resources.assembleKeyring(target, pkg)
       val parameters = target.parameters

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -60,7 +60,7 @@ object CloudFormation extends DeploymentType {
     documentation = "The CloudFormation parameter name for the AMI"
   ).default("AMI")
 
-  override def perAppActions = {
+  override def actions = {
     case "updateStack" => pkg => (resources, target) => {
       implicit val keyRing = resources.assembleKeyring(target, pkg)
       implicit val artifactClient = resources.artifactClient

--- a/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
@@ -17,7 +17,7 @@ object ElasticSearch extends DeploymentType with S3AclParams {
       | (also used as the wait time for the instance termination)"""
   ).default(15 * 60)
 
-  def perAppActions = {
+  def actions = {
     case "deploy" => (pkg) => (resources, target) => {
       implicit val keyRing = resources.assembleKeyring(target, pkg)
       val parameters = target.parameters

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Fastly.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Fastly.scala
@@ -9,7 +9,7 @@ object Fastly  extends DeploymentType {
       |Deploy a new set of VCL configuration files to the [fastly](http://www.fastly.com/) CDN via the fastly API.
     """.stripMargin
 
-  def perAppActions = {
+  def actions = {
     case "deploy" => pkg => (resources, target) => {
       implicit val keyRing = resources.assembleKeyring(target, pkg)
       implicit val artifactClient = resources.artifactClient

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -84,7 +84,7 @@ object Lambda extends DeploymentType  {
     List(stack.nameOption, Some(params.stage.name), Some(pkg.name), Some(fileName)).flatten.mkString("/")
   }
 
-  def perAppActions = {
+  def actions = {
     case "uploadLambda" => (pkg) => (resources, target) => {
       implicit val keyRing = resources.assembleKeyring(target, pkg)
       implicit val artifactClient = resources.artifactClient

--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
@@ -108,7 +108,7 @@ object S3 extends DeploymentType with S3AclParams {
     }
   }
 
-  def perAppActions = {
+  def actions = {
     case "uploadStaticFiles" => (pkg) => (resources, target) => {
       def resourceLookupFor(resource: Param[String]): Option[Datum] = {
         resource.get(pkg).flatMap { resourceName =>

--- a/magenta-lib/src/main/scala/magenta/json/JsonInputFile.scala
+++ b/magenta-lib/src/main/scala/magenta/json/JsonInputFile.scala
@@ -33,7 +33,6 @@ case class JsonPackage(
 case class JsonRecipe(
   actionsBeforeApp: List[String] = Nil,
   actionsPerHost: List[String] = Nil,
-  @deprecated(message = "only here for backwards compatibility - use 'actionsPerHost'", since = "1.0")
   actions: List[String] = Nil,
   depends: List[String] = Nil
 ) {
@@ -71,8 +70,7 @@ object JsonReader {
 
     Recipe(
       name = name,
-      actionsBeforeApp = jsonRecipe.actionsBeforeApp map parseAction,
-      actionsPerHost = (jsonRecipe.actionsPerHost ++ jsonRecipe.actions) map parseAction,
+      actions = (jsonRecipe.actionsBeforeApp ++ jsonRecipe.actionsPerHost ++ jsonRecipe.actions) map parseAction,
       dependsOn = jsonRecipe.depends
     )
   }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -26,7 +26,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
 
     val p = DeploymentPackage("app", app, data, "asg-elb", S3Package("artifact-bucket", "test/123/app"))
 
-    AutoScaling.perAppActions("deploy")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack)) should be (List(
+    AutoScaling.actions("deploy")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack)) should be (List(
       CheckForStabilization(p, PROD, UnnamedStack),
       CheckGroupSize(p, PROD, UnnamedStack),
       SuspendAlarmNotifications(p, PROD, UnnamedStack),
@@ -53,7 +53,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
 
     val p = DeploymentPackage("app", app, data, "asg-elb", S3Package("artifact-bucket", "test/123/app"))
 
-    AutoScaling.perAppActions("deploy")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack)) should be (List(
+    AutoScaling.actions("deploy")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack)) should be (List(
       CheckForStabilization(p, PROD, UnnamedStack),
       CheckGroupSize(p, PROD, UnnamedStack),
       SuspendAlarmNotifications(p, PROD, UnnamedStack),

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -26,7 +26,7 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
     val cfnStackName = s"cfn-app-PROD"
     val p = DeploymentPackage("app", app, data, "cloudformation", S3Package("artifact-bucket", "test/123"))
 
-    inside(CloudFormation.perAppActions("updateStack")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), stack))) {
+    inside(CloudFormation.actions("updateStack")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), stack))) {
       case List(updateTask, checkTask) =>
         inside(updateTask) {
           case UpdateCloudFormationTask(stackName, path, userParams, amiParam, amiTags, _, stage, stack, ifAbsent) =>

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -32,7 +32,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package)
 
     val thrown = the[NoSuchElementException] thrownBy {
-      S3.perAppActions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)) should be (
+      S3.actions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)) should be (
         List(S3Upload(
           "bucket-1234",
           Seq(sourceS3Package -> "CODE/myapp"),
@@ -53,7 +53,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
 
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package)
 
-    S3.perAppActions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)) should be (
+    S3.actions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)) should be (
       List(S3Upload(
         "bucket-1234",
         Seq(sourceS3Package -> "CODE/myapp"),
@@ -74,7 +74,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
 
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package)
 
-    inside(S3.perAppActions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)).head) {
+    inside(S3.actions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)).head) {
       case upload: S3Upload => upload.cacheControlPatterns should be(List(PatternValue("^sub", "no-cache"), PatternValue(".*", "public; max-age:3600")))
     }
   }
@@ -92,7 +92,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
 
     val lookup = stubLookup(List(Host("the_host", stage=CODE.name).app(app1)), Map("s3-path-prefix" -> Seq(Datum(None, app1.name, CODE.name, "testing/2016/05/brexit-companion", None))))
 
-    inside(S3.perAppActions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookup, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)).head) {
+    inside(S3.actions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookup, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)).head) {
       case upload: S3Upload => upload.paths should be(Seq(sourceS3Package -> "testing/2016/05/brexit-companion"))
     }
   }
@@ -109,7 +109,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
 
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-lambda", S3Package("artifact-bucket", "test/123"))
 
-    Lambda.perAppActions("updateLambda")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)) should be (
+    Lambda.actions("updateLambda")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)) should be (
       List(UpdateLambda(S3Path("artifact-bucket","test/123/lambda.zip"), "myLambda")
       ))
   }
@@ -126,7 +126,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
     val p = DeploymentPackage("myapp", Seq.empty, badData, "aws-lambda", S3Package("artifact-bucket", "test/123"))
 
     val thrown = the[FailException] thrownBy {
-      Lambda.perAppActions("updateLambda")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)) should be (
+      Lambda.actions("updateLambda")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)) should be (
         List(UpdateLambda(S3Path("artifact-bucket","test/123/lambda.zip"), "myLambda")
         ))
     }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
@@ -30,7 +30,7 @@ class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
   val pkg = DeploymentPackage("lambda", app, data, "aws-s3-lambda", S3Package("artifact-bucket", "test/123/lambda"))
 
   it should "produce an S3 upload task" in {
-    val tasks = Lambda.perAppActions("uploadLambda")(pkg)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("test")))
+    val tasks = Lambda.actions("uploadLambda")(pkg)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("test")))
     tasks should be (List(
       S3Upload(
         bucket = "lambda-bucket",
@@ -40,7 +40,7 @@ class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
   }
 
   it should "produce a lambda update task" in {
-    val tasks = Lambda.perAppActions("updateLambda")(pkg)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("test")))
+    val tasks = Lambda.actions("updateLambda")(pkg)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("test")))
     tasks should be (List(
       UpdateS3Lambda(
         functionName = "MyFunction-PROD",
@@ -60,7 +60,7 @@ class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
     val app = Seq(App("lambda"))
     val pkg = DeploymentPackage("lambda", app, dataWithStack, "aws-s3-lambda", S3Package("artifact-bucket", "test/123/lambda"))
 
-    val tasks = Lambda.perAppActions("updateLambda")(pkg)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("some-stack")))
+    val tasks = Lambda.actions("updateLambda")(pkg)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("some-stack")))
     tasks should be (List(
       UpdateS3Lambda(
         functionName = "some-stackMyFunction-PROD",

--- a/magenta-lib/src/test/scala/magenta/fixtures/fixtures.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/fixtures.scala
@@ -19,9 +19,7 @@ case class StubPerAppAction(description: String, apps: Seq[App]) extends Action 
 }
 
 case class StubDeploymentType(
-  override val perHostActions:
-    PartialFunction[String, DeploymentPackage => (DeployReporter, Host, KeyRing) => List[Task]] = Map.empty,
-  override val perAppActions:
+  override val actions:
     PartialFunction[String, DeploymentPackage => (DeploymentResources, DeployTarget) => List[Task]] = Map.empty
                             ) extends DeploymentType {
   def name = "stub-package-type"

--- a/magenta-lib/src/test/scala/magenta/fixtures/package.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/package.scala
@@ -12,11 +12,10 @@ package object fixtures {
 
   val lookupSingleHost = stubLookup(List(Host("the_host", stage=CODE.name).app(app1)))
 
-  val basePackageType = stubPackageType(Seq("init_action_one"), Seq("action_one"))
+  val basePackageType = stubPackageType(Seq("init_action_one"))
 
   val baseRecipe = Recipe("one",
-    actionsBeforeApp = basePackageType.mkAction("init_action_one")(stubPackage) :: Nil,
-    actionsPerHost = basePackageType.mkAction("action_one")(stubPackage) :: Nil,
+    actions = basePackageType.mkAction("init_action_one")(stubPackage) :: Nil,
     dependsOn = Nil)
 
   def project(recipes: Recipe*) = Project(Map.empty, recipes.map(r => r.name -> r).toMap)
@@ -25,13 +24,12 @@ package object fixtures {
 
   def stubPackage = DeploymentPackage("stub project", Seq(app1), Map(), "stub-package-type", null)
 
-  def stubPackageType(perAppActionNames: Seq[String], perHostActionNames: Seq[String]) = StubDeploymentType(
-    perAppActions = {
-      case name if perAppActionNames.contains(name) => pkg => (_, _) => List(StubTask(name + " per app task"))
-    },
-    perHostActions = {
-      case name if perHostActionNames.contains(name) => pkg => (_, host, _) =>
-        List(StubTask(name + " per host task on " + host.name, Some(host)))
+  def stubPackageType(actionNames: Seq[String]) = StubDeploymentType(
+    actions = {
+      case name if actionNames.contains(name) => pkg => (_, _) => List(
+        StubTask(name + " per app task number one"),
+        StubTask(name + " per app task number two")
+      )
     }
   )
 

--- a/magenta-lib/src/test/scala/magenta/json/JsonReaderTest.scala
+++ b/magenta-lib/src/test/scala/magenta/json/JsonReaderTest.scala
@@ -75,12 +75,11 @@ class JsonReaderTest extends FlatSpec with Matchers {
 
     val recipes = parsed.recipes
     recipes.size should be (4)
-    recipes("all") should be (Recipe("all", Nil, Nil, List("index-build-only", "api-only")))
+    recipes("all") should be (Recipe("all", Nil, List("index-build-only", "api-only")))
 
     val apiCounterRecipe = recipes("api-counter-only")
 
-    apiCounterRecipe.actionsPerHost.toSeq.length should be (2)
-    apiCounterRecipe.actionsBeforeApp.toSeq.length should be (2)
+    apiCounterRecipe.actions.toSeq.length should be (4)
   }
 
   val minimalExample = """
@@ -111,7 +110,7 @@ class JsonReaderTest extends FlatSpec with Matchers {
 
     val recipes = parsed.recipes
     recipes.size should be(1)
-    recipes("default") should be (Recipe("default", actionsPerHost = parsed.packages.values.map(_.mkAction("deploy"))))
+    recipes("default") should be (Recipe("default", actions   = parsed.packages.values.map(_.mkAction("deploy"))))
   }
 
   "json parser" should "default to using the package name for the file name" in {

--- a/riff-raff/app/views/deploy/previewContent.scala.html
+++ b/riff-raff/app/views/deploy/previewContent.scala.html
@@ -5,15 +5,9 @@
     @CSRF.formField
     <table class="table table-hover">
         <tbody>
-        @preview.recipeTasks.filterNot(rt => rt.recipe.actionsBeforeApp.isEmpty && rt.recipe.actionsPerHost.isEmpty).map { recipeTasks =>
+        @preview.recipeTasks.filterNot(rt => rt.recipe.actions.isEmpty).map { recipeTasks =>
             <tr>
                 <td><span class="no-hyphenation">@recipeTasks.recipeName</span></td>
-                @if(recipeTasks.disabled) {
-                  <td colspan="2"><div><em>
-                      This recipe has been disabled.  This is because there are no valid hosts available for per-host
-                      tasks specified in this recipe or a recipe that depends on this.
-                  </em></div></td>
-                } else {
                 <td>
                         @if(recipeTasks.hosts.isEmpty) {
                             <div><em>No hosts</em></div>
@@ -32,7 +26,6 @@
                     }
                 </ul>
                 </td>
-                }
             </tr>
         }
         </tbody>


### PR DESCRIPTION
Per-host actions are barely used anymore so this removes the concept from the codebase.

The single remaining place this was used was for Riff-Raff's own self-deployment mechanism which has been re-written to do the host lookup within the deployment type.