### PR TITLE
Fix post deploy hooks

### DIFF
--- a/riff-raff/app/AppLoader.scala
+++ b/riff-raff/app/AppLoader.scala
@@ -1,12 +1,12 @@
-import play.api.{Application, ApplicationLoader, Logger}
-import play.api.ApplicationLoader.Context
+import ci.Builds
+import com.gu.management.play.InternalManagementServerImpl
+import conf.DeployMetrics
+import deployment.Deployments
 import lifecycle.ShutdownWhenInactive
 import notification.HooksClient
 import persistence.SummariseDeploysHousekeeping
-import ci.{Builds, ContinuousDeployment}
-import com.gu.management.play.{InternalManagementServer, InternalManagementServerImpl}
-import conf.DeployMetrics
-import deployment.Deployments
+import play.api.ApplicationLoader.Context
+import play.api.{Application, ApplicationLoader, Logger}
 import utils.ScheduledAgent
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -17,11 +17,13 @@ class AppLoader extends ApplicationLoader {
   override def load(context: Context): Application = {
     val components = new AppComponents(context)
 
+    val hooksClient = new HooksClient(components.wsClient)
+
     val lifecycleSingletons = Seq(
       ScheduledAgent,
       Deployments,
       DeployMetrics,
-      HooksClient,
+      hooksClient,
       Builds,
       SummariseDeploysHousekeeping,
       components.continuousDeployment,

--- a/riff-raff/app/ci/Builds.scala
+++ b/riff-raff/app/ci/Builds.scala
@@ -3,10 +3,10 @@ package ci
 import akka.agent.Agent
 import ci.Context._
 import controllers.Logging
-import lifecycle.LifecycleWithoutApp
+import lifecycle.Lifecycle
 import rx.lang.scala.Subscription
 
-object Builds extends LifecycleWithoutApp with Logging {
+object Builds extends Lifecycle with Logging {
 
   private var subscriptions = Seq.empty[Subscription]
 

--- a/riff-raff/app/ci/ContinuousDeployment.scala
+++ b/riff-raff/app/ci/ContinuousDeployment.scala
@@ -2,7 +2,7 @@ package ci
 
 import controllers.Logging
 import deployment.Deployments
-import lifecycle.LifecycleWithoutApp
+import lifecycle.Lifecycle
 import magenta.{DeployParameters, Deployer, RecipeName, Stage, Build => MagentaBuild}
 import persistence.ContinuousDeploymentConfigRepository.getContinuousDeploymentList
 import rx.lang.scala.{Observable, Subscription}
@@ -11,7 +11,7 @@ import utils.ChangeFreeze
 import scala.util.{Failure, Try}
 import scala.util.control.NonFatal
 
-class ContinuousDeployment(deployments: Deployments) extends LifecycleWithoutApp with Logging {
+class ContinuousDeployment(deployments: Deployments) extends Lifecycle with Logging {
   import ContinuousDeployment._
 
   var sub: Option[Subscription] = None

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -9,7 +9,7 @@ import com.gu.management.play.{Management => PlayManagement}
 import com.gu.conf.ConfigurationFactory
 import magenta._
 import controllers.{Logging, routes}
-import lifecycle.{LifecycleWithoutApp, ShutdownWhenInactive}
+import lifecycle.{Lifecycle, ShutdownWhenInactive}
 import java.util.UUID
 
 import com.amazonaws.ClientConfiguration
@@ -216,7 +216,7 @@ class BuildInfoPage extends ManagementPage {
 
 object PlayRequestMetrics extends com.gu.management.play.RequestMetrics.Standard
 
-object DeployMetrics extends LifecycleWithoutApp {
+object DeployMetrics extends Lifecycle {
   val runningDeploys = mutable.Buffer[UUID]()
 
   object DeployStart extends CountMetric("riffraff", "start_deploy", "Start deploy", "Number of deploys that are kicked off")

--- a/riff-raff/app/deployment/Deployments.scala
+++ b/riff-raff/app/deployment/Deployments.scala
@@ -72,6 +72,7 @@ object Deployments extends Logging with Lifecycle {
 
   /**
     * Attempt to disable deploys from running.
+ *
     * @return true if successful and false if this failed because a deploy was currently running
     */
   def atomicDisableDeploys:Boolean = {

--- a/riff-raff/app/deployment/Deployments.scala
+++ b/riff-raff/app/deployment/Deployments.scala
@@ -8,7 +8,7 @@ import akka.util.Switch
 import ci._
 import com.gu.management.DefaultSwitch
 import controllers.Logging
-import lifecycle.LifecycleWithoutApp
+import lifecycle.Lifecycle
 import magenta._
 import persistence.DocumentStoreConverter
 import play.api.libs.concurrent.Execution.Implicits._
@@ -51,7 +51,7 @@ class Deployments(deploymentEngine: DeploymentEngine) extends Logging {
 
 }
 
-object Deployments extends Logging with LifecycleWithoutApp {
+object Deployments extends Logging with Lifecycle {
   lazy val completed: Observable[UUID] = deployCompleteSubject
   private lazy val deployCompleteSubject = Subject[UUID]()
 

--- a/riff-raff/app/lifecycle/Lifecycle.scala
+++ b/riff-raff/app/lifecycle/Lifecycle.scala
@@ -1,20 +1,11 @@
 package lifecycle
 
-import play.api.Application
-
 /**
  * Any objects with this trait mixed in will automatically get
  * instantiated and lifecycled.  init() called by the Global
  * onStart() and shutdown called by onStop().
  */
 trait Lifecycle {
-  def init(app: Application)
-  def shutdown(app: Application)
-}
-
-trait LifecycleWithoutApp extends Lifecycle {
-  def init(app:Application) {init()}
-  def shutdown(app:Application) {shutdown()}
   def init()
   def shutdown()
 }

--- a/riff-raff/app/lifecycle/ShutdownWhenInactive.scala
+++ b/riff-raff/app/lifecycle/ShutdownWhenInactive.scala
@@ -7,7 +7,7 @@ import deployment.Deployments
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
 
-object ShutdownWhenInactive extends LifecycleWithoutApp with Logging {
+object ShutdownWhenInactive extends Lifecycle with Logging {
   val EXITCODE = 217
 
   // switch to enable this mode

--- a/riff-raff/app/notification/hooks.scala
+++ b/riff-raff/app/notification/hooks.scala
@@ -6,7 +6,7 @@ import java.util.UUID
 import akka.actor.{Actor, ActorSystem, Props}
 import com.mongodb.casbah.commons.MongoDBObject
 import controllers.Logging
-import lifecycle.LifecycleWithoutApp
+import lifecycle.Lifecycle
 import magenta.{Deploy, DeployParameters, FinishContext, _}
 import org.joda.time.DateTime
 import persistence.{DeployRecordDocument, HookConfigRepository, MongoFormat, MongoSerialisable, Persistence}
@@ -85,7 +85,7 @@ object HookConfig {
     HookConfig(UUID.randomUUID(), projectName, stage, url, enabled, new DateTime(), updatedBy)
 }
 
-object HooksClient extends LifecycleWithoutApp with Logging {
+object HooksClient extends Lifecycle with Logging {
   trait Event
   case class Finished(uuid: UUID, params: DeployParameters)
 

--- a/riff-raff/app/notification/hooks.scala
+++ b/riff-raff/app/notification/hooks.scala
@@ -92,7 +92,11 @@ object HooksClient extends LifecycleWithoutApp with Logging {
   lazy val system = ActorSystem("notify")
   val actor = try {
     Some(system.actorOf(Props[HooksClient], "hook-client"))
-  } catch { case t:Throwable => None }
+  } catch {
+    case t:Throwable =>
+      log.error("Failed to start HookClient", t)
+      None
+  }
 
   def finishedBuild(uuid: UUID, parameters: DeployParameters) {
     actor.foreach(_ ! Finished(uuid, parameters))

--- a/riff-raff/app/persistence/housekeeping.scala
+++ b/riff-raff/app/persistence/housekeeping.scala
@@ -1,13 +1,13 @@
 package persistence
 
-import lifecycle.LifecycleWithoutApp
+import lifecycle.Lifecycle
 import conf.Configuration.housekeeping
 import org.joda.time.{LocalDate, LocalTime}
 import persistence.Persistence.store
 import utils.{DailyScheduledAgentUpdate, ScheduledAgent}
 import controllers.Logging
 
-object SummariseDeploysHousekeeping extends LifecycleWithoutApp with Logging {
+object SummariseDeploysHousekeeping extends Lifecycle with Logging {
   lazy val maxAgeDays = housekeeping.summariseDeploysAfterDays
   lazy val housekeepingTime = new LocalTime(housekeeping.hour, housekeeping.minute)
 

--- a/riff-raff/app/utils/ScheduledAgent.scala
+++ b/riff-raff/app/utils/ScheduledAgent.scala
@@ -3,11 +3,11 @@ package utils
 import akka.actor.{Cancellable, ActorSystem}
 import akka.agent.Agent
 import controllers.Logging
-import lifecycle.LifecycleWithoutApp
+import lifecycle.Lifecycle
 import scala.concurrent.duration._
 import org.joda.time.{DateTime, Interval, LocalDate, LocalTime}
 
-object ScheduledAgent extends LifecycleWithoutApp {
+object ScheduledAgent extends Lifecycle {
   val scheduleSystem = ActorSystem("scheduled-agent")
 
   def apply[T](initialDelay: FiniteDuration, frequency: FiniteDuration)(block: => T): ScheduledAgent[T] = {


### PR DESCRIPTION
A couple of problems have combined to mean that post deploy hooks haven't been working for a while.
 - Some actor wiring was slightly off since the Play 2.5 upgrade
 - The role permissions needed to grant access to the index - done in https://github.com/guardian/deploy-tools-platform/pull/46

I've also tidied up the `Lifecycle` traits.