### PR TITLE
Add the ability to deploy lambda cross-regions

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -4,6 +4,7 @@ import java.nio.ByteBuffer
 
 import com.amazonaws._
 import com.amazonaws.auth.{AWSCredentialsProvider, AWSCredentialsProviderChain, BasicAWSCredentials}
+import com.amazonaws.regions.Region
 import com.amazonaws.retry.{PredefinedRetryPolicies, RetryPolicy}
 import com.amazonaws.services.autoscaling.AmazonAutoScalingClient
 import com.amazonaws.services.autoscaling.model.{Instance => ASGInstance, _}
@@ -18,15 +19,16 @@ import magenta.{App, DeployReporter, DeploymentPackage, KeyRing, NamedStack, Sta
 
 import scala.collection.JavaConversions._
 
+
 trait S3 extends AWS {
   def s3client(keyRing: KeyRing, config: ClientConfiguration = clientConfiguration) =
     new AmazonS3Client(provider(keyRing), config)
 }
 
 trait Lambda extends AWS {
-  def lambdaClient(implicit keyRing: KeyRing) = {
+  def lambdaClient(region: Region)(implicit keyRing: KeyRing) = {
     val client = new AWSLambdaClient(provider(keyRing), clientConfiguration)
-    client.setEndpoint("lambda.eu-west-1.amazonaws.com")
+    client.withRegion(region)
     client
   }
 

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -4,6 +4,7 @@ import java.io.File
 import java.util.UUID
 
 import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.regions.{Region, Regions}
 import magenta.artifact.{S3Package, S3Path}
 import magenta.deployment_type.{Lambda, PatternValue, S3}
 import magenta.fixtures._
@@ -23,6 +24,8 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
   }
 
   private val sourceS3Package = S3Package("artifact-bucket", "test/123/static-files")
+
+  private val defaultRegion = Region.getRegion(Regions.fromName("eu-west-1"))
 
   it should "throw a NoSuchElementException if a required parameter is missing" in {
     val data: Map[String, JValue] = Map(
@@ -110,7 +113,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-lambda", S3Package("artifact-bucket", "test/123"))
 
     Lambda.actions("updateLambda")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)) should be (
-      List(UpdateLambda(S3Path("artifact-bucket","test/123/lambda.zip"), "myLambda")
+      List(UpdateLambda(S3Path("artifact-bucket","test/123/lambda.zip"), "myLambda", defaultRegion)
       ))
   }
 
@@ -127,7 +130,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
 
     val thrown = the[FailException] thrownBy {
       Lambda.actions("updateLambda")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)) should be (
-        List(UpdateLambda(S3Path("artifact-bucket","test/123/lambda.zip"), "myLambda")
+        List(UpdateLambda(S3Path("artifact-bucket","test/123/lambda.zip"), "myLambda", defaultRegion)
         ))
     }
 


### PR DESCRIPTION
The associated changes add the capability to deploy a lambda in multiple regions which can be specified in the deployment configuration file.

If not provided, `eu-west-1` region (the current default) is used.  