### PR TITLE
Build a deployment graph from a list of deployments

### DIFF
--- a/magenta-lib/src/main/scala/magenta/graph/DeploymentGraph.scala
+++ b/magenta-lib/src/main/scala/magenta/graph/DeploymentGraph.scala
@@ -6,7 +6,7 @@ case class DeploymentTasks(tasks: List[Task], name: String)
 
 object DeploymentGraph {
   def apply(tasks: List[Task], name: String, priority: Int = 1): Graph[DeploymentTasks] = {
-    val deploymentNode = MidNode(DeploymentTasks(tasks, name))
+    val deploymentNode = ValueNode(DeploymentTasks(tasks, name))
     Graph(StartNode ~> deploymentNode, deploymentNode ~> EndNode)
   }
 

--- a/magenta-lib/src/main/scala/magenta/graph/Graph.scala
+++ b/magenta-lib/src/main/scala/magenta/graph/Graph.scala
@@ -22,9 +22,12 @@ case class Edge[+T](from: Node[T], to: Node[T], priority: Int = 1) {
 object Graph {
   def apply[T](edges: Edge[T]*): Graph[T] = Graph(edges.toSet)
 
-  def apply[T](singleton: T): Graph[T] = Graph(StartNode ~> MidNode(singleton), MidNode(singleton) ~> EndNode)
+  def apply[T](singleton: T): Graph[T] = {
+    val node = MidNode(singleton)
+    Graph(StartNode ~> node, node ~> EndNode)
+  }
 
-  def from[T](values: T*): Graph[T] = {
+  def from[T](values: Seq[T]): Graph[T] = {
     val nodes: Seq[Node[T]] = StartNode +: values.map(MidNode.apply) :+ EndNode
     val edges = nodes.sliding(2).map{ window => window.head ~> window.tail.head }.toSet
     Graph(edges)
@@ -101,10 +104,10 @@ case class Graph[T](edges: Set[Edge[T]]) {
     * End or Mid nodes with multiple nodes. The incoming and outgoing edges of each node of this graph will be replaced
     * by edges that map to the start and end nodes of the graph returned from f.
     *
-    * An identity mapping for flatMap would be start and end nodes to empty map and mid nodes to a single value graph
+    * An identity mapping for flatMap would be start and end nodes to empty graph and mid nodes to a single value graph
     * containing the value of the node.
     *
-    * It is not possible to map a mid node to an empty node.
+    * It is not possible to map a mid node to an empty graph.
     * @param f the function to apply to each element
     * @return a new graph with the graphs substituted
     */

--- a/magenta-lib/src/main/scala/magenta/graph/Graph.scala
+++ b/magenta-lib/src/main/scala/magenta/graph/Graph.scala
@@ -2,6 +2,7 @@ package magenta.graph
 
 sealed trait Node[+T] {
   def ~>[R >: T](to: Node[R]): Edge[R] = Edge(this, to)
+  def ~[R >: T](priority: Int): EdgeBuilder[R] = EdgeBuilder(this, priority)
   def maybeValue: Option[T] = None
 }
 case object StartNode extends Node[Nothing]
@@ -10,21 +11,50 @@ case class MidNode[T](value: T) extends Node[T] {
 }
 case object EndNode extends Node[Nothing]
 
+case class EdgeBuilder[+T](from: Node[T], priority: Int) {
+  def ~>[R >: T](to: Node[R]): Edge[R] = Edge(from, to, priority)
+}
+
 case class Edge[+T](from: Node[T], to: Node[T], priority: Int = 1) {
-  def incPriority(n: Int) = this.copy(priority = priority + n)
   def ~=[R >: T](other: Edge[R]) = from == other.from && to == other.to
 }
 
 object Graph {
   def apply[T](edges: Edge[T]*): Graph[T] = Graph(edges.toSet)
 
+  def apply[T](singleton: T): Graph[T] = Graph(StartNode ~> MidNode(singleton), MidNode(singleton) ~> EndNode)
+
+  def from[T](values: T*): Graph[T] = {
+    val nodes: Seq[Node[T]] = StartNode +: values.map(MidNode.apply) :+ EndNode
+    val edges = nodes.sliding(2).map{ window => window.head ~> window.tail.head }.toSet
+    Graph(edges)
+  }
+
   def empty[T] = Graph[T](StartNode ~> EndNode)
+
+  /**
+    * Generate the set of edges that are needed to join the end of the from graph to the start of the to graph
+ *
+    * @param from The graph whose end you wish to join
+    * @param to The graph whose start you wish to join
+    * @return Set of joining edges that would join these two graphs together
+    */
+  private[graph] def joiningEdges[R](from: Graph[R], to: Graph[R]): Set[Edge[R]] = {
+    val fromEndEdges = from.incoming(EndNode)
+    val toStartEdges = to.orderedOutgoing(StartNode)
+    fromEndEdges.foldLeft(Set.empty[Edge[R]]) { case (acc, endEdge) =>
+      val existing = from.orderedOutgoing(endEdge.from)
+      val targetEdges = toStartEdges.map(startEdge => Edge(endEdge.from, startEdge.to))
+      val replacement = existing.replace(endEdge, targetEdges).reprioritise
+      acc -- existing ++ replacement
+    }
+  }
 }
 
 case class Graph[T](edges: Set[Edge[T]]) {
   val nodes = edges.map(_.from) ++ edges.map(_.to)
-  val underlyingNodes = nodes.flatMap(_.maybeValue)
-  val dataNodes = nodes.filterMidNodes
+  private val underlyingNodes = nodes.flatMap(_.maybeValue)
+  private val dataNodes = nodes.filterMidNodes
 
   val isValid: Either[List[String], Boolean] = {
     val errors =
@@ -66,6 +96,50 @@ case class Graph[T](edges: Set[Edge[T]]) {
     Graph(newEdges)
   }
 
+  /**
+    * Flat map keeps the shape of this graph whilst mapping each node to a graph. This means one can replace the Start,
+    * End or Mid nodes with multiple nodes. The incoming and outgoing edges of each node of this graph will be replaced
+    * by edges that map to the start and end nodes of the graph returned from f.
+    *
+    * An identity mapping for flatMap would be start and end nodes to empty map and mid nodes to a single value graph
+    * containing the value of the node.
+    *
+    * It is not possible to map a mid node to an empty node.
+    * @param f the function to apply to each element
+    * @return a new graph with the graphs substituted
+    */
+  def flatMap[R](f: Node[T] => Graph[R]): Graph[R] = {
+    val nodeToGraphMap: Map[Node[T], Graph[R]] = nodes.map(n => n -> f(n)).toMap
+    // find all of the edges that we won't adjoin to another graph
+    val allInternalEdges = nodeToGraphMap.flatMap{
+      case (StartNode, graph) => graph.edges -- graph.incoming(EndNode)
+      case (MidNode(_), graph) =>
+        assert(!graph.isEmpty, "It is not possible to flatMap a MidNode to an empty graph")
+        graph.edges -- graph.incoming(EndNode) -- graph.outgoing(StartNode)
+      case (EndNode, graph) => graph.edges -- graph.outgoing(StartNode)
+    }.toSet
+
+    // sort the edges by priority - this means we can re-calculate the priorities correctly
+    val joiningEdges = edges.toList.sortBy(_.priority)
+      .foldLeft(Set.empty[Edge[R]]) { case(acc, oldEdge) =>
+
+      val fromGraph = nodeToGraphMap(oldEdge.from)
+      val toGraph = nodeToGraphMap(oldEdge.to)
+      // get the joining edges
+      val newEdges = Graph.joiningEdges(fromGraph, toGraph)
+        // deduplicate any edges that we've already generated
+        .filterNot(e1 => acc.exists(e1 ~= _))
+        // fix up the priorities
+        .map{ newEdge =>
+          val maxPriority = acc.filter(_.from == newEdge.from).map(_.priority).reduceOption(Math.max).getOrElse(0)
+          newEdge.copy(priority = newEdge.priority + maxPriority)
+        }
+      acc ++ newEdges
+    }
+
+    Graph(allInternalEdges ++ joiningEdges)
+  }
+
   def joinParallel(other: Graph[T]): Graph[T] = {
     if (other.isEmpty) this
     else if (isEmpty) other
@@ -79,17 +153,10 @@ case class Graph[T](edges: Set[Edge[T]]) {
     }
   }
 
-  def joinSeries(other: Graph[T]): Graph[T] = {
-    val ourEndEdges = incoming(EndNode)
-    val otherStartEdges = other.orderedOutgoing(StartNode)
-    val joiningEdges = ourEndEdges.foldLeft(edges) { case (acc, endEdge) =>
-      val existing = orderedOutgoing(endEdge.from)
-      val targetEdges = otherStartEdges.map(startEdge => Edge(endEdge.from, startEdge.to))
-      val replacement = existing.replace(endEdge, targetEdges).reprioritise
-      acc -- existing ++ replacement
-    }
-    val mergedEdges = joiningEdges ++ (other.edges -- otherStartEdges)
-    Graph(mergedEdges)
+  def joinSeries(other: Graph[T]): Graph[T] = flatMap {
+    case StartNode => Graph.empty
+    case MidNode(value) => Graph(value)
+    case EndNode => other
   }
 
   lazy val nodeList: List[Node[T]] = {
@@ -113,13 +180,17 @@ case class Graph[T](edges: Set[Edge[T]]) {
   lazy val toList: List[T] = nodeList.flatMap(_.maybeValue)
 
   override def toString: String = {
-    val nodeNumbers = nodeList.zipWithIndex
-    val nodeNumberMap = nodeNumbers.toMap
+    val identifiers = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+    val nodeNumbers = (nodeList ::: (nodes -- nodeList).toList).zipWithIndex
+    val nodeNumberMap: Map[Node[T], String] = nodeNumbers.toMap.mapValues{
+      case index if index < identifiers.length => identifiers(index).toString
+      case index => (index - identifiers.length).toString
+    }
     val numberedEdges = edges.toList.map { case Edge(from, to, priority) =>
       (nodeNumberMap(from), priority, nodeNumberMap(to))
     }.sorted
-    val edgeList = numberedEdges.map{ case (f, p, t) => s"$f --($p)--> $t"}
-    val nodeNumberList = nodeNumbers.map{case(n, i) => s"$i: $n"}
+    val edgeList = numberedEdges.map{ case (f, p, t) => s"$f ~$p~> $t"}
+    val nodeNumberList = nodeNumbers.map{case(n, i) => s"${nodeNumberMap(n)}: $n"}
     s"Graph(nodes: ${nodeNumberList.mkString("; ")} edges: ${edgeList.mkString(", ")}"
   }
 }

--- a/magenta-lib/src/main/scala/magenta/graph/Graph.scala
+++ b/magenta-lib/src/main/scala/magenta/graph/Graph.scala
@@ -1,43 +1,98 @@
 package magenta.graph
 
+/** A Node corresponds to a node in a graph that can be joined by edges
+  *
+  * @tparam T The type of the underlying values held by a graph
+  */
 sealed trait Node[+T] {
   def ~>[R >: T](to: Node[R]): Edge[R] = Edge(this, to)
   def ~[R >: T](priority: Int): EdgeBuilder[R] = EdgeBuilder(this, priority)
+
+  /** Returns the underlying value for this node.
+    *
+    * @return Returns Some(value) or None if this node has no underlying value.
+    */
   def maybeValue: Option[T] = None
 }
+
+/** A StartNode indicates the entry point to a graph */
 case object StartNode extends Node[Nothing]
-case class MidNode[T](value: T) extends Node[T] {
+
+/** A ValueNode is a node in a graph that holds a value.
+  *
+  * @param value The underlying value held by this node
+  * @tparam T The type of the underlying values held by a graph
+  */
+case class ValueNode[T](value: T) extends Node[T] {
   override def maybeValue: Option[T] = Some(value)
 }
+
+/** The EndNode indicates the final node in a graph */
 case object EndNode extends Node[Nothing]
 
+/**
+  * EdgeBuilder should not be used directly. It is used (alongside the ~ method in [[magenta.graph.Node]]) to construct
+  * the edge DSL of the form `~3~>` for an edge with priority three.
+  *
+  * @param from The node from which this edgebuilder will build an edge.
+  * @param priority The priority with which this edge builder will build an edge.
+  * @tparam T The type of the underlying values held by a graph.
+  */
 case class EdgeBuilder[+T](from: Node[T], priority: Int) {
   def ~>[R >: T](to: Node[R]): Edge[R] = Edge(from, to, priority)
 }
 
+/**
+  * Represents a directional edge in a graph with an accompanying priority. In the case where there are multiple edges
+  * in a graph which have the same from Node the priority can be used in order to deterministically traverse the graph.
+  *
+  * @param from The start Node of this directional Edge
+  * @param to The finish Node of this directional Edge
+  * @param priority The priority of this Edge
+  * @tparam T The type of the underlying values held by a graph.
+  */
 case class Edge[+T](from: Node[T], to: Node[T], priority: Int = 1) {
   def ~=[R >: T](other: Edge[R]) = from == other.from && to == other.to
 }
 
 object Graph {
+  /** Create a graph using edges provided as var args
+    *
+    * @param edges The edges to build the graph from
+    * @tparam T The type of the underlying values held by a graph.
+    * @return A graph containing the provided edges
+    */
   def apply[T](edges: Edge[T]*): Graph[T] = Graph(edges.toSet)
 
+  /** Constructs a graph with a singleton value.
+    *
+    * @param singleton The singleton value.
+    * @tparam T The type of the underlying value held by this singleton graph.
+    * @return A singleton graph with the structure `StartNode ~> ValueNode(singleton) ~> EndNode`
+    */
   def apply[T](singleton: T): Graph[T] = {
-    val node = MidNode(singleton)
+    val node = ValueNode(singleton)
     Graph(StartNode ~> node, node ~> EndNode)
   }
 
+  /** Constructs a graph containing these values in series. For example - providing the strings `"one"` and `"two"` as
+    * parameters then you'll get a graph such as `StartNode ~> ValueNode("one") ~> ValueNode("two") ~> EndNode`.
+    *
+    * @param values values to construct series graph
+    * @tparam T The type of the underlying values held by a graph.
+    * @return series graph containing the provided values
+    */
   def from[T](values: Seq[T]): Graph[T] = {
-    val nodes: Seq[Node[T]] = StartNode +: values.map(MidNode.apply) :+ EndNode
+    val nodes: Seq[Node[T]] = StartNode +: values.map(ValueNode.apply) :+ EndNode
     val edges = nodes.sliding(2).map{ window => window.head ~> window.tail.head }.toSet
     Graph(edges)
   }
 
+  /** Convenience method to create a graph with no value nodes */
   def empty[T] = Graph[T](StartNode ~> EndNode)
 
-  /**
-    * Generate the set of edges that are needed to join the end of the from graph to the start of the to graph
- *
+  /** Generate the set of edges that are needed to join the end of the from Graph to the start of the to Graph
+    *
     * @param from The graph whose end you wish to join
     * @param to The graph whose start you wish to join
     * @return Set of joining edges that would join these two graphs together
@@ -54,31 +109,133 @@ object Graph {
   }
 }
 
+/** A relatively simple graph implementation with a specific purpose in mind. That is, this is not a general purpose
+  * graph datatype.
+  *
+  * It is designed to allow multiple parts of a deployment to be executed simultaneously. As a datatype it holds only a
+  * set of directional [[magenta.graph.Edge]]s that link two nodes together. A graph does not know directly about
+  * [[magenta.graph.Node]]s. Instead the graph contains the set of all of the nodes that a referenced by all edges.
+  *
+  * The purpose of this graph led to the design having these properties:
+  *  - a unique node only appears once in a graph - merging together two graphs that contain the same unique node will
+  *    result in a single node with additional edges
+  *  - it is possible to traverse all nodes in the graph in a deterministic order
+  *
+  * The following must be true about the structure of a graph and is asserted when a new Graph is created
+  *  - each graph must contain a StartNode and an EndNode
+  *  - no two edges from a single node has the same priority
+  *  - each node in a graph must be reachable by following edges from the StartNode
+  *  - for each node it must possible to follow edges to the EndNode
+  *  - the graph must be acyclic
+  *
+  * @param edges The edges that make up the structure of this graph
+  * @tparam T The type of the underlying values held by a graph.
+  */
 case class Graph[T](edges: Set[Edge[T]]) {
   val nodes = edges.map(_.from) ++ edges.map(_.to)
-  private val underlyingNodes = nodes.flatMap(_.maybeValue)
-  private val dataNodes = nodes.filterMidNodes
+  private val valueNodes = nodes.filterValueNodes
 
-  val isValid: Either[List[String], Boolean] = {
-    val errors =
-      ((if (!nodes.contains(StartNode)) Some("No start node") else None) ::
-        (if (!nodes.contains(EndNode)) Some("No end node") else None) :: Nil).flatten
-    if (errors.isEmpty) Right(true) else Left(errors)
+  /** Error is a utility class for collecting errors */
+  case class Error(messages: List[String]) {
+    var asOption: Option[Error] = if (messages.isEmpty) None else Some(this)
+    def +(other: Error) = Error(messages ::: other.messages)
   }
-  assert(isValid.isRight, s"Graph isn't valid: ${isValid.left.get.mkString(", ")}")
+  private object Error {
+    def apply(message: String): Error = Error(List(message))
+    def apply(isError: => Boolean, message: => String): Error = if (isError) Error(message) else empty
+    val empty = apply(Nil)
+  }
 
-  val isEmpty = dataNodes.isEmpty
+  /** Traverse this graph starting at the StartNode until we reach the EndNode.
+    *
+    * This produces a list of all of the nodes in the graph in a deterministically produced order according to the
+    * priorities on each edge. The traversal starts at the StartNode and then follows each outgoing edge in order until
+    * a node is found that has an incoming edge that has not yet been traversed.
+    *
+    * The result can either be the list of nodes or an Error if we discover that a graph is not acyclic or if there are
+    * nodes that cannot reach the EndNode.
+    */
+  val traverse: Either[Error,List[Node[T]]] = {
+    def traverseFrom(node: Node[T], traversed: Set[Edge[T]]): Either[Error, (List[Node[T]], Set[Edge[T]])] = {
+      val incoming: Set[Edge[T]] = this.incoming(node)
+      if ((incoming -- traversed).nonEmpty) {
+        // if there are some incoming edges to this node that we haven't yet traversed then ignore this node - we'll be back
+        Right(Nil, traversed)
+      } else {
+        // if we've traversed all of the incoming edges then follow all the outgoing edges
+        val outgoing = this.orderedOutgoing(node)
 
-  def get(node: T): MidNode[T] = dataNodes.find(_.value == node).get
+        if (outgoing.isEmpty && node != EndNode) Left(Error(s"Node $node has no outgoing edges"))
+        if (outgoing.exists(traversed.contains)) Left(Error(s"Graph not acyclic - already traversed outgoing edges from $node"))
 
+        outgoing.foldLeft[Either[Error, (List[Node[T]], Set[Edge[T]])]](Right(List(node), traversed)){
+          case (Right((nodeAcc, edgeAcc)), successor) =>
+            val next = traverseFrom(successor.to, edgeAcc + successor)
+            next.right.map { result =>
+              (nodeAcc ::: result._1, edgeAcc ++ result._2)
+            }
+          case (error, _) => error
+        }
+      }
+    }
+    traverseFrom(StartNode, Set.empty).right.map(_._1)
+  }
+
+  /** Check whether this Graph follows the constraints that are set out in the [[magenta.graph.Graph]] documentation.
+    *
+    * Any errors with the Graph will be returned here.
+    */
+  val constraintErrors: Option[Error] = {
+    def checkStartAndEndNodes = Error(!nodes.contains(StartNode), "No start node") + Error(!nodes.contains(EndNode), "No end node")
+    def checkEdgePriorties = nodes.foldLeft(Error.empty){ (error, node) =>
+        val priorities = outgoing(node).toList.map(_.priority)
+        error + Error(priorities.size != priorities.toSet.size, s"Multiple outgoing edges have same priority from node $node (${priorities.mkString(",")}")
+      }
+    def checkTraversable = {
+      traverse.right.flatMap{ nodeListResult =>
+        if (nodeListResult.toSet.size != nodes.size) {
+          Left(Error(s"Graph was not fully traversed by nodeList (expected to traverse ${nodes.size} nodes but actually traversed ${nodeListResult.toSet.size})"))
+        } else {
+          Right(nodeListResult)
+        }
+      }.left.getOrElse(Error.empty)
+    }
+
+    val errors = checkStartAndEndNodes +
+      checkEdgePriorties +
+      checkTraversable
+
+    errors.asOption
+  }
+
+  assert(constraintErrors.isEmpty, s"Graph isn't valid: ${constraintErrors.get.messages.mkString(", ")}")
+
+  /** true if this graph only contains a StartNode and EndNode */
+  val isEmpty = valueNodes.isEmpty
+
+  /** returns the [[magenta.graph.ValueNode]] for a given underlying node */
+  def get(node: T): ValueNode[T] = valueNodes.find(_.value == node).get
+
+  /** returns edges going from this node to another */
   def outgoing(node: Node[T]): Set[Edge[T]] = edges.filter(_.from == node)
+  /** returns nodes that can be directly reached from this node */
   def successors(node: Node[T]): Set[Node[T]] = outgoing(node).map(_.to)
+  /** returns edges going from this node to another ordered by the priority of the edge */
   def orderedOutgoing(node: Node[T]): List[Edge[T]] = outgoing(node).toList.sortBy(_.priority)
+  /** returns node that can be directly reached from this node ordered by the priority of the edges */
   def orderedSuccessors(node: Node[T]): List[Node[T]] = orderedOutgoing(node).map(_.to)
 
+  /** returns edges that arrive at this node from another */
   def incoming(node: Node[T]): Set[Edge[T]] = edges.filter(_.to == node)
+  /** returns nodes that can reach this node */
   def predecessors(node: Node[T]): Set[Node[T]] = incoming(node).map(_.from)
 
+  /** Replace a single node in the graph with another node of the same type.
+    *
+    * @param node the node you wish to replace
+    * @param withNode the node to substitute for `node`
+    * @return newly constructed graph with the substituted node
+    */
   def replace(node: Node[T], withNode: Node[T]): Graph[T] = {
     val newEdges = edges.map {
       case Edge(from, to, priority) if from == node => Edge(withNode, to, priority)
@@ -88,9 +245,17 @@ case class Graph[T](edges: Set[Edge[T]]) {
     Graph(newEdges)
   }
 
+  /** Builds a new graph by applying a function to each value in this graph. This retains the structure of the graph
+    * but replaces the values of any [[magenta.graph.ValueNode]]. You cannot map two distinct values in the graph to a
+    * single value as this would alter the structure of the graph.
+    *
+    * @param f function to apply to each existing value
+    * @tparam R the type of the value in the new graph
+    * @return new graph with the same structure but values from the function
+    */
   def map[R](f: T => R): Graph[R] = {
-    val newNodeMap: Map[Node[T], Node[R]] = dataNodes.map { currentNode =>
-      currentNode -> MidNode(f(currentNode.value))
+    val newNodeMap: Map[Node[T], Node[R]] = valueNodes.map { currentNode =>
+      currentNode -> ValueNode(f(currentNode.value))
     }.toMap ++ Map(StartNode -> StartNode, EndNode -> EndNode)
     assert(newNodeMap.size == newNodeMap.values.toSet.size, "Source nodes must be mapped onto unique target nodes")
     val newEdges = edges.map { oldEdge =>
@@ -100,14 +265,24 @@ case class Graph[T](edges: Set[Edge[T]]) {
   }
 
   /**
-    * Flat map keeps the shape of this graph whilst mapping each node to a graph. This means one can replace the Start,
-    * End or Mid nodes with multiple nodes. The incoming and outgoing edges of each node of this graph will be replaced
-    * by edges that map to the start and end nodes of the graph returned from f.
+    * Build a new graph by applying a function to each node in this graph and combining the results.
+    *
+    * Keeps the shape of this graph whilst mapping each node to a graph. This means one can replace the
+    * [[magenta.graph.StartNode]], [[magenta.graph.EndNode]] or [[magenta.graph.ValueNode]] with multiple nodes. The
+    * incoming and outgoing edges of each node of this graph will be replaced by edges that map to the start and end
+    * nodes of the graph returned from f.
     *
     * An identity mapping for flatMap would be start and end nodes to empty graph and mid nodes to a single value graph
-    * containing the value of the node.
+    * containing the value of the node. e.g.
+    * {{{
+    * graph flatMap {
+    *   case ValueNode(n) => Graph(n)
+    *   case _ => Graph.empty
+    * }
+    * }}}
     *
-    * It is not possible to map a mid node to an empty graph.
+    * It is not possible to map a [[magenta.graph.ValueNode]] to an empty graph.
+    *
     * @param f the function to apply to each element
     * @return a new graph with the graphs substituted
     */
@@ -116,7 +291,7 @@ case class Graph[T](edges: Set[Edge[T]]) {
     // find all of the edges that we won't adjoin to another graph
     val allInternalEdges = nodeToGraphMap.flatMap{
       case (StartNode, graph) => graph.edges -- graph.incoming(EndNode)
-      case (MidNode(_), graph) =>
+      case (ValueNode(_), graph) =>
         assert(!graph.isEmpty, "It is not possible to flatMap a MidNode to an empty graph")
         graph.edges -- graph.incoming(EndNode) -- graph.outgoing(StartNode)
       case (EndNode, graph) => graph.edges -- graph.outgoing(StartNode)
@@ -143,6 +318,18 @@ case class Graph[T](edges: Set[Edge[T]]) {
     Graph(allInternalEdges ++ joiningEdges)
   }
 
+  /** Add two graphs together so they are traversed in parallel. Outgoing edges from the StartNode of either graph will
+    * be combined to be outgoing edges from the StartNode in the resulting graph. Likewise the incoming edges to the
+    * EndNode of both graphs will be combined. In fact any duplicate nodes between the two graphs will be merged
+    * together and outgoing edges will be re-prioritised appropriately. Duplicate edges (from and to the same node) will
+    * be removed.
+    *
+    * The priorities in the resulting graph will be such that the priorities of the edges from the `other` graph will be
+    * lower than the priorities of this graph.
+    *
+    * @param other graph to add to this graph
+    * @return merged graph containing the edges from both
+    */
   def joinParallel(other: Graph[T]): Graph[T] = {
     if (other.isEmpty) this
     else if (isEmpty) other
@@ -156,28 +343,34 @@ case class Graph[T](edges: Set[Edge[T]]) {
     }
   }
 
+  /** Add two graphs together so they are traversed in series. In essence it will be as if an edge from the EndNode of
+    * `this` graph to the StartNode of the `other` graph has been created. In reality edges will be created from all
+    * predecessors of the EndNode of the first graph to all successors of the StartNode in the second graph.
+    *
+    * Duplicate nodes between the two graphs will not work as de-duplicating such nodes will inevitably result in a
+    * cyclic graph.
+    *
+    * @param other graph to add to this graph
+    * @return merged graph containing the edges from both
+    */
   def joinSeries(other: Graph[T]): Graph[T] = flatMap {
     case StartNode => Graph.empty
-    case MidNode(value) => Graph(value)
+    case ValueNode(value) => Graph(value)
     case EndNode => other
   }
 
-  lazy val nodeList: List[Node[T]] = {
-    def traverseFrom(node: Node[T], traversed: Set[Edge[T]]): (List[Node[T]], Set[Edge[T]]) = {
-      val incoming: Set[Edge[T]] = this.incoming(node)
-      if ((incoming -- traversed).nonEmpty) {
-        // if there are some incoming edges to this node that we haven't yet traversed then ignore this node - we'll be back
-        (Nil, traversed)
-      } else {
-        // if we've traversed all of the incoming edges then follow all the outgoing edges
-        val outgoing = this.orderedOutgoing(node)
-        outgoing.foldLeft((List(node), traversed)){ case ((nodeAcc, edgeAcc), successor) =>
-          val next = traverseFrom(successor.to, edgeAcc + successor)
-          (nodeAcc ::: next._1, edgeAcc ++ next._2)
-        }
-      }
-    }
-    traverseFrom(StartNode, Set.empty)._1
+  /** Returns a deterministically ordered set of nodes using [[magenta.graph.Graph.traverse]].
+    *
+    * In theory this can throw an exception if the graph cannot be traversed. In reality this is checked at the time
+    * the graph is created and should never happen.
+    *
+    * @return
+    * @throws IllegalStateException if the graph cannot be traversed
+    */
+  def nodeList = {
+    traverse fold({ error =>
+      throw new IllegalStateException(s"Couldn't traverse graph: $error")
+    }, identity)
   }
 
   lazy val toList: List[T] = nodeList.flatMap(_.maybeValue)
@@ -197,3 +390,4 @@ case class Graph[T](edges: Set[Edge[T]]) {
     s"Graph(nodes: ${nodeNumberList.mkString("; ")} edges: ${edgeList.mkString(", ")}"
   }
 }
+

--- a/magenta-lib/src/main/scala/magenta/graph/package.scala
+++ b/magenta-lib/src/main/scala/magenta/graph/package.scala
@@ -2,10 +2,10 @@ package magenta
 
 package object graph {
   implicit class RichNodeSet[T](nodes: Set[Node[T]]) {
-    def filterMidNodes: Set[MidNode[T]] = nodes.collect{ case mn:MidNode[T] => mn }
+    def filterValueNodes: Set[ValueNode[T]] = nodes.collect{ case valueNode:ValueNode[T] => valueNode }
   }
   implicit class RichNodeList[T](nodes: List[Node[T]]) {
-    def filterMidNodes: List[MidNode[T]] = nodes.collect{ case mn:MidNode[T] => mn }
+    def filterValueNodes: List[ValueNode[T]] = nodes.collect{ case valueNode:ValueNode[T] => valueNode }
   }
   implicit class RichEdgeList[T](edges: List[Edge[T]]) {
     def replace(old: Edge[T], newEdges: List[Edge[T]]): List[Edge[T]] = edges.patch(edges.indexOf(old), newEdges, 1)

--- a/magenta-lib/src/main/scala/magenta/input/RiffRaffYamlReader.scala
+++ b/magenta-lib/src/main/scala/magenta/input/RiffRaffYamlReader.scala
@@ -27,7 +27,7 @@ object RiffRaffYamlReader {
     }
   }
 
-  def fromString(yaml: String) = {
+  def fromString(yaml: String): RiffRaffDeployConfig = {
     // convert form YAML to JSON
     val tree = new ObjectMapper(new YAMLFactory()).readTree(yaml)
     val jsonString = new ObjectMapper()

--- a/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentGraphActionFlattening.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentGraphActionFlattening.scala
@@ -1,12 +1,12 @@
 package magenta.input.resolver
 
-import magenta.graph.{Graph, MidNode}
+import magenta.graph.{Graph, ValueNode}
 import magenta.input.Deployment
 
 object DeploymentGraphActionFlattening {
   def flattenActions(deploymentGraph: Graph[Deployment]): Graph[Deployment] = {
     deploymentGraph.flatMap{
-      case MidNode(deployment) =>
+      case ValueNode(deployment) =>
         val deploymentPerAction = for {
           actionsList <- deployment.actions.toList
           action <- actionsList

--- a/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentGraphActionFlattening.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentGraphActionFlattening.scala
@@ -11,7 +11,7 @@ object DeploymentGraphActionFlattening {
           actionsList <- deployment.actions.toList
           action <- actionsList
         } yield deployment.copy(actions = Some(List(action)))
-        Graph.from(deploymentPerAction: _*)
+        Graph.from(deploymentPerAction)
       case _ => Graph.empty
     }
   }

--- a/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentGraphActionFlattening.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentGraphActionFlattening.scala
@@ -1,0 +1,18 @@
+package magenta.input.resolver
+
+import magenta.graph.{Graph, MidNode}
+import magenta.input.Deployment
+
+object DeploymentGraphActionFlattening {
+  def flattenActions(deploymentGraph: Graph[Deployment]): Graph[Deployment] = {
+    deploymentGraph.flatMap{
+      case MidNode(deployment) =>
+        val deploymentPerAction = for {
+          actionsList <- deployment.actions.toList
+          action <- actionsList
+        } yield deployment.copy(actions = Some(List(action)))
+        Graph.from(deploymentPerAction: _*)
+      case _ => Graph.empty
+    }
+  }
+}

--- a/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentGraphBuilder.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentGraphBuilder.scala
@@ -5,23 +5,19 @@ import magenta.input.Deployment
 
 object DeploymentGraphBuilder {
   def buildGraph(deployments: List[Deployment]): Graph[Deployment] = {
-    val edges = allEdges(deployments)
-    Graph(edges.toSet)
-  }
-
-  private[resolver] def allEdges(deployments: List[Deployment]) = {
     val deploymentNodes = deployments.map(MidNode.apply)
-    for {
-      from <- StartNode :: deploymentNodes
+    val edges = for {
+      dependency <- StartNode :: deploymentNodes
       edge <- {
-        val targets = from match {
+        val dependents = dependency match {
           case StartNode => deploymentNodes.filterNot(_.value.dependencies.exists(deployments.map(_.name).contains))
           case MidNode(deployment) => deploymentNodes.filter(_.value.dependencies.contains(deployment.name))
           case EndNode => throw new IllegalStateException("EndNode is not valid as the source of an edge")
         }
-        val to = if (targets.nonEmpty) targets else List(EndNode)
-        to.map(from ~>).reprioritise
+        val toNodes = if (dependents.nonEmpty) dependents else List(EndNode)
+        toNodes.map(dependency ~>).reprioritise
       }
     } yield edge
+    Graph(edges.toSet)
   }
 }

--- a/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentGraphBuilder.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentGraphBuilder.scala
@@ -1,0 +1,46 @@
+package magenta.input.resolver
+
+import magenta.graph.{Edge, EndNode, Graph, MidNode, Node, StartNode}
+import magenta.input.Deployment
+
+object DeploymentGraphBuilder {
+  def buildGraph(deployments: List[Deployment]): Graph[Deployment] = {
+    val edges = startEdges(deployments) ::: midEdges(deployments) ::: endEdges(deployments)
+    Graph(edges.toSet)
+  }
+
+  implicit class RichDeploymentList(deployments: List[Deployment]) {
+    def names: Set[String] = deployments.map(_.name).toSet
+    def dependencies: Set[String] = deployments.flatMap(_.dependencies).toSet
+  }
+
+  private[resolver] def startEdges(deployments: List[Deployment]): List[Edge[Deployment]] = {
+    val targetNodes = for {
+      deployment <- deployments
+      if !deployment.dependencies.exists(deployments.names.contains)
+    } yield MidNode(deployment)
+    edges(StartNode, targetNodes)
+  }
+
+  private[resolver] def midEdges(deployments: List[Deployment]): List[Edge[Deployment]] = {
+    deployments.flatMap { dependency =>
+      val targetNodes = for {
+        dependent <- deployments.filter(_.dependencies.contains(dependency.name))
+      } yield MidNode(dependent)
+      edges(MidNode(dependency), targetNodes)
+    }
+  }
+
+  private[resolver] def endEdges(deployments: List[Deployment]): List[Edge[Deployment]] = {
+    for {
+      deployment <- deployments
+      if deployments.forall(!_.dependencies.contains(deployment.name))
+    } yield {
+      MidNode(deployment) ~> EndNode
+    }
+  }
+
+  private[resolver] def edges(from: Node[Deployment], to: List[Node[Deployment]]): List[Edge[Deployment]] = {
+    to.map(from ~>).reprioritise
+  }
+}

--- a/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentGraphBuilder.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentGraphBuilder.scala
@@ -1,17 +1,17 @@
 package magenta.input.resolver
 
-import magenta.graph.{EndNode, Graph, MidNode, StartNode}
+import magenta.graph.{EndNode, Graph, ValueNode, StartNode}
 import magenta.input.Deployment
 
 object DeploymentGraphBuilder {
   def buildGraph(deployments: List[Deployment]): Graph[Deployment] = {
-    val deploymentNodes = deployments.map(MidNode.apply)
+    val deploymentNodes = deployments.map(ValueNode.apply)
     val edges = for {
       dependency <- StartNode :: deploymentNodes
       edge <- {
         val dependents = dependency match {
           case StartNode => deploymentNodes.filterNot(_.value.dependencies.exists(deployments.map(_.name).contains))
-          case MidNode(deployment) => deploymentNodes.filter(_.value.dependencies.contains(deployment.name))
+          case ValueNode(deployment) => deploymentNodes.filter(_.value.dependencies.contains(deployment.name))
           case EndNode => throw new IllegalStateException("EndNode is not valid as the source of an edge")
         }
         val toNodes = if (dependents.nonEmpty) dependents else List(EndNode)

--- a/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentResolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentResolver.scala
@@ -1,5 +1,6 @@
-package magenta.input
+package magenta.input.resolver
 
+import magenta.input.{ConfigError, Deployment, DeploymentOrTemplate, RiffRaffDeployConfig}
 
 object DeploymentResolver {
   val DEFAULT_REGIONS = List("eu-west-1")

--- a/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentTypeResolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentTypeResolver.scala
@@ -1,6 +1,7 @@
-package magenta.input
+package magenta.input.resolver
 
 import magenta.deployment_type.DeploymentType
+import magenta.input.{ConfigError, Deployment}
 
 object DeploymentTypeResolver {
   def validateDeploymentType(deployment: Deployment, availableTypes: Seq[DeploymentType]): Either[ConfigError, Deployment] = {

--- a/magenta-lib/src/main/scala/magenta/input/resolver/Resolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/Resolver.scala
@@ -1,0 +1,34 @@
+package magenta.input.resolver
+
+import magenta.graph.Graph
+import magenta.input.{Deployment, RiffRaffDeployConfig}
+
+object Resolver {
+  def resolve(config: RiffRaffDeployConfig) = {
+    // this is a place holder that tries to tie some things together
+
+    // turn the config into a set of deployments (resolve templates etc)
+    // val deployments = DeploymentResolver.resolve(config)
+
+    // validate that deployment types and dependencies all exist
+    // val validatedDeployments = DeploymentTypeResolver.validateDeploymentType(deployment, DeploymentType.all)
+
+    // this is a placeholder for how we filter previews in the UI
+    // val filteredDeployment = ???
+
+    // now convert it into a graph
+//    val componentGraphs: List[Graph[Deployment]] = for {
+//      stack <- stacks
+//      region <- regions
+//      deploymentsForStackAndRegion = filterDeployments(stack, region, ...)
+//      graphForStackAndRegion = DeploymentGraphBuilder.buildGraph()
+//    } yield graphForStackAndRegion
+//    val graph = componentGraphs.reduceLeft(_ joinParallel _)
+
+    // now flatten out the actions
+    //val flattenedGraph = DeploymentGraphActionFlattening.flattenActions(graph)
+
+    // now resolve each deployment into tasks
+    //val deploymentTaskGraph = DeploymentTaskResolver.resolveGraph(flattenedGraph)
+  }
+}

--- a/magenta-lib/src/test/scala/magenta/ResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/ResolverTest.scala
@@ -6,7 +6,7 @@ import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.{ListObjectsV2Request, ListObjectsV2Result}
 import magenta.artifact.{S3Artifact, S3Package}
 import magenta.fixtures.{StubDeploymentType, StubTask, _}
-import magenta.graph.{DeploymentGraph, DeploymentTasks, MidNode, StartNode}
+import magenta.graph.{DeploymentGraph, DeploymentTasks, ValueNode, StartNode}
 import magenta.json._
 import magenta.tasks.{S3Upload, Task}
 import org.mockito.Matchers._
@@ -155,10 +155,10 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
     successors.size should be(4)
 
     successors should be(List(
-      MidNode(DeploymentTasks(List(StubTask("stacked", stack = Some(NamedStack("foo")))), "project -> foo")),
-      MidNode(DeploymentTasks(List(StubTask("stacked", stack = Some(NamedStack("bar")))), "project -> bar")),
-      MidNode(DeploymentTasks(List(StubTask("stacked", stack = Some(NamedStack("monkey")))), "project -> monkey")),
-      MidNode(DeploymentTasks(List(StubTask("stacked", stack = Some(NamedStack("litre")))), "project -> litre"))
+      ValueNode(DeploymentTasks(List(StubTask("stacked", stack = Some(NamedStack("foo")))), "project -> foo")),
+      ValueNode(DeploymentTasks(List(StubTask("stacked", stack = Some(NamedStack("bar")))), "project -> bar")),
+      ValueNode(DeploymentTasks(List(StubTask("stacked", stack = Some(NamedStack("monkey")))), "project -> monkey")),
+      ValueNode(DeploymentTasks(List(StubTask("stacked", stack = Some(NamedStack("litre")))), "project -> litre"))
     ))
   }
 

--- a/magenta-lib/src/test/scala/magenta/graph/DeploymentGraphTest.scala
+++ b/magenta-lib/src/test/scala/magenta/graph/DeploymentGraphTest.scala
@@ -14,7 +14,7 @@ class DeploymentGraphTest extends FlatSpec with ShouldMatchers with MockitoSugar
     val graph = DeploymentGraph(threeSimpleTasks, "unnamed")
     graph.nodes.size should be(3)
     graph.edges.size should be(2)
-    graph.nodes.filterMidNodes.head.value.tasks should be(threeSimpleTasks)
+    graph.nodes.filterValueNodes.head.value.tasks should be(threeSimpleTasks)
     DeploymentGraph.toTaskList(graph) should be(threeSimpleTasks)
   }
 

--- a/magenta-lib/src/test/scala/magenta/graph/GraphTest.scala
+++ b/magenta-lib/src/test/scala/magenta/graph/GraphTest.scala
@@ -5,11 +5,11 @@ import org.scalatest._
 class GraphTest extends FlatSpec with ShouldMatchers {
 
   val start = StartNode
-  val one = MidNode("one")
-  val two = MidNode("two")
-  val three = MidNode("three")
-  val four = MidNode("four")
-  val five = MidNode("five")
+  val one = ValueNode("one")
+  val two = ValueNode("two")
+  val three = ValueNode("three")
+  val four = ValueNode("four")
+  val five = ValueNode("five")
   val end = EndNode
 
   "Graph" should "correctly flatten a graph to a list" in {
@@ -32,9 +32,9 @@ class GraphTest extends FlatSpec with ShouldMatchers {
     val mergedGraph = graph.joinParallel(graph2)
     val successors = mergedGraph.orderedSuccessors(StartNode)
     successors.size should be(2)
-    val nodes = successors.filterMidNodes
-    nodes.head should matchPattern{case MidNode("one") =>}
-    nodes(1) should matchPattern{case MidNode("two") =>}
+    val nodes = successors.filterValueNodes
+    nodes.head should matchPattern{case ValueNode("one") =>}
+    nodes(1) should matchPattern{case ValueNode("two") =>}
   }
 
   it should "parallel join two complex graphs together" in {
@@ -179,10 +179,10 @@ class GraphTest extends FlatSpec with ShouldMatchers {
     transformedGraph.nodes.size should be(6)
     transformedGraph.edges.size should be(mergedGraph.edges.size)
     transformedGraph.orderedSuccessors(StartNode) should be (List(
-      MidNode(List("one", "one")),
-      MidNode(List("two", "two")),
-      MidNode(List("three", "three")),
-      MidNode(List("four", "four"))
+      ValueNode(List("one", "one")),
+      ValueNode(List("two", "two")),
+      ValueNode(List("three", "three")),
+      ValueNode(List("four", "four"))
     ))
   }
 
@@ -199,7 +199,7 @@ class GraphTest extends FlatSpec with ShouldMatchers {
 
   it should "noop when adding an empty graph onto the end of a graph" in {
     Graph(4) flatMap {
-      case MidNode(n) => Graph(n)
+      case ValueNode(n) => Graph(n)
       case _ => Graph.empty[Int]
     } shouldBe Graph(4)
   }
@@ -208,30 +208,30 @@ class GraphTest extends FlatSpec with ShouldMatchers {
   it should "allow nodes to be flatMapped to a series graph" in {
     val graph = Graph(start ~> one, one ~> end).joinParallel(Graph(start ~> two, two ~> end))
     val mappedGraph = graph.flatMap{
-      case MidNode(node) => Graph(start ~> MidNode((node, 1)), MidNode((node, 1)) ~> MidNode((node, 2)), MidNode((node, 2)) ~> end)
+      case ValueNode(node) => Graph(start ~> ValueNode((node, 1)), ValueNode((node, 1)) ~> ValueNode((node, 2)), ValueNode((node, 2)) ~> end)
       case _ => Graph.empty[(String, Int)]
     }
     mappedGraph should be(Graph(
-      start ~> MidNode(("one", 1)), MidNode(("one", 1)) ~> MidNode(("one", 2)), MidNode(("one", 2)) ~> end,
-      start ~2~> MidNode(("two", 1)), MidNode(("two", 1)) ~> MidNode(("two", 2)), MidNode(("two", 2)) ~> end
+      start ~> ValueNode(("one", 1)), ValueNode(("one", 1)) ~> ValueNode(("one", 2)), ValueNode(("one", 2)) ~> end,
+      start ~2~> ValueNode(("two", 1)), ValueNode(("two", 1)) ~> ValueNode(("two", 2)), ValueNode(("two", 2)) ~> end
     ))
   }
 
   it should "allow nodes to be flatMapped to a parallel graph" in {
     val graph = Graph(start ~> one, one ~> end).joinParallel(Graph(start ~> two, two ~> end))
     val mappedGraph = graph.flatMap{
-      case MidNode(node) =>
+      case ValueNode(node) =>
         Graph(
-          start ~> MidNode((node, 1)), MidNode((node, 1)) ~> end,
-          start ~2~> MidNode((node, 2)), MidNode((node, 2)) ~> end
+          start ~> ValueNode((node, 1)), ValueNode((node, 1)) ~> end,
+          start ~2~> ValueNode((node, 2)), ValueNode((node, 2)) ~> end
         )
       case _ => Graph.empty[(String, Int)]
     }
     mappedGraph should be(Graph(
-      start ~> MidNode(("one", 1)), MidNode(("one", 1)) ~> end,
-      start ~2~> MidNode(("one", 2)), MidNode(("one", 2)) ~> end,
-      start ~3~> MidNode(("two", 1)), MidNode(("two", 1)) ~> end,
-      start ~4~> MidNode(("two", 2)), MidNode(("two", 2)) ~> end
+      start ~> ValueNode(("one", 1)), ValueNode(("one", 1)) ~> end,
+      start ~2~> ValueNode(("one", 2)), ValueNode(("one", 2)) ~> end,
+      start ~3~> ValueNode(("two", 1)), ValueNode(("two", 1)) ~> end,
+      start ~4~> ValueNode(("two", 2)), ValueNode(("two", 2)) ~> end
     ))
   }
 
@@ -249,7 +249,7 @@ class GraphTest extends FlatSpec with ShouldMatchers {
   }
 
   it should "produce a single edge for two simple graphs" in {
-    Graph.joiningEdges(Graph(1), Graph(2)) shouldBe Set(MidNode(1) ~> MidNode(2))
+    Graph.joiningEdges(Graph(1), Graph(2)) shouldBe Set(ValueNode(1) ~> ValueNode(2))
   }
 
   it should "produce a set of edges for two more complex graphs" in {

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentGraphActionFlatteningTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentGraphActionFlatteningTest.scala
@@ -1,0 +1,20 @@
+package magenta.input.resolver
+
+import magenta.graph.{EndNode, Graph, MidNode, StartNode}
+import magenta.input.Deployment
+import org.scalatest.{FlatSpec, Matchers}
+
+class DeploymentGraphActionFlatteningTest extends FlatSpec with Matchers {
+  "flattenActions" should "flatten out the actions in a deployment graph" in {
+    val deploymentWithActions =
+      Deployment("bob", "autoscaling", List("stackName"), List("eu-west-1"), Some(List("action1", "action2")), "bob", "bob", Nil, Map.empty)
+    val graph = Graph(deploymentWithActions)
+    val flattenedGraph = DeploymentGraphActionFlattening.flattenActions(graph)
+
+    val action1 = deploymentWithActions.copy(actions=Some(List("action1")))
+    val action2 = deploymentWithActions.copy(actions=Some(List("action2")))
+    flattenedGraph shouldBe Graph(
+      StartNode ~> MidNode(action1), MidNode(action1) ~> MidNode(action2), MidNode(action2) ~> EndNode
+    )
+  }
+}

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentGraphActionFlatteningTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentGraphActionFlatteningTest.scala
@@ -1,6 +1,6 @@
 package magenta.input.resolver
 
-import magenta.graph.{EndNode, Graph, MidNode, StartNode}
+import magenta.graph.{EndNode, Graph, ValueNode, StartNode}
 import magenta.input.Deployment
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -14,7 +14,7 @@ class DeploymentGraphActionFlatteningTest extends FlatSpec with Matchers {
     val action1 = deploymentWithActions.copy(actions=Some(List("action1")))
     val action2 = deploymentWithActions.copy(actions=Some(List("action2")))
     flattenedGraph shouldBe Graph(
-      StartNode ~> MidNode(action1), MidNode(action1) ~> MidNode(action2), MidNode(action2) ~> EndNode
+      StartNode ~> ValueNode(action1), ValueNode(action1) ~> ValueNode(action2), ValueNode(action2) ~> EndNode
     )
   }
 }

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentResolverTest.scala
@@ -1,7 +1,8 @@
-package magenta.input
+package magenta.input.resolver
 
+import magenta.input.{ConfigError, Deployment, RiffRaffYamlReader}
 import org.scalatest.{EitherValues, FlatSpec, ShouldMatchers}
-import play.api.libs.json.{JsNumber, JsString, JsValue}
+import play.api.libs.json.{JsNumber, JsString}
 
 class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherValues {
   "DeploymentResolver" should "parse a simple deployment with defaults" in {

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTasksGraphBuilderTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTasksGraphBuilderTest.scala
@@ -1,0 +1,62 @@
+package magenta.input.resolver
+
+import magenta.graph.{EndNode, Graph, MidNode, StartNode}
+import magenta.input.Deployment
+import org.scalatest.{FlatSpec, ShouldMatchers}
+
+class DeploymentTasksGraphBuilderTest extends FlatSpec with ShouldMatchers {
+  val deployment = Deployment("bob", "autoscaling", List("stackName"), List("eu-west-1"), Some(List("deploy")), "bob", "bob", Nil, Map.empty)
+
+  "buildGraph" should "build a simple graph for a single deployment" in {
+    val graph = DeploymentGraphBuilder.buildGraph(List(deployment))
+    graph shouldBe Graph(StartNode ~> MidNode(deployment), MidNode(deployment) ~> EndNode)
+  }
+
+  it should "build a parallel graph for two deployments with no dependencies" in {
+    val deployment2 = deployment.copy(name="bob2")
+    val graph = DeploymentGraphBuilder.buildGraph(List(deployment, deployment2))
+    graph shouldBe Graph(
+      StartNode ~> MidNode(deployment), MidNode(deployment) ~> EndNode,
+      StartNode ~2~> MidNode(deployment2), MidNode(deployment2) ~> EndNode
+    )
+  }
+
+  it should "build a series graph for two deployments where one is dependent on the other" in {
+    val deployment2 = deployment.copy(name="bob2", dependencies = List("bob"))
+    val graph = DeploymentGraphBuilder.buildGraph(List(deployment, deployment2))
+    graph shouldBe Graph(
+      StartNode ~> MidNode(deployment), MidNode(deployment) ~> MidNode(deployment2), MidNode(deployment2) ~> EndNode
+    )
+  }
+
+  it should "build a graph with three deployments, one of which is a common dependency" in {
+    val deployment2 = deployment.copy(name="bob2", dependencies = List("bob"))
+    val deployment3 = deployment.copy(name="bob3", dependencies = List("bob"))
+    val graph = DeploymentGraphBuilder.buildGraph(List(deployment, deployment2, deployment3))
+    graph shouldBe Graph(
+      StartNode ~> MidNode(deployment),
+      MidNode(deployment) ~> MidNode(deployment2), MidNode(deployment2) ~> EndNode,
+      MidNode(deployment) ~2~> MidNode(deployment3), MidNode(deployment3) ~> EndNode
+    )
+  }
+
+  it should "build a simple graph when there are missing dependencies" in {
+    val deploymentWithMissingDependency = deployment.copy(dependencies = List("missingDep"))
+    val graph = DeploymentGraphBuilder.buildGraph(List(deploymentWithMissingDependency))
+    graph shouldBe Graph(
+      StartNode ~> MidNode(deploymentWithMissingDependency),
+      MidNode(deploymentWithMissingDependency) ~> EndNode
+    )
+  }
+
+  it should "build a graph with three deployments when there are missing dependencies" in {
+    val deployment2 = deployment.copy(name="bob2", dependencies = List("bob", "missingDep1"))
+    val deployment3 = deployment.copy(name="bob3", dependencies = List("bob", "missingDep2"))
+    val graph = DeploymentGraphBuilder.buildGraph(List(deployment, deployment2, deployment3))
+    graph shouldBe Graph(
+      StartNode ~> MidNode(deployment),
+      MidNode(deployment) ~> MidNode(deployment2), MidNode(deployment2) ~> EndNode,
+      MidNode(deployment) ~2~> MidNode(deployment3), MidNode(deployment3) ~> EndNode
+    )
+  }
+}

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTasksGraphBuilderTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTasksGraphBuilderTest.scala
@@ -1,6 +1,6 @@
 package magenta.input.resolver
 
-import magenta.graph.{EndNode, Graph, MidNode, StartNode}
+import magenta.graph.{EndNode, Graph, ValueNode, StartNode}
 import magenta.input.Deployment
 import org.scalatest.{FlatSpec, ShouldMatchers}
 
@@ -9,15 +9,15 @@ class DeploymentTasksGraphBuilderTest extends FlatSpec with ShouldMatchers {
 
   "buildGraph" should "build a simple graph for a single deployment" in {
     val graph = DeploymentGraphBuilder.buildGraph(List(deployment))
-    graph shouldBe Graph(StartNode ~> MidNode(deployment), MidNode(deployment) ~> EndNode)
+    graph shouldBe Graph(StartNode ~> ValueNode(deployment), ValueNode(deployment) ~> EndNode)
   }
 
   it should "build a parallel graph for two deployments with no dependencies" in {
     val deployment2 = deployment.copy(name="bob2")
     val graph = DeploymentGraphBuilder.buildGraph(List(deployment, deployment2))
     graph shouldBe Graph(
-      StartNode ~> MidNode(deployment), MidNode(deployment) ~> EndNode,
-      StartNode ~2~> MidNode(deployment2), MidNode(deployment2) ~> EndNode
+      StartNode ~> ValueNode(deployment), ValueNode(deployment) ~> EndNode,
+      StartNode ~2~> ValueNode(deployment2), ValueNode(deployment2) ~> EndNode
     )
   }
 
@@ -25,7 +25,7 @@ class DeploymentTasksGraphBuilderTest extends FlatSpec with ShouldMatchers {
     val deployment2 = deployment.copy(name="bob2", dependencies = List("bob"))
     val graph = DeploymentGraphBuilder.buildGraph(List(deployment, deployment2))
     graph shouldBe Graph(
-      StartNode ~> MidNode(deployment), MidNode(deployment) ~> MidNode(deployment2), MidNode(deployment2) ~> EndNode
+      StartNode ~> ValueNode(deployment), ValueNode(deployment) ~> ValueNode(deployment2), ValueNode(deployment2) ~> EndNode
     )
   }
 
@@ -34,9 +34,9 @@ class DeploymentTasksGraphBuilderTest extends FlatSpec with ShouldMatchers {
     val deployment3 = deployment.copy(name="bob3", dependencies = List("bob"))
     val graph = DeploymentGraphBuilder.buildGraph(List(deployment, deployment2, deployment3))
     graph shouldBe Graph(
-      StartNode ~> MidNode(deployment),
-      MidNode(deployment) ~> MidNode(deployment2), MidNode(deployment2) ~> EndNode,
-      MidNode(deployment) ~2~> MidNode(deployment3), MidNode(deployment3) ~> EndNode
+      StartNode ~> ValueNode(deployment),
+      ValueNode(deployment) ~> ValueNode(deployment2), ValueNode(deployment2) ~> EndNode,
+      ValueNode(deployment) ~2~> ValueNode(deployment3), ValueNode(deployment3) ~> EndNode
     )
   }
 
@@ -44,8 +44,8 @@ class DeploymentTasksGraphBuilderTest extends FlatSpec with ShouldMatchers {
     val deploymentWithMissingDependency = deployment.copy(dependencies = List("missingDep"))
     val graph = DeploymentGraphBuilder.buildGraph(List(deploymentWithMissingDependency))
     graph shouldBe Graph(
-      StartNode ~> MidNode(deploymentWithMissingDependency),
-      MidNode(deploymentWithMissingDependency) ~> EndNode
+      StartNode ~> ValueNode(deploymentWithMissingDependency),
+      ValueNode(deploymentWithMissingDependency) ~> EndNode
     )
   }
 
@@ -54,9 +54,9 @@ class DeploymentTasksGraphBuilderTest extends FlatSpec with ShouldMatchers {
     val deployment3 = deployment.copy(name="bob3", dependencies = List("bob", "missingDep2"))
     val graph = DeploymentGraphBuilder.buildGraph(List(deployment, deployment2, deployment3))
     graph shouldBe Graph(
-      StartNode ~> MidNode(deployment),
-      MidNode(deployment) ~> MidNode(deployment2), MidNode(deployment2) ~> EndNode,
-      MidNode(deployment) ~2~> MidNode(deployment3), MidNode(deployment3) ~> EndNode
+      StartNode ~> ValueNode(deployment),
+      ValueNode(deployment) ~> ValueNode(deployment2), ValueNode(deployment2) ~> EndNode,
+      ValueNode(deployment) ~2~> ValueNode(deployment3), ValueNode(deployment3) ~> EndNode
     )
   }
 
@@ -70,13 +70,13 @@ class DeploymentTasksGraphBuilderTest extends FlatSpec with ShouldMatchers {
     val deployments = List(deployment, bob2a, bob2b, bob3, bob4, bob5a, bob5b)
     val graph = DeploymentGraphBuilder.buildGraph(deployments)
 
-    val bobNode = MidNode(deployment)
-    val bob2aNode = MidNode(bob2a)
-    val bob2bNode = MidNode(bob2b)
-    val bob3Node = MidNode(bob3)
-    val bob4Node = MidNode(bob4)
-    val bob5aNode = MidNode(bob5a)
-    val bob5bNode = MidNode(bob5b)
+    val bobNode = ValueNode(deployment)
+    val bob2aNode = ValueNode(bob2a)
+    val bob2bNode = ValueNode(bob2b)
+    val bob3Node = ValueNode(bob3)
+    val bob4Node = ValueNode(bob4)
+    val bob5aNode = ValueNode(bob5a)
+    val bob5bNode = ValueNode(bob5b)
     graph shouldBe Graph(
       StartNode ~> bobNode,
       bobNode ~> bob2aNode, bobNode ~2~> bob2bNode,

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTasksGraphBuilderTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTasksGraphBuilderTest.scala
@@ -59,4 +59,31 @@ class DeploymentTasksGraphBuilderTest extends FlatSpec with ShouldMatchers {
       MidNode(deployment) ~2~> MidNode(deployment3), MidNode(deployment3) ~> EndNode
     )
   }
+
+  it should "build a graph with a long chain of dependencies" in {
+    val bob2a = deployment.copy(name = "bob2a", dependencies = List("bob"))
+    val bob2b = deployment.copy(name = "bob2b", dependencies = List("bob"))
+    val bob3 = deployment.copy(name = "bob3", dependencies = List("bob2a", "bob2b"))
+    val bob4 = deployment.copy(name = "bob4", dependencies = List("bob3"))
+    val bob5a = deployment.copy(name = "bob5a", dependencies = List("bob4"))
+    val bob5b = deployment.copy(name = "bob5b", dependencies = List("bob4"))
+    val deployments = List(deployment, bob2a, bob2b, bob3, bob4, bob5a, bob5b)
+    val graph = DeploymentGraphBuilder.buildGraph(deployments)
+
+    val bobNode = MidNode(deployment)
+    val bob2aNode = MidNode(bob2a)
+    val bob2bNode = MidNode(bob2b)
+    val bob3Node = MidNode(bob3)
+    val bob4Node = MidNode(bob4)
+    val bob5aNode = MidNode(bob5a)
+    val bob5bNode = MidNode(bob5b)
+    graph shouldBe Graph(
+      StartNode ~> bobNode,
+      bobNode ~> bob2aNode, bobNode ~2~> bob2bNode,
+      bob2aNode ~> bob3Node, bob2bNode ~> bob3Node,
+      bob3Node ~> bob4Node,
+      bob4Node ~> bob5aNode, bob4Node ~2~> bob5bNode,
+      bob5aNode ~> EndNode, bob5bNode ~> EndNode
+    )
+  }
 }

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTypeResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTypeResolverTest.scala
@@ -1,6 +1,7 @@
-package magenta.input
+package magenta.input.resolver
 
 import magenta.fixtures._
+import magenta.input.Deployment
 import org.scalatest.{EitherValues, FlatSpec, Matchers}
 
 class DeploymentTypeResolverTest extends FlatSpec with Matchers with EitherValues {


### PR DESCRIPTION
From a list of deployments with dependencies we should build a graph of deployments. This is achieved using a graph builder that creates all of the necessary edges to fulfil the deployments. We create three sets of edges:
 - from the `StartNode` to all nodes that have no listed dependencies (i.e. nothing goes before them)
 - from a dependency node to a dependent node (i.e. each edge that is expressed by an entry in a deployment's dependencies list)
 - from any node on which no nodes depend to the `EndNode`

These three sets joined together creates a complete graph for the Deployments.

It was realised that building a graph at this stage only makes sense if we can make later transformations easy. As such this PR also implements a `flatMap` on `Graph` that allows individual nodes to be replaced with multiple nodes. This makes sense for splitting out actions for example or even stacks and regions - although this is likely to be done in completely different graphs which are later joined together.

Finally, this PR also improves the DSL for creating edges so that priorities can be more cleanly expressed - mostly done during tests.