### PR TITLE
Report fastly validation response

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/FastlyTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/FastlyTasks.scala
@@ -109,6 +109,7 @@ case class UpdateFastlyConfig(s3Package: S3Package)(implicit val keyRing: KeyRin
       reporter.info(s"Validating new config $versionNumber")
       val response = block(client.versionValidate(versionNumber))
       val validationResponse = Json.parse(response.getResponseBody) \\ "status"
+      reporter.info(s"Fastly validation response: $validationResponse")
       validationResponse == JsString("ok")
     }
   }


### PR DESCRIPTION
Report fastly validation response so a user could self understand the issue if not the one expected.