### PR TITLE
Regions as first class concept

### DIFF
--- a/magenta-lib/src/main/scala/magenta/DeployContext.scala
+++ b/magenta-lib/src/main/scala/magenta/DeployContext.scala
@@ -2,8 +2,7 @@ package magenta
 
 import java.util.UUID
 
-import com.amazonaws.services.s3.AmazonS3
-import magenta.graph.{DeploymentTasks, DeploymentGraph, Graph}
+import magenta.graph.{DeploymentGraph, DeploymentTasks, Graph}
 
 object DeployContext {
   def apply(deployId: UUID, parameters: DeployParameters, project: Project,

--- a/magenta-lib/src/main/scala/magenta/DeployContext.scala
+++ b/magenta-lib/src/main/scala/magenta/DeployContext.scala
@@ -7,20 +7,19 @@ import magenta.graph.{DeploymentTasks, DeploymentGraph, Graph}
 
 object DeployContext {
   def apply(deployId: UUID, parameters: DeployParameters, project: Project,
-    resourceLookup: Lookup, rootReporter: DeployReporter, artifactClient: AmazonS3): DeployContext = {
+    resources: DeploymentResources, region: Region): DeployContext = {
 
     val tasks = {
-      rootReporter.info("Resolving tasks...")
-      val tasks = Resolver.resolve(project, resourceLookup, parameters, rootReporter, artifactClient)
-      rootReporter.taskList(DeploymentGraph.toTaskList(tasks))
+      resources.reporter.info("Resolving tasks...")
+      val tasks = Resolver.resolve(project, parameters, resources, region)
+      resources.reporter.taskList(DeploymentGraph.toTaskList(tasks))
       tasks
     }
-    DeployContext(deployId, parameters, project, tasks)
+    DeployContext(deployId, parameters, tasks)
   }
 }
 
-case class DeployContext(uuid: UUID, parameters: DeployParameters, project: Project,
-  tasks: Graph[DeploymentTasks]) {
+case class DeployContext(uuid: UUID, parameters: DeployParameters, tasks: Graph[DeploymentTasks]) {
   val deployer = parameters.deployer
   val buildName = parameters.build.projectName
   val buildId = parameters.build.id

--- a/magenta-lib/src/main/scala/magenta/DeploymentPackage.scala
+++ b/magenta-lib/src/main/scala/magenta/DeploymentPackage.scala
@@ -1,6 +1,6 @@
 package magenta
 
-import magenta.artifact.S3Package
+import magenta.artifact.S3Path
 import magenta.deployment_type.DeploymentType
 import play.api.libs.json.JsValue
 
@@ -9,7 +9,7 @@ case class DeploymentPackage(
   pkgApps: Seq[App],
   pkgSpecificData: Map[String, JsValue],
   deploymentTypeName: String,
-  s3Package: S3Package) {
+  s3Package: S3Path) {
 
   def mkAction(name: String): Action = pkgType.mkAction(name)(this)
 

--- a/magenta-lib/src/main/scala/magenta/Project.scala
+++ b/magenta-lib/src/main/scala/magenta/Project.scala
@@ -72,7 +72,7 @@ case class DeploymentResources(reporter: DeployReporter, lookup: Lookup, artifac
     lookup.keyRing(target.parameters.stage, pkg.apps.toSet, target.stack)
 }
 
-case class DeployTarget(parameters: DeployParameters, stack: Stack)
+case class DeployTarget(parameters: DeployParameters, stack: Stack, region: Region)
 
 /*
  An action represents a step within a recipe. It isn't executable
@@ -117,6 +117,8 @@ case object UnnamedStack extends Stack {
   override def nameOption = None
 }
 
+case class Region(name: String) extends AnyVal
+
 case class Deployer(name: String)
 
 case class DeployParameters(
@@ -128,8 +130,8 @@ case class DeployParameters(
                              hostList: List[String] = Nil
                              ) {
 
-  def toDeployContext(uuid: UUID, project: Project, resources: DeploymentResources): DeployContext = {
-    DeployContext(uuid, this, project, resources)
+  def toDeployContext(uuid: UUID, project: Project, resources: DeploymentResources, region: Region): DeployContext = {
+    DeployContext(uuid, this, project, resources, region)
   }
 
   def matchingHost(hostName:String) = hostList.isEmpty || hostList.contains(hostName)

--- a/magenta-lib/src/main/scala/magenta/Project.scala
+++ b/magenta-lib/src/main/scala/magenta/Project.scala
@@ -128,11 +128,4 @@ case class DeployParameters(
                              recipe: RecipeName = DefaultRecipe(),
                              stacks: Seq[NamedStack] = Seq(),
                              hostList: List[String] = Nil
-                             ) {
-
-  def toDeployContext(uuid: UUID, project: Project, resources: DeploymentResources, region: Region): DeployContext = {
-    DeployContext(uuid, this, project, resources, region)
-  }
-
-  def matchingHost(hostName:String) = hostList.isEmpty || hostList.contains(hostName)
-}
+                             )

--- a/magenta-lib/src/main/scala/magenta/Project.scala
+++ b/magenta-lib/src/main/scala/magenta/Project.scala
@@ -128,8 +128,8 @@ case class DeployParameters(
                              hostList: List[String] = Nil
                              ) {
 
-  def toDeployContext(uuid: UUID, project: Project, resourceLookup: Lookup, reporter: DeployReporter, artifactClient: AmazonS3): DeployContext = {
-    DeployContext(uuid, this, project, resourceLookup, reporter, artifactClient)
+  def toDeployContext(uuid: UUID, project: Project, resources: DeploymentResources): DeployContext = {
+    DeployContext(uuid, this, project, resources)
   }
 
   def matchingHost(hostName:String) = hostList.isEmpty || hostList.contains(hostName)

--- a/magenta-lib/src/main/scala/magenta/artifact/S3ZipArtifact.scala
+++ b/magenta-lib/src/main/scala/magenta/artifact/S3ZipArtifact.scala
@@ -13,13 +13,13 @@ import scalax.file.Path
 import scalax.io.{Resource, ScalaIOException}
 
 object S3ZipArtifact {
-  def download(artifact: S3Artifact)(implicit client: AmazonS3, reporter: DeployReporter): File = {
+  def download(artifact: S3JsonArtifact)(implicit client: AmazonS3, reporter: DeployReporter): File = {
     val dir = Path.createTempDirectory(prefix="riffraff-", suffix="")
     download(artifact, dir)(client, reporter)
     dir
   }
 
-  def download(artifact: S3Artifact, dir: File)(implicit client: AmazonS3, reporter: DeployReporter) {
+  def download(artifact: S3JsonArtifact, dir: File)(implicit client: AmazonS3, reporter: DeployReporter) {
     reporter.info("Downloading artifact")
 
     val path = s"${artifact.key}/artifacts.zip"
@@ -44,12 +44,12 @@ object S3ZipArtifact {
     }
   }
 
-  def delete(artifact: S3Artifact)(implicit client: AmazonS3): Unit = {
+  def delete(artifact: S3JsonArtifact)(implicit client: AmazonS3): Unit = {
     val path = s"${artifact.key}/artifacts.zip"
     client.deleteObject(artifact.bucket, path)
   }
 
-  def withDownload[T](artifact: S3Artifact)(block: File => T)
+  def withDownload[T](artifact: S3JsonArtifact)(block: File => T)
     (client: AmazonS3, reporter: DeployReporter): T = {
     val tempDir = Try { download(artifact)(client, reporter) }
     val result = tempDir.map(block)

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -92,17 +92,17 @@ object AutoScaling  extends DeploymentType with S3AclParams {
       val parameters = target.parameters
       val stack = target.stack
       List(
-        CheckForStabilization(pkg, parameters.stage, stack),
-        CheckGroupSize(pkg, parameters.stage, stack),
-        SuspendAlarmNotifications(pkg, parameters.stage, stack),
-        TagCurrentInstancesWithTerminationTag(pkg, parameters.stage, stack),
-        DoubleSize(pkg, parameters.stage, stack),
+        CheckForStabilization(pkg, parameters.stage, stack, target.region),
+        CheckGroupSize(pkg, parameters.stage, stack, target.region),
+        SuspendAlarmNotifications(pkg, parameters.stage, stack, target.region),
+        TagCurrentInstancesWithTerminationTag(pkg, parameters.stage, stack, target.region),
+        DoubleSize(pkg, parameters.stage, stack, target.region),
         HealthcheckGrace(healthcheckGrace(pkg) * 1000),
-        WaitForStabilization(pkg, parameters.stage, stack, secondsToWait(pkg) * 1000),
+        WaitForStabilization(pkg, parameters.stage, stack, secondsToWait(pkg) * 1000, target.region),
         WarmupGrace(warmupGrace(pkg) * 1000),
-        WaitForStabilization(pkg, parameters.stage, stack, secondsToWait(pkg) * 1000),
-        CullInstancesWithTerminationTag(pkg, parameters.stage, stack),
-        ResumeAlarmNotifications(pkg, parameters.stage, stack)
+        WaitForStabilization(pkg, parameters.stage, stack, secondsToWait(pkg) * 1000, target.region),
+        CullInstancesWithTerminationTag(pkg, parameters.stage, stack, target.region),
+        ResumeAlarmNotifications(pkg, parameters.stage, stack, target.region)
       )
     }
     case "uploadArtifacts" => (pkg) => (resources, target) =>
@@ -123,6 +123,7 @@ object AutoScaling  extends DeploymentType with S3AclParams {
         )
       List(
         S3Upload(
+          target.region,
           bucket.get(pkg).orElse(target.stack.nameOption.map(stackName => s"$stackName-dist")).get,
           Seq(pkg.s3Package -> prefix),
           publicReadAcl = publicReadAcl(pkg)

--- a/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
@@ -25,14 +25,14 @@ object ElasticSearch extends DeploymentType with S3AclParams {
       val parameters = target.parameters
       val stack = target.stack
       List(
-        CheckGroupSize(pkg, parameters.stage, stack),
-        WaitForElasticSearchClusterGreen(pkg, parameters.stage, stack, secondsToWait(pkg) * 1000),
-        SuspendAlarmNotifications(pkg, parameters.stage, stack),
-        TagCurrentInstancesWithTerminationTag(pkg, parameters.stage, stack),
-        DoubleSize(pkg, parameters.stage, stack),
-        WaitForElasticSearchClusterGreen(pkg, parameters.stage, stack, secondsToWait(pkg) * 1000),
-        CullElasticSearchInstancesWithTerminationTag(pkg, parameters.stage, stack, secondsToWait(pkg) * 1000),
-        ResumeAlarmNotifications(pkg, parameters.stage, stack)
+        CheckGroupSize(pkg, parameters.stage, stack, target.region),
+        WaitForElasticSearchClusterGreen(pkg, parameters.stage, stack, secondsToWait(pkg) * 1000, target.region),
+        SuspendAlarmNotifications(pkg, parameters.stage, stack, target.region),
+        TagCurrentInstancesWithTerminationTag(pkg, parameters.stage, stack, target.region),
+        DoubleSize(pkg, parameters.stage, stack, target.region),
+        WaitForElasticSearchClusterGreen(pkg, parameters.stage, stack, secondsToWait(pkg) * 1000, target.region),
+        CullElasticSearchInstancesWithTerminationTag(pkg, parameters.stage, stack, secondsToWait(pkg) * 1000, target.region),
+        ResumeAlarmNotifications(pkg, parameters.stage, stack, target.region)
       )
     }
     case "uploadArtifacts" => (pkg) => (resources, target) =>
@@ -41,6 +41,7 @@ object ElasticSearch extends DeploymentType with S3AclParams {
       val prefix: String = S3Upload.prefixGenerator(target.stack, target.parameters.stage, pkg.name)
       List(
         S3Upload(
+          target.region,
           bucket(pkg),
           Seq(pkg.s3Package -> prefix),
           publicReadAcl = publicReadAcl(pkg)

--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
@@ -128,6 +128,7 @@ object S3 extends DeploymentType with S3AclParams {
       ))
       List(
         S3Upload(
+          target.region,
           bucket = bucketName,
           paths = Seq(pkg.s3Package -> prefix),
           cacheControlPatterns = cacheControl(pkg),

--- a/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
@@ -42,6 +42,7 @@ object SelfDeploy extends DeploymentType with S3AclParams {
       val prefix = S3Upload.prefixGenerator(target.stack, target.parameters.stage, pkg.name)
       List(
         S3Upload(
+          target.region,
           bucket.get(pkg).orElse(target.stack.nameOption.map(stackName => s"$stackName-dist")).get,
           paths = Seq(pkg.s3Package -> prefix)
         )

--- a/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentResolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentResolver.scala
@@ -3,8 +3,6 @@ package magenta.input.resolver
 import magenta.input.{ConfigError, Deployment, DeploymentOrTemplate, RiffRaffDeployConfig}
 
 object DeploymentResolver {
-  val DEFAULT_REGIONS = List("eu-west-1")
-
   def resolve(config: RiffRaffDeployConfig): List[Either[ConfigError, Deployment]] = {
     config.deployments.map { case (label, rawDeployment) =>
       for {
@@ -23,12 +21,13 @@ object DeploymentResolver {
     for {
       deploymentType <- templated.`type`.toRight(ConfigError(label, "No type field provided")).right
       stacks <- templated.stacks.orElse(globalStacks).toRight(ConfigError(label, "No stacks provided")).right
+      regions <- templated.regions.orElse(globalRegions).toRight(ConfigError(label, "No regions provided")).right
     } yield {
       Deployment(
         name              = label,
         `type`            = deploymentType,
         stacks            = stacks,
-        regions           = templated.regions.orElse(globalRegions).getOrElse(DEFAULT_REGIONS),
+        regions           = regions,
         actions           = templated.actions,
         app               = templated.app.getOrElse(label),
         contentDirectory  = templated.contentDirectory.getOrElse(label),

--- a/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
@@ -1,14 +1,14 @@
 package magenta.tasks
 
-import magenta._
 import com.amazonaws.AmazonServiceException
+import com.amazonaws.services.autoscaling.AmazonAutoScalingClient
 import com.amazonaws.services.autoscaling.model.AutoScalingGroup
-import collection.JavaConversions._
-import magenta.KeyRing
-import magenta.Stage
+import magenta.{KeyRing, Stage, _}
 
-case class CheckGroupSize(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean) {
+import scala.collection.JavaConversions._
+
+case class CheckGroupSize(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean)(implicit asgClient: AmazonAutoScalingClient) {
     val doubleCapacity = asg.getDesiredCapacity * 2
     if (asg.getMaxSize < doubleCapacity || doubleCapacity == 0) {
       reporter.fail(
@@ -20,18 +20,19 @@ case class CheckGroupSize(pkg: DeploymentPackage, stage: Stage, stack: Stack)(im
   lazy val description = "Checking there is enough capacity to deploy"
 }
 
-case class TagCurrentInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean) {
-    EC2.setTag(asg.getInstances.toList, "Magenta", "Terminate")(keyRing)
+case class TagCurrentInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean)(implicit asgClient: AmazonAutoScalingClient) {
+    implicit val ec2Client = EC2.makeEc2Client(keyRing, region)
+    EC2.setTag(asg.getInstances.toList, "Magenta", "Terminate")
   }
 
   lazy val description = "Tag existing instances of the auto-scaling group for termination"
 }
 
-case class DoubleSize(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
+case class DoubleSize(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
 
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean) {
-    desiredCapacity(asg.getAutoScalingGroupName, asg.getDesiredCapacity * 2)(keyRing)
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean)(implicit asgClient: AmazonAutoScalingClient) {
+    ASG.desiredCapacity(asg.getAutoScalingGroupName, asg.getDesiredCapacity * 2)
   }
 
   lazy val description = s"Double the size of the auto-scaling group in $stage, $stack for apps ${pkg.apps.mkString(", ")}"
@@ -54,20 +55,22 @@ case class WarmupGrace(durationMillis: Long)(implicit keyRing: KeyRing) extends 
   def verbose: String = s"Wait extra ${durationMillis}ms to let instances in Load Balancer warm up"
 }
 
-case class CheckForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean) {
-    isStabilized(asg)
+case class CheckForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean)(implicit asgClient: AmazonAutoScalingClient) {
+    implicit val elbClient = ELB.makeElbClient(keyRing, region)
+    ASG.isStabilized(asg)
   }
   lazy val description: String = "Check the desired number of hosts in both the ASG and ELB are up and that the number of hosts match"
 }
 
-case class WaitForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Stack, duration: Long)(implicit val keyRing: KeyRing) extends ASGTask
+case class WaitForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Stack, duration: Long, region: Region)(implicit val keyRing: KeyRing) extends ASGTask
     with SlowRepeatedPollingCheck {
 
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean) {
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean)(implicit asgClient: AmazonAutoScalingClient) {
+    implicit val elbClient = ELB.makeElbClient(keyRing, region)
     check(reporter, stopFlag) {
       try {
-        isStabilized(refresh(asg))
+        ASG.isStabilized(ASG.refresh(asg))
       } catch {
         case e: AmazonServiceException if isRateExceeded(e) => {
           reporter.info(e.getMessage)
@@ -83,47 +86,49 @@ case class WaitForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Sta
   lazy val description: String = "Check the desired number of hosts in both the ASG and ELB are up and that the number of hosts match"
 }
 
-case class CullInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean) {
-    val instancesToKill = asg.getInstances.filter(instance => EC2.hasTag(instance, "Magenta", "Terminate")(keyRing))
+case class CullInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean)(implicit asgClient: AmazonAutoScalingClient) {
+    implicit val ec2Client = EC2.makeEc2Client(keyRing, region)
+    implicit val elbClient = ELB.makeElbClient(keyRing, region)
+    val instancesToKill = asg.getInstances.filter(instance => EC2.hasTag(instance, "Magenta", "Terminate"))
     val orderedInstancesToKill = instancesToKill.transposeBy(_.getAvailabilityZone)
-    orderedInstancesToKill.foreach(instance => cull(asg, instance)(keyRing))
+    orderedInstancesToKill.foreach(instance => ASG.cull(asg, instance))
   }
 
   lazy val description = "Terminate instances with the termination tag for this deploy"
 }
 
-case class SuspendAlarmNotifications(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
+case class SuspendAlarmNotifications(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
 
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean) {
-    suspendAlarmNotifications(asg.getAutoScalingGroupName)(keyRing)
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean)(implicit asgClient: AmazonAutoScalingClient) {
+    ASG.suspendAlarmNotifications(asg.getAutoScalingGroupName)
   }
 
   lazy val description = "Suspending Alarm Notifications - group will no longer scale on any configured alarms"
 }
 
-case class ResumeAlarmNotifications(pkg: DeploymentPackage, stage: Stage, stack: Stack)(implicit val keyRing: KeyRing) extends ASGTask {
+case class ResumeAlarmNotifications(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
 
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean) {
-    resumeAlarmNotifications(asg.getAutoScalingGroupName)(keyRing)
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean)(implicit asgClient: AmazonAutoScalingClient) {
+    ASG.resumeAlarmNotifications(asg.getAutoScalingGroupName)
   }
 
   lazy val description = "Resuming Alarm Notifications - group will scale on any configured alarms"
 }
 
-trait ASGTask extends Task with ASG {
+trait ASGTask extends Task {
+  def region: Region
   def pkg: DeploymentPackage
   def stage: Stage
   def stack: Stack
 
   def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean)
+    (implicit asgClient: AmazonAutoScalingClient)
 
   override def execute(reporter: DeployReporter, stopFlag: => Boolean) {
-    implicit val key = keyRing
-    implicit val dl = reporter
-
-    val group = groupForAppAndStage(pkg, stage, stack)
-    execute(group, reporter, stopFlag)
+    val asgClient = ASG.makeAsgClient(keyRing, region)
+    val group = ASG.groupForAppAndStage(pkg, stage, stack)(asgClient, reporter)
+    execute(group, reporter, stopFlag)(asgClient)
   }
 
   def verbose = description

--- a/magenta-lib/src/main/scala/magenta/tasks/FastlyTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/FastlyTasks.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.Executors
 import com.amazonaws.services.s3.AmazonS3
 import com.gu.fastly.api.FastlyApiClient
 import magenta._
-import magenta.artifact.S3Package
+import magenta.artifact.S3Path
 import play.api.libs.json.{JsString, Json}
 
 import scala.concurrent.duration._
@@ -21,7 +21,7 @@ object Vcl {
   implicit val reads = Json.reads[Vcl]
 }
 
-case class UpdateFastlyConfig(s3Package: S3Package)(implicit val keyRing: KeyRing, artifactClient: AmazonS3) extends Task {
+case class UpdateFastlyConfig(s3Package: S3Path)(implicit val keyRing: KeyRing, artifactClient: AmazonS3) extends Task {
 
   implicit val ec = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(10))
 
@@ -76,7 +76,7 @@ case class UpdateFastlyConfig(s3Package: S3Package)(implicit val keyRing: KeyRin
     }
   }
 
-  private def uploadNewVclFilesTo(versionNumber: Int, s3Package: S3Package, client: FastlyApiClient, reporter: DeployReporter, stopFlag: => Boolean): Unit = {
+  private def uploadNewVclFilesTo(versionNumber: Int, s3Package: S3Path, client: FastlyApiClient, reporter: DeployReporter, stopFlag: => Boolean): Unit = {
     stopOnFlag(stopFlag) {
       s3Package.listAll()(artifactClient).map { obj =>
         if (obj.extension.contains("vcl")) {

--- a/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
+++ b/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
@@ -19,7 +19,8 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
   it should "resolve a set of tasks" in {
     val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
     val parameters = DeployParameters(Deployer("tester"), Build("project","1"), CODE, oneRecipeName)
-    val context = DeployContext(UUID.randomUUID(), parameters, project(baseRecipe), lookupSingleHost, reporter, artifactClient)
+    val resources = DeploymentResources(reporter, lookupSingleHost, artifactClient)
+    val context = DeployContext(UUID.randomUUID(), parameters, project(baseRecipe), resources)
     DeploymentGraph.toTaskList(context.tasks) should be(List(
       StubTask("init_action_one per app task number one"),
       StubTask("init_action_one per app task number two")
@@ -33,7 +34,8 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
     val messages = Buffer[Message]()
     DeployReporter.messages.filter(_.stack.deployParameters == Some(parameters)).subscribe(messages += _.stack.top)
 
-    val context = DeployContext(reporter.messageContext.deployId, parameters, project(baseRecipe), lookupSingleHost, reporter, artifactClient)
+    val resources = DeploymentResources(reporter, lookupSingleHost, artifactClient)
+    val context = DeployContext(reporter.messageContext.deployId, parameters, project(baseRecipe), resources)
 
     messages.filter(_.getClass == classOf[Info]) should have size (1)
     messages.filter(_.getClass == classOf[TaskList]) should have size (1)
@@ -42,7 +44,8 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
   it should "execute the task" in {
     val parameters = DeployParameters(Deployer("tester"), Build("prooecjt","1"), CODE, oneRecipeName)
     val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), parameters)
-    val context = DeployContext(reporter.messageContext.deployId, parameters, project(baseMockRecipe), lookupSingleHost, reporter, artifactClient)
+    val resources = DeploymentResources(reporter, lookupSingleHost, artifactClient)
+    val context = DeployContext(reporter.messageContext.deployId, parameters, project(baseMockRecipe), resources)
     context.execute(reporter)
     val task = DeploymentGraph.toTaskList(context.tasks).head
 
@@ -63,7 +66,8 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
     )
 
     val reporter = DeployReporter.startDeployContext(DeployReporter.rootReporterFor(UUID.randomUUID(), parameters))
-    val context = DeployContext(reporter.messageContext.deployId, parameters, project(baseRecipe), lookupSingleHost, reporter, artifactClient)
+    val resources = DeploymentResources(reporter, lookupSingleHost, artifactClient)
+    val context = DeployContext(reporter.messageContext.deployId, parameters, project(baseRecipe), resources)
 
     context.execute(reporter)
 
@@ -89,7 +93,8 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
     )
 
     val reporter = DeployReporter.startDeployContext(DeployReporter.rootReporterFor(UUID.randomUUID(), parameters))
-    val context = DeployContext(reporter.messageContext.deployId, parameters, project(baseRecipe), lookupSingleHost, reporter, artifactClient)
+    val resources = DeploymentResources(reporter, lookupSingleHost, artifactClient)
+    val context = DeployContext(reporter.messageContext.deployId, parameters, project(baseRecipe), resources)
 
     context.execute(reporter)
 

--- a/magenta-lib/src/test/scala/magenta/artifact/S3ArtifactTest.scala
+++ b/magenta-lib/src/test/scala/magenta/artifact/S3ArtifactTest.scala
@@ -6,14 +6,8 @@ import org.scalatest.{FlatSpec, Matchers}
 class S3ArtifactTest extends FlatSpec with Matchers {
   "S3Artifact" should "create an S3Artifact instance from a build and bucket" in {
     val build = Build("testProject", "123")
-    val artifact = S3Artifact(build, "myBucket")
+    val artifact = S3JsonArtifact(build, "myBucket")
     artifact.bucket should be("myBucket")
     artifact.key should be("testProject/123")
-  }
-
-  it should "correctly create S3Package objects" in {
-    val artifact = S3Artifact("myBucket", "testProject/123")
-    val pkg = artifact.getPackage("testPackage")
-    pkg should be (S3Package("myBucket", "testProject/123/packages/testPackage"))
   }
 }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -2,6 +2,7 @@ package magenta
 
 import java.util.UUID
 
+import com.amazonaws.regions.RegionUtils
 import com.amazonaws.services.s3.AmazonS3
 import magenta.artifact.S3Path
 import magenta.deployment_type.AutoScaling
@@ -14,6 +15,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
   implicit val fakeKeyRing = KeyRing()
   implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
   implicit val artifactClient: AmazonS3 = null
+  val region = Region("eu-west-1")
 
   "auto-scaling with ELB package type" should "have a deploy action" in {
     val data: Map[String, JsValue] = Map(
@@ -24,18 +26,18 @@ class AutoScalingTest extends FlatSpec with Matchers {
 
     val p = DeploymentPackage("app", app, data, "asg-elb", S3Path("artifact-bucket", "test/123/app"))
 
-    AutoScaling.actions("deploy")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack)) should be (List(
-      CheckForStabilization(p, PROD, UnnamedStack),
-      CheckGroupSize(p, PROD, UnnamedStack),
-      SuspendAlarmNotifications(p, PROD, UnnamedStack),
-      TagCurrentInstancesWithTerminationTag(p, PROD, UnnamedStack),
-      DoubleSize(p, PROD, UnnamedStack),
+    AutoScaling.actions("deploy")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack, region)) should be (List(
+      CheckForStabilization(p, PROD, UnnamedStack, Region("eu-west-1")),
+      CheckGroupSize(p, PROD, UnnamedStack, Region("eu-west-1")),
+      SuspendAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1")),
+      TagCurrentInstancesWithTerminationTag(p, PROD, UnnamedStack, Region("eu-west-1")),
+      DoubleSize(p, PROD, UnnamedStack, Region("eu-west-1")),
       HealthcheckGrace(20000),
-      WaitForStabilization(p, PROD, UnnamedStack, 15 * 60 * 1000),
+      WaitForStabilization(p, PROD, UnnamedStack, 15 * 60 * 1000, Region("eu-west-1")),
       WarmupGrace(1000),
-      WaitForStabilization(p, PROD, UnnamedStack, 15 * 60 * 1000),
-      CullInstancesWithTerminationTag(p, PROD, UnnamedStack),
-      ResumeAlarmNotifications(p, PROD, UnnamedStack)
+      WaitForStabilization(p, PROD, UnnamedStack, 15 * 60 * 1000, Region("eu-west-1")),
+      CullInstancesWithTerminationTag(p, PROD, UnnamedStack, Region("eu-west-1")),
+      ResumeAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1"))
     ))
   }
 
@@ -51,18 +53,18 @@ class AutoScalingTest extends FlatSpec with Matchers {
 
     val p = DeploymentPackage("app", app, data, "asg-elb", S3Path("artifact-bucket", "test/123/app"))
 
-    AutoScaling.actions("deploy")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack)) should be (List(
-      CheckForStabilization(p, PROD, UnnamedStack),
-      CheckGroupSize(p, PROD, UnnamedStack),
-      SuspendAlarmNotifications(p, PROD, UnnamedStack),
-      TagCurrentInstancesWithTerminationTag(p, PROD, UnnamedStack),
-      DoubleSize(p, PROD, UnnamedStack),
+    AutoScaling.actions("deploy")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack, region)) should be (List(
+      CheckForStabilization(p, PROD, UnnamedStack, Region("eu-west-1")),
+      CheckGroupSize(p, PROD, UnnamedStack, Region("eu-west-1")),
+      SuspendAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1")),
+      TagCurrentInstancesWithTerminationTag(p, PROD, UnnamedStack, Region("eu-west-1")),
+      DoubleSize(p, PROD, UnnamedStack, Region("eu-west-1")),
       HealthcheckGrace(30000),
-      WaitForStabilization(p, PROD, UnnamedStack, 3 * 60 * 1000),
+      WaitForStabilization(p, PROD, UnnamedStack, 3 * 60 * 1000, Region("eu-west-1")),
       WarmupGrace(20000),
-      WaitForStabilization(p, PROD, UnnamedStack, 3 * 60 * 1000),
-      CullInstancesWithTerminationTag(p, PROD, UnnamedStack),
-      ResumeAlarmNotifications(p, PROD, UnnamedStack)
+      WaitForStabilization(p, PROD, UnnamedStack, 3 * 60 * 1000, Region("eu-west-1")),
+      CullInstancesWithTerminationTag(p, PROD, UnnamedStack, Region("eu-west-1")),
+      ResumeAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1"))
     ))
   }
 }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -3,7 +3,7 @@ package magenta
 import java.util.UUID
 
 import com.amazonaws.services.s3.AmazonS3
-import magenta.artifact.S3Package
+import magenta.artifact.S3Path
 import magenta.deployment_type.AutoScaling
 import magenta.fixtures._
 import magenta.tasks._
@@ -22,7 +22,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
 
     val app = Seq(App("app"))
 
-    val p = DeploymentPackage("app", app, data, "asg-elb", S3Package("artifact-bucket", "test/123/app"))
+    val p = DeploymentPackage("app", app, data, "asg-elb", S3Path("artifact-bucket", "test/123/app"))
 
     AutoScaling.actions("deploy")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack)) should be (List(
       CheckForStabilization(p, PROD, UnnamedStack),
@@ -49,7 +49,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
 
     val app = Seq(App("app"))
 
-    val p = DeploymentPackage("app", app, data, "asg-elb", S3Package("artifact-bucket", "test/123/app"))
+    val p = DeploymentPackage("app", app, data, "asg-elb", S3Path("artifact-bucket", "test/123/app"))
 
     AutoScaling.actions("deploy")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack)) should be (List(
       CheckForStabilization(p, PROD, UnnamedStack),

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -2,6 +2,7 @@ package magenta.deployment_type
 
 import java.util.UUID
 
+import com.amazonaws.regions.RegionUtils
 import com.amazonaws.services.s3.AmazonS3
 import magenta._
 import magenta.artifact.S3Path
@@ -15,6 +16,7 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
   implicit val fakeKeyRing = KeyRing()
   implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
   implicit val artifactClient: AmazonS3 = null
+  val region = Region("eu-west-1")
 
   "cloudformation deployment type" should "have an updateStack action" in {
     val data: Map[String, JsValue] = Map()
@@ -23,7 +25,7 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
     val cfnStackName = s"cfn-app-PROD"
     val p = DeploymentPackage("app", app, data, "cloudformation", S3Path("artifact-bucket", "test/123"))
 
-    inside(CloudFormation.actions("updateStack")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), stack))) {
+    inside(CloudFormation.actions("updateStack")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), stack, region))) {
       case List(updateTask, checkTask) =>
         inside(updateTask) {
           case UpdateCloudFormationTask(stackName, path, userParams, amiParam, amiTags, _, stage, stack, ifAbsent) =>

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import com.amazonaws.services.s3.AmazonS3
 import magenta._
-import magenta.artifact.{S3Package, S3Path}
+import magenta.artifact.S3Path
 import magenta.fixtures._
 import magenta.tasks.UpdateCloudFormationTask._
 import magenta.tasks._
@@ -21,7 +21,7 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
     val app = Seq(App("app"))
     val stack = NamedStack("cfn")
     val cfnStackName = s"cfn-app-PROD"
-    val p = DeploymentPackage("app", app, data, "cloudformation", S3Package("artifact-bucket", "test/123"))
+    val p = DeploymentPackage("app", app, data, "cloudformation", S3Path("artifact-bucket", "test/123"))
 
     inside(CloudFormation.actions("updateStack")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), stack))) {
       case List(updateTask, checkTask) =>

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -3,7 +3,6 @@ package magenta
 import java.util.UUID
 
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.regions.{Region, Regions}
 import magenta.artifact.S3Path
 import magenta.deployment_type.param_reads.PatternValue
 import magenta.deployment_type.{Lambda, S3}
@@ -16,6 +15,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
   implicit val fakeKeyRing = KeyRing()
   implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
   implicit val artifactClient: AmazonS3 = null
+  val region = Region("eu-west-1")
 
   "Deployment types" should "automatically register params in the params Seq" in {
     S3.params should have size 9
@@ -24,7 +24,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
 
   private val sourceS3Package = S3Path("artifact-bucket", "test/123/static-files")
 
-  private val defaultRegion = Region.getRegion(Regions.fromName("eu-west-1"))
+  private val defaultRegion = Region("eu-west-1")
 
   it should "throw a NoSuchElementException if a required parameter is missing" in {
     val data: Map[String, JsValue] = Map(
@@ -34,8 +34,9 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package)
 
     val thrown = the[NoSuchElementException] thrownBy {
-      S3.actions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)) should be (
+      S3.actions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)) should be (
         List(S3Upload(
+          Region("eu-west-1"),
           "bucket-1234",
           Seq(sourceS3Package -> "CODE/myapp"),
           List(PatternValue(".*", "no-cache"))
@@ -55,8 +56,9 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
 
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package)
 
-    S3.actions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)) should be (
+    S3.actions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)) should be (
       List(S3Upload(
+        Region("eu-west-1"),
         "bucket-1234",
         Seq(sourceS3Package -> "CODE/myapp"),
         List(PatternValue(".*", "no-cache")),
@@ -76,7 +78,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
 
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package)
 
-    inside(S3.actions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)).head) {
+    inside(S3.actions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)).head) {
       case upload: S3Upload => upload.cacheControlPatterns should be(List(PatternValue("^sub", "no-cache"), PatternValue(".*", "public; max-age:3600")))
     }
   }
@@ -94,7 +96,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
 
     val lookup = stubLookup(List(Host("the_host", stage=CODE.name).app(app1)), Map("s3-path-prefix" -> Seq(Datum(None, app1.name, CODE.name, "testing/2016/05/brexit-companion", None))))
 
-    inside(S3.actions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookup, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)).head) {
+    inside(S3.actions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookup, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)).head) {
       case upload: S3Upload => upload.paths should be(Seq(sourceS3Package -> "testing/2016/05/brexit-companion"))
     }
   }
@@ -111,7 +113,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
 
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-lambda", S3Path("artifact-bucket", "test/123"))
 
-    Lambda.actions("updateLambda")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)) should be (
+    Lambda.actions("updateLambda")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)) should be (
       List(UpdateLambda(S3Path("artifact-bucket","test/123/lambda.zip"), "myLambda", defaultRegion)
       ))
   }
@@ -128,7 +130,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
     val p = DeploymentPackage("myapp", Seq.empty, badData, "aws-lambda", S3Path("artifact-bucket", "test/123"))
 
     val thrown = the[FailException] thrownBy {
-      Lambda.actions("updateLambda")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)) should be (
+      Lambda.actions("updateLambda")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)) should be (
         List(UpdateLambda(S3Path("artifact-bucket","test/123/lambda.zip"), "myLambda", defaultRegion)
         ))
     }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.regions.{Region, Regions}
-import magenta.artifact.{S3Package, S3Path}
+import magenta.artifact.S3Path
 import magenta.deployment_type.param_reads.PatternValue
 import magenta.deployment_type.{Lambda, S3}
 import magenta.fixtures._
@@ -22,7 +22,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
     S3.params.map(_.name).toSet should be(Set("prefixStage","prefixPackage","prefixStack", "pathPrefixResource","bucket","publicReadAcl","bucketResource","cacheControl","mimeTypes"))
   }
 
-  private val sourceS3Package = S3Package("artifact-bucket", "test/123/static-files")
+  private val sourceS3Package = S3Path("artifact-bucket", "test/123/static-files")
 
   private val defaultRegion = Region.getRegion(Regions.fromName("eu-west-1"))
 
@@ -109,7 +109,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
       )
     )
 
-    val p = DeploymentPackage("myapp", Seq.empty, data, "aws-lambda", S3Package("artifact-bucket", "test/123"))
+    val p = DeploymentPackage("myapp", Seq.empty, data, "aws-lambda", S3Path("artifact-bucket", "test/123"))
 
     Lambda.actions("updateLambda")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)) should be (
       List(UpdateLambda(S3Path("artifact-bucket","test/123/lambda.zip"), "myLambda", defaultRegion)
@@ -125,7 +125,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
       )
     )
 
-    val p = DeploymentPackage("myapp", Seq.empty, badData, "aws-lambda", S3Package("artifact-bucket", "test/123"))
+    val p = DeploymentPackage("myapp", Seq.empty, badData, "aws-lambda", S3Path("artifact-bucket", "test/123"))
 
     val thrown = the[FailException] thrownBy {
       Lambda.actions("updateLambda")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack)) should be (

--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import com.amazonaws.regions.{Regions, Region}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
-import magenta.artifact.{S3Package, S3Path}
+import magenta.artifact.S3Path
 import magenta.fixtures._
 import magenta.tasks.{S3Upload, UpdateS3Lambda}
 import magenta.{App, DeployReporter, DeployTarget, DeploymentPackage, DeploymentResources, KeyRing, NamedStack, fixtures}
@@ -28,7 +28,7 @@ class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
   )
 
   val app = Seq(App("lambda"))
-  val pkg = DeploymentPackage("lambda", app, data, "aws-s3-lambda", S3Package("artifact-bucket", "test/123/lambda"))
+  val pkg = DeploymentPackage("lambda", app, data, "aws-s3-lambda", S3Path("artifact-bucket", "test/123/lambda"))
   val defaultRegion = Region.getRegion(Regions.fromName("eu-west-1"))
 
   it should "produce an S3 upload task" in {
@@ -61,7 +61,7 @@ class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
       "functionNames" -> Json.arr("MyFunction-")
     )
     val app = Seq(App("lambda"))
-    val pkg = DeploymentPackage("lambda", app, dataWithStack, "aws-s3-lambda", S3Package("artifact-bucket", "test/123/lambda"))
+    val pkg = DeploymentPackage("lambda", app, dataWithStack, "aws-s3-lambda", S3Path("artifact-bucket", "test/123/lambda"))
 
     val tasks = Lambda.actions("updateLambda")(pkg)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("some-stack")))
     tasks should be (List(

--- a/magenta-lib/src/test/scala/magenta/graph/DeploymentGraphTest.scala
+++ b/magenta-lib/src/test/scala/magenta/graph/DeploymentGraphTest.scala
@@ -1,7 +1,7 @@
 package magenta.graph
 
 import com.amazonaws.services.s3.AmazonS3Client
-import magenta.{Host, KeyRing}
+import magenta.{Host, KeyRing, Region}
 import magenta.tasks.{HealthcheckGrace, S3Upload, SayHello}
 import org.scalatest.{FlatSpec, ShouldMatchers}
 import org.scalatest.mock.MockitoSugar
@@ -19,7 +19,7 @@ class DeploymentGraphTest extends FlatSpec with ShouldMatchers with MockitoSugar
   }
 
   val threeSimpleTasks = List(
-    S3Upload("test-bucket", Seq()),
+    S3Upload(Region("eu-west-1"), "test-bucket", Seq()),
     SayHello(Host("testHost")),
     HealthcheckGrace(1000)
   )

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentResolverTest.scala
@@ -14,6 +14,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         |    parameters:
         |      testParam: testValue
         |    stacks: [testStack]
+        |    regions: [eu-west-1]
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = DeploymentResolver.resolve(yaml)
@@ -88,6 +89,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
   it should "use values from a simple template" in {
     val yamlString =
       """
+        |regions: ["eu-west-1"]
         |templates:
         |  testTemplate:
         |    type: testType
@@ -278,6 +280,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
     val yamlString =
       """
         |stacks: [global-stack]
+        |regions: [global-region]
         |templates:
         |  nestedTemplate:
         |    type: testType
@@ -307,6 +310,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
     val yamlString =
       """
         |stacks: [global-stack]
+        |regions: [global-region]
         |templates:
         |  nestedTemplate:
         |    type: testType
@@ -333,6 +337,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
     val yamlString =
       """
         |stacks: [global-stack]
+        |regions: [global-region]
         |templates:
         |  nestedTemplate:
         |    type: testType
@@ -356,6 +361,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
     val yamlString =
       """
         |stacks: [global-stack]
+        |regions: [global-region]
         |templates:
         |  nestedTemplate:
         |    type: testType
@@ -376,6 +382,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
     val yamlString =
       """
         |stacks: [global-stack]
+        |regions: [global-region]
         |deployments:
         |  test:
         |    type: autoscaling
@@ -391,6 +398,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
   it should "report an error if no stacks are provided" in {
     val yamlString =
       """
+        |regions: [global-region]
         |deployments:
         |  test:
         |    type: autoscaling
@@ -398,6 +406,19 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = DeploymentResolver.resolve(yaml)
     deployments.head.left.value should be(ConfigError("test", "No stacks provided"))
+  }
+
+  it should "report an error if no regions are provided" in {
+    val yamlString =
+      """
+        |stacks: [global-stack]
+        |deployments:
+        |  test:
+        |    type: autoscaling
+      """.stripMargin
+    val yaml = RiffRaffYamlReader.fromString(yamlString)
+    val deployments = DeploymentResolver.resolve(yaml)
+    deployments.head.left.value should be(ConfigError("test", "No regions provided"))
   }
 
   def assertDeployments(maybeDeployments: List[Either[ConfigError, Deployment]]): List[Deployment] = {

--- a/magenta-lib/src/test/scala/magenta/json/JsonReaderTest.scala
+++ b/magenta-lib/src/test/scala/magenta/json/JsonReaderTest.scala
@@ -1,7 +1,7 @@
 package magenta
 package json
 
-import magenta.artifact.{S3Artifact, S3Package}
+import magenta.artifact.{S3JsonArtifact, S3Path}
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.{JsString, Json}
 
@@ -61,14 +61,14 @@ class JsonReaderTest extends FlatSpec with Matchers {
                           """
 
   "json parser" should "parse json and resolve links" in {
-    val parsed = JsonReader.parse(deployJsonExample, S3Artifact("artifact-bucket", "test/123"))
+    val parsed = JsonReader.parse(deployJsonExample, S3JsonArtifact("artifact-bucket", "test/123"))
 
     parsed.applications should be (Set(App("index-builder"), App("api"), App("solr")))
 
     parsed.packages.size should be (3)
-    parsed.packages("index-builder") should be (DeploymentPackage("index-builder", Seq(App("index-builder")), Map.empty, "autoscaling", S3Package("artifact-bucket", "test/123/packages/index-builder")))
-    parsed.packages("api") should be (DeploymentPackage("api", Seq(App("api")), Map("healthcheck_paths" -> Json.arr("/api/index.json","/api/search.json")), "autoscaling", S3Package("artifact-bucket", "test/123/packages/api")))
-    parsed.packages("solr") should be (DeploymentPackage("solr", Seq(App("solr")), Map("port" -> JsString("8400")), "autoscaling", S3Package("artifact-bucket", "test/123/packages/solr")))
+    parsed.packages("index-builder") should be (DeploymentPackage("index-builder", Seq(App("index-builder")), Map.empty, "autoscaling", S3Path("artifact-bucket", "test/123/packages/index-builder")))
+    parsed.packages("api") should be (DeploymentPackage("api", Seq(App("api")), Map("healthcheck_paths" -> Json.arr("/api/index.json","/api/search.json")), "autoscaling", S3Path("artifact-bucket", "test/123/packages/api")))
+    parsed.packages("solr") should be (DeploymentPackage("solr", Seq(App("solr")), Map("port" -> JsString("8400")), "autoscaling", S3Path("artifact-bucket", "test/123/packages/solr")))
 
     val recipes = parsed.recipes
     recipes.size should be (4)
@@ -88,7 +88,7 @@ class JsonReaderTest extends FlatSpec with Matchers {
 """
 
   "json parser" should "infer a single app if none specified" in {
-    val parsed = JsonReader.parse(minimalExample, S3Artifact("artifact-bucket", "test/123"))
+    val parsed = JsonReader.parse(minimalExample, S3JsonArtifact("artifact-bucket", "test/123"))
 
     parsed.applications should be (Set(App("dinky")))
   }
@@ -103,7 +103,7 @@ class JsonReaderTest extends FlatSpec with Matchers {
 """
 
   "json parser" should "infer a default recipe that deploys all packages" in {
-    val parsed = JsonReader.parse(twoPackageExample, S3Artifact("artifact-bucket", "test/123"))
+    val parsed = JsonReader.parse(twoPackageExample, S3JsonArtifact("artifact-bucket", "test/123"))
 
     val recipes = parsed.recipes
     recipes.size should be(1)
@@ -111,9 +111,9 @@ class JsonReaderTest extends FlatSpec with Matchers {
   }
 
   "json parser" should "default to using the package name for the file name" in {
-    val parsed = JsonReader.parse(minimalExample, S3Artifact("artifact-bucket", "test/123"))
+    val parsed = JsonReader.parse(minimalExample, S3JsonArtifact("artifact-bucket", "test/123"))
 
-    parsed.packages("dinky").s3Package should be(S3Package("artifact-bucket", "test/123/packages/dinky"))
+    parsed.packages("dinky").s3Package should be(S3Path("artifact-bucket", "test/123/packages/dinky"))
   }
 
   val withExplicitFileName = """
@@ -128,8 +128,8 @@ class JsonReaderTest extends FlatSpec with Matchers {
 """
 
   "json parser" should "use override file name if specified" in {
-    val parsed = JsonReader.parse(withExplicitFileName, S3Artifact("artifact-bucket", "test/123"))
+    val parsed = JsonReader.parse(withExplicitFileName, S3JsonArtifact("artifact-bucket", "test/123"))
 
-    parsed.packages("dinky").s3Package should be(S3Package("artifact-bucket", "test/123/packages/awkward"))
+    parsed.packages("dinky").s3Package should be(S3Path("artifact-bucket", "test/123/packages/awkward"))
   }
 }

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing = KeyRing()
-  implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
+  val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
 
   it should "double the size of the autoscaling group" in {
     val asg = new AutoScalingGroup().withDesiredCapacity(3).withAutoScalingGroupName("test").withMaxSize(10)
@@ -22,7 +22,7 @@ class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
 
     val task = new DoubleSize(p, Stage("PROD"), UnnamedStack, Region("eu-west-1"))
 
-    task.execute(asg, reporter, false)(asgClientMock)
+    task.execute(asg, reporter, false, asgClientMock)
 
     verify(asgClientMock).setDesiredCapacity(
       new SetDesiredCapacityRequest().withAutoScalingGroupName("test").withDesiredCapacity(6)
@@ -39,9 +39,8 @@ class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
 
     val task = new CheckGroupSize(p, Stage("PROD"), UnnamedStack, Region("eu-west-1"))
 
-    val thrown = intercept[FailException](task.execute(asg, reporter, false)(asgClientMock))
+    val thrown = intercept[FailException](task.execute(asg, reporter, false, asgClientMock))
 
     thrown.getMessage should startWith ("Autoscaling group does not have the capacity")
-
   }
 }

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
@@ -20,13 +20,9 @@ class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
 
     val p = DeploymentPackage("test", Seq(App("app")), Map.empty, "test", S3Path("artifact-bucket", "project/123/test"))
 
-    val task = new DoubleSize(p, Stage("PROD"), UnnamedStack) {
-      override def client(implicit keyRing: KeyRing) = asgClientMock
-      override def groupForAppAndStage(pkg: DeploymentPackage,  stage: Stage, stack: Stack)
-                                      (implicit keyRing: KeyRing, reporter: DeployReporter) = asg
-    }
+    val task = new DoubleSize(p, Stage("PROD"), UnnamedStack, Region("eu-west-1"))
 
-    task.execute(reporter)
+    task.execute(asg, reporter, false)(asgClientMock)
 
     verify(asgClientMock).setDesiredCapacity(
       new SetDesiredCapacityRequest().withAutoScalingGroupName("test").withDesiredCapacity(6)
@@ -41,13 +37,9 @@ class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
 
     val p = DeploymentPackage("test", Seq(App("app")), Map.empty, "test", S3Path("artifact-bucket", "project/123/test"))
 
-    val task = new CheckGroupSize(p, Stage("PROD"), UnnamedStack) {
-      override def client(implicit keyRing: KeyRing) = asgClientMock
-      override def groupForAppAndStage(pkg: DeploymentPackage, stage: Stage, stack: Stack)
-                                      (implicit keyRing: KeyRing, reporter: DeployReporter) = asg
-    }
+    val task = new CheckGroupSize(p, Stage("PROD"), UnnamedStack, Region("eu-west-1"))
 
-    val thrown = intercept[FailException](task.execute(reporter))
+    val thrown = intercept[FailException](task.execute(asg, reporter, false)(asgClientMock))
 
     thrown.getMessage should startWith ("Autoscaling group does not have the capacity")
 

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
@@ -1,11 +1,10 @@
 package magenta.tasks
 
-import java.io.File
 import java.util.UUID
 
 import com.amazonaws.services.autoscaling.AmazonAutoScalingClient
 import com.amazonaws.services.autoscaling.model.{AutoScalingGroup, SetDesiredCapacityRequest}
-import magenta.artifact.S3Package
+import magenta.artifact.S3Path
 import magenta.{KeyRing, Stage, _}
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
@@ -19,7 +18,7 @@ class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
     val asg = new AutoScalingGroup().withDesiredCapacity(3).withAutoScalingGroupName("test").withMaxSize(10)
     val asgClientMock = mock[AmazonAutoScalingClient]
 
-    val p = DeploymentPackage("test", Seq(App("app")), Map.empty, "test", S3Package("artifact-bucket", "project/123/test"))
+    val p = DeploymentPackage("test", Seq(App("app")), Map.empty, "test", S3Path("artifact-bucket", "project/123/test"))
 
     val task = new DoubleSize(p, Stage("PROD"), UnnamedStack) {
       override def client(implicit keyRing: KeyRing) = asgClientMock
@@ -40,7 +39,7 @@ class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
 
     val asgClientMock = mock[AmazonAutoScalingClient]
 
-    val p = DeploymentPackage("test", Seq(App("app")), Map.empty, "test", S3Package("artifact-bucket", "project/123/test"))
+    val p = DeploymentPackage("test", Seq(App("app")), Map.empty, "test", S3Path("artifact-bucket", "project/123/test"))
 
     val task = new CheckGroupSize(p, Stage("PROD"), UnnamedStack) {
       override def client(implicit keyRing: KeyRing) = asgClientMock

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
@@ -1,13 +1,12 @@
 package magenta.tasks
 
-import java.io.File
 import java.util.UUID
 
 import com.amazonaws.services.autoscaling.AmazonAutoScalingClient
 import com.amazonaws.services.autoscaling.model.{Instance => ASGInstance, _}
 import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClient
 import com.amazonaws.services.elasticloadbalancing.model.{DescribeInstanceHealthRequest, DescribeInstanceHealthResult, InstanceState, Instance => ELBInstance}
-import magenta.artifact.S3Package
+import magenta.artifact.S3Path
 import magenta.{App, KeyRing, Stage, _}
 import org.mockito.Matchers._
 import org.mockito.Mockito._
@@ -35,7 +34,7 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         AutoScalingGroup("App" -> "example", "Stage" -> "TEST")
       ))
 
-    val p = DeploymentPackage("example", Seq(App("app")), Map.empty, "nowt much", S3Package("artifact-bucket", "project/123/example"))
+    val p = DeploymentPackage("example", Seq(App("app")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"))
     asg.groupForAppAndStage(p, Stage("PROD"), UnnamedStack) should be (desiredGroup)
   }
 
@@ -54,7 +53,7 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         AutoScalingGroup(("Role" -> "example"), ("Stage" -> "TEST"))
       ))
 
-    val p = DeploymentPackage("example", Seq(App("app")), Map.empty, "nowt much", S3Package("artifact-bucket", "project/123/example"))
+    val p = DeploymentPackage("example", Seq(App("app")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"))
     asg.groupForAppAndStage(p, Stage("PROD"), UnnamedStack) should be (desiredGroup)
   }
 
@@ -76,7 +75,7 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         AutoScalingGroup("Stack" -> "monkey", "App" -> "logcabin", "Stage" -> "PROD")
       ))
 
-    val p = DeploymentPackage("example", Seq(App("logcabin")), Map.empty, "nowt much", S3Package("artifact-bucket", "project/123/example"))
+    val p = DeploymentPackage("example", Seq(App("logcabin")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"))
     asg.groupForAppAndStage(p, Stage("PROD"), NamedStack("contentapi")) should be (desiredGroup)
   }
 
@@ -98,7 +97,7 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         AutoScalingGroup("Stack" -> "monkey", "App" -> "logcabin", "Stage" -> "PROD")
       ))
 
-    val p = DeploymentPackage("example", Seq(App("logcabin"), App("elasticsearch")), Map.empty, "nowt much", S3Package("artifact-bucket", "project/123/example"))
+    val p = DeploymentPackage("example", Seq(App("logcabin"), App("elasticsearch")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"))
     asg.groupForAppAndStage(p, Stage("PROD"), NamedStack("contentapi")) should be (desiredGroup)
   }
 
@@ -121,7 +120,7 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         AutoScalingGroup("Stack" -> "monkey", "App" -> "logcabin", "Stage" -> "PROD")
       ))
 
-    val p = DeploymentPackage("example", Seq(App("logcabin"), App("elasticsearch")), Map.empty, "nowt much", S3Package("artifact-bucket", "project/123/example"))
+    val p = DeploymentPackage("example", Seq(App("logcabin"), App("elasticsearch")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"))
 
     a [FailException] should be thrownBy {
       asg.groupForAppAndStage(p, Stage("PROD"), NamedStack("contentapi")) should be (desiredGroup)
@@ -205,7 +204,7 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         desiredGroup
       ))
 
-    val p = DeploymentPackage("example", Seq(App("logcabin"), App("elasticsearch")), Map.empty, "nowt much", S3Package("artifact-bucket", "project/123/example"))
+    val p = DeploymentPackage("example", Seq(App("logcabin"), App("elasticsearch")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"))
     asg.groupForAppAndStage(p, Stage("PROD"), NamedStack("contentapi")) should be (desiredGroup)
   }
 

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -141,7 +141,7 @@ class Configuration(val application: String, val webappConfDirectory: String = "
       lazy val credentialsProvider = credentialsProviderChain(accessKey, secretKey)
       lazy val regionName = configuration.getStringProperty("artifact.aws.region", "eu-west-1")
       lazy val region = awsRegion(regionName)
-      implicit lazy val client = new AmazonS3Client(credentialsProvider).withRegion(region)
+      implicit lazy val client: AmazonS3Client = new AmazonS3Client(credentialsProvider).withRegion(region)
     }
   }
 
@@ -154,7 +154,7 @@ class Configuration(val application: String, val webappConfDirectory: String = "
       lazy val credentialsProvider = credentialsProviderChain(accessKey, secretKey)
       lazy val regionName = configuration.getStringProperty("build.aws.region", "eu-west-1")
       lazy val region = awsRegion(regionName)
-      implicit lazy val client = new AmazonS3Client(credentialsProvider).withRegion(region)
+      implicit lazy val client: AmazonS3Client = new AmazonS3Client(credentialsProvider).withRegion(region)
     }
   }
 
@@ -166,7 +166,7 @@ class Configuration(val application: String, val webappConfDirectory: String = "
       lazy val credentialsProvider = credentialsProviderChain(accessKey, secretKey)
       lazy val regionName = configuration.getStringProperty("tag.aws.region", "eu-west-1")
       lazy val region = awsRegion(regionName)
-      implicit lazy val client = new AmazonS3Client(credentialsProvider).withRegion(region)
+      implicit lazy val client: AmazonS3Client = new AmazonS3Client(credentialsProvider).withRegion(region)
     }
   }
 

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -172,7 +172,7 @@ class Configuration(val application: String, val webappConfDirectory: String = "
 
   object target {
     object aws {
-      lazy val defaultRegionName = configuration.getStringProperty("target.aws.defaultRegion", "eu-west-1")
+      lazy val deployJsonRegionName = configuration.getStringProperty("target.aws.deployJsonRegion", "eu-west-1")
     }
   }
 

--- a/riff-raff/app/controllers/Application.scala
+++ b/riff-raff/app/controllers/Application.scala
@@ -6,7 +6,7 @@ import play.api.{Environment, Logger}
 import magenta.deployment_type.DeploymentType
 import magenta.{App, DeploymentPackage}
 import magenta.withResource
-import magenta.artifact.S3Package
+import magenta.artifact.S3Path
 import play.api.libs.ws.WSClient
 import resources.PrismLookup
 
@@ -150,7 +150,7 @@ class Application(prismLookup: PrismLookup)(implicit environment: Environment, v
                       case (Some(default), _) => Some(default.toString)
                       case (None, Some(pkgFunction)) =>
                         Some(pkgFunction(
-                          DeploymentPackage("<packageName>",Seq(App("<app>")),Map.empty,"<deploymentType>", S3Package("<bucket>", "<prefix>"))
+                          DeploymentPackage("<packageName>",Seq(App("<app>")),Map.empty,"<deploymentType>", S3Path("<bucket>", "<prefix>"))
                         ).toString)
                       case (_, _) => None
                     }

--- a/riff-raff/app/controllers/DeployController.scala
+++ b/riff-raff/app/controllers/DeployController.scala
@@ -6,7 +6,7 @@ import ci.{Builds, S3Tag, TagClassification}
 import conf.Configuration
 import deployment.{Deployments, PreviewController, PreviewResult}
 import magenta._
-import magenta.artifact.S3Artifact
+import magenta.artifact.{S3JsonArtifact, S3Location}
 import org.joda.time.{DateTime, DateTimeZone}
 import org.joda.time.format.DateTimeFormat
 import play.api.data.Form
@@ -245,9 +245,9 @@ class DeployController(deployments: Deployments, prismLookup: PrismLookup)
   }
 
   def deployObject(projectName: String, id: String) = AuthAction { implicit request =>
-    val artifact = S3Artifact(Build(projectName, id), Configuration.artifact.aws.bucketName)
+    val artifact = S3JsonArtifact(Build(projectName, id), Configuration.artifact.aws.bucketName)
     val deployObjectPath = artifact.deployObject
-    val deployObjectContent = deployObjectPath.fetchContentAsString()(Configuration.artifact.aws.client)
+    val deployObjectContent = S3Location.fetchContentAsString(deployObjectPath)(Configuration.artifact.aws.client)
     (deployObjectContent, deployObjectPath.extension) match {
       case (Some(json), Some("json")) => Ok(json).as("application/json")
       case _ => NotFound(s"JSON file ${artifact.deployObjectName} not found for $projectName $id")

--- a/riff-raff/app/deployment/actors/DeployGroupRunner.scala
+++ b/riff-raff/app/deployment/actors/DeployGroupRunner.scala
@@ -174,7 +174,7 @@ class DeployGroupRunner(
 //            safeReporter.fail(s"Failed to successfully resolve the deployment: ${errors.errors.size} errors")
 //          case Right(success) => success
 //        }
-        ???
+        safeReporter.fail("Riff-Raff does not yet support riff-raff.yaml files")
       } getOrElse {
         safeReporter.info("Falling back to deploy.json")
         val s3Artifact = S3JsonArtifact(record.parameters.build, bucketName)
@@ -182,7 +182,7 @@ class DeployGroupRunner(
           Try(artifact.deployObject.fetchContentAsString()(client).get)
         }(client, safeReporter)
         val project = JsonReader.parse(json, s3Artifact)
-        record.parameters.toDeployContext(record.uuid, project, resources, Region(target.aws.defaultRegionName))
+        DeployContext(record.uuid, record.parameters, project, resources, Region(target.aws.deployJsonRegionName))
       }
 
       if (DeploymentGraph.toTaskList(context.tasks).isEmpty)

--- a/riff-raff/app/deployment/actors/DeployGroupRunner.scala
+++ b/riff-raff/app/deployment/actors/DeployGroupRunner.scala
@@ -12,7 +12,7 @@ import magenta.deployment_type.DeploymentType
 import magenta.graph.{DeploymentGraph, DeploymentTasks, Graph, StartNode, ValueNode}
 import magenta.input.resolver.Resolver
 import magenta.json.JsonReader
-import magenta.{DeployContext, DeployReporter, DeployStoppedException, DeploymentResources}
+import magenta.{DeployContext, DeployReporter, DeployStoppedException, DeploymentResources, Region}
 import org.joda.time.DateTime
 import resources.PrismLookup
 
@@ -182,7 +182,7 @@ class DeployGroupRunner(
           Try(artifact.deployObject.fetchContentAsString()(client).get)
         }(client, safeReporter)
         val project = JsonReader.parse(json, s3Artifact)
-        record.parameters.toDeployContext(record.uuid, project, resources))
+        record.parameters.toDeployContext(record.uuid, project, resources, Region(target.aws.defaultRegionName))
       }
 
       if (DeploymentGraph.toTaskList(context.tasks).isEmpty)

--- a/riff-raff/app/deployment/preview.scala
+++ b/riff-raff/app/deployment/preview.scala
@@ -68,7 +68,7 @@ object Preview {
    */
   def apply(parameters: DeployParameters, resources: DeploymentResources): Preview = {
     val project = Preview.getProject(parameters.build, resources)
-    Preview(project, parameters, resources, Region(target.aws.defaultRegionName))
+    Preview(project, parameters, resources, Region(target.aws.deployJsonRegionName))
   }
 }
 

--- a/riff-raff/test/deployment/Fixtures.scala
+++ b/riff-raff/test/deployment/Fixtures.scala
@@ -3,8 +3,8 @@ package deployment
 import java.util.UUID
 
 import com.amazonaws.services.s3.AmazonS3Client
-import magenta.graph.{DeploymentTasks, DeploymentGraph, Graph}
-import magenta.{Build, DeployContext, DeployParameters, DeployReporter, Deployer, Host, KeyRing, NamedStack, Project, Stage}
+import magenta.graph.{DeploymentGraph, DeploymentTasks, Graph}
+import magenta.{Build, DeployContext, DeployParameters, DeployReporter, Deployer, Host, KeyRing, NamedStack, Project, Region, Stage}
 import magenta.tasks._
 import org.scalatest.mock.MockitoSugar
 
@@ -13,13 +13,13 @@ object Fixtures extends MockitoSugar {
   implicit val artifactClient = mock[AmazonS3Client]
 
   val threeSimpleTasks: List[Task] = List(
-    S3Upload("test-bucket", Seq()),
+    S3Upload(Region("eu-west-1"), "test-bucket", Seq()),
     SayHello(Host("testHost")),
     HealthcheckGrace(1000)
   )
 
   val twoTasks = List(
-    S3Upload("test-bucket", Seq()),
+    S3Upload(Region("eu-west-1"), "test-bucket", Seq()),
     HealthcheckGrace(1000)
   )
 

--- a/riff-raff/test/deployment/Fixtures.scala
+++ b/riff-raff/test/deployment/Fixtures.scala
@@ -45,7 +45,7 @@ object Fixtures extends MockitoSugar {
   def createContext(tasks: List[Task], uuid: UUID, parameters: DeployParameters): DeployContext =
     createContext(DeploymentGraph(tasks, parameters.stacks.head.name), uuid, parameters)
   def createContext(taskGraph: Graph[DeploymentTasks], uuid: UUID, parameters: DeployParameters): DeployContext =
-    DeployContext(uuid, parameters, Project(), taskGraph)
+    DeployContext(uuid, parameters, taskGraph)
 
   def createReporter(record: Record) = DeployReporter.rootReporterFor(record.uuid, record.parameters)
 }


### PR DESCRIPTION
I'm afraid this bundles a handful of changes together (be glad I stopped here). I've tried to separate it into two commits to aid reviewing - but I've not managed to separate them cleanly enough to make it worth splitting this PR.

The first commit is concerned with:
 - More consistent use of DeploymentResources
 - `S3Artifact` is split into `S3YamlArtifact` and `S3JsonArtifact`
 - `S3Package` is eliminated

The second commit is all about making Regions a first class concept within Riff-Raff which is required now that regions can be configured in the new config file.