### PR TITLE
I must never use a default parameter for a critical flag

### DIFF
--- a/magenta-lib/src/main/scala/magenta/DeploymentPackage.scala
+++ b/magenta-lib/src/main/scala/magenta/DeploymentPackage.scala
@@ -10,7 +10,7 @@ case class DeploymentPackage(
   pkgSpecificData: Map[String, JsValue],
   deploymentTypeName: String,
   s3Package: S3Path,
-  legacyConfig: Boolean = true) {
+  legacyConfig: Boolean) {
 
   def mkAction(name: String): Action = pkgType.mkAction(name)(this)
 

--- a/magenta-lib/src/main/scala/magenta/input/resolver/TaskResolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/TaskResolver.scala
@@ -33,7 +33,8 @@ object TaskResolver {
       pkgApps = Seq(App(deployment.app)),
       pkgSpecificData = deployment.parameters,
       deploymentTypeName = deployment.`type`,
-      s3Package = S3Path(artifact, deployment.contentDirectory)
+      s3Package = S3Path(artifact, deployment.contentDirectory),
+      legacyConfig = false
     )
   }
 

--- a/magenta-lib/src/main/scala/magenta/json/JsonInputFile.scala
+++ b/magenta-lib/src/main/scala/magenta/json/JsonInputFile.scala
@@ -87,7 +87,8 @@ object JsonReader {
       },
       jsonPackage.safeData,
       jsonPackage.`type`,
-      S3Path(artifact, s"packages/${jsonPackage.fileName.getOrElse(name)}")
+      S3Path(artifact, s"packages/${jsonPackage.fileName.getOrElse(name)}"),
+      legacyConfig = true
     )
 
 }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -24,7 +24,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
 
     val app = Seq(App("app"))
 
-    val p = DeploymentPackage("app", app, data, "asg-elb", S3Path("artifact-bucket", "test/123/app"))
+    val p = DeploymentPackage("app", app, data, "asg-elb", S3Path("artifact-bucket", "test/123/app"), true)
 
     AutoScaling.actions("deploy")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack, region)) should be (List(
       CheckForStabilization(p, PROD, UnnamedStack, Region("eu-west-1")),
@@ -41,6 +41,20 @@ class AutoScalingTest extends FlatSpec with Matchers {
     ))
   }
 
+  it should "default publicReadAcl to false when a new style package" in {
+    val data: Map[String, JsValue] = Map(
+      "bucket" -> JsString("asg-bucket")
+    )
+
+    val app = Seq(App("app"))
+
+    val p = DeploymentPackage("app", app, data, "asg-elb", S3Path("artifact-bucket", "test/123/app"), false)
+
+    AutoScaling.actions("uploadArtifacts")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack, region)) should matchPattern {
+      case List(S3Upload(_,_,_,_,_,false,_)) =>
+    }
+  }
+
   "seconds to wait" should "be overridable" in {
     val data: Map[String, JsValue] = Map(
       "bucket" -> JsString("asg-bucket"),
@@ -51,7 +65,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
 
     val app = Seq(App("app"))
 
-    val p = DeploymentPackage("app", app, data, "asg-elb", S3Path("artifact-bucket", "test/123/app"))
+    val p = DeploymentPackage("app", app, data, "asg-elb", S3Path("artifact-bucket", "test/123/app"), true)
 
     AutoScaling.actions("deploy")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack, region)) should be (List(
       CheckForStabilization(p, PROD, UnnamedStack, Region("eu-west-1")),

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -23,7 +23,7 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
     val app = Seq(App("app"))
     val stack = NamedStack("cfn")
     val cfnStackName = s"cfn-app-PROD"
-    val p = DeploymentPackage("app", app, data, "cloudformation", S3Path("artifact-bucket", "test/123"))
+    val p = DeploymentPackage("app", app, data, "cloudformation", S3Path("artifact-bucket", "test/123"), true)
 
     inside(CloudFormation.actions("updateStack")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), stack, region))) {
       case List(updateTask, checkTask) =>

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -31,7 +31,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
       "bucket" -> JsString("bucket-1234")
     )
 
-    val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package)
+    val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package, true)
 
     val thrown = the[NoSuchElementException] thrownBy {
       S3.actions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)) should be (
@@ -54,7 +54,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
       "cacheControl" -> JsString("no-cache")
     )
 
-    val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package)
+    val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package, true)
 
     S3.actions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)) should be (
       List(S3Upload(
@@ -76,7 +76,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
       )
     )
 
-    val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package)
+    val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package, true)
 
     inside(S3.actions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)).head) {
       case upload: S3Upload => upload.cacheControlPatterns should be(List(PatternValue("^sub", "no-cache"), PatternValue(".*", "public; max-age:3600")))
@@ -92,7 +92,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
       "prefixPackage" -> JsBoolean(false)
     )
 
-    val p = DeploymentPackage("myapp", Seq(app1), data, "aws-s3", sourceS3Package)
+    val p = DeploymentPackage("myapp", Seq(app1), data, "aws-s3", sourceS3Package, true)
 
     val lookup = stubLookup(List(Host("the_host", stage=CODE.name).app(app1)), Map("s3-path-prefix" -> Seq(Datum(None, app1.name, CODE.name, "testing/2016/05/brexit-companion", None))))
 
@@ -111,7 +111,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
       )
     )
 
-    val p = DeploymentPackage("myapp", Seq.empty, data, "aws-lambda", S3Path("artifact-bucket", "test/123"))
+    val p = DeploymentPackage("myapp", Seq.empty, data, "aws-lambda", S3Path("artifact-bucket", "test/123"), true)
 
     Lambda.actions("updateLambda")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)) should be (
       List(UpdateLambda(S3Path("artifact-bucket","test/123/lambda.zip"), "myLambda", defaultRegion)
@@ -127,7 +127,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside {
       )
     )
 
-    val p = DeploymentPackage("myapp", Seq.empty, badData, "aws-lambda", S3Path("artifact-bucket", "test/123"))
+    val p = DeploymentPackage("myapp", Seq.empty, badData, "aws-lambda", S3Path("artifact-bucket", "test/123"), true)
 
     val thrown = the[FailException] thrownBy {
       Lambda.actions("updateLambda")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)) should be (

--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
@@ -26,7 +26,7 @@ class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
   )
 
   val app = Seq(App("lambda"))
-  val pkg = DeploymentPackage("lambda", app, data, "aws-s3-lambda", S3Path("artifact-bucket", "test/123/lambda"))
+  val pkg = DeploymentPackage("lambda", app, data, "aws-s3-lambda", S3Path("artifact-bucket", "test/123/lambda"), true)
   val defaultRegion = Region("eu-west-1")
 
   it should "produce an S3 upload task" in {
@@ -60,7 +60,7 @@ class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
       "functionNames" -> Json.arr("MyFunction-")
     )
     val app = Seq(App("lambda"))
-    val pkg = DeploymentPackage("lambda", app, dataWithStack, "aws-s3-lambda", S3Path("artifact-bucket", "test/123/lambda"))
+    val pkg = DeploymentPackage("lambda", app, dataWithStack, "aws-s3-lambda", S3Path("artifact-bucket", "test/123/lambda"), true)
 
     val tasks = Lambda.actions("updateLambda")(pkg)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("some-stack"), region))
     tasks should be (List(
@@ -82,7 +82,7 @@ class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
       "regions" -> Json.arr("us-east-1", "ap-southeast-2")
     )
     val app = Seq(App("lambda"))
-    val pkg = DeploymentPackage("lambda", app, dataWithStack, "aws-s3-lambda", S3Path("artifact-bucket", "test/123/lambda"))
+    val pkg = DeploymentPackage("lambda", app, dataWithStack, "aws-s3-lambda", S3Path("artifact-bucket", "test/123/lambda"), true)
 
     val tasks = Lambda.actions("updateLambda")(pkg)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("some-stack"), region))
     tasks should be (List(

--- a/magenta-lib/src/test/scala/magenta/fixtures/package.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/package.scala
@@ -22,7 +22,7 @@ package object fixtures {
 
   def project(recipe: Recipe, stacks: Stack*) = Project(Map.empty, Map(recipe.name -> recipe), defaultStacks = stacks)
 
-  def stubPackage = DeploymentPackage("stub project", Seq(app1), Map(), "stub-package-type", null)
+  def stubPackage = DeploymentPackage("stub project", Seq(app1), Map(), "stub-package-type", null, false)
 
   def stubPackageType(actionNames: Seq[String]) = StubDeploymentType(
     actions = {

--- a/magenta-lib/src/test/scala/magenta/json/JsonReaderTest.scala
+++ b/magenta-lib/src/test/scala/magenta/json/JsonReaderTest.scala
@@ -66,9 +66,12 @@ class JsonReaderTest extends FlatSpec with Matchers {
     parsed.applications should be (Set(App("index-builder"), App("api"), App("solr")))
 
     parsed.packages.size should be (3)
-    parsed.packages("index-builder") should be (DeploymentPackage("index-builder", Seq(App("index-builder")), Map.empty, "autoscaling", S3Path("artifact-bucket", "test/123/packages/index-builder")))
-    parsed.packages("api") should be (DeploymentPackage("api", Seq(App("api")), Map("healthcheck_paths" -> Json.arr("/api/index.json","/api/search.json")), "autoscaling", S3Path("artifact-bucket", "test/123/packages/api")))
-    parsed.packages("solr") should be (DeploymentPackage("solr", Seq(App("solr")), Map("port" -> JsString("8400")), "autoscaling", S3Path("artifact-bucket", "test/123/packages/solr")))
+    parsed.packages("index-builder") shouldBe
+      DeploymentPackage("index-builder", Seq(App("index-builder")), Map.empty, "autoscaling", S3Path("artifact-bucket", "test/123/packages/index-builder"), true)
+    parsed.packages("api") shouldBe
+      DeploymentPackage("api", Seq(App("api")), Map("healthcheck_paths" -> Json.arr("/api/index.json","/api/search.json")), "autoscaling", S3Path("artifact-bucket", "test/123/packages/api"), true)
+    parsed.packages("solr") shouldBe
+      DeploymentPackage("solr", Seq(App("solr")), Map("port" -> JsString("8400")), "autoscaling", S3Path("artifact-bucket", "test/123/packages/solr"), true)
 
     val recipes = parsed.recipes
     recipes.size should be (4)

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
@@ -18,7 +18,7 @@ class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
     val asg = new AutoScalingGroup().withDesiredCapacity(3).withAutoScalingGroupName("test").withMaxSize(10)
     val asgClientMock = mock[AmazonAutoScalingClient]
 
-    val p = DeploymentPackage("test", Seq(App("app")), Map.empty, "test", S3Path("artifact-bucket", "project/123/test"))
+    val p = DeploymentPackage("test", Seq(App("app")), Map.empty, "test", S3Path("artifact-bucket", "project/123/test"), true)
 
     val task = new DoubleSize(p, Stage("PROD"), UnnamedStack, Region("eu-west-1"))
 
@@ -35,7 +35,7 @@ class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
 
     val asgClientMock = mock[AmazonAutoScalingClient]
 
-    val p = DeploymentPackage("test", Seq(App("app")), Map.empty, "test", S3Path("artifact-bucket", "project/123/test"))
+    val p = DeploymentPackage("test", Seq(App("app")), Map.empty, "test", S3Path("artifact-bucket", "project/123/test"), true)
 
     val task = new CheckGroupSize(p, Stage("PROD"), UnnamedStack, Region("eu-west-1"))
 

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
@@ -31,7 +31,7 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         AutoScalingGroup("App" -> "example", "Stage" -> "TEST")
       ))
 
-    val p = DeploymentPackage("example", Seq(App("app")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"))
+    val p = DeploymentPackage("example", Seq(App("app")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"), true)
     ASG.groupForAppAndStage(p, Stage("PROD"), UnnamedStack, asgClientMock, reporter) should be (desiredGroup)
   }
 
@@ -47,7 +47,7 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         AutoScalingGroup(("Role" -> "example"), ("Stage" -> "TEST"))
       ))
 
-    val p = DeploymentPackage("example", Seq(App("app")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"))
+    val p = DeploymentPackage("example", Seq(App("app")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"), true)
     ASG.groupForAppAndStage(p, Stage("PROD"), UnnamedStack, asgClientMock, reporter) should be (desiredGroup)
   }
 
@@ -66,7 +66,7 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         AutoScalingGroup("Stack" -> "monkey", "App" -> "logcabin", "Stage" -> "PROD")
       ))
 
-    val p = DeploymentPackage("example", Seq(App("logcabin")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"))
+    val p = DeploymentPackage("example", Seq(App("logcabin")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"), true)
     ASG.groupForAppAndStage(p, Stage("PROD"), NamedStack("contentapi"), asgClientMock, reporter) should be (desiredGroup)
   }
 
@@ -85,7 +85,7 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         AutoScalingGroup("Stack" -> "monkey", "App" -> "logcabin", "Stage" -> "PROD")
       ))
 
-    val p = DeploymentPackage("example", Seq(App("logcabin"), App("elasticsearch")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"))
+    val p = DeploymentPackage("example", Seq(App("logcabin"), App("elasticsearch")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"), true)
     ASG.groupForAppAndStage(p, Stage("PROD"), NamedStack("contentapi"), asgClientMock, reporter) should be (desiredGroup)
   }
 
@@ -105,7 +105,7 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         AutoScalingGroup("Stack" -> "monkey", "App" -> "logcabin", "Stage" -> "PROD")
       ))
 
-    val p = DeploymentPackage("example", Seq(App("logcabin"), App("elasticsearch")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"))
+    val p = DeploymentPackage("example", Seq(App("logcabin"), App("elasticsearch")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"), true)
 
     a [FailException] should be thrownBy {
       ASG.groupForAppAndStage(p, Stage("PROD"), NamedStack("contentapi"), asgClientMock, reporter) should be (desiredGroup)
@@ -172,7 +172,7 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         desiredGroup
       ))
 
-    val p = DeploymentPackage("example", Seq(App("logcabin"), App("elasticsearch")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"))
+    val p = DeploymentPackage("example", Seq(App("logcabin"), App("elasticsearch")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"), true)
     ASG.groupForAppAndStage(p, Stage("PROD"), NamedStack("contentapi"), asgClientMock, reporter) should be (desiredGroup)
   }
 


### PR DESCRIPTION
The field on this case class was never set in the case where it _wasn't_ a `legacyConfig`. Thus everything was treated as if it was a legacy configuration. This is a lesson to not use a default parameter in order to avoid updating all of the tests.