### PR TITLE
Numerous parameter validation improvements

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
@@ -32,6 +32,7 @@ object AmiCloudFormationParameter extends DeploymentType {
   override def actions = {
     case "update" => pkg => (resources, target) => {
       implicit val keyRing = resources.assembleKeyring(target, pkg)
+      implicit val reporter = resources.reporter
 
       val stackName = target.stack.nameOption.filter(_ => prependStackToCloudFormationStackName(pkg))
       val stageName = Some(target.parameters.stage.name).filter(_ => appendStageToCloudFormationStackName(pkg))

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
@@ -32,18 +32,18 @@ object AmiCloudFormationParameter extends DeploymentType {
   override def actions = {
     case "update" => pkg => (resources, target) => {
       implicit val keyRing = resources.assembleKeyring(target, pkg)
-      implicit val reporter = resources.reporter
+      val reporter = resources.reporter
 
-      val stackName = target.stack.nameOption.filter(_ => prependStackToCloudFormationStackName(pkg))
-      val stageName = Some(target.parameters.stage.name).filter(_ => appendStageToCloudFormationStackName(pkg))
-      val cloudFormationStackNameParts = Seq(stackName, Some(cloudFormationStackName(pkg)), stageName).flatten
+      val stackName = target.stack.nameOption.filter(_ => prependStackToCloudFormationStackName(pkg, reporter))
+      val stageName = Some(target.parameters.stage.name).filter(_ => appendStageToCloudFormationStackName(pkg, reporter))
+      val cloudFormationStackNameParts = Seq(stackName, Some(cloudFormationStackName(pkg, reporter)), stageName).flatten
       val fullCloudFormationStackName = cloudFormationStackNameParts.mkString("-")
 
       List(
         UpdateAmiCloudFormationParameterTask(
           fullCloudFormationStackName,
-          amiParameter(pkg),
-          amiTags(pkg),
+          amiParameter(pkg, reporter),
+          amiTags(pkg, reporter),
           resources.lookup.getLatestAmi,
           target.parameters.stage,
           target.stack

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -93,6 +93,7 @@ object AutoScaling  extends DeploymentType {
   def actions = {
     case "deploy" => (pkg) => (resources, target) => {
       implicit val keyRing = resources.assembleKeyring(target, pkg)
+      implicit val reporter = resources.reporter
       val parameters = target.parameters
       val stack = target.stack
       List(
@@ -112,6 +113,7 @@ object AutoScaling  extends DeploymentType {
     case "uploadArtifacts" => (pkg) => (resources, target) =>
       implicit val keyRing = resources.assembleKeyring(target, pkg)
       implicit val artifactClient = resources.artifactClient
+      implicit val reporter = resources.reporter
       val prefix = S3Upload.prefixGenerator(
         stack = if (prefixStack(pkg)) Some(target.stack) else None,
         stage = if (prefixStage(pkg)) Some(target.parameters.stage) else None,

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -66,6 +66,7 @@ object CloudFormation extends DeploymentType {
     case "updateStack" => pkg => (resources, target) => {
       implicit val keyRing = resources.assembleKeyring(target, pkg)
       implicit val artifactClient = resources.artifactClient
+      implicit val reporter = resources.reporter
 
       val stackName = target.stack.nameOption.filter(_ => prependStackToCloudFormationStackName(pkg))
       val stageName = Some(target.parameters.stage.name).filter(_ => appendStageToCloudFormationStackName(pkg))

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -66,28 +66,28 @@ object CloudFormation extends DeploymentType {
     case "updateStack" => pkg => (resources, target) => {
       implicit val keyRing = resources.assembleKeyring(target, pkg)
       implicit val artifactClient = resources.artifactClient
-      implicit val reporter = resources.reporter
+      val reporter = resources.reporter
 
-      val stackName = target.stack.nameOption.filter(_ => prependStackToCloudFormationStackName(pkg))
-      val stageName = Some(target.parameters.stage.name).filter(_ => appendStageToCloudFormationStackName(pkg))
-      val cloudFormationStackNameParts = Seq(stackName, Some(cloudFormationStackName(pkg)), stageName).flatten
+      val stackName = target.stack.nameOption.filter(_ => prependStackToCloudFormationStackName(pkg, reporter))
+      val stageName = Some(target.parameters.stage.name).filter(_ => appendStageToCloudFormationStackName(pkg, reporter))
+      val cloudFormationStackNameParts = Seq(stackName, Some(cloudFormationStackName(pkg, reporter)), stageName).flatten
       val fullCloudFormationStackName = cloudFormationStackNameParts.mkString("-")
 
-      val globalParams = templateParameters(pkg)
-      val stageParams = templateStageParameters(pkg).lift.apply(target.parameters.stage.name).getOrElse(Map())
+      val globalParams = templateParameters(pkg, reporter)
+      val stageParams = templateStageParameters(pkg, reporter).lift.apply(target.parameters.stage.name).getOrElse(Map())
       val params = globalParams ++ stageParams
 
       List(
         UpdateCloudFormationTask(
           fullCloudFormationStackName,
-          S3Path(pkg.s3Package, templatePath(pkg)),
+          S3Path(pkg.s3Package, templatePath(pkg, reporter)),
           params,
-          amiParameter(pkg),
-          amiTags(pkg),
+          amiParameter(pkg, reporter),
+          amiTags(pkg, reporter),
           resources.lookup.getLatestAmi,
           target.parameters.stage,
           target.stack,
-          createStackIfAbsent(pkg)
+          createStackIfAbsent(pkg, reporter)
         ),
         CheckUpdateEventsTask(fullCloudFormationStackName)
       )

--- a/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
@@ -53,7 +53,7 @@ case class Param[T](name: String,
 
   def get(pkg: DeploymentPackage)(implicit reads: Reads[T]): Option[T] =
     pkg.pkgSpecificData.get(name).flatMap(jsValue => Json.fromJson[T](jsValue).asOpt)
-  def apply(pkg: DeploymentPackage)(implicit reporter: DeployReporter, reads: Reads[T], manifest: Manifest[T]): T = {
+  def apply(pkg: DeploymentPackage, reporter: DeployReporter)(implicit reads: Reads[T], manifest: Manifest[T]): T = {
     val maybeValue = get(pkg)
     val maybeDefault = defaultValue.orElse(defaultValueFromPackage.map(_ (pkg)))
     if (!pkg.legacyConfig && maybeDefault.isDefined && maybeValue == maybeDefault) {

--- a/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
@@ -27,31 +27,31 @@ object ElasticSearch extends DeploymentType {
   def actions = {
     case "deploy" => (pkg) => (resources, target) => {
       implicit val keyRing = resources.assembleKeyring(target, pkg)
-      implicit val reporter = resources.reporter
+      val reporter = resources.reporter
       val parameters = target.parameters
       val stack = target.stack
       List(
         CheckGroupSize(pkg, parameters.stage, stack, target.region),
-        WaitForElasticSearchClusterGreen(pkg, parameters.stage, stack, secondsToWait(pkg) * 1000, target.region),
+        WaitForElasticSearchClusterGreen(pkg, parameters.stage, stack, secondsToWait(pkg, reporter) * 1000, target.region),
         SuspendAlarmNotifications(pkg, parameters.stage, stack, target.region),
         TagCurrentInstancesWithTerminationTag(pkg, parameters.stage, stack, target.region),
         DoubleSize(pkg, parameters.stage, stack, target.region),
-        WaitForElasticSearchClusterGreen(pkg, parameters.stage, stack, secondsToWait(pkg) * 1000, target.region),
-        CullElasticSearchInstancesWithTerminationTag(pkg, parameters.stage, stack, secondsToWait(pkg) * 1000, target.region),
+        WaitForElasticSearchClusterGreen(pkg, parameters.stage, stack, secondsToWait(pkg, reporter) * 1000, target.region),
+        CullElasticSearchInstancesWithTerminationTag(pkg, parameters.stage, stack, secondsToWait(pkg, reporter) * 1000, target.region),
         ResumeAlarmNotifications(pkg, parameters.stage, stack, target.region)
       )
     }
     case "uploadArtifacts" => (pkg) => (resources, target) =>
       implicit val keyRing = resources.assembleKeyring(target, pkg)
       implicit val artifactClient = resources.artifactClient
-      implicit val reporter = resources.reporter
+      val reporter = resources.reporter
       val prefix: String = S3Upload.prefixGenerator(target.stack, target.parameters.stage, pkg.name)
       List(
         S3Upload(
           target.region,
-          bucket(pkg),
+          bucket(pkg, reporter),
           Seq(pkg.s3Package -> prefix),
-          publicReadAcl = publicReadAcl(pkg)
+          publicReadAcl = publicReadAcl(pkg, reporter)
         )
       )
   }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
@@ -27,6 +27,7 @@ object ElasticSearch extends DeploymentType {
   def actions = {
     case "deploy" => (pkg) => (resources, target) => {
       implicit val keyRing = resources.assembleKeyring(target, pkg)
+      implicit val reporter = resources.reporter
       val parameters = target.parameters
       val stack = target.stack
       List(
@@ -43,6 +44,7 @@ object ElasticSearch extends DeploymentType {
     case "uploadArtifacts" => (pkg) => (resources, target) =>
       implicit val keyRing = resources.assembleKeyring(target, pkg)
       implicit val artifactClient = resources.artifactClient
+      implicit val reporter = resources.reporter
       val prefix: String = S3Upload.prefixGenerator(target.stack, target.parameters.stage, pkg.name)
       List(
         S3Upload(

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -74,7 +74,7 @@ object Lambda extends DeploymentType  {
 
   def defaultActions = List("uploadLambda", "updateLambda")
 
-  def lambdaToProcess(pkg: DeploymentPackage, stage: String, stack: Stack, targetRegion: Region)(implicit reporter: DeployReporter): List[LambdaFunction] = {
+  def lambdaToProcess(pkg: DeploymentPackage, stage: String, stack: Stack, targetRegion: Region, reporter: DeployReporter): List[LambdaFunction] = {
     val bucketOption = bucketParam.get(pkg)
     if (bucketOption.isEmpty) {
       if (pkg.legacyConfig)
@@ -87,13 +87,13 @@ object Lambda extends DeploymentType  {
     if (!pkg.legacyConfig && regionsOption.isDefined) reporter.fail(s"The regions parameter for the aws-lambda deployment type should not be used in the riff-raff.yaml format. Use the global, template or deployment regions fields of the riff-raff.yaml format instead.")
     val regions: List[Region] = regionsOption.map(_.filter(regionExists(_)(reporter)).map(Region)).getOrElse(List(targetRegion))
 
-    (functionNamesParam.get(pkg), functionsParam.get(pkg), prefixStackParam(pkg)) match {
+    (functionNamesParam.get(pkg), functionsParam.get(pkg), prefixStackParam(pkg, reporter)) match {
       case (Some(functionNames), None, prefixStack) =>
         val stackNamePrefix = stack.nameOption.filter(_ => prefixStack).getOrElse("")
         for {
           name <- functionNames
           region <- regions
-        } yield LambdaFunction(s"$stackNamePrefix$name$stage", fileNameParam(pkg), region, bucketOption)
+        } yield LambdaFunction(s"$stackNamePrefix$name$stage", fileNameParam(pkg, reporter), region, bucketOption)
         
       case (None, Some(functionsMap), _) =>
         val functionDefinition = functionsMap.getOrElse(stage, reporter.fail(s"Function not defined for stage $stage"))
@@ -124,7 +124,7 @@ object Lambda extends DeploymentType  {
     case "uploadLambda" => (pkg) => (resources, target) => {
       implicit val keyRing = resources.assembleKeyring(target, pkg)
       implicit val artifactClient = resources.artifactClient
-      lambdaToProcess(pkg, target.parameters.stage.name, target.stack, target.region)(resources.reporter).flatMap {
+      lambdaToProcess(pkg, target.parameters.stage.name, target.stack, target.region, resources.reporter).flatMap {
         case LambdaFunctionFromZip(_,_, _) => None
 
         case LambdaFunctionFromS3(functionName, fileName, region, s3Bucket) =>
@@ -139,7 +139,7 @@ object Lambda extends DeploymentType  {
     case "updateLambda" => (pkg) => (resources, target) => {
       implicit val keyRing = resources.assembleKeyring(target, pkg)
       implicit val artifactClient = resources.artifactClient
-      lambdaToProcess(pkg, target.parameters.stage.name, target.stack, target.region)(resources.reporter).flatMap {
+      lambdaToProcess(pkg, target.parameters.stage.name, target.stack, target.region, resources.reporter).flatMap {
         case LambdaFunctionFromZip(functionName, fileName, region) =>
           Some(UpdateLambda(S3Path(pkg.s3Package,fileName), functionName, region))
 

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -74,7 +74,7 @@ object Lambda extends DeploymentType  {
 
   def defaultActions = List("uploadLambda", "updateLambda")
 
-  def lambdaToProcess(pkg: DeploymentPackage, stage: String, stack: Stack, targetRegion: Region)(reporter: DeployReporter): List[LambdaFunction] = {
+  def lambdaToProcess(pkg: DeploymentPackage, stage: String, stack: Stack, targetRegion: Region)(implicit reporter: DeployReporter): List[LambdaFunction] = {
     val bucketOption = bucketParam.get(pkg)
     if (bucketOption.isEmpty) {
       if (pkg.legacyConfig)

--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
@@ -117,6 +117,7 @@ object S3 extends DeploymentType {
 
       implicit val keyRing = resources.assembleKeyring(target, pkg)
       implicit val artifactClient = resources.artifactClient
+      implicit val reporter = resources.reporter
 
       assert(bucket.get(pkg).isDefined != bucketResource.get(pkg).isDefined, "One, and only one, of bucket or bucketResource must be specified")
       val bucketName = bucket.get(pkg) getOrElse {

--- a/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
@@ -51,14 +51,14 @@ object SelfDeploy extends DeploymentType {
       )
     case "selfDeploy" => (pkg) => (resources, target) =>
       implicit val keyRing = resources.assembleKeyring(target, pkg)
-      implicit val reporter = resources.reporter
+      val reporter = resources.reporter
       val hosts = pkg.apps.toList.flatMap(app => resources.lookup.hosts.get(pkg, app, target.parameters, target.stack))
       hosts.map{ host =>
         ChangeSwitch(
           host,
-          managementProtocol(pkg),
-          managementPort(pkg),
-          switchboardPath(pkg),
+          managementProtocol(pkg, reporter),
+          managementPort(pkg, reporter),
+          switchboardPath(pkg, reporter),
           "shutdown-when-inactive",
           desiredState=true
         )

--- a/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
@@ -51,6 +51,7 @@ object SelfDeploy extends DeploymentType {
       )
     case "selfDeploy" => (pkg) => (resources, target) =>
       implicit val keyRing = resources.assembleKeyring(target, pkg)
+      implicit val reporter = resources.reporter
       val hosts = pkg.apps.toList.flatMap(app => resources.lookup.hosts.get(pkg, app, target.parameters, target.stack))
       hosts.map{ host =>
         ChangeSwitch(

--- a/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
+++ b/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
@@ -130,7 +130,7 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
 
   val oneRecipeName = RecipeName("one")
 
-  val basePackageType = stubPackageType(Seq("init_action_one"))
+  val basePackageType = stubDeploymentType(Seq("init_action_one"))
 
   val baseRecipe = Recipe("one",
     actions = basePackageType.mkAction("init_action_one")(stubPackage) :: Nil,

--- a/magenta-lib/src/test/scala/magenta/ResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/ResolverTest.scala
@@ -78,7 +78,7 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
   }
 
   it should "prepare dependsOn actions correctly" in {
-    val basePackageType = stubPackageType(Seq("main_init_action"))
+    val basePackageType = stubDeploymentType(Seq("main_init_action"))
 
     val mainRecipe = Recipe("main",
       actions = basePackageType.mkAction("main_init_action")(stubPackage) :: Nil,
@@ -96,7 +96,7 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
   }
 
   it should "only include dependencies once" in {
-    val basePackageType = stubPackageType(Seq("main_init_action", "init_action_two"))
+    val basePackageType = stubDeploymentType(Seq("main_init_action", "init_action_two"))
 
     val indirectDependencyRecipe = Recipe("two",
       actions = basePackageType.mkAction("init_action_two")(stubPackage) :: Nil,

--- a/magenta-lib/src/test/scala/magenta/fixtures/fixtures.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/fixtures.scala
@@ -1,7 +1,7 @@
 package magenta
 package fixtures
 
-import magenta.deployment_type.DeploymentType
+import magenta.deployment_type.{DeploymentType, Param, ParamRegister}
 import magenta.tasks.Task
 
 case class StubTask(description: String, region: Region, stack: Option[Stack] = None,
@@ -19,8 +19,11 @@ case class StubPerAppAction(description: String, apps: Seq[App]) extends Action 
 case class StubDeploymentType(
   override val actions:
     PartialFunction[String, DeploymentPackage => (DeploymentResources, DeployTarget) => List[Task]] = Map.empty,
-  override val defaultActions: List[String]
+  override val defaultActions: List[String],
+  parameters: ParamRegister => List[Param[_]] = _ => Nil
 ) extends DeploymentType {
+  parameters(register)
+
   def name = "stub-package-type"
 
   val documentation = "Documentation for the testing stub"

--- a/magenta-lib/src/test/scala/magenta/fixtures/package.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/package.scala
@@ -1,5 +1,6 @@
 package magenta
 
+import magenta.deployment_type.{Param, ParamRegister}
 import org.joda.time.DateTime
 
 package object fixtures {
@@ -12,7 +13,7 @@ package object fixtures {
 
   val lookupSingleHost = stubLookup(List(Host("the_host", stage=CODE.name).app(app1)))
 
-  val basePackageType = stubPackageType(Seq("init_action_one"))
+  val basePackageType = stubDeploymentType(Seq("init_action_one"))
 
   val baseRecipe = Recipe("one",
     actions = basePackageType.mkAction("init_action_one")(stubPackage) :: Nil,
@@ -24,14 +25,15 @@ package object fixtures {
 
   def stubPackage = DeploymentPackage("stub project", Seq(app1), Map(), "stub-package-type", null, false)
 
-  def stubPackageType(actionNames: Seq[String]) = StubDeploymentType(
+  def stubDeploymentType(actionNames: Seq[String], params: ParamRegister => List[Param[_]] = _ => Nil) = StubDeploymentType(
     actions = {
       case name if actionNames.contains(name) => pkg => (_, target) => List(
         StubTask(name + " per app task number one", target.region),
         StubTask(name + " per app task number two", target.region)
       )
     },
-    actionNames.toList
+    actionNames.toList,
+    params
   )
 
   def testParams() = DeployParameters(


### PR DESCRIPTION
In the new riff-raff.yaml world we:
 - Error fast when a required parameter is missing
 - Error when a parameter is supplied that is not used by the deployment type
 - Log a warning when a parameter is explicitly set to the default value of the parameter