### PR TITLE
Switch to ValidatedNel / Validated instead of Either

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/param_reads/PatternValue.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/param_reads/PatternValue.scala
@@ -1,5 +1,8 @@
 package magenta.deployment_type.param_reads
 
+import cats.data.Validated
+import cats.data.Validated.{Invalid, Valid}
+import cats.instances.list._
 import play.api.data.validation.ValidationError
 import play.api.libs.json.{JsArray, JsError, JsPath, _}
 
@@ -11,16 +14,13 @@ object PatternValue {
       json match {
         case JsString(default) => JsSuccess(List(PatternValue(".*", default)))
         case JsArray(patternValues) =>
-          type Errors = Seq[(JsPath, Seq[ValidationError])]
-          def locate(e: Errors, key: String) = e.map { case (p, valerr) => (JsPath \ key) ++ p -> valerr }
-
-          patternValues.zipWithIndex.foldLeft(Right(Nil): Either[Errors, List[PatternValue]]) {
-            case (acc, (value, index)) => (acc, Json.fromJson[PatternValue](value)) match {
-              case (Right(vs), JsSuccess(v, _)) => Right(vs :+ v)
-              case (Right(_), JsError(e)) => Left(locate(e, index.toString))
-              case (Left(e), _: JsSuccess[_]) => Left(e)
-              case (Left(e1), JsError(e2)) => Left(e1 ++ locate(e2, index.toString))
-            }
+          patternValues.zipWithIndex.foldLeft(Valid(Nil): Validated[List[(JsPath, Seq[ValidationError])], List[PatternValue]]) {
+            case (acc, (value, index)) =>
+              val validated = Json.fromJson[PatternValue](value) match {
+                case JsSuccess(v, _) => Valid(List(v))
+                case JsError(e) => Invalid(e.toList.map { case (p, valerr) => (JsPath \ index.toString) ++ p -> valerr } )
+              }
+              acc combine validated
           }.fold(JsError.apply, res => JsSuccess(res))
         case other => JsError("Need a string or an array of objects with pattern and value fields")
       }

--- a/magenta-lib/src/main/scala/magenta/input/RiffRaffYamlReader.scala
+++ b/magenta-lib/src/main/scala/magenta/input/RiffRaffYamlReader.scala
@@ -1,10 +1,11 @@
 package magenta.input
 
 import cats.data.Validated.{Invalid, Valid}
-import cats.data.{NonEmptyList => NEL, ValidatedNel}
+import cats.data.{ValidatedNel, NonEmptyList => NEL}
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import magenta._
 import play.api.data.validation.ValidationError
 import play.api.libs.json._
 
@@ -44,6 +45,7 @@ object RiffRaffYamlReader {
         Invalid(nelErrors.map{ case (path, validationErrors) =>
           ConfigError(s"Parsing $path", validationErrors.map(ve => ve.message).mkString(", "))
         })
+      case JsError(_) => `wtf?`
     }
   }
 }

--- a/magenta-lib/src/main/scala/magenta/input/RiffRaffYamlReader.scala
+++ b/magenta-lib/src/main/scala/magenta/input/RiffRaffYamlReader.scala
@@ -1,5 +1,7 @@
 package magenta.input
 
+import cats.data.Validated.{Invalid, Valid}
+import cats.data.{NonEmptyList => NEL, ValidatedNel}
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
@@ -27,7 +29,7 @@ object RiffRaffYamlReader {
     }
   }
 
-  def fromString(yaml: String): RiffRaffDeployConfig = {
+  def fromString(yaml: String): ValidatedNel[ConfigError, RiffRaffDeployConfig] = {
     // convert form YAML to JSON
     val tree = new ObjectMapper(new YAMLFactory()).readTree(yaml)
     val jsonString = new ObjectMapper()
@@ -36,8 +38,12 @@ object RiffRaffYamlReader {
 
     val json = Json.parse(jsonString)
     Json.fromJson[RiffRaffDeployConfig](json) match {
-      case JsSuccess(s, _) => s
-      case JsError(errors) => throw new RuntimeException(s"Errors parsing YAML: $errors")
+      case JsSuccess(config, _) => Valid(config)
+      case JsError(errors :: tail) =>
+        val nelErrors = NEL(errors, tail)
+        Invalid(nelErrors.map{ case (path, validationErrors) =>
+          ConfigError(s"Parsing $path", validationErrors.map(ve => ve.message).mkString(", "))
+        })
     }
   }
 }

--- a/magenta-lib/src/main/scala/magenta/input/models.scala
+++ b/magenta-lib/src/main/scala/magenta/input/models.scala
@@ -1,9 +1,18 @@
 package magenta.input
 
-import cats.data.NonEmptyList
+import cats.data.{NonEmptyList => NEL}
+import cats.kernel.Semigroup
 import play.api.libs.json._
 
 case class ConfigError(context: String, message: String)
+case class ConfigErrors(errors: NEL[ConfigError])
+object ConfigErrors {
+  def apply(context: String, message: String): ConfigErrors = ConfigErrors(ConfigError(context, message))
+  def apply(error: ConfigError): ConfigErrors = ConfigErrors(NEL.of(error))
+  implicit val sg = new Semigroup[ConfigErrors] {
+    def combine(x: ConfigErrors, y: ConfigErrors): ConfigErrors = ConfigErrors(x.errors.concat(y.errors))
+  }
+}
 
 case class RiffRaffDeployConfig(
   stacks: Option[List[String]],
@@ -51,8 +60,8 @@ object DeploymentOrTemplate {
 case class Deployment(
   name: String,
   `type`: String,
-  stacks: NonEmptyList[String],
-  regions: NonEmptyList[String],
+  stacks: NEL[String],
+  regions: NEL[String],
   actions: Option[List[String]],
   app: String,
   contentDirectory: String,

--- a/magenta-lib/src/main/scala/magenta/input/models.scala
+++ b/magenta-lib/src/main/scala/magenta/input/models.scala
@@ -1,11 +1,11 @@
 package magenta.input
 
+import cats.data.NonEmptyList
 import play.api.libs.json._
 
 case class ConfigError(context: String, message: String)
-case class ConfigErrors(errors: List[ConfigError]) {
-  def :::(other: ConfigErrors) = ConfigErrors(other.errors ::: errors)
-  def ::(other: ConfigError) = ConfigErrors(other :: errors)
+object ConfigError {
+  def nel(context: String, message: String) = NonEmptyList.of(ConfigError(context, message))
 }
 
 case class RiffRaffDeployConfig(
@@ -54,8 +54,8 @@ object DeploymentOrTemplate {
 case class Deployment(
   name: String,
   `type`: String,
-  stacks: List[String],
-  regions: List[String],
+  stacks: NonEmptyList[String],
+  regions: NonEmptyList[String],
   actions: Option[List[String]],
   app: String,
   contentDirectory: String,

--- a/magenta-lib/src/main/scala/magenta/input/models.scala
+++ b/magenta-lib/src/main/scala/magenta/input/models.scala
@@ -4,9 +4,6 @@ import cats.data.NonEmptyList
 import play.api.libs.json._
 
 case class ConfigError(context: String, message: String)
-object ConfigError {
-  def nel(context: String, message: String) = NonEmptyList.of(ConfigError(context, message))
-}
 
 case class RiffRaffDeployConfig(
   stacks: Option[List[String]],

--- a/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentResolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentResolver.scala
@@ -1,38 +1,40 @@
 package magenta.input.resolver
 
+import cats.data.Validated.{Invalid, Valid}
+import cats.data.{NonEmptyList => NEL, Validated, ValidatedNel}
+import cats.syntax.cartesian._
+import cats.instances.all._
 import magenta.input.{ConfigError, Deployment, DeploymentOrTemplate, RiffRaffDeployConfig}
 
 object DeploymentResolver {
-  def resolve(config: RiffRaffDeployConfig): List[Either[ConfigError, Deployment]] = {
+  def resolve(config: RiffRaffDeployConfig): ValidatedNel[ConfigError, List[Deployment]] = {
     config.deployments.map { case (label, rawDeployment) =>
-      for {
-        templated <- applyTemplates(label, rawDeployment, config.templates).right
-        deployment <- resolveDeployment(label, templated, config.stacks, config.regions).right
-        _ <- validateDependencies(label, deployment, config.deployments).right
-      } yield deployment
-    }
+      applyTemplates(label, rawDeployment, config.templates).andThen { templated =>
+        resolveDeployment(label, templated, config.stacks, config.regions)
+      }.andThen { deployment =>
+        validateDependencies(label, deployment, config.deployments)
+      }.map(List(_))
+    }.reduceLeft(_ combine _)
   }
 
   /**
     * Validates and resolves a templated deployment by merging its
     * deployment attributes with any globally defined properties.
     */
-  private[input] def resolveDeployment(label: String, templated: DeploymentOrTemplate, globalStacks: Option[List[String]], globalRegions: Option[List[String]]): Either[ConfigError, Deployment] = {
-    for {
-      deploymentType <- templated.`type`.toRight(ConfigError(label, "No type field provided")).right
-      stacks <- templated.stacks.orElse(globalStacks).toRight(ConfigError(label, "No stacks provided")).right
-      regions <- templated.regions.orElse(globalRegions).toRight(ConfigError(label, "No regions provided")).right
-    } yield {
+  private[input] def resolveDeployment(label: String, templated: DeploymentOrTemplate, globalStacks: Option[List[String]], globalRegions: Option[List[String]]): ValidatedNel[ConfigError, Deployment] = {
+    (Validated.fromOption(templated.`type`, ConfigError.nel(label, "No type field provided")) |@|
+      Validated.fromOption(templated.stacks.orElse(globalStacks), ConfigError.nel(label, "No stacks provided")) |@|
+      Validated.fromOption(templated.regions.orElse(globalRegions), ConfigError.nel(label, "No regions provided"))) map { (deploymentType, stacks, regions) =>
       Deployment(
-        name              = label,
-        `type`            = deploymentType,
-        stacks            = stacks,
-        regions           = regions,
-        actions           = templated.actions,
-        app               = templated.app.getOrElse(label),
-        contentDirectory  = templated.contentDirectory.getOrElse(label),
-        dependencies      = templated.dependencies.getOrElse(Nil),
-        parameters        = templated.parameters.getOrElse(Map.empty)
+        name = label,
+        `type` = deploymentType,
+        stacks = NEL.fromListUnsafe(stacks),
+        regions = NEL.fromListUnsafe(regions),
+        actions = templated.actions,
+        app = templated.app.getOrElse(label),
+        contentDirectory = templated.contentDirectory.getOrElse(label),
+        dependencies = templated.dependencies.getOrElse(Nil),
+        parameters = templated.parameters.getOrElse(Map.empty)
       )
     }
   }
@@ -41,26 +43,25 @@ object DeploymentResolver {
     * Recursively apply named templates by merging the provided
     * deployment template with named parent templates.
     */
-  private[input] def applyTemplates(templateName: String, template: DeploymentOrTemplate, templates: Option[Map[String, DeploymentOrTemplate]]): Either[ConfigError, DeploymentOrTemplate] = {
+  private[input] def applyTemplates(templateName: String, template: DeploymentOrTemplate, templates: Option[Map[String, DeploymentOrTemplate]]): ValidatedNel[ConfigError, DeploymentOrTemplate] = {
     template.template match {
       case None =>
-        Right(template)
+        Valid(template)
       case Some(parentTemplateName) =>
-        for {
-          parentTemplate <- templates.flatMap(_.get(parentTemplateName))
-            .toRight(ConfigError(templateName, s"Template with name $parentTemplateName does not exist")).right
-          resolvedParent <- applyTemplates(parentTemplateName, parentTemplate, templates).right
-        } yield {
+        Validated.fromOption(templates.flatMap(_.get(parentTemplateName)),
+          ConfigError.nel(templateName, s"Template with name $parentTemplateName does not exist")).andThen { parentTemplate =>
+          applyTemplates(parentTemplateName, parentTemplate, templates)
+        }.map { resolvedParent =>
           DeploymentOrTemplate(
-            `type`            = template.`type`.orElse(resolvedParent.`type`),
-            template          = None,
-            stacks            = template.stacks.orElse(resolvedParent.stacks),
-            regions           = template.regions.orElse(resolvedParent.regions),
-            actions           = template.actions.orElse(resolvedParent.actions),
-            app               = template.app.orElse(resolvedParent.app),
-            contentDirectory  = template.contentDirectory.orElse(resolvedParent.contentDirectory),
-            dependencies      = template.dependencies.orElse(resolvedParent.dependencies),
-            parameters        = Some(resolvedParent.parameters.getOrElse(Map.empty) ++ template.parameters.getOrElse(Map.empty))
+            `type` = template.`type`.orElse(resolvedParent.`type`),
+            template = None,
+            stacks = template.stacks.orElse(resolvedParent.stacks),
+            regions = template.regions.orElse(resolvedParent.regions),
+            actions = template.actions.orElse(resolvedParent.actions),
+            app = template.app.orElse(resolvedParent.app),
+            contentDirectory = template.contentDirectory.orElse(resolvedParent.contentDirectory),
+            dependencies = template.dependencies.orElse(resolvedParent.dependencies),
+            parameters = Some(resolvedParent.parameters.getOrElse(Map.empty) ++ template.parameters.getOrElse(Map.empty))
           )
         }
     }
@@ -69,13 +70,13 @@ object DeploymentResolver {
   /**
     * Ensures that when deployments have named dependencies, deployments with those names exists.
     */
-  private[input] def validateDependencies(label: String, deployment: Deployment, allDeployments: List[(String, DeploymentOrTemplate)]): Either[ConfigError, Deployment] = {
+  private[input] def validateDependencies(label: String, deployment: Deployment, allDeployments: List[(String, DeploymentOrTemplate)]): ValidatedNel[ConfigError, Deployment] = {
     val allDeploymentNames = allDeployments.map { case (name, _) => name }
     deployment.dependencies.filterNot(allDeploymentNames.contains) match {
       case Nil =>
-        Right(deployment)
+        Valid(deployment)
       case missingDependencies =>
-        Left(ConfigError(label, missingDependencies.mkString(s"Missing deployment dependencies ", ", ", "")))
+        Invalid(ConfigError.nel(label, missingDependencies.mkString(s"Missing deployment dependencies ", ", ", "")))
     }
   }
 }

--- a/magenta-lib/src/main/scala/magenta/input/resolver/Resolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/Resolver.scala
@@ -3,6 +3,7 @@ package magenta.input.resolver
 import cats.data.Validated.{Invalid, Valid}
 import cats.data.{ValidatedNel, NonEmptyList => NEL}
 import cats.instances.all._
+import cats.syntax.traverse._
 import magenta.artifact.S3Artifact
 import magenta.deployment_type.DeploymentType
 import magenta.graph.{DeploymentTasks, Graph}
@@ -13,46 +14,53 @@ object Resolver {
   def resolve(yamlConfig: String, deploymentResources: DeploymentResources, parameters: DeployParameters,
     deploymentTypes: Seq[DeploymentType], artifact: S3Artifact): ValidatedNel[ConfigError, Graph[DeploymentTasks]] = {
 
-    resolveDeploymentGraph(yamlConfig).andThen { graph =>
-      val flattenedGraph = DeploymentGraphActionFlattening.flattenActions(graph)
-      val deploymentTaskGraph = flattenedGraph.map { deployment =>
-        TaskResolver.resolve(deployment, deploymentResources, parameters, deploymentTypes, artifact)
-      }
-
-      if (deploymentTaskGraph.nodes.values.exists(_.isInvalid)) {
-        Invalid(deploymentTaskGraph.toList.collect { case Invalid(errors) => errors }.reduce(_ concat _))
-      } else {
-        // we know they are all good
-        Valid(deploymentTaskGraph.map(_.toOption.get))
-      }
-    }
+    for {
+      deploymentGraph <- resolveDeploymentGraph(yamlConfig)
+      taskGraph <- buildTaskGraph(deploymentResources, parameters, deploymentTypes, artifact, deploymentGraph)
+    } yield taskGraph
   }
 
   def resolveDeploymentGraph(yamlConfig: String): ValidatedNel[ConfigError, Graph[Deployment]] = {
-    val validatedDeployments = RiffRaffYamlReader.fromString(yamlConfig).andThen { config =>
-      DeploymentResolver.resolve(config)
-    }.andThen { deployments =>
-      deployments.map { deployment =>
-        DeploymentTypeResolver.validateDeploymentType(deployment, DeploymentType.all).map(List(_))
-      }.reduceLeft(_ combine _)
+    for {
+      config <- RiffRaffYamlReader.fromString(yamlConfig)
+      deployments <- DeploymentResolver.resolve(config)
+      validatedDeployments <- deployments.traverseU[ValidatedNel[ConfigError, Deployment]]{deployment =>
+        DeploymentTypeResolver.validateDeploymentType(deployment, DeploymentType.all)
+      }
+      userSelectedDeployments = validatedDeployments
+      graph = buildParallelisedGraph(userSelectedDeployments)
+    } yield graph
+  }
+
+  private def buildTaskGraph(deploymentResources: DeploymentResources, parameters: DeployParameters,
+    deploymentTypes: Seq[DeploymentType], artifact: S3Artifact, graph: Graph[Deployment]) = {
+
+    val flattenedGraph = DeploymentGraphActionFlattening.flattenActions(graph)
+    val deploymentTaskGraph = flattenedGraph.map { deployment =>
+      TaskResolver.resolve(deployment, deploymentResources, parameters, deploymentTypes, artifact)
     }
 
-    validatedDeployments.map { deployments =>
-      // TODO: this is a placeholder for when we filter previews in the UI
-      val userSelectedDeployments = deployments
-
-      val stacks = userSelectedDeployments.flatMap(_.stacks.toList).distinct
-      val regions = userSelectedDeployments.flatMap(_.regions.toList).distinct
-
-      val stackRegionGraphs: List[Graph[Deployment]] = for {
-        stack <- stacks
-        region <- regions
-        deploymentsForStackAndRegion = filterDeployments(userSelectedDeployments, stack, region)
-        graphForStackAndRegion = DeploymentGraphBuilder.buildGraph(deploymentsForStackAndRegion)
-      } yield graphForStackAndRegion
-
-      stackRegionGraphs.reduceLeft(_ joinParallel _)
+    if (deploymentTaskGraph.nodes.values.exists(_.isInvalid)) {
+      Invalid(deploymentTaskGraph.toList.collect { case Invalid(errors) => errors }.reduce(_ concat _))
+    } else {
+      // we know they are all good
+      Valid(deploymentTaskGraph.map(_.toOption.get))
     }
+  }
+
+
+  private def buildParallelisedGraph(userSelectedDeployments: List[Deployment]) = {
+    val stacks = userSelectedDeployments.flatMap(_.stacks.toList).distinct
+    val regions = userSelectedDeployments.flatMap(_.regions.toList).distinct
+
+    val stackRegionGraphs: List[Graph[Deployment]] = for {
+      stack <- stacks
+      region <- regions
+      deploymentsForStackAndRegion = filterDeployments(userSelectedDeployments, stack, region)
+      graphForStackAndRegion = DeploymentGraphBuilder.buildGraph(deploymentsForStackAndRegion)
+    } yield graphForStackAndRegion
+
+    stackRegionGraphs.reduceLeft(_ joinParallel _)
   }
 
   private[resolver] def filterDeployments(deployments: List[Deployment], stack: String, region: String): List[Deployment] = {

--- a/magenta-lib/src/main/scala/magenta/input/resolver/Resolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/Resolver.scala
@@ -1,34 +1,48 @@
 package magenta.input.resolver
 
+import cats.data.Validated.{Invalid, Valid}
+import cats.data.{ValidatedNel, NonEmptyList => NEL}
+import cats.instances.all._
 import magenta.artifact.S3Artifact
-import magenta.{DeployParameters, DeploymentResources}
 import magenta.deployment_type.DeploymentType
 import magenta.graph.{DeploymentTasks, Graph}
 import magenta.input._
+import magenta.{DeployParameters, DeploymentResources}
 
 object Resolver {
   def resolve(yamlConfig: String, deploymentResources: DeploymentResources, parameters: DeployParameters,
-    deploymentTypes: Seq[DeploymentType], artifact: S3Artifact): Either[ConfigErrors, Graph[DeploymentTasks]] = {
+    deploymentTypes: Seq[DeploymentType], artifact: S3Artifact): ValidatedNel[ConfigError, Graph[DeploymentTasks]] = {
 
-    val config = RiffRaffYamlReader.fromString(yamlConfig)
-    val deployments = DeploymentResolver.resolve(config)
+    resolveDeploymentGraph(yamlConfig).andThen { graph =>
+      val flattenedGraph = DeploymentGraphActionFlattening.flattenActions(graph)
+      val deploymentTaskGraph = flattenedGraph.map { deployment =>
+        TaskResolver.resolve(deployment, deploymentResources, parameters, deploymentTypes, artifact)
+      }
 
-    val validatedDeployments = deployments.map { either =>
-      either.right.flatMap { deployment =>
-        DeploymentTypeResolver.validateDeploymentType(deployment, DeploymentType.all)
+      if (deploymentTaskGraph.nodes.values.exists(_.isInvalid)) {
+        Invalid(deploymentTaskGraph.toList.collect { case Invalid(errors) => errors }.reduce(_ concat _))
+      } else {
+        // we know they are all good
+        Valid(deploymentTaskGraph.map(_.toOption.get))
       }
     }
+  }
 
-    if (validatedDeployments.exists(_.isLeft)) {
-      Left(ConfigErrors(validatedDeployments.flatMap(_.left.toOption)))
-    } else {
-      val deployments = validatedDeployments.map(_.right.get)
+  def resolveDeploymentGraph(yamlConfig: String): ValidatedNel[ConfigError, Graph[Deployment]] = {
+    val validatedDeployments = RiffRaffYamlReader.fromString(yamlConfig).andThen { config =>
+      DeploymentResolver.resolve(config)
+    }.andThen { deployments =>
+      deployments.map { deployment =>
+        DeploymentTypeResolver.validateDeploymentType(deployment, DeploymentType.all).map(List(_))
+      }.reduceLeft(_ combine _)
+    }
 
+    validatedDeployments.map { deployments =>
       // TODO: this is a placeholder for when we filter previews in the UI
       val userSelectedDeployments = deployments
 
-      val stacks = userSelectedDeployments.flatMap(_.stacks).distinct
-      val regions = userSelectedDeployments.flatMap(_.regions).distinct
+      val stacks = userSelectedDeployments.flatMap(_.stacks.toList).distinct
+      val regions = userSelectedDeployments.flatMap(_.regions.toList).distinct
 
       val stackRegionGraphs: List[Graph[Deployment]] = for {
         stack <- stacks
@@ -37,24 +51,14 @@ object Resolver {
         graphForStackAndRegion = DeploymentGraphBuilder.buildGraph(deploymentsForStackAndRegion)
       } yield graphForStackAndRegion
 
-      val combinedGraph = stackRegionGraphs.reduceLeft(_ joinParallel _)
-      val flattenedGraph = DeploymentGraphActionFlattening.flattenActions(combinedGraph)
-      val deploymentTaskGraph = flattenedGraph.map { deployment =>
-        TaskResolver.resolve(deployment, deploymentResources, parameters, deploymentTypes, artifact)
-      }
-
-      if (deploymentTaskGraph.nodes.values.exists(_.isLeft)) {
-        Left(ConfigErrors(deploymentTaskGraph.nodes.toList.values.flatMap(_.left.toOption)))
-      } else {
-        Right(deploymentTaskGraph.map(_.right.get))
-      }
+      stackRegionGraphs.reduceLeft(_ joinParallel _)
     }
   }
 
   private[resolver] def filterDeployments(deployments: List[Deployment], stack: String, region: String): List[Deployment] = {
     deployments.flatMap { deployment =>
-      if (deployment.stacks.contains(stack) && deployment.regions.contains(region))
-        Some(deployment.copy(stacks = List(stack), regions = List(region)))
+      if (deployment.stacks.exists(stack ==) && deployment.regions.exists(region ==))
+        Some(deployment.copy(stacks = NEL.of(stack), regions = NEL.of(region)))
       else None
     }
   }

--- a/magenta-lib/src/main/scala/magenta/input/resolver/package.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/package.scala
@@ -1,0 +1,9 @@
+package magenta.input
+
+import cats.data.Validated
+
+package object resolver {
+  implicit class RichValidated[E, A](validated: Validated[E, A]) {
+    def flatMap[EE >: E, B](f: A => Validated[EE, B]): Validated[EE, B] = validated.andThen(f)
+  }
+}

--- a/magenta-lib/src/main/scala/magenta/package.scala
+++ b/magenta-lib/src/main/scala/magenta/package.scala
@@ -46,4 +46,8 @@ object `package` {
       case Failure(t) => throw t
     }
   }
+
+  /** This can be used when you have high confidence it will never be reached. An example might be exhaustive cases in
+    * a match statement. */
+  def `wtf?` : Nothing = throw new IllegalStateException("WTF?")
 }

--- a/magenta-lib/src/test/scala/magenta/fixtures/ValidatedValues.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/ValidatedValues.scala
@@ -1,0 +1,43 @@
+package magenta.fixtures
+
+import cats.data.Validated
+import cats.data.Validated.{Invalid, Valid}
+import org.scalatest.exceptions.TestFailedException
+
+/**
+  * This trait is inspired strongly by [[org.scalatest.EitherValues]] as a way of simply asserting that you expect
+  * either a Valid or Invalid value from a Validated type.
+  *
+  * Two functions are pimped onto Validated for the purposes of testing and if the value is not of the expected type
+  * then the test will fail detailing what the unexpected value was.
+  */
+trait ValidatedValues {
+
+  import scala.language.implicitConversions
+
+  implicit class ScalaTestValidated[E, A](validated: Validated[E, A]) {
+    def valid: A = {
+      validated match {
+        case Valid(value) => value
+        case Invalid(errors) =>
+          throw new TestFailedException(
+            s"$validated was not of type Valid",
+            1
+          )
+      }
+    }
+    def invalid: E = {
+      validated match {
+        case Valid(value) =>
+          throw new TestFailedException(
+            s"$validated was not of type Invalid",
+            1
+          )
+        case Invalid(errors) => errors
+      }
+    }
+  }
+
+}
+
+object ValidatedValues extends ValidatedValues

--- a/magenta-lib/src/test/scala/magenta/input/RiffRaffYamlReaderTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/RiffRaffYamlReaderTest.scala
@@ -1,9 +1,10 @@
 package magenta.input
 
+import magenta.fixtures.ValidatedValues
 import org.scalatest.{FlatSpec, ShouldMatchers}
 import play.api.libs.json.{JsArray, JsNumber, JsString, Json}
 
-class RiffRaffYamlReaderTest extends FlatSpec with ShouldMatchers{
+class RiffRaffYamlReaderTest extends FlatSpec with ShouldMatchers with ValidatedValues {
   "RiffRaffYamlReader" should "read a minimal file" in {
     val yaml =
       """
@@ -13,7 +14,7 @@ class RiffRaffYamlReaderTest extends FlatSpec with ShouldMatchers{
         |  monkey:
         |    type: autoscaling
       """.stripMargin
-    val input = RiffRaffYamlReader.fromString(yaml)
+    val input = RiffRaffYamlReader.fromString(yaml).valid
     input.stacks.isDefined should be(true)
     input.stacks.get.size should be(1)
     input.stacks.get should be(List("banana"))
@@ -51,7 +52,7 @@ class RiffRaffYamlReaderTest extends FlatSpec with ShouldMatchers{
         |  elephant:
         |    type: dung
       """.stripMargin
-    val input = RiffRaffYamlReader.fromString(yaml)
+    val input = RiffRaffYamlReader.fromString(yaml).valid
     input.stacks.isDefined should be(true)
     input.stacks.get.size should be(2)
     input.stacks.get should be(List("banana", "cabbage"))

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentGraphActionFlatteningTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentGraphActionFlatteningTest.scala
@@ -1,13 +1,14 @@
 package magenta.input.resolver
 
-import magenta.graph.{EndNode, Graph, ValueNode, StartNode}
+import cats.data.{NonEmptyList => NEL}
+import magenta.graph.{EndNode, Graph, StartNode, ValueNode}
 import magenta.input.Deployment
 import org.scalatest.{FlatSpec, Matchers}
 
 class DeploymentGraphActionFlatteningTest extends FlatSpec with Matchers {
   "flattenActions" should "flatten out the actions in a deployment graph" in {
     val deploymentWithActions =
-      Deployment("bob", "autoscaling", List("stackName"), List("eu-west-1"), Some(List("action1", "action2")), "bob", "bob", Nil, Map.empty)
+      Deployment("bob", "autoscaling", NEL.of("stackName"), NEL.of("eu-west-1"), Some(List("action1", "action2")), "bob", "bob", Nil, Map.empty)
     val graph = Graph(deploymentWithActions)
     val flattenedGraph = DeploymentGraphActionFlattening.flattenActions(graph)
 

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentResolverTest.scala
@@ -20,7 +20,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.toList.size should be (1)
+    deployments.size should be (1)
     deployments.head should have (
       'type ("testType"),
       'stacks (NEL.of("testStack")),
@@ -46,7 +46,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.toList.size should be (1)
+    deployments.size should be (1)
     deployments.head should have (
       'type ("testType"),
       'stacks (NEL.of("stack1", "stack2")),
@@ -75,7 +75,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.toList.size should be (1)
+    deployments.size should be (1)
     deployments.head should have (
       'type ("testType"),
       'stacks (NEL.of("testStack")),
@@ -106,7 +106,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.toList.size should be (1)
+    deployments.size should be (1)
     deployments.head should have (
       'type ("testType"),
       'stacks (NEL.of("testStack")),
@@ -136,7 +136,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.toList.size should be (1)
+    deployments.size should be (1)
     deployments.head should have(
       'stacks (NEL.of("deployment-stack")),
       'regions (NEL.of("deployment-region"))
@@ -159,7 +159,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.toList.size should be (1)
+    deployments.size should be (1)
     deployments.head should have(
       'stacks (NEL.of("template-stack")),
       'regions (NEL.of("template-region"))
@@ -180,7 +180,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.toList.size should be (1)
+    deployments.size should be (1)
     deployments.head should have(
       'stacks (NEL.of("global-stack")),
       'regions (NEL.of("global-region"))
@@ -206,7 +206,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.toList.size should be (1)
+    deployments.size should be (1)
     deployments.head should have(
       'stacks (NEL.of("nested-template-stack")),
       'regions (NEL.of("template-region"))
@@ -242,7 +242,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.toList.size should be (1)
+    deployments.size should be (1)
     val deployment = deployments.head
     deployment.parameters.size should be(6)
     deployment.parameters should contain("nestedParameter" -> JsNumber(1984))
@@ -270,7 +270,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.toList.size should be (1)
+    deployments.size should be (1)
     deployments.head should have(
       'app ("templateApp"),
       'actions (Some(List("templateAction"))),
@@ -303,7 +303,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.toList.size should be (4)
+    deployments.size should be (4)
     val deployment = deployments.find(_.name == "test").get
     deployment.dependencies should be(List("deployment-dep"))
   }
@@ -330,7 +330,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.toList.size should be (3)
+    deployments.size should be (3)
     val deployment = deployments.find(_.name == "test").get
     deployment.dependencies should be(List("template-dep"))
   }
@@ -354,7 +354,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.toList.size should be (2)
+    deployments.size should be (2)
     val deployment = deployments.find(_.name == "test").get
     deployment.dependencies should be(List("nested-dep"))
   }

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentResolverTest.scala
@@ -375,9 +375,9 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
         |    template: nonExistentTemplate
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
-    val deployments = yaml.andThen(DeploymentResolver.resolve).invalid
-    deployments.toList.size should be (1)
-    deployments.head should be(ConfigError("test", "Template with name nonExistentTemplate does not exist"))
+    val configErrors = yaml.andThen(DeploymentResolver.resolve).invalid
+    configErrors.errors.toList.size should be (1)
+    configErrors.errors.head should be(ConfigError("test", "Template with name nonExistentTemplate does not exist"))
   }
 
   it should "report an error if a named dependency does not exist" in {
@@ -391,9 +391,9 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
         |    dependencies: [missing-dep]
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
-    val deployments = yaml.andThen(DeploymentResolver.resolve).invalid
-    deployments.toList.size should be (1)
-    deployments.head should be(ConfigError("test", "Missing deployment dependencies missing-dep"))
+    val configErrors = yaml.andThen(DeploymentResolver.resolve).invalid
+    configErrors.errors.toList.size should be (1)
+    configErrors.errors.head should be(ConfigError("test", "Missing deployment dependencies missing-dep"))
 
   }
 
@@ -406,8 +406,8 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
         |    type: autoscaling
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
-    val deployments = yaml.andThen(DeploymentResolver.resolve).invalid
-    deployments.head should be(ConfigError("test", "No stacks provided"))
+    val configErrors = yaml.andThen(DeploymentResolver.resolve).invalid
+    configErrors.errors.head should be(ConfigError("test", "No stacks provided"))
   }
 
   it should "report an error if no regions are provided" in {
@@ -419,7 +419,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
         |    type: autoscaling
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
-    val deployments = yaml.andThen(DeploymentResolver.resolve).invalid
-    deployments.head should be(ConfigError("test", "No regions provided"))
+    val configErrors = yaml.andThen(DeploymentResolver.resolve).invalid
+    configErrors.errors.head should be(ConfigError("test", "No regions provided"))
   }
 }

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentResolverTest.scala
@@ -1,10 +1,12 @@
 package magenta.input.resolver
 
+import cats.data.{NonEmptyList => NEL}
+import magenta.fixtures.ValidatedValues
 import magenta.input.{ConfigError, Deployment, RiffRaffYamlReader}
-import org.scalatest.{EitherValues, FlatSpec, ShouldMatchers}
+import org.scalatest.{FlatSpec, ShouldMatchers}
 import play.api.libs.json.{JsNumber, JsString}
 
-class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherValues {
+class DeploymentResolverTest extends FlatSpec with ShouldMatchers with ValidatedValues {
   "DeploymentResolver" should "parse a simple deployment with defaults" in {
     val yamlString =
       """
@@ -17,12 +19,12 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         |    regions: [eu-west-1]
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
-    val deployments = DeploymentResolver.resolve(yaml)
-    deployments.size should be (1)
-    deployments.head.right.value should have (
+    val deployments = yaml.andThen(DeploymentResolver.resolve).valid
+    deployments.toList.size should be (1)
+    deployments.head should have (
       'type ("testType"),
-      'stacks (List("testStack")),
-      'regions (List("eu-west-1")),
+      'stacks (NEL.of("testStack")),
+      'regions (NEL.of("eu-west-1")),
       'app ("test"),
       'contentDirectory ("test"),
       'actions (None),
@@ -43,12 +45,12 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         |      testParam: testValue
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
-    val deployments = DeploymentResolver.resolve(yaml)
-    deployments.size should be (1)
-    deployments.head.right.value should have (
+    val deployments = yaml.andThen(DeploymentResolver.resolve).valid
+    deployments.toList.size should be (1)
+    deployments.head should have (
       'type ("testType"),
-      'stacks (List("stack1", "stack2")),
-      'regions (List("oceania-south-1")),
+      'stacks (NEL.of("stack1", "stack2")),
+      'regions (NEL.of("oceania-south-1")),
       'app ("test"),
       'contentDirectory ("test"),
       'actions (None),
@@ -72,12 +74,12 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         |    regions: [eurasia-north-1]
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
-    val deployments = DeploymentResolver.resolve(yaml)
-    deployments.size should be (1)
-    deployments.head.right.value should have (
+    val deployments = yaml.andThen(DeploymentResolver.resolve).valid
+    deployments.toList.size should be (1)
+    deployments.head should have (
       'type ("testType"),
-      'stacks (List("testStack")),
-      'regions (List("eurasia-north-1")),
+      'stacks (NEL.of("testStack")),
+      'regions (NEL.of("eurasia-north-1")),
       'app ("test"),
       'contentDirectory ("test"),
       'actions (Some(List("deploymentAction"))),
@@ -103,12 +105,12 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         |      anotherParam: 1984
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
-    val deployments = DeploymentResolver.resolve(yaml)
-    deployments.size should be (1)
-    deployments.head.right.value should have (
+    val deployments = yaml.andThen(DeploymentResolver.resolve).valid
+    deployments.toList.size should be (1)
+    deployments.head should have (
       'type ("testType"),
-      'stacks (List("testStack")),
-      'regions (List("eu-west-1")),
+      'stacks (NEL.of("testStack")),
+      'regions (NEL.of("eu-west-1")),
       'app ("test"),
       'contentDirectory ("test"),
       'dependencies (Nil),
@@ -133,11 +135,11 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         |    regions: [deployment-region]
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
-    val deployments = DeploymentResolver.resolve(yaml)
-    deployments.size should be (1)
-    deployments.head.right.value should have(
-      'stacks (List("deployment-stack")),
-      'regions (List("deployment-region"))
+    val deployments = yaml.andThen(DeploymentResolver.resolve).valid
+    deployments.toList.size should be (1)
+    deployments.head should have(
+      'stacks (NEL.of("deployment-stack")),
+      'regions (NEL.of("deployment-region"))
     )
   }
 
@@ -156,11 +158,11 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         |    template: testTemplate
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
-    val deployments = DeploymentResolver.resolve(yaml)
-    deployments.size should be (1)
-    deployments.head.right.value should have(
-      'stacks (List("template-stack")),
-      'regions (List("template-region"))
+    val deployments = yaml.andThen(DeploymentResolver.resolve).valid
+    deployments.toList.size should be (1)
+    deployments.head should have(
+      'stacks (NEL.of("template-stack")),
+      'regions (NEL.of("template-region"))
     )
   }
 
@@ -177,11 +179,11 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         |    template: testTemplate
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
-    val deployments = DeploymentResolver.resolve(yaml)
-    deployments.size should be (1)
-    deployments.head.right.value should have(
-      'stacks (List("global-stack")),
-      'regions (List("global-region"))
+    val deployments = yaml.andThen(DeploymentResolver.resolve).valid
+    deployments.toList.size should be (1)
+    deployments.head should have(
+      'stacks (NEL.of("global-stack")),
+      'regions (NEL.of("global-region"))
     )
   }
 
@@ -203,11 +205,11 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         |    template: testTemplate
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
-    val deployments = DeploymentResolver.resolve(yaml)
-    deployments.size should be (1)
-    deployments.head.right.value should have(
-      'stacks (List("nested-template-stack")),
-      'regions (List("template-region"))
+    val deployments = yaml.andThen(DeploymentResolver.resolve).valid
+    deployments.toList.size should be (1)
+    deployments.head should have(
+      'stacks (NEL.of("nested-template-stack")),
+      'regions (NEL.of("template-region"))
     )
   }
 
@@ -239,9 +241,9 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         |      sandwichParameter: deployment
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
-    val deployments = DeploymentResolver.resolve(yaml)
-    deployments.size should be (1)
-    val deployment = deployments.head.right.value
+    val deployments = yaml.andThen(DeploymentResolver.resolve).valid
+    deployments.toList.size should be (1)
+    val deployment = deployments.head
     deployment.parameters.size should be(6)
     deployment.parameters should contain("nestedParameter" -> JsNumber(1984))
     deployment.parameters should contain("templateParameter" -> JsNumber(2016))
@@ -267,9 +269,9 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         |    template: testTemplate
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
-    val deployments = DeploymentResolver.resolve(yaml)
-    deployments.size should be (1)
-    deployments.head.right.value should have(
+    val deployments = yaml.andThen(DeploymentResolver.resolve).valid
+    deployments.toList.size should be (1)
+    deployments.head should have(
       'app ("templateApp"),
       'actions (Some(List("templateAction"))),
       'contentDirectory ("templateContentDirectory")
@@ -300,8 +302,8 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         |    dependencies: [deployment-dep]
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
-    val deployments = assertDeployments(DeploymentResolver.resolve(yaml))
-    deployments.size should be (4)
+    val deployments = yaml.andThen(DeploymentResolver.resolve).valid
+    deployments.toList.size should be (4)
     val deployment = deployments.find(_.name == "test").get
     deployment.dependencies should be(List("deployment-dep"))
   }
@@ -327,8 +329,8 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         |    template: testTemplate
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
-    val deployments = assertDeployments(DeploymentResolver.resolve(yaml))
-    deployments.size should be (3)
+    val deployments = yaml.andThen(DeploymentResolver.resolve).valid
+    deployments.toList.size should be (3)
     val deployment = deployments.find(_.name == "test").get
     deployment.dependencies should be(List("template-dep"))
   }
@@ -351,8 +353,8 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         |    template: testTemplate
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
-    val deployments = assertDeployments(DeploymentResolver.resolve(yaml))
-    deployments.size should be (2)
+    val deployments = yaml.andThen(DeploymentResolver.resolve).valid
+    deployments.toList.size should be (2)
     val deployment = deployments.find(_.name == "test").get
     deployment.dependencies should be(List("nested-dep"))
   }
@@ -373,9 +375,9 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         |    template: nonExistentTemplate
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
-    val deployments = DeploymentResolver.resolve(yaml)
-    deployments.size should be (1)
-    deployments.head.left.value should be(ConfigError("test", "Template with name nonExistentTemplate does not exist"))
+    val deployments = yaml.andThen(DeploymentResolver.resolve).invalid
+    deployments.toList.size should be (1)
+    deployments.head should be(ConfigError("test", "Template with name nonExistentTemplate does not exist"))
   }
 
   it should "report an error if a named dependency does not exist" in {
@@ -389,9 +391,9 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         |    dependencies: [missing-dep]
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
-    val deployments = DeploymentResolver.resolve(yaml)
-    deployments.size should be (1)
-    deployments.head.left.value should be(ConfigError("test", "Missing deployment dependencies missing-dep"))
+    val deployments = yaml.andThen(DeploymentResolver.resolve).invalid
+    deployments.toList.size should be (1)
+    deployments.head should be(ConfigError("test", "Missing deployment dependencies missing-dep"))
 
   }
 
@@ -404,8 +406,8 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         |    type: autoscaling
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
-    val deployments = DeploymentResolver.resolve(yaml)
-    deployments.head.left.value should be(ConfigError("test", "No stacks provided"))
+    val deployments = yaml.andThen(DeploymentResolver.resolve).invalid
+    deployments.head should be(ConfigError("test", "No stacks provided"))
   }
 
   it should "report an error if no regions are provided" in {
@@ -417,14 +419,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with EitherVal
         |    type: autoscaling
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
-    val deployments = DeploymentResolver.resolve(yaml)
-    deployments.head.left.value should be(ConfigError("test", "No regions provided"))
-  }
-
-  def assertDeployments(maybeDeployments: List[Either[ConfigError, Deployment]]): List[Deployment] = {
-    maybeDeployments.flatMap{ either =>
-      either should matchPattern { case Right(_) => }
-      either.right.toOption
-    }
+    val deployments = yaml.andThen(DeploymentResolver.resolve).invalid
+    deployments.head should be(ConfigError("test", "No regions provided"))
   }
 }

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTasksGraphBuilderTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTasksGraphBuilderTest.scala
@@ -1,11 +1,12 @@
 package magenta.input.resolver
 
-import magenta.graph.{EndNode, Graph, ValueNode, StartNode}
+import cats.data.{NonEmptyList => NEL}
+import magenta.graph.{EndNode, Graph, StartNode, ValueNode}
 import magenta.input.Deployment
 import org.scalatest.{FlatSpec, ShouldMatchers}
 
 class DeploymentTasksGraphBuilderTest extends FlatSpec with ShouldMatchers {
-  val deployment = Deployment("bob", "autoscaling", List("stackName"), List("eu-west-1"), Some(List("deploy")), "bob", "bob", Nil, Map.empty)
+  val deployment = Deployment("bob", "autoscaling", NEL.of("stackName"), NEL.of("eu-west-1"), Some(List("deploy")), "bob", "bob", Nil, Map.empty)
 
   "buildGraph" should "build a simple graph for a single deployment" in {
     val graph = DeploymentGraphBuilder.buildGraph(List(deployment))

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTypeResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTypeResolverTest.scala
@@ -1,54 +1,55 @@
 package magenta.input.resolver
 
+import cats.data.{NonEmptyList => NEL}
 import magenta.deployment_type.Param
 import magenta.fixtures._
 import magenta.input.{ConfigError, Deployment}
-import org.scalatest.{EitherValues, FlatSpec, Matchers}
+import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.JsNumber
 
-class DeploymentTypeResolverTest extends FlatSpec with Matchers with EitherValues {
-  val deployment = Deployment("bob", "stub-package-type", List("stack"), List("eu-west-1"), actions=None, "bob", "bob", Nil, Map.empty)
+class DeploymentTypeResolverTest extends FlatSpec with Matchers with ValidatedValues {
+  val deployment = Deployment("bob", "stub-package-type", NEL.of("stack"), NEL.of("eu-west-1"), actions=None, "bob", "bob", Nil, Map.empty)
   val deploymentTypes = List(stubDeploymentType(Seq("upload", "deploy")))
 
   "validateDeploymentType" should "fail on invalid deployment type" in {
     val deploymentWithInvalidType = deployment.copy(`type` = "invalidType")
-    val configError = DeploymentTypeResolver.validateDeploymentType(deploymentWithInvalidType, deploymentTypes).left.value
-    configError.context shouldBe "bob"
-    configError.message should include(s"Unknown type invalidType")
+    val configError = DeploymentTypeResolver.validateDeploymentType(deploymentWithInvalidType, deploymentTypes).invalid
+    configError.head.context shouldBe "bob"
+    configError.head.message should include(s"Unknown type invalidType")
   }
 
   it should "fail if explicitly given empty actions" in {
     val deploymentWithNoActions = deployment.copy(actions = Some(Nil))
-    val configError = DeploymentTypeResolver.validateDeploymentType(deploymentWithNoActions, deploymentTypes).left.value
-    configError.context shouldBe "bob"
-    configError.message should include(s"Either specify at least one action or omit the actions parameter")
+    val configError = DeploymentTypeResolver.validateDeploymentType(deploymentWithNoActions, deploymentTypes).invalid
+    configError.head.context shouldBe "bob"
+    configError.head.message should include(s"Either specify at least one action or omit the actions parameter")
   }
 
   it should "fail if given an invalid action" in {
     val deploymentWithInvalidAction = deployment.copy(actions = Some(List("invalidAction")))
-    val configError = DeploymentTypeResolver.validateDeploymentType(deploymentWithInvalidAction, deploymentTypes).left.value
-    configError.context shouldBe "bob"
-    configError.message should include(s"Invalid action invalidAction for type stub-package-type")
+    val configError = DeploymentTypeResolver.validateDeploymentType(deploymentWithInvalidAction, deploymentTypes).invalid
+    configError.head.context shouldBe "bob"
+    configError.head.message should include(s"Invalid action invalidAction for type stub-package-type")
   }
 
   it should "populate the deployment with default actions if no actions are provided" in {
-    val validatedDeployment = DeploymentTypeResolver.validateDeploymentType(deployment, deploymentTypes).right.value
+    val validatedDeployment = DeploymentTypeResolver.validateDeploymentType(deployment, deploymentTypes).valid
     validatedDeployment.actions shouldBe Some(List("upload", "deploy"))
   }
 
   it should "use specified actions if they are provided" in {
     val deploymentWithSpecifiedActions = deployment.copy(actions = Some(List("upload")))
-    val validatedDeployment = DeploymentTypeResolver.validateDeploymentType(deploymentWithSpecifiedActions, deploymentTypes).right.value
+    val validatedDeployment = DeploymentTypeResolver.validateDeploymentType(deploymentWithSpecifiedActions, deploymentTypes).valid
     validatedDeployment.actions shouldBe Some(List("upload"))
   }
 
   it should "preserve other fields" in {
-    val validatedDeployment = DeploymentTypeResolver.validateDeploymentType(deployment, deploymentTypes).right.value
+    val validatedDeployment = DeploymentTypeResolver.validateDeploymentType(deployment, deploymentTypes).valid
     validatedDeployment should have(
       'name ("bob"),
       'type ("stub-package-type"),
-      'stacks (List("stack")),
-      'regions (List("eu-west-1")),
+      'stacks (NEL.of("stack")),
+      'regions (NEL.of("eu-west-1")),
       'app ("bob"),
       'contentDirectory ("bob"),
       'dependencies (Nil),
@@ -58,8 +59,8 @@ class DeploymentTypeResolverTest extends FlatSpec with Matchers with EitherValue
 
   it should "fail if given an invalid parameter" in {
     val deploymentWithParameters = deployment.copy(parameters = Map("param1" -> JsNumber(1234)))
-    val configError = DeploymentTypeResolver.validateDeploymentType(deploymentWithParameters, deploymentTypes).left.value
-    configError shouldBe ConfigError("bob", "Parameters provided but not used by stub-package-type deployments: param1")
+    val configError = DeploymentTypeResolver.validateDeploymentType(deploymentWithParameters, deploymentTypes).invalid
+    configError.head shouldBe ConfigError("bob", "Parameters provided but not used by stub-package-type deployments: param1")
   }
 
   it should "fail if a parameter with no default is not provided" in {
@@ -69,8 +70,8 @@ class DeploymentTypeResolverTest extends FlatSpec with Matchers with EitherValue
         register => List(Param[String]("param1")(register))
       )
     )
-    val configError = DeploymentTypeResolver.validateDeploymentType(deployment, deploymentTypesWithParams).left.value
-    configError shouldBe ConfigError("bob", "Parameters required for stub-package-type deployments not provided: param1")
+    val configError = DeploymentTypeResolver.validateDeploymentType(deployment, deploymentTypesWithParams).invalid
+    configError.head shouldBe ConfigError("bob", "Parameters required for stub-package-type deployments not provided: param1")
   }
 
   it should "succeed if a default is provided" in {
@@ -80,7 +81,7 @@ class DeploymentTypeResolverTest extends FlatSpec with Matchers with EitherValue
         register => List(Param[String]("param1", defaultValue = Some("defaultValue"))(register))
       )
     )
-    DeploymentTypeResolver.validateDeploymentType(deployment, deploymentTypesWithParams).right.value
+    DeploymentTypeResolver.validateDeploymentType(deployment, deploymentTypesWithParams).valid
   }
 
   it should "succeed if a default from package is provided" in {
@@ -90,6 +91,6 @@ class DeploymentTypeResolverTest extends FlatSpec with Matchers with EitherValue
         register => List(Param[String]("param1", defaultValueFromPackage = Some(_.name))(register))
       )
     )
-    DeploymentTypeResolver.validateDeploymentType(deployment, deploymentTypesWithParams).right.value
+    DeploymentTypeResolver.validateDeploymentType(deployment, deploymentTypesWithParams).valid
   }
 }

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTypeResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTypeResolverTest.scala
@@ -13,23 +13,23 @@ class DeploymentTypeResolverTest extends FlatSpec with Matchers with ValidatedVa
 
   "validateDeploymentType" should "fail on invalid deployment type" in {
     val deploymentWithInvalidType = deployment.copy(`type` = "invalidType")
-    val configError = DeploymentTypeResolver.validateDeploymentType(deploymentWithInvalidType, deploymentTypes).invalid
-    configError.head.context shouldBe "bob"
-    configError.head.message should include(s"Unknown type invalidType")
+    val configErrors = DeploymentTypeResolver.validateDeploymentType(deploymentWithInvalidType, deploymentTypes).invalid
+    configErrors.errors.head.context shouldBe "bob"
+    configErrors.errors.head.message should include(s"Unknown type invalidType")
   }
 
   it should "fail if explicitly given empty actions" in {
     val deploymentWithNoActions = deployment.copy(actions = Some(Nil))
-    val configError = DeploymentTypeResolver.validateDeploymentType(deploymentWithNoActions, deploymentTypes).invalid
-    configError.head.context shouldBe "bob"
-    configError.head.message should include(s"Either specify at least one action or omit the actions parameter")
+    val configErrors = DeploymentTypeResolver.validateDeploymentType(deploymentWithNoActions, deploymentTypes).invalid
+    configErrors.errors.head.context shouldBe "bob"
+    configErrors.errors.head.message should include(s"Either specify at least one action or omit the actions parameter")
   }
 
   it should "fail if given an invalid action" in {
     val deploymentWithInvalidAction = deployment.copy(actions = Some(List("invalidAction")))
-    val configError = DeploymentTypeResolver.validateDeploymentType(deploymentWithInvalidAction, deploymentTypes).invalid
-    configError.head.context shouldBe "bob"
-    configError.head.message should include(s"Invalid action invalidAction for type stub-package-type")
+    val configErrors = DeploymentTypeResolver.validateDeploymentType(deploymentWithInvalidAction, deploymentTypes).invalid
+    configErrors.errors.head.context shouldBe "bob"
+    configErrors.errors.head.message should include(s"Invalid action invalidAction for type stub-package-type")
   }
 
   it should "populate the deployment with default actions if no actions are provided" in {
@@ -59,8 +59,8 @@ class DeploymentTypeResolverTest extends FlatSpec with Matchers with ValidatedVa
 
   it should "fail if given an invalid parameter" in {
     val deploymentWithParameters = deployment.copy(parameters = Map("param1" -> JsNumber(1234)))
-    val configError = DeploymentTypeResolver.validateDeploymentType(deploymentWithParameters, deploymentTypes).invalid
-    configError.head shouldBe ConfigError("bob", "Parameters provided but not used by stub-package-type deployments: param1")
+    val configErrors = DeploymentTypeResolver.validateDeploymentType(deploymentWithParameters, deploymentTypes).invalid
+    configErrors.errors.head shouldBe ConfigError("bob", "Parameters provided but not used by stub-package-type deployments: param1")
   }
 
   it should "fail if a parameter with no default is not provided" in {
@@ -70,8 +70,8 @@ class DeploymentTypeResolverTest extends FlatSpec with Matchers with ValidatedVa
         register => List(Param[String]("param1")(register))
       )
     )
-    val configError = DeploymentTypeResolver.validateDeploymentType(deployment, deploymentTypesWithParams).invalid
-    configError.head shouldBe ConfigError("bob", "Parameters required for stub-package-type deployments not provided: param1")
+    val configErrors = DeploymentTypeResolver.validateDeploymentType(deployment, deploymentTypesWithParams).invalid
+    configErrors.errors.head shouldBe ConfigError("bob", "Parameters required for stub-package-type deployments not provided: param1")
   }
 
   it should "succeed if a default is provided" in {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,6 +15,7 @@ object Dependencies {
   val commonDeps = Seq(
     "io.reactivex" %% "rxscala" % "0.26.2",
     "org.parboiled" %% "parboiled" % "2.0.1",
+    "org.typelevel" %% "cats" % "0.7.2",
     "org.scalatest" %% "scalatest" % "2.2.6" % Test,
     "org.mockito" % "mockito-core" % "1.10.19" % Test
   )

--- a/riff-raff/app/controllers/api.scala
+++ b/riff-raff/app/controllers/api.scala
@@ -384,7 +384,7 @@ class Api(deployments: Deployments)(implicit val messagesApi: MessagesApi, val w
             "response" -> Json.obj(
               "status" -> "ok",
               "result" -> "failed",
-              "errors" -> errors.toList.map { err =>
+              "errors" -> errors.errors.toList.map { err =>
                 Json.obj(
                   "context" -> err.context,
                   "message" -> err.message

--- a/riff-raff/app/deployment/actors/DeployGroupRunner.scala
+++ b/riff-raff/app/deployment/actors/DeployGroupRunner.scala
@@ -171,8 +171,8 @@ class DeployGroupRunner(
         val graph = Resolver.resolve(yaml, resources, record.parameters, DeploymentType.all, riffRaffYaml)
         graph.map(DeployContext(record.uuid, record.parameters, _)) match {
           case Invalid(errors) =>
-            errors.toList.foreach(error => safeReporter.warning(s"${error.context}: ${error.message}"))
-            safeReporter.fail(s"Failed to successfully resolve the deployment: ${errors.toList.size} errors")
+            errors.errors.toList.foreach(error => safeReporter.warning(s"${error.context}: ${error.message}"))
+            safeReporter.fail(s"Failed to successfully resolve the deployment: ${errors.errors.toList.size} errors")
           case Valid(success) => success
         }
       } getOrElse {

--- a/riff-raff/app/views/validation/validationErrors.scala.html
+++ b/riff-raff/app/views/validation/validationErrors.scala.html
@@ -1,0 +1,11 @@
+@import cats.data.NonEmptyList
+@import magenta.input.ConfigError
+@(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], errors: NonEmptyList[ConfigError])
+
+@main("Validation errors", request) {
+    <div class="clearfix"><p>&nbsp;</p></div>
+    @errors.map { error =>
+        Error: @error
+    }
+    <div class="clearfix"></div>
+}

--- a/riff-raff/app/views/validation/validationErrors.scala.html
+++ b/riff-raff/app/views/validation/validationErrors.scala.html
@@ -1,10 +1,9 @@
-@import cats.data.NonEmptyList
-@import magenta.input.ConfigError
-@(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], errors: NonEmptyList[ConfigError])
+@import magenta.input.ConfigErrors
+@(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], errors: ConfigErrors)
 
 @main("Validation errors", request) {
     <div class="clearfix"><p>&nbsp;</p></div>
-    @errors.map { error =>
+    @errors.errors.map { error =>
         Error: @error
     }
     <div class="clearfix"></div>

--- a/riff-raff/app/views/validation/validationForm.scala.html
+++ b/riff-raff/app/views/validation/validationForm.scala.html
@@ -1,0 +1,21 @@
+@(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity])
+@import b3.vertical.fieldConstructor
+@import helper.CSRF
+
+@main("Validation form", request) {
+    <div class="clearfix"><p>&nbsp;</p></div>
+    <div class="col-md-6">
+    @b3.form(routes.Application.validateConfiguration, 'class -> "well") {
+        @CSRF.formField
+        <fieldset>
+            <legend>Paste your riff-raff.yaml content to validate it...</legend>
+            <textarea name="configuration"></textarea>
+
+            <div class="actions">
+                <button name="action" type="submit" value="deploy" class="btn btn-primary">Validate</button>
+            </div>
+        </fieldset>
+    }
+    </div>
+    <div class="clearfix"></div>
+}

--- a/riff-raff/app/views/validation/validationPassed.scala.html
+++ b/riff-raff/app/views/validation/validationPassed.scala.html
@@ -1,0 +1,11 @@
+@import magenta.input.Deployment
+@import magenta.graph.Graph
+@(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], deployments: Graph[Deployment])
+
+@main("Validation output", request) {
+    <div class="clearfix"><p>&nbsp;</p></div>
+    @deployments.toList.map { deployment =>
+        Deployment: @deployment
+    }
+    <div class="clearfix"></div>
+}

--- a/riff-raff/conf/logback-dev.xml
+++ b/riff-raff/conf/logback-dev.xml
@@ -1,0 +1,39 @@
+<configuration>
+
+    <contextName>riff-raff</contextName>
+
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/riff-raff.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/riff-raff.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%date [%thread{10}] %-5level %logger{20} - %msg%n%xException{20}</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date [%thread{10}] %-5level %logger{20} - %msg%n%xException{3}</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.amazonaws.request" level="WARN" />
+
+    <logger name="deployment" level="DEBUG" />
+    <!--<logger name="deployment.actors.DeployCoordinator" level="DEBUG" />-->
+    <!--<logger name="deployment.TaskRunner" level="DEBUG" />-->
+    <!--<logger name="ci" level="DEBUG" />-->
+    <!--<logger name="utils.ScheduledAgent" level="DEBUG" />-->
+    <!--<logger name="persistence.MongoDatastore" level="DEBUG" />-->
+    <logger name="org.mongodb.driver.cluster" level="WARN" />
+
+    <root level="INFO">
+        <appender-ref ref="LOGFILE"/>
+        <!--<appender-ref ref="CONSOLE"/>-->
+    </root>
+
+</configuration>

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -13,6 +13,9 @@ GET         /deployinfo/hosts                               controllers.Applicat
 GET         /docs/                                          controllers.Application.documentation(resource="")
 GET         /docs/*resource                                 controllers.Application.documentation(resource)
 
+GET         /configuration/validation                                controllers.Application.validationForm
+POST        /configuration/validation                                controllers.Application.validateConfiguration
+
 # Deployment pages
 GET         /deployment/request                             controllers.DeployController.deploy
 POST        /deployment/request                             controllers.DeployController.processForm
@@ -78,6 +81,7 @@ GET         /api/history                                    controllers.Api.hist
 GET         /api/deploy/view                                controllers.Api.view(uuid:String)
 POST        /api/deploy/request                             controllers.Api.deploy
 POST        /api/deploy/stop                                controllers.Api.stop
+POST        /api/validate                                   controllers.Api.validate
 
 # Testing pages (for changing styling without running deploys)
 GET         /testing/reportTestPartial                      controllers.Testing.reportTestPartial(take:Int ?= 20, verbose:Boolean ?= false)


### PR DESCRIPTION
This makes much of the code a bit cleaner and easier to reason about and in come cases means that we can return multiple errors. As a bonus some of the Json reads code becomes a little easier to reason about as well.

This adds an API endpoint to which YAML can be sent for validation and some **very** rudimentary web pages that let you do the same (your eyes will hurt!)

Would be interested in doing a code review of all of this in person with anyone who has used cats before.