### PR TITLE
When parsing the YAML check for extra fields

### DIFF
--- a/magenta-lib/src/main/scala/magenta/input/RiffRaffYamlReader.scala
+++ b/magenta-lib/src/main/scala/magenta/input/RiffRaffYamlReader.scala
@@ -43,7 +43,8 @@ object RiffRaffYamlReader {
       case JsError(errors :: tail) =>
         val nelErrors = NEL(errors, tail)
         Invalid(ConfigErrors(nelErrors.map{ case (path, validationErrors) =>
-          ConfigError(s"Parsing $path", validationErrors.map(ve => ve.message).mkString(", "))
+          val pathName = if (path.path.isEmpty) "YAML" else path.toString
+          ConfigError(s"Parsing $pathName", validationErrors.map(ve => ve.message).mkString(", "))
         }))
       case JsError(_) => `wtf?`
     }

--- a/magenta-lib/src/main/scala/magenta/input/models.scala
+++ b/magenta-lib/src/main/scala/magenta/input/models.scala
@@ -22,7 +22,7 @@ case class RiffRaffDeployConfig(
 )
 object RiffRaffDeployConfig {
   import RiffRaffYamlReader.readObjectAsList
-  implicit val reads: Reads[RiffRaffDeployConfig] = Json.reads
+  implicit val reads: Reads[RiffRaffDeployConfig] = checkedReads(Json.reads)
 }
 
 /**
@@ -51,7 +51,7 @@ case class DeploymentOrTemplate(
   parameters: Option[Map[String, JsValue]]
 )
 object DeploymentOrTemplate {
-  implicit val reads: Reads[DeploymentOrTemplate] = Json.reads
+  implicit val reads: Reads[DeploymentOrTemplate] = checkedReads(Json.reads)
 }
 
 /**

--- a/magenta-lib/src/main/scala/magenta/input/package.scala
+++ b/magenta-lib/src/main/scala/magenta/input/package.scala
@@ -1,0 +1,21 @@
+package magenta
+
+import play.api.libs.json._
+
+import scala.reflect.runtime.universe._
+
+package object input {
+  def checkedReads[T](underlyingReads: Reads[T])(implicit typeTag: TypeTag[T]): Reads[T] = new Reads[T] {
+    def classFields[T: TypeTag]: Set[String] = typeOf[T].members.collect {
+      case m: MethodSymbol if m.isCaseAccessor => m.name.decodedName.toString
+    }.toSet
+    def reads(json: JsValue): JsResult[T] = {
+      val caseClassFields = classFields[T]
+      json match {
+        case JsObject(fields) if (fields.keySet -- caseClassFields).nonEmpty =>
+          JsError(s"Unexpected fields provided: ${(fields.keySet -- caseClassFields).mkString(", ")}")
+        case _ => underlyingReads.reads(json)
+      }
+    }
+  }
+}


### PR DESCRIPTION
If a field is provided that we are not using then this is probably a bad thing. In many cases it will be because someone has made a typo (e.g. they may have used `template` instead of `templates`). This is another opportunity to fail fast to make life easier for users.