### PR TITLE
Enable desktop notification upon deployment

### DIFF
--- a/riff-raff/app/assets/javascripts/auto-refresh.coffee
+++ b/riff-raff/app/assets/javascripts/auto-refresh.coffee
@@ -55,6 +55,10 @@ $ ->
 addPostRefreshCallback = (callback) ->
   callbackList.add callback
 
+removePostRefreshCallBack = (callback) ->
+  callbackList.remove callback
+
 @autoRefresh = {
   postRefresh : addPostRefreshCallback
+  remove: removePostRefreshCallBack
 }

--- a/riff-raff/app/assets/javascripts/notifications.coffee
+++ b/riff-raff/app/assets/javascripts/notifications.coffee
@@ -1,7 +1,4 @@
-$ ->
-  $("#enable-notifications").click (e) ->
-    e.preventDefault()
-    Notification.requestPermission()
+Notification.requestPermission()
 
 intervalId = null
 
@@ -14,7 +11,7 @@ checkStatus = () ->
     disableCheck()
 
 if $('[data-run-state]').length == 0
-  intervalId = setInterval checkStatus, 1000
+  intervalId = setInterval checkStatus, 800
 
 disableCheck = ->
   clearInterval(intervalId) if intervalId?

--- a/riff-raff/app/assets/javascripts/notifications.coffee
+++ b/riff-raff/app/assets/javascripts/notifications.coffee
@@ -6,8 +6,8 @@ checkStatus = () ->
   if $('[data-run-state]').length != 0
     buildName = window.riffraff.buildName
     switch $('[data-run-state]').data('run-state')
-      when 'Failed' then new Notification('Riffraff', {body: 'Deployment of ' + buildName + ' failed!'})
-      when 'Completed' then new Notification('Riffraff', {body: 'Deployment of ' + buildName + ' is finished'})
+      when 'Failed' then new Notification('Riffraff', {body: 'Deployment of ' + buildName + ' has failed!'})
+      when 'Completed' then new Notification('Riffraff', {body: 'Deployment of ' + buildName + ' has finished'})
     disableCheck()
 
 if $('[data-run-state]').length == 0

--- a/riff-raff/app/assets/javascripts/notifications.coffee
+++ b/riff-raff/app/assets/javascripts/notifications.coffee
@@ -1,16 +1,17 @@
-Notification.requestPermission()
-
 intervalId = null
 
 checkStatus = () ->
   if $('[data-run-state]').length != 0
     buildName = window.riffraff.buildName
+    stage = window.riffraff.stage
+    buildId = window.riffraff.buildId
     switch $('[data-run-state]').data('run-state')
-      when 'Failed' then new Notification('Riffraff', {body: 'Deployment of ' + buildName + ' has failed!'})
-      when 'Completed' then new Notification('Riffraff', {body: 'Deployment of ' + buildName + ' has finished'})
+      when 'Failed' then new Notification('Riffraff', {body: 'Deployment of ' + buildName + ' (' + buildId + ')' + ' in ' + stage + ' has failed!'})
+      when 'Completed' then new Notification('Riffraff', {body: 'Deployment of ' + buildName + ' (' + buildId + ')' + ' in ' + stage + ' has finished'})
     disableCheck()
 
-if $('[data-run-state]').length == 0
+if !window.riffraff.isDone
+  Notification.requestPermission()
   intervalId = setInterval checkStatus, 800
 
 disableCheck = ->

--- a/riff-raff/app/assets/javascripts/notifications.coffee
+++ b/riff-raff/app/assets/javascripts/notifications.coffee
@@ -1,0 +1,20 @@
+$ ->
+  $("#enable-notifications").click (e) ->
+    e.preventDefault()
+    Notification.requestPermission()
+
+intervalId = null
+
+checkStatus = () ->
+  if $('[data-run-state]').length != 0
+    buildName = window.riffraff.buildName
+    switch $('[data-run-state]').data('run-state')
+      when 'Failed' then new Notification('Riffraff', {body: 'Deployment of ' + buildName + ' failed!'})
+      when 'Completed' then new Notification('Riffraff', {body: 'Deployment of ' + buildName + ' is finished'})
+    disableCheck()
+
+if $('[data-run-state]').length == 0
+  intervalId = setInterval checkStatus, 1000
+
+disableCheck = ->
+  clearInterval(intervalId) if intervalId?

--- a/riff-raff/app/assets/javascripts/notifications.coffee
+++ b/riff-raff/app/assets/javascripts/notifications.coffee
@@ -1,12 +1,15 @@
+notify = (message) ->
+  new Notification('Riffraff', {body: message})
+  disableCheck()
+
 checkStatus = () ->
   if $('[data-run-state]').length != 0
     buildName = window.riffraff.buildName
     stage = window.riffraff.stage
     buildId = window.riffraff.buildId
     switch $('[data-run-state]').data('run-state')
-      when 'Failed' then new Notification('Riffraff', {body: 'Deployment of ' + buildName + ' (' + buildId + ')' + ' in ' + stage + ' has failed!'})
-      when 'Completed' then new Notification('Riffraff', {body: 'Deployment of ' + buildName + ' (' + buildId + ')' + ' in ' + stage + ' has finished'})
-    disableCheck()
+      when 'Failed' then notify('Deployment of ' + buildName + ' (' + buildId + ')' + ' in ' + stage + ' has failed!')
+      when 'Completed' then notify('Deployment of ' + buildName + ' (' + buildId + ')' + ' in ' + stage + ' has finished')
 
 if !window.riffraff.isDone && window.autoRefresh
   Notification.requestPermission()

--- a/riff-raff/app/assets/javascripts/notifications.coffee
+++ b/riff-raff/app/assets/javascripts/notifications.coffee
@@ -1,5 +1,3 @@
-intervalId = null
-
 checkStatus = () ->
   if $('[data-run-state]').length != 0
     buildName = window.riffraff.buildName
@@ -10,9 +8,10 @@ checkStatus = () ->
       when 'Completed' then new Notification('Riffraff', {body: 'Deployment of ' + buildName + ' (' + buildId + ')' + ' in ' + stage + ' has finished'})
     disableCheck()
 
-if !window.riffraff.isDone
+if !window.riffraff.isDone && window.autoRefresh
   Notification.requestPermission()
-  intervalId = setInterval checkStatus, 800
+  window.autoRefresh.postRefresh checkStatus
 
 disableCheck = ->
-  clearInterval(intervalId) if intervalId?
+  if window.autoRefresh
+    window.autoRefresh.remove checkStatus

--- a/riff-raff/app/views/deploy/logSummary.scala.html
+++ b/riff-raff/app/views/deploy/logSummary.scala.html
@@ -5,10 +5,10 @@
     }
     @defining(record.state) { state =>
         @state match {
-            case RunState.NotRunning => { <div class="alert alert-info"><p class="lead">Waiting to run</p></div> }
-            case RunState.Completed => { <div class="alert alert-success"><p class="lead">Completed</p></div> }
+            case RunState.NotRunning => { <div class="alert alert-info" data-run-state="NotRunning"><p class="lead">Waiting to run</p></div> }
+            case RunState.Completed => { <div class="alert alert-success" data-run-state="Completed"><p class="lead">Completed</p></div> }
             case RunState.Failed => {
-                <div class="alert alert-danger">
+                <div class="alert alert-danger" data-run-state="Failed">
                     <p class="lead">Failed</p>
                     @defining(java.util.UUID.randomUUID.toString) { id =>
                         @record.report.failureMessage.map{ fail =>

--- a/riff-raff/app/views/deploy/viewDeploy.scala.html
+++ b/riff-raff/app/views/deploy/viewDeploy.scala.html
@@ -1,17 +1,21 @@
 @(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], record: deployment.Record, verbose: Boolean = false, stopFlag: Boolean = false)
 @import helper.CSRF
 
+<script language="JavaScript">
+        window.riffraff = {
+            buildId: '@record.buildId',
+            buildName: '@record.buildName',
+            stage: '@record.stage.name',
+            isDone: @{record.isDone}
+        }
+</script>
+
 @main(s"Deploy for ${record.buildName}", request, List("auto-refresh", "deploy-verbose", "stop-deploy", "notifications")) {
     <style>
     span.message-verbose {
       display:@if(!verbose) {none} else {list-item};
     }
     </style>
-    <script language="JavaScript">
-        window.riffraff = {
-            buildName: '@record.buildName'
-        }
-    </script>
 
     <div class="row">
         <div class="col-md-8">

--- a/riff-raff/app/views/deploy/viewDeploy.scala.html
+++ b/riff-raff/app/views/deploy/viewDeploy.scala.html
@@ -1,12 +1,17 @@
 @(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], record: deployment.Record, verbose: Boolean = false, stopFlag: Boolean = false)
 @import helper.CSRF
 
-@main(s"Deploy for ${record.buildName}", request, List("auto-refresh", "deploy-verbose", "stop-deploy")) {
+@main(s"Deploy for ${record.buildName}", request, List("auto-refresh", "deploy-verbose", "stop-deploy", "notifications")) {
     <style>
     span.message-verbose {
       display:@if(!verbose) {none} else {list-item};
     }
     </style>
+    <script language="JavaScript">
+        window.riffraff = {
+            buildName: '@record.buildName'
+        }
+    </script>
 
     <div class="row">
         <div class="col-md-8">


### PR DESCRIPTION
The user will be prompted to allow or reject notifications on the first deployment. Users can disable notifications later by modifying their browser authorisations.

The appearance will vary depending on your system.

![screenshot from 2016-10-10 18-13-33](https://cloud.githubusercontent.com/assets/3389563/19244704/7a5ff1ac-8f15-11e6-9ab7-19aeada14e96.png)
