### PR TITLE
Fix the stop button by adding CSRF handling

### DIFF
--- a/riff-raff/app/AppLoader.scala
+++ b/riff-raff/app/AppLoader.scala
@@ -6,7 +6,7 @@ import lifecycle.ShutdownWhenInactive
 import notification.HooksClient
 import persistence.SummariseDeploysHousekeeping
 import play.api.ApplicationLoader.Context
-import play.api.{Application, ApplicationLoader, Logger}
+import play.api.{Application, ApplicationLoader, Logger, LoggerConfigurator}
 import utils.ScheduledAgent
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -15,6 +15,10 @@ import scala.util.control.NonFatal
 class AppLoader extends ApplicationLoader {
 
   override def load(context: Context): Application = {
+    LoggerConfigurator(context.environment.classLoader).foreach {
+      _.configure(context.environment)
+    }
+
     val components = new AppComponents(context)
 
     val hooksClient = new HooksClient(components.wsClient)

--- a/riff-raff/app/assets/javascripts/stop-deploy.coffee
+++ b/riff-raff/app/assets/javascripts/stop-deploy.coffee
@@ -1,8 +1,14 @@
 $ ->
   $(".stop-deploy-button").click (e) ->
     e.preventDefault()
-    uuid = $(this).val()
-    jsRoutes.controllers.DeployController.stop(uuid).ajax
+    button = $(this)
+    uuid = button.val()
+    endpoint = jsRoutes.controllers.DeployController.stop(uuid)
+    csrfTokenValue = button.siblings("input").val()
+    $.ajax
+      url: endpoint.url
+      type: endpoint.method
+      data: {csrfToken: csrfTokenValue}
       context: this
       success: ->
         $(".stop-deploy-button").addClass("disabled")

--- a/riff-raff/app/views/deploy/stopDeployButton.scala.html
+++ b/riff-raff/app/views/deploy/stopDeployButton.scala.html
@@ -1,8 +1,10 @@
-@(record: deployment.Record, stopFlag: Boolean)
+@(record: deployment.Record, stopFlag: Boolean)(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity])
+@import helper.CSRF
 
 @if(!record.isDone){
 
     @helper.form(routes.DeployController.stop(record.uuid.toString), 'class -> "form-make-inline pull-right stop-deploy-hide") {
+        @CSRF.formField
         @if(stopFlag) {
             <button name="action" type="button" value="@record.uuid" class="stop-deploy-button refresh-disabled-hide btn btn-danger disabled">
                 Stopping Deploy...


### PR DESCRIPTION
I had a couple of reports of this not working. The reason was the the AJAX stop call was being nixed by the global CSRF filter.

This change isn't perfect but probably good enough for now - we extract the token from the input field and submit it in the AJAX call.