### PR TITLE
Further improve parameter validation

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
@@ -55,7 +55,7 @@ trait ParamRegister {
   *                       might be needed if the value is not required to have a default or when only one of two
   *                       different parameters are specified.
   * @param defaultValue The default value for this parameter - used when a value is not found in the map
-  * @param defaultValueFromContext A function that returns a defualt value for this parameter based on the package for
+  * @param defaultValueFromContext A function that returns a default value for this parameter based on the package for
   *                                this deployment
   * @param register The parameter register - a Param self registers
   * @tparam T The type of the parameter to extract

--- a/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
@@ -45,31 +45,61 @@ trait ParamRegister {
   def add(param: Param[_])
 }
 
-case class Param[T](name: String,
-                    documentation: String = "_undocumented_",
-                    defaultValue: Option[T] = None,
-                    defaultValueFromPackage: Option[DeploymentPackage => T] = None)(implicit register:ParamRegister) {
+/**
+  * A parameter for a deployment type
+ *
+  * @param name The name of the parameter that should be extracted from the parameter map (riff-raff.yaml) or data map
+  *             (deploy.json)
+  * @param documentation A documentation string (in markdown) that describes this parameter
+  * @param optionalInYaml This can be set to true to make the parameter optional even when there are no defaults. This
+  *                       might be needed if the value is not required to have a default or when only one of two
+  *                       different parameters are specified.
+  * @param defaultValue The default value for this parameter - used when a value is not found in the map
+  * @param defaultValueFromContext A function that returns a defualt value for this parameter based on the package for
+  *                                this deployment
+  * @param register The parameter register - a Param self registers
+  * @tparam T The type of the parameter to extract
+  */
+case class Param[T](
+  name: String,
+  documentation: String = "_undocumented_",
+  optionalInYaml: Boolean = false,
+  defaultValue: Option[T] = None,
+  defaultValueFromContext: Option[(DeploymentPackage, DeployTarget) => Either[String,T]] = None
+)(implicit register:ParamRegister) {
   register.add(this)
+
+  val requiredInYaml = !optionalInYaml && defaultValue.isEmpty && defaultValueFromContext.isEmpty
 
   def get(pkg: DeploymentPackage)(implicit reads: Reads[T]): Option[T] =
     pkg.pkgSpecificData.get(name).flatMap(jsValue => Json.fromJson[T](jsValue).asOpt)
-  def apply(pkg: DeploymentPackage, reporter: DeployReporter)(implicit reads: Reads[T], manifest: Manifest[T]): T = {
+  def apply(pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter)(implicit reads: Reads[T], manifest: Manifest[T]): T = {
     val maybeValue = get(pkg)
-    val maybeDefault = defaultValue.orElse(defaultValueFromPackage.map(_ (pkg)))
-    if (!pkg.legacyConfig && maybeDefault.isDefined && maybeValue == maybeDefault) {
-      reporter.warning(s"Parameter $name is unnecessarily set to the default value of ${defaultValue.get}")
+    val defaultFromContext = defaultValueFromContext.map(_ (pkg, target))
+    if (!pkg.legacyConfig) {
+      val default = defaultValue.orElse(defaultFromContext.flatMap(_.right.toOption))
+      if (default.isDefined && default == maybeValue)
+        reporter.warning(s"Parameter $name is unnecessarily explicitly set to the default value of ${defaultValue.get}")
     }
-    maybeValue.orElse(maybeDefault).getOrElse {
-      throw new NoSuchElementException(
-        s"Package ${pkg.name} [${pkg.deploymentTypeName}] requires parameter $name of type ${manifest.runtimeClass.getSimpleName}"
-      )
+    (maybeValue, defaultValue, defaultFromContext) match {
+      case (Some(userDefined), _, _) => userDefined
+      case (_, Some(default), _) => default
+      case (_, _, Some(Right(contextDefault))) => contextDefault
+      case (_, _, Some(Left(contextError))) =>
+        throw new NoSuchElementException(
+          s"Error whilst generating default for parameter $name in package ${pkg.name} [${pkg.deploymentTypeName}]: $contextError"
+        )
+      case _ =>
+        throw new NoSuchElementException(
+          s"Package ${pkg.name} [${pkg.deploymentTypeName}] requires parameter $name of type ${manifest.runtimeClass.getSimpleName}"
+        )
     }
   }
 
   def default(default: T) = {
     this.copy(defaultValue = Some(default))
   }
-  def defaultFromPackage(defaultFromPackage: DeploymentPackage => T) = {
-    this.copy(defaultValueFromPackage = Some((p: DeploymentPackage) => defaultFromPackage(p)))
+  def defaultFromContext(defaultFromContext: (DeploymentPackage, DeployTarget) => Either[String,T]) = {
+    this.copy(defaultValueFromContext = Some(defaultFromContext))
   }
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
@@ -15,7 +15,7 @@ object ElasticSearch extends DeploymentType {
 
   val publicReadAcl = Param[Boolean]("publicReadAcl",
     "Whether the uploaded artifacts should be given the PublicRead Canned ACL. (Default is true!)"
-  ).defaultFromPackage(_.legacyConfig)
+  ).defaultFromContext((pkg, _) => Right(pkg.legacyConfig))
 
   val secondsToWait = Param("secondsToWait",
     """Number of seconds to wait for the ElasticSearch cluster to become green
@@ -32,12 +32,12 @@ object ElasticSearch extends DeploymentType {
       val stack = target.stack
       List(
         CheckGroupSize(pkg, parameters.stage, stack, target.region),
-        WaitForElasticSearchClusterGreen(pkg, parameters.stage, stack, secondsToWait(pkg, reporter) * 1000, target.region),
+        WaitForElasticSearchClusterGreen(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
         SuspendAlarmNotifications(pkg, parameters.stage, stack, target.region),
         TagCurrentInstancesWithTerminationTag(pkg, parameters.stage, stack, target.region),
         DoubleSize(pkg, parameters.stage, stack, target.region),
-        WaitForElasticSearchClusterGreen(pkg, parameters.stage, stack, secondsToWait(pkg, reporter) * 1000, target.region),
-        CullElasticSearchInstancesWithTerminationTag(pkg, parameters.stage, stack, secondsToWait(pkg, reporter) * 1000, target.region),
+        WaitForElasticSearchClusterGreen(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
+        CullElasticSearchInstancesWithTerminationTag(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
         ResumeAlarmNotifications(pkg, parameters.stage, stack, target.region)
       )
     }
@@ -49,9 +49,9 @@ object ElasticSearch extends DeploymentType {
       List(
         S3Upload(
           target.region,
-          bucket(pkg, reporter),
+          bucket(pkg, target, reporter),
           Seq(pkg.s3Package -> prefix),
-          publicReadAcl = publicReadAcl(pkg, reporter)
+          publicReadAcl = publicReadAcl(pkg, target, reporter)
         )
       )
   }

--- a/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentTypeResolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentTypeResolver.scala
@@ -31,7 +31,7 @@ object DeploymentTypeResolver {
   private[input] def verifyDeploymentParameters(deployment: Deployment, deploymentType: DeploymentType): Validated[ConfigErrors, Deployment] = {
     val validParameterNames = deploymentType.params.map(_.name)
     val requiredParameterNames =
-      deploymentType.params.filterNot(dt => dt.defaultValue.isDefined || dt.defaultValueFromPackage.isDefined).map(_.name).toSet
+      deploymentType.params.filter(_.requiredInYaml).map(_.name).toSet
 
     val actualParamNames = deployment.parameters.keySet
     val missingParameters = requiredParameterNames -- actualParamNames

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -63,7 +63,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
 
     S3.actions("uploadStaticFiles")(p)(DeploymentResources(mockReporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region))
 
-    verify(mockReporter).warning("Parameter prefixStage is unnecessarily set to the default value of true")
+    verify(mockReporter).warning("Parameter prefixStage is unnecessarily explicitly set to the default value of true")
   }
 
   it should "not log a warning when a default is explicitly set in a legacy config" in {

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTypeResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTypeResolverTest.scala
@@ -74,6 +74,16 @@ class DeploymentTypeResolverTest extends FlatSpec with Matchers with ValidatedVa
     configErrors.errors.head shouldBe ConfigError("bob", "Parameters required for stub-package-type deployments not provided: param1")
   }
 
+  it should "succeed if an optional parameter is not provided" in {
+    val deploymentTypesWithParams = List(
+      stubDeploymentType(
+        Seq("upload", "deploy"),
+        register => List(Param[String]("param1", optionalInYaml = true)(register))
+      )
+    )
+    DeploymentTypeResolver.validateDeploymentType(deployment, deploymentTypesWithParams).valid
+  }
+
   it should "succeed if a default is provided" in {
     val deploymentTypesWithParams = List(
       stubDeploymentType(
@@ -88,7 +98,7 @@ class DeploymentTypeResolverTest extends FlatSpec with Matchers with ValidatedVa
     val deploymentTypesWithParams = List(
       stubDeploymentType(
         Seq("upload", "deploy"),
-        register => List(Param[String]("param1", defaultValueFromPackage = Some(_.name))(register))
+        register => List(Param[String]("param1", defaultValueFromContext = Some((pkg, _) => Right(pkg.name)))(register))
       )
     )
     DeploymentTypeResolver.validateDeploymentType(deployment, deploymentTypesWithParams).valid

--- a/riff-raff/app/views/documentation/deploymentTypeSnippet.scala.html
+++ b/riff-raff/app/views/documentation/deploymentTypeSnippet.scala.html
@@ -16,8 +16,13 @@
     <tr>
       <td>@name</td>
       <td>@docs.MarkDown.toHtml(desc)</td>
-      <td nowrap="nowrap"><em>@defaultYaml.getOrElse{<strong>&lt;no default&gt;</strong>}</em></td>
-      <td nowrap="nowrap"><em>@defaultJson.getOrElse{<strong>&lt;no default&gt;</strong>}</em></td>
+        @if(defaultJson != defaultYaml) {
+            <td nowrap="nowrap"><em><strong>@defaultYaml.getOrElse{&lt;no default&gt;}</strong></em></td>
+            <td nowrap="nowrap"><em><strong>@defaultJson.getOrElse{&lt;no default&gt;}</strong></em></td>
+        } else {
+            <td nowrap="nowrap"><em>@defaultYaml.getOrElse{<strong>&lt;no default&gt;</strong>}</em></td>
+            <td nowrap="nowrap"><em>@defaultJson.getOrElse{<strong>&lt;no default&gt;</strong>}</em></td>
+        }
     </tr>
     }
 </table>


### PR DESCRIPTION
I had been overly enthusiastic about parameter validation and it turned out that there are some cases in which no default is specified and that's still OK (i.e. the parameter has no default but is optional). One of these cases is when there are two parameters and you need to set one and only one of these.

This adds an optional field and also enhances the withDefault functionality to provide the DeployTarget instance - this means that we can shift more default logic into the parameters and make fewer params optional when really they default from stack or some such deploy time data.