### PR TITLE
Move Param classes into own file and write some tests

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
@@ -2,7 +2,6 @@ package magenta.deployment_type
 
 import magenta._
 import magenta.tasks.Task
-import play.api.libs.json.{Json, Reads}
 
 import scala.collection.mutable
 
@@ -39,70 +38,4 @@ object DeploymentType {
   def all: Seq[DeploymentType] = Seq(
     ElasticSearch, S3, AutoScaling, Fastly, CloudFormation, Lambda, AmiCloudFormationParameter, SelfDeploy
   )
-}
-
-trait ParamRegister {
-  def add(param: Param[_])
-}
-
-/**
-  * A parameter for a deployment type
- *
-  * @param name The name of the parameter that should be extracted from the parameter map (riff-raff.yaml) or data map
-  *             (deploy.json)
-  * @param documentation A documentation string (in markdown) that describes this parameter
-  * @param optionalInYaml This can be set to true to make the parameter optional even when there are no defaults. This
-  *                       might be needed if the value is not required to have a default or when only one of two
-  *                       different parameters are specified.
-  * @param defaultValue The default value for this parameter - used when a value is not found in the map
-  * @param defaultValueFromContext A function that returns a default value for this parameter based on the package for
-  *                                this deployment
-  * @param register The parameter register - a Param self registers
-  * @tparam T The type of the parameter to extract
-  */
-case class Param[T](
-  name: String,
-  documentation: String = "_undocumented_",
-  optionalInYaml: Boolean = false,
-  defaultValue: Option[T] = None,
-  defaultValueFromContext: Option[(DeploymentPackage, DeployTarget) => Either[String,T]] = None
-)(implicit register:ParamRegister) {
-  register.add(this)
-
-  val requiredInYaml = !optionalInYaml && defaultValue.isEmpty && defaultValueFromContext.isEmpty
-
-  def get(pkg: DeploymentPackage)(implicit reads: Reads[T]): Option[T] =
-    pkg.pkgSpecificData.get(name).flatMap(jsValue => Json.fromJson[T](jsValue).asOpt)
-  def apply(pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter)(implicit reads: Reads[T], manifest: Manifest[T]): T = {
-    val maybeValue = get(pkg)
-    val defaultFromContext = defaultValueFromContext.map(_ (pkg, target))
-
-    val maybeDefault = defaultValue.orElse(defaultFromContext.flatMap(_.right.toOption))
-    (pkg.legacyConfig, maybeDefault, maybeValue) match {
-      case (false, Some(default), Some(value)) if default == value =>
-        reporter.warning(s"Parameter $name is unnecessarily explicitly set to the default value of $default")
-      case _ => // otherwise do nothing
-    }
-
-    (maybeValue, defaultValue, defaultFromContext) match {
-      case (Some(userDefined), _, _) => userDefined
-      case (_, Some(default), _) => default
-      case (_, _, Some(Right(contextDefault))) => contextDefault
-      case (_, _, Some(Left(contextError))) =>
-        throw new NoSuchElementException(
-          s"Error whilst generating default for parameter $name in package ${pkg.name} [${pkg.deploymentTypeName}]: $contextError"
-        )
-      case _ =>
-        throw new NoSuchElementException(
-          s"Package ${pkg.name} [${pkg.deploymentTypeName}] requires parameter $name of type ${manifest.runtimeClass.getSimpleName}"
-        )
-    }
-  }
-
-  def default(default: T) = {
-    this.copy(defaultValue = Some(default))
-  }
-  def defaultFromContext(defaultFromContext: (DeploymentPackage, DeployTarget) => Either[String,T]) = {
-    this.copy(defaultValueFromContext = Some(defaultFromContext))
-  }
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Param.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Param.scala
@@ -1,0 +1,70 @@
+package magenta.deployment_type
+
+import magenta.{DeployReporter, DeployTarget, DeploymentPackage}
+import play.api.libs.json.{Json, Reads}
+
+trait ParamRegister {
+  def add(param: Param[_])
+}
+
+/**
+  * A parameter for a deployment type
+  *
+  * @param name The name of the parameter that should be extracted from the parameter map (riff-raff.yaml) or data map
+  *             (deploy.json)
+  * @param documentation A documentation string (in markdown) that describes this parameter
+  * @param optionalInYaml This can be set to true to make the parameter optional even when there are no defaults. This
+  *                       might be needed if the value is not required to have a default or when only one of two
+  *                       different parameters are specified.
+  * @param defaultValue The default value for this parameter - used when a value is not found in the map
+  * @param defaultValueFromContext A function that returns a default value for this parameter based on the package for
+  *                                this deployment
+  * @param register The parameter register - a Param self registers
+  * @tparam T The type of the parameter to extract
+  */
+case class Param[T](
+  name: String,
+  documentation: String = "_undocumented_",
+  optionalInYaml: Boolean = false,
+  defaultValue: Option[T] = None,
+  defaultValueFromContext: Option[(DeploymentPackage, DeployTarget) => Either[String,T]] = None
+)(implicit register:ParamRegister) {
+  register.add(this)
+
+  val requiredInYaml = !optionalInYaml && defaultValue.isEmpty && defaultValueFromContext.isEmpty
+
+  def get(pkg: DeploymentPackage)(implicit reads: Reads[T]): Option[T] =
+    pkg.pkgSpecificData.get(name).flatMap(jsValue => Json.fromJson[T](jsValue).asOpt)
+  def apply(pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter)(implicit reads: Reads[T], manifest: Manifest[T]): T = {
+    val maybeValue = get(pkg)
+    val defaultFromContext = defaultValueFromContext.map(_ (pkg, target))
+
+    val maybeDefault = defaultValue.orElse(defaultFromContext.flatMap(_.right.toOption))
+    (pkg.legacyConfig, maybeDefault, maybeValue) match {
+      case (false, Some(default), Some(value)) if default == value =>
+        reporter.warning(s"Parameter $name is unnecessarily explicitly set to the default value of $default")
+      case _ => // otherwise do nothing
+    }
+
+    (maybeValue, defaultValue, defaultFromContext) match {
+      case (Some(userDefined), _, _) => userDefined
+      case (_, Some(default), _) => default
+      case (_, _, Some(Right(contextDefault))) => contextDefault
+      case (_, _, Some(Left(contextError))) =>
+        throw new NoSuchElementException(
+          s"Error whilst generating default for parameter $name in package ${pkg.name} [${pkg.deploymentTypeName}]: $contextError"
+        )
+      case _ =>
+        throw new NoSuchElementException(
+          s"Package ${pkg.name} [${pkg.deploymentTypeName}] requires parameter $name of type ${manifest.runtimeClass.getSimpleName}"
+        )
+    }
+  }
+
+  def default(default: T) = {
+    this.copy(defaultValue = Some(default))
+  }
+  def defaultFromContext(defaultFromContext: (DeploymentPackage, DeployTarget) => Either[String,T]) = {
+    this.copy(defaultValueFromContext = Some(defaultFromContext))
+  }
+}

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -1,15 +1,15 @@
-package magenta
+package magenta.deployment_type
 
 import java.util.UUID
 
 import com.amazonaws.services.s3.AmazonS3
+import magenta._
 import magenta.artifact.S3Path
 import magenta.deployment_type.param_reads.PatternValue
-import magenta.deployment_type.{Lambda, S3}
 import magenta.fixtures._
 import magenta.tasks._
-import org.mockito.Mockito._
 import org.mockito.Matchers._
+import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{FlatSpec, Inside, Matchers}
 import play.api.libs.json.{JsBoolean, JsString, JsValue, Json}

--- a/magenta-lib/src/test/scala/magenta/deployment_type/ParamTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/ParamTest.scala
@@ -1,0 +1,122 @@
+package magenta.deployment_type
+
+import java.util.UUID
+
+import magenta.artifact.S3Path
+import magenta._
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.libs.json.JsString
+
+import scala.collection.mutable
+
+class TestRegister extends ParamRegister {
+  val paramsList = mutable.Map.empty[String, Param[_]]
+  def add(param: Param[_]) = paramsList += param.name -> param
+}
+
+class ParamTest extends FlatSpec with Matchers with MockitoSugar {
+  val target = DeployTarget(fixtures.parameters(), NamedStack("testStack"), Region("testRegion"))
+  val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), target.parameters)
+
+  "Param" should "register itself with a register" in {
+    implicit val register = new TestRegister
+
+    val param = Param[String]("test")
+
+    register.paramsList.size shouldBe 1
+    register.paramsList should contain("test" -> param)
+  }
+
+  it should "extract a value from a package using get" in {
+    implicit val register = new TestRegister
+    val pkg = DeploymentPackage("testPackage", Nil, Map("key" -> JsString("myValue")), "testDeploymentType", S3Path("test", "test"), legacyConfig = true)
+    val key = Param[String]("key").default("valueDefault")
+    val paramValue = key.get(pkg)
+    paramValue shouldBe Some("myValue")
+  }
+
+  it should "extract None using get when the value isn't in a package" in {
+    implicit val register = new TestRegister
+    val pkg = DeploymentPackage("testPackage", Nil, Map.empty, "testDeploymentType", S3Path("test", "test"), legacyConfig = true)
+    val key = Param[String]("key").default("valueDefault")
+    val paramValue = key.get(pkg)
+    paramValue shouldBe None
+  }
+
+  it should "extract a value using apply" in {
+    implicit val register = new TestRegister
+    val pkg = DeploymentPackage("testPackage", Nil, Map("key" -> JsString("myValue")), "testDeploymentType", S3Path("test", "test"), legacyConfig = true)
+    val key = Param[String]("key").default("valueDefault")
+    val paramValue = key.apply(pkg, target, reporter)
+    paramValue shouldBe "myValue"
+  }
+
+  it should "throw an exception if a value is not specified and has no default" in {
+    implicit val register = new TestRegister
+    val pkg = DeploymentPackage("testPackage", Nil, Map.empty, "testDeploymentType", S3Path("test", "test"), legacyConfig = true)
+    val key = Param[String]("key")
+    val thrown = the [NoSuchElementException] thrownBy {
+      key.apply(pkg, target, reporter)
+    }
+    thrown.getMessage shouldBe "Package testPackage [testDeploymentType] requires parameter key of type String"
+  }
+
+  it should "return the param default from apply when no value is specified" in {
+    implicit val register = new TestRegister
+    val pkg = DeploymentPackage("testPackage", Nil, Map.empty, "testDeploymentType", S3Path("test", "test"), legacyConfig = true)
+    val key = Param[String]("key").default("valueDefault")
+    val paramValue = key.apply(pkg, target, reporter)
+    paramValue shouldBe "valueDefault"
+  }
+
+  it should "return the param context default from apply when no value is specified" in {
+    implicit val register = new TestRegister
+    val pkg = DeploymentPackage("testPackage", Nil, Map.empty, "testDeploymentType", S3Path("test", "test"), legacyConfig = true)
+    val key = Param[String]("key").defaultFromContext((pkg, target) => Right(s"${target.region.name} and ${pkg.legacyConfig}"))
+    val paramValue = key.apply(pkg, target, reporter)
+    paramValue shouldBe "testRegion and true"
+  }
+
+  it should "throw an exception if defaultFromContext returns a Left value" in {
+    implicit val register = new TestRegister
+    val pkg = DeploymentPackage("testPackage", Nil, Map.empty, "testDeploymentType", S3Path("test", "test"), legacyConfig = true)
+    val key = Param[String]("key").defaultFromContext((pkg, target) => Left("something was wrong"))
+    val thrown = the [NoSuchElementException] thrownBy {
+      key.apply(pkg, target, reporter)
+    }
+    thrown.getMessage shouldBe "Error whilst generating default for parameter key in package testPackage [testDeploymentType]: something was wrong"
+  }
+
+  it should "log a warning if the value you've specified is the same as the default" in {
+    val mockReporter = mock[DeployReporter]
+    implicit val register = new TestRegister
+    val pkg = DeploymentPackage("testPackage", Nil, Map("key" -> JsString("sameValue")), "testDeploymentType", S3Path("test", "test"), legacyConfig = false)
+    val key = Param[String]("key").default("sameValue")
+    val paramValue = key.apply(pkg, target, mockReporter)
+    paramValue shouldBe "sameValue"
+    verify(mockReporter).warning("Parameter key is unnecessarily explicitly set to the default value of sameValue")
+  }
+
+  it should "log a warning if the value you've specified is the same as the default from context" in {
+    val mockReporter = mock[DeployReporter]
+    implicit val register = new TestRegister
+    val pkg = DeploymentPackage("testPackage", Nil, Map("key" -> JsString("sameValue")), "testDeploymentType", S3Path("test", "test"), legacyConfig = false)
+    val key = Param[String]("key").defaultFromContext((_, _) => Right("sameValue"))
+    val paramValue = key.apply(pkg, target, mockReporter)
+    paramValue shouldBe "sameValue"
+    verify(mockReporter).warning("Parameter key is unnecessarily explicitly set to the default value of sameValue")
+  }
+
+  it should "log not warning if the value you've specified is the same as the default but it is a legacy config" in {
+    val mockReporter = mock[DeployReporter]
+    implicit val register = new TestRegister
+    val pkg = DeploymentPackage("testPackage", Nil, Map("key" -> JsString("sameValue")), "testDeploymentType", S3Path("test", "test"), legacyConfig = true)
+    val key = Param[String]("key").default("sameValue")
+    val paramValue = key.apply(pkg, target, mockReporter)
+    paramValue shouldBe "sameValue"
+    verify(mockReporter, never).warning(any())
+  }
+}


### PR DESCRIPTION
As promised in #377 here are some tests for the `Param` class.

I've also moved `Param` into a separate file.