### PR TITLE
Eliminate use of DeploymentType.all global

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
@@ -33,9 +33,3 @@ trait DeploymentType {
     def description = pkg.name + "." + actionName
   }
 }
-
-object DeploymentType {
-  def all: Seq[DeploymentType] = Seq(
-    ElasticSearch, S3, AutoScaling, Fastly, CloudFormation, Lambda, AmiCloudFormationParameter, SelfDeploy
-  )
-}

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Param.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Param.scala
@@ -52,11 +52,11 @@ case class Param[T](
       case (_, _, Some(Right(contextDefault))) => contextDefault
       case (_, _, Some(Left(contextError))) =>
         throw new NoSuchElementException(
-          s"Error whilst generating default for parameter $name in package ${pkg.name} [${pkg.deploymentTypeName}]: $contextError"
+          s"Error whilst generating default for parameter $name in package ${pkg.name} [${pkg.deploymentType.name}]: $contextError"
         )
       case _ =>
         throw new NoSuchElementException(
-          s"Package ${pkg.name} [${pkg.deploymentTypeName}] requires parameter $name of type ${manifest.runtimeClass.getSimpleName}"
+          s"Package ${pkg.name} [${pkg.deploymentType.name}] requires parameter $name of type ${manifest.runtimeClass.getSimpleName}"
         )
     }
   }

--- a/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
+++ b/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
@@ -133,7 +133,7 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
   val basePackageType = stubDeploymentType(Seq("init_action_one"))
 
   val baseRecipe = Recipe("one",
-    actions = basePackageType.mkAction("init_action_one")(stubPackage) :: Nil,
+    actions = basePackageType.mkAction("init_action_one")(stubPackage(basePackageType)) :: Nil,
     dependsOn = Nil)
 
   val baseMockRecipe = Recipe("one",

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import com.amazonaws.regions.RegionUtils
 import com.amazonaws.services.s3.AmazonS3
 import magenta.artifact.S3Path
-import magenta.deployment_type.AutoScaling
+import magenta.deployment_type.{AutoScaling, DeploymentType}
 import magenta.fixtures._
 import magenta.tasks._
 import org.scalatest.{FlatSpec, Matchers}
@@ -16,6 +16,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
   implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
   implicit val artifactClient: AmazonS3 = null
   val region = Region("eu-west-1")
+  val deploymentTypes = Seq(AutoScaling)
 
   "auto-scaling with ELB package type" should "have a deploy action" in {
     val data: Map[String, JsValue] = Map(
@@ -24,7 +25,8 @@ class AutoScalingTest extends FlatSpec with Matchers {
 
     val app = Seq(App("app"))
 
-    val p = DeploymentPackage("app", app, data, "asg-elb", S3Path("artifact-bucket", "test/123/app"), true)
+    val p = DeploymentPackage("app", app, data, "autoscaling", S3Path("artifact-bucket", "test/123/app"), true,
+      deploymentTypes)
 
     AutoScaling.actions("deploy")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack, region)) should be (List(
       CheckForStabilization(p, PROD, UnnamedStack, Region("eu-west-1")),
@@ -48,7 +50,8 @@ class AutoScalingTest extends FlatSpec with Matchers {
 
     val app = Seq(App("app"))
 
-    val p = DeploymentPackage("app", app, data, "asg-elb", S3Path("artifact-bucket", "test/123/app"), false)
+    val p = DeploymentPackage("app", app, data, "autoscaling", S3Path("artifact-bucket", "test/123/app"), false,
+      deploymentTypes)
 
     AutoScaling.actions("uploadArtifacts")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack, region)) should matchPattern {
       case List(S3Upload(_,_,_,_,_,false,_)) =>
@@ -65,7 +68,8 @@ class AutoScalingTest extends FlatSpec with Matchers {
 
     val app = Seq(App("app"))
 
-    val p = DeploymentPackage("app", app, data, "asg-elb", S3Path("artifact-bucket", "test/123/app"), true)
+    val p = DeploymentPackage("app", app, data, "autoscaling", S3Path("artifact-bucket", "test/123/app"), true,
+      deploymentTypes)
 
     AutoScaling.actions("deploy")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack, region)) should be (List(
       CheckForStabilization(p, PROD, UnnamedStack, Region("eu-west-1")),

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -17,13 +17,15 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
   implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
   implicit val artifactClient: AmazonS3 = null
   val region = Region("eu-west-1")
+  val deploymentTypes = Seq(CloudFormation)
 
   "cloudformation deployment type" should "have an updateStack action" in {
     val data: Map[String, JsValue] = Map()
     val app = Seq(App("app"))
     val stack = NamedStack("cfn")
     val cfnStackName = s"cfn-app-PROD"
-    val p = DeploymentPackage("app", app, data, "cloudformation", S3Path("artifact-bucket", "test/123"), true)
+    val p = DeploymentPackage("app", app, data, "cloud-formation", S3Path("artifact-bucket", "test/123"), true,
+      deploymentTypes)
 
     inside(CloudFormation.actions("updateStack")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), stack, region))) {
       case List(updateTask, checkTask) =>

--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
@@ -16,6 +16,7 @@ class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
   implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
   implicit val artifactClient: AmazonS3 = mock[AmazonS3Client]
   val region = Region("eu-west-1")
+  val deploymentTypes = Seq(Lambda)
 
   behavior of "Lambda deployment action uploadLambda"
 
@@ -26,7 +27,8 @@ class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
   )
 
   val app = Seq(App("lambda"))
-  val pkg = DeploymentPackage("lambda", app, data, "aws-s3-lambda", S3Path("artifact-bucket", "test/123/lambda"), true)
+  val pkg = DeploymentPackage("lambda", app, data, "aws-lambda", S3Path("artifact-bucket", "test/123/lambda"), true,
+    deploymentTypes)
   val defaultRegion = Region("eu-west-1")
 
   it should "produce an S3 upload task" in {
@@ -60,7 +62,8 @@ class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
       "functionNames" -> Json.arr("MyFunction-")
     )
     val app = Seq(App("lambda"))
-    val pkg = DeploymentPackage("lambda", app, dataWithStack, "aws-s3-lambda", S3Path("artifact-bucket", "test/123/lambda"), true)
+    val pkg = DeploymentPackage("lambda", app, dataWithStack, "aws-lambda",
+      S3Path("artifact-bucket", "test/123/lambda"), true, deploymentTypes)
 
     val tasks = Lambda.actions("updateLambda")(pkg)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("some-stack"), region))
     tasks should be (List(
@@ -82,7 +85,8 @@ class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
       "regions" -> Json.arr("us-east-1", "ap-southeast-2")
     )
     val app = Seq(App("lambda"))
-    val pkg = DeploymentPackage("lambda", app, dataWithStack, "aws-s3-lambda", S3Path("artifact-bucket", "test/123/lambda"), true)
+    val pkg = DeploymentPackage("lambda", app, dataWithStack, "aws-lambda",
+      S3Path("artifact-bucket", "test/123/lambda"), true, deploymentTypes)
 
     val tasks = Lambda.actions("updateLambda")(pkg)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("some-stack"), region))
     tasks should be (List(

--- a/magenta-lib/src/test/scala/magenta/deployment_type/ParamTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/ParamTest.scala
@@ -4,6 +4,7 @@ import java.util.UUID
 
 import magenta.artifact.S3Path
 import magenta._
+import magenta.fixtures._
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
@@ -20,6 +21,7 @@ class TestRegister extends ParamRegister {
 class ParamTest extends FlatSpec with Matchers with MockitoSugar {
   val target = DeployTarget(fixtures.parameters(), NamedStack("testStack"), Region("testRegion"))
   val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), target.parameters)
+  val deploymentTypes = Seq(stubDeploymentType(name="testDeploymentType", actionNames = Seq("testAction")))
 
   "Param" should "register itself with a register" in {
     implicit val register = new TestRegister
@@ -32,7 +34,8 @@ class ParamTest extends FlatSpec with Matchers with MockitoSugar {
 
   it should "extract a value from a package using get" in {
     implicit val register = new TestRegister
-    val pkg = DeploymentPackage("testPackage", Nil, Map("key" -> JsString("myValue")), "testDeploymentType", S3Path("test", "test"), legacyConfig = true)
+    val pkg = DeploymentPackage("testPackage", Nil, Map("key" -> JsString("myValue")), "testDeploymentType",
+      S3Path("test", "test"), legacyConfig = true, deploymentTypes)
     val key = Param[String]("key").default("valueDefault")
     val paramValue = key.get(pkg)
     paramValue shouldBe Some("myValue")
@@ -40,7 +43,8 @@ class ParamTest extends FlatSpec with Matchers with MockitoSugar {
 
   it should "extract None using get when the value isn't in a package" in {
     implicit val register = new TestRegister
-    val pkg = DeploymentPackage("testPackage", Nil, Map.empty, "testDeploymentType", S3Path("test", "test"), legacyConfig = true)
+    val pkg = DeploymentPackage("testPackage", Nil, Map.empty, "testDeploymentType", S3Path("test", "test"),
+      legacyConfig = true, deploymentTypes)
     val key = Param[String]("key").default("valueDefault")
     val paramValue = key.get(pkg)
     paramValue shouldBe None
@@ -48,7 +52,8 @@ class ParamTest extends FlatSpec with Matchers with MockitoSugar {
 
   it should "extract a value using apply" in {
     implicit val register = new TestRegister
-    val pkg = DeploymentPackage("testPackage", Nil, Map("key" -> JsString("myValue")), "testDeploymentType", S3Path("test", "test"), legacyConfig = true)
+    val pkg = DeploymentPackage("testPackage", Nil, Map("key" -> JsString("myValue")), "testDeploymentType",
+      S3Path("test", "test"), legacyConfig = true, deploymentTypes)
     val key = Param[String]("key").default("valueDefault")
     val paramValue = key.apply(pkg, target, reporter)
     paramValue shouldBe "myValue"
@@ -56,7 +61,8 @@ class ParamTest extends FlatSpec with Matchers with MockitoSugar {
 
   it should "throw an exception if a value is not specified and has no default" in {
     implicit val register = new TestRegister
-    val pkg = DeploymentPackage("testPackage", Nil, Map.empty, "testDeploymentType", S3Path("test", "test"), legacyConfig = true)
+    val pkg = DeploymentPackage("testPackage", Nil, Map.empty, "testDeploymentType", S3Path("test", "test"),
+      legacyConfig = true, deploymentTypes)
     val key = Param[String]("key")
     val thrown = the [NoSuchElementException] thrownBy {
       key.apply(pkg, target, reporter)
@@ -66,7 +72,8 @@ class ParamTest extends FlatSpec with Matchers with MockitoSugar {
 
   it should "return the param default from apply when no value is specified" in {
     implicit val register = new TestRegister
-    val pkg = DeploymentPackage("testPackage", Nil, Map.empty, "testDeploymentType", S3Path("test", "test"), legacyConfig = true)
+    val pkg = DeploymentPackage("testPackage", Nil, Map.empty, "testDeploymentType", S3Path("test", "test"),
+      legacyConfig = true, deploymentTypes)
     val key = Param[String]("key").default("valueDefault")
     val paramValue = key.apply(pkg, target, reporter)
     paramValue shouldBe "valueDefault"
@@ -74,7 +81,8 @@ class ParamTest extends FlatSpec with Matchers with MockitoSugar {
 
   it should "return the param context default from apply when no value is specified" in {
     implicit val register = new TestRegister
-    val pkg = DeploymentPackage("testPackage", Nil, Map.empty, "testDeploymentType", S3Path("test", "test"), legacyConfig = true)
+    val pkg = DeploymentPackage("testPackage", Nil, Map.empty, "testDeploymentType", S3Path("test", "test"),
+      legacyConfig = true, deploymentTypes)
     val key = Param[String]("key").defaultFromContext((pkg, target) => Right(s"${target.region.name} and ${pkg.legacyConfig}"))
     val paramValue = key.apply(pkg, target, reporter)
     paramValue shouldBe "testRegion and true"
@@ -82,7 +90,8 @@ class ParamTest extends FlatSpec with Matchers with MockitoSugar {
 
   it should "throw an exception if defaultFromContext returns a Left value" in {
     implicit val register = new TestRegister
-    val pkg = DeploymentPackage("testPackage", Nil, Map.empty, "testDeploymentType", S3Path("test", "test"), legacyConfig = true)
+    val pkg = DeploymentPackage("testPackage", Nil, Map.empty, "testDeploymentType", S3Path("test", "test"),
+      legacyConfig = true, deploymentTypes)
     val key = Param[String]("key").defaultFromContext((pkg, target) => Left("something was wrong"))
     val thrown = the [NoSuchElementException] thrownBy {
       key.apply(pkg, target, reporter)
@@ -93,7 +102,8 @@ class ParamTest extends FlatSpec with Matchers with MockitoSugar {
   it should "log a warning if the value you've specified is the same as the default" in {
     val mockReporter = mock[DeployReporter]
     implicit val register = new TestRegister
-    val pkg = DeploymentPackage("testPackage", Nil, Map("key" -> JsString("sameValue")), "testDeploymentType", S3Path("test", "test"), legacyConfig = false)
+    val pkg = DeploymentPackage("testPackage", Nil, Map("key" -> JsString("sameValue")), "testDeploymentType",
+      S3Path("test", "test"), legacyConfig = false, deploymentTypes)
     val key = Param[String]("key").default("sameValue")
     val paramValue = key.apply(pkg, target, mockReporter)
     paramValue shouldBe "sameValue"
@@ -103,17 +113,19 @@ class ParamTest extends FlatSpec with Matchers with MockitoSugar {
   it should "log a warning if the value you've specified is the same as the default from context" in {
     val mockReporter = mock[DeployReporter]
     implicit val register = new TestRegister
-    val pkg = DeploymentPackage("testPackage", Nil, Map("key" -> JsString("sameValue")), "testDeploymentType", S3Path("test", "test"), legacyConfig = false)
+    val pkg = DeploymentPackage("testPackage", Nil, Map("key" -> JsString("sameValue")), "testDeploymentType",
+      S3Path("test", "test"), legacyConfig = false, deploymentTypes)
     val key = Param[String]("key").defaultFromContext((_, _) => Right("sameValue"))
     val paramValue = key.apply(pkg, target, mockReporter)
     paramValue shouldBe "sameValue"
     verify(mockReporter).warning("Parameter key is unnecessarily explicitly set to the default value of sameValue")
   }
 
-  it should "log not warning if the value you've specified is the same as the default but it is a legacy config" in {
+  it should "not log warning if the value you've specified is the same as the default but it is a legacy config" in {
     val mockReporter = mock[DeployReporter]
     implicit val register = new TestRegister
-    val pkg = DeploymentPackage("testPackage", Nil, Map("key" -> JsString("sameValue")), "testDeploymentType", S3Path("test", "test"), legacyConfig = true)
+    val pkg = DeploymentPackage("testPackage", Nil, Map("key" -> JsString("sameValue")), "testDeploymentType",
+      S3Path("test", "test"), legacyConfig = true, deploymentTypes)
     val key = Param[String]("key").default("sameValue")
     val paramValue = key.apply(pkg, target, mockReporter)
     paramValue shouldBe "sameValue"

--- a/magenta-lib/src/test/scala/magenta/fixtures/fixtures.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/fixtures.scala
@@ -20,11 +20,10 @@ case class StubDeploymentType(
   override val actions:
     PartialFunction[String, DeploymentPackage => (DeploymentResources, DeployTarget) => List[Task]] = Map.empty,
   override val defaultActions: List[String],
-  parameters: ParamRegister => List[Param[_]] = _ => Nil
+  parameters: ParamRegister => List[Param[_]] = _ => Nil,
+  override val name: String = "stub-package-type"
 ) extends DeploymentType {
   parameters(register)
-
-  def name = "stub-package-type"
 
   val documentation = "Documentation for the testing stub"
 }

--- a/magenta-lib/src/test/scala/magenta/fixtures/package.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/package.scala
@@ -1,6 +1,6 @@
 package magenta
 
-import magenta.deployment_type.{Param, ParamRegister}
+import magenta.deployment_type.{DeploymentType, Param, ParamRegister}
 import org.joda.time.DateTime
 
 package object fixtures {
@@ -16,25 +16,28 @@ package object fixtures {
   val basePackageType = stubDeploymentType(Seq("init_action_one"))
 
   val baseRecipe = Recipe("one",
-    actions = basePackageType.mkAction("init_action_one")(stubPackage) :: Nil,
+    actions = basePackageType.mkAction("init_action_one")(stubPackage(basePackageType)) :: Nil,
     dependsOn = Nil)
 
   def project(recipes: Recipe*) = Project(Map.empty, recipes.map(r => r.name -> r).toMap)
 
   def project(recipe: Recipe, stacks: Stack*) = Project(Map.empty, Map(recipe.name -> recipe), defaultStacks = stacks)
 
-  def stubPackage = DeploymentPackage("stub project", Seq(app1), Map(), "stub-package-type", null, false)
+  def stubPackage(deploymentType: DeploymentType) =
+    DeploymentPackage("stub project", Seq(app1), Map(), "stub-package-type", null, false, Seq(deploymentType))
 
-  def stubDeploymentType(actionNames: Seq[String], params: ParamRegister => List[Param[_]] = _ => Nil) = StubDeploymentType(
-    actions = {
-      case name if actionNames.contains(name) => pkg => (_, target) => List(
-        StubTask(name + " per app task number one", target.region),
-        StubTask(name + " per app task number two", target.region)
-      )
-    },
-    actionNames.toList,
-    params
-  )
+  def stubDeploymentType(actionNames: Seq[String], params: ParamRegister => List[Param[_]] = _ => Nil,
+    name: String = "stub-package-type") = StubDeploymentType(
+      actions = {
+        case name if actionNames.contains(name) => pkg => (_, target) => List(
+          StubTask(name + " per app task number one", target.region),
+          StubTask(name + " per app task number two", target.region)
+        )
+      },
+      actionNames.toList,
+      params,
+      name
+    )
 
   def testParams() = DeployParameters(
     Deployer("default deployer"),

--- a/magenta-lib/src/test/scala/magenta/input/resolver/TaskResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/TaskResolverTest.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import cats.data.{NonEmptyList => NEL}
 import com.amazonaws.services.s3.AmazonS3Client
 import magenta.artifact.S3YamlArtifact
+import magenta.deployment_type.AutoScaling
 import magenta.fixtures._
 import magenta.input.Deployment
 import magenta.{Build, DeployParameters, DeployReporter, Deployer, DeploymentResources, NamedStack, Region, Stage, fixtures}
@@ -65,11 +66,11 @@ class TaskResolverTest extends FlatSpec with Matchers with MockitoSugar with Val
       deployment = Deployment("test", "autoscaling", NEL.of("stack"), NEL.of("region"), Some(List("uploadArtifact", "deploy")), "app", "directory", Nil, Map("bucket" -> JsString("bucketName"))),
       deploymentResources = DeploymentResources(reporter, stubLookup(), artifactClient),
       parameters = DeployParameters(Deployer("Test user"), Build("test-project", "1"), Stage("PROD")),
-      deploymentTypes = List(),
+      deploymentTypes = Nil,
       artifact = S3YamlArtifact("artifact-bucket", "/path/to/test-project/1")
     )
 
-    deploymentTask.invalid.head.context shouldBe "test"
-    deploymentTask.invalid.head.message shouldBe "Deployment type autoscaling not found"
+    deploymentTask.invalid.errors.head.context shouldBe "test"
+    deploymentTask.invalid.errors.head.message shouldBe "Deployment type autoscaling not found"
   }
 }

--- a/magenta-lib/src/test/scala/magenta/json/JsonReaderTest.scala
+++ b/magenta-lib/src/test/scala/magenta/json/JsonReaderTest.scala
@@ -2,10 +2,12 @@ package magenta
 package json
 
 import magenta.artifact.{S3JsonArtifact, S3Path}
+import magenta.deployment_type.{AutoScaling, DeploymentType}
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.{JsString, Json}
 
 class JsonReaderTest extends FlatSpec with Matchers {
+  val deploymentTypes = Seq(AutoScaling)
   val deployJsonExample = """
   {
     "stack":"content-api",
@@ -61,17 +63,17 @@ class JsonReaderTest extends FlatSpec with Matchers {
                           """
 
   "json parser" should "parse json and resolve links" in {
-    val parsed = JsonReader.parse(deployJsonExample, S3JsonArtifact("artifact-bucket", "test/123"))
+    val parsed = JsonReader.parse(deployJsonExample, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
 
     parsed.applications should be (Set(App("index-builder"), App("api"), App("solr")))
 
     parsed.packages.size should be (3)
     parsed.packages("index-builder") shouldBe
-      DeploymentPackage("index-builder", Seq(App("index-builder")), Map.empty, "autoscaling", S3Path("artifact-bucket", "test/123/packages/index-builder"), true)
+      DeploymentPackage("index-builder", Seq(App("index-builder")), Map.empty, "autoscaling", S3Path("artifact-bucket", "test/123/packages/index-builder"), true, deploymentTypes)
     parsed.packages("api") shouldBe
-      DeploymentPackage("api", Seq(App("api")), Map("healthcheck_paths" -> Json.arr("/api/index.json","/api/search.json")), "autoscaling", S3Path("artifact-bucket", "test/123/packages/api"), true)
+      DeploymentPackage("api", Seq(App("api")), Map("healthcheck_paths" -> Json.arr("/api/index.json","/api/search.json")), "autoscaling", S3Path("artifact-bucket", "test/123/packages/api"), true, deploymentTypes)
     parsed.packages("solr") shouldBe
-      DeploymentPackage("solr", Seq(App("solr")), Map("port" -> JsString("8400")), "autoscaling", S3Path("artifact-bucket", "test/123/packages/solr"), true)
+      DeploymentPackage("solr", Seq(App("solr")), Map("port" -> JsString("8400")), "autoscaling", S3Path("artifact-bucket", "test/123/packages/solr"), true, deploymentTypes)
 
     val recipes = parsed.recipes
     recipes.size should be (4)
@@ -91,7 +93,7 @@ class JsonReaderTest extends FlatSpec with Matchers {
 """
 
   "json parser" should "infer a single app if none specified" in {
-    val parsed = JsonReader.parse(minimalExample, S3JsonArtifact("artifact-bucket", "test/123"))
+    val parsed = JsonReader.parse(minimalExample, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
 
     parsed.applications should be (Set(App("dinky")))
   }
@@ -106,7 +108,7 @@ class JsonReaderTest extends FlatSpec with Matchers {
 """
 
   "json parser" should "infer a default recipe that deploys all packages" in {
-    val parsed = JsonReader.parse(twoPackageExample, S3JsonArtifact("artifact-bucket", "test/123"))
+    val parsed = JsonReader.parse(twoPackageExample, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
 
     val recipes = parsed.recipes
     recipes.size should be(1)
@@ -114,7 +116,7 @@ class JsonReaderTest extends FlatSpec with Matchers {
   }
 
   "json parser" should "default to using the package name for the file name" in {
-    val parsed = JsonReader.parse(minimalExample, S3JsonArtifact("artifact-bucket", "test/123"))
+    val parsed = JsonReader.parse(minimalExample, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
 
     parsed.packages("dinky").s3Package should be(S3Path("artifact-bucket", "test/123/packages/dinky"))
   }
@@ -131,7 +133,7 @@ class JsonReaderTest extends FlatSpec with Matchers {
 """
 
   "json parser" should "use override file name if specified" in {
-    val parsed = JsonReader.parse(withExplicitFileName, S3JsonArtifact("artifact-bucket", "test/123"))
+    val parsed = JsonReader.parse(withExplicitFileName, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
 
     parsed.packages("dinky").s3Package should be(S3Path("artifact-bucket", "test/123/packages/awkward"))
   }

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
@@ -5,6 +5,8 @@ import java.util.UUID
 import com.amazonaws.services.autoscaling.AmazonAutoScalingClient
 import com.amazonaws.services.autoscaling.model.{AutoScalingGroup, SetDesiredCapacityRequest}
 import magenta.artifact.S3Path
+import magenta.deployment_type.DeploymentType
+import magenta.fixtures._
 import magenta.{KeyRing, Stage, _}
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
@@ -13,12 +15,14 @@ import org.scalatest.{FlatSpec, Matchers}
 class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing = KeyRing()
   val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
+  val deploymentTypes = Seq(stubDeploymentType(name="testDeploymentType", actionNames = Seq("testAction")))
 
   it should "double the size of the autoscaling group" in {
     val asg = new AutoScalingGroup().withDesiredCapacity(3).withAutoScalingGroupName("test").withMaxSize(10)
     val asgClientMock = mock[AmazonAutoScalingClient]
 
-    val p = DeploymentPackage("test", Seq(App("app")), Map.empty, "test", S3Path("artifact-bucket", "project/123/test"), true)
+    val p = DeploymentPackage("test", Seq(App("app")), Map.empty, "testDeploymentType", S3Path("artifact-bucket", "project/123/test"),
+      true, deploymentTypes)
 
     val task = new DoubleSize(p, Stage("PROD"), UnnamedStack, Region("eu-west-1"))
 
@@ -35,7 +39,8 @@ class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
 
     val asgClientMock = mock[AmazonAutoScalingClient]
 
-    val p = DeploymentPackage("test", Seq(App("app")), Map.empty, "test", S3Path("artifact-bucket", "project/123/test"), true)
+    val p = DeploymentPackage("test", Seq(App("app")), Map.empty, "testDeploymentType", S3Path("artifact-bucket", "project/123/test"),
+      true, deploymentTypes)
 
     val task = new CheckGroupSize(p, Stage("PROD"), UnnamedStack, Region("eu-west-1"))
 

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
@@ -7,6 +7,7 @@ import com.amazonaws.services.autoscaling.model.{Instance => ASGInstance, _}
 import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClient
 import com.amazonaws.services.elasticloadbalancing.model.{DescribeInstanceHealthRequest, DescribeInstanceHealthResult, InstanceState, Instance => ELBInstance}
 import magenta.artifact.S3Path
+import magenta.deployment_type.DeploymentType
 import magenta.{App, KeyRing, Stage, _}
 import org.mockito.Matchers._
 import org.mockito.Mockito._
@@ -18,6 +19,7 @@ import scala.collection.JavaConversions._
 class ASGTest extends FlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing = KeyRing()
   val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
+  val deploymentTypes = Nil
 
   it should "find the matching auto-scaling group with App tagging" in {
     val asgClientMock = mock[AmazonAutoScalingClient]
@@ -31,7 +33,8 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         AutoScalingGroup("App" -> "example", "Stage" -> "TEST")
       ))
 
-    val p = DeploymentPackage("example", Seq(App("app")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"), true)
+    val p = DeploymentPackage("example", Seq(App("app")), Map.empty, deploymentType = null,
+      S3Path("artifact-bucket", "project/123/example"), true)
     ASG.groupForAppAndStage(p, Stage("PROD"), UnnamedStack, asgClientMock, reporter) should be (desiredGroup)
   }
 
@@ -47,7 +50,8 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         AutoScalingGroup(("Role" -> "example"), ("Stage" -> "TEST"))
       ))
 
-    val p = DeploymentPackage("example", Seq(App("app")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"), true)
+    val p = DeploymentPackage("example", Seq(App("app")), Map.empty, deploymentType = null,
+      S3Path("artifact-bucket", "project/123/example"), true)
     ASG.groupForAppAndStage(p, Stage("PROD"), UnnamedStack, asgClientMock, reporter) should be (desiredGroup)
   }
 
@@ -66,7 +70,8 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         AutoScalingGroup("Stack" -> "monkey", "App" -> "logcabin", "Stage" -> "PROD")
       ))
 
-    val p = DeploymentPackage("example", Seq(App("logcabin")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"), true)
+    val p = DeploymentPackage("example", Seq(App("logcabin")), Map.empty, deploymentType = null,
+      S3Path("artifact-bucket", "project/123/example"), true)
     ASG.groupForAppAndStage(p, Stage("PROD"), NamedStack("contentapi"), asgClientMock, reporter) should be (desiredGroup)
   }
 
@@ -85,7 +90,8 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         AutoScalingGroup("Stack" -> "monkey", "App" -> "logcabin", "Stage" -> "PROD")
       ))
 
-    val p = DeploymentPackage("example", Seq(App("logcabin"), App("elasticsearch")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"), true)
+    val p = DeploymentPackage("example", Seq(App("logcabin"), App("elasticsearch")), Map.empty, deploymentType = null,
+      S3Path("artifact-bucket", "project/123/example"), true)
     ASG.groupForAppAndStage(p, Stage("PROD"), NamedStack("contentapi"), asgClientMock, reporter) should be (desiredGroup)
   }
 
@@ -105,7 +111,8 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         AutoScalingGroup("Stack" -> "monkey", "App" -> "logcabin", "Stage" -> "PROD")
       ))
 
-    val p = DeploymentPackage("example", Seq(App("logcabin"), App("elasticsearch")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"), true)
+    val p = DeploymentPackage("example", Seq(App("logcabin"), App("elasticsearch")), Map.empty, deploymentType = null,
+      S3Path("artifact-bucket", "project/123/example"), true)
 
     a [FailException] should be thrownBy {
       ASG.groupForAppAndStage(p, Stage("PROD"), NamedStack("contentapi"), asgClientMock, reporter) should be (desiredGroup)
@@ -172,7 +179,8 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         desiredGroup
       ))
 
-    val p = DeploymentPackage("example", Seq(App("logcabin"), App("elasticsearch")), Map.empty, "nowt much", S3Path("artifact-bucket", "project/123/example"), true)
+    val p = DeploymentPackage("example", Seq(App("logcabin"), App("elasticsearch")), Map.empty, deploymentType = null,
+      S3Path("artifact-bucket", "project/123/example"), true)
     ASG.groupForAppAndStage(p, Stage("PROD"), NamedStack("contentapi"), asgClientMock, reporter) should be (desiredGroup)
   }
 

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -1,21 +1,22 @@
+import ci.ContinuousDeployment
+import controllers._
+import deployment.{DeploymentEngine, Deployments}
+import magenta.deployment_type._
 import play.api.ApplicationLoader.Context
-import play.api.{BuiltInComponentsFromContext, Logger}
 import play.api.http.DefaultHttpErrorHandler
 import play.api.i18n.I18nComponents
 import play.api.libs.ws.ahc.AhcWSComponents
-import play.api.mvc.{RequestHeader, Result}
 import play.api.mvc.Results.InternalServerError
+import play.api.mvc.{RequestHeader, Result}
 import play.api.routing.Router
+import play.api.{BuiltInComponentsFromContext, Logger}
 import play.filters.csrf.CSRFComponents
 import play.filters.gzip.GzipFilterComponents
 import resources.PrismLookup
 import utils.HstsFilter
-import ci.ContinuousDeployment
-import controllers._
-import deployment.{DeploymentEngine, Deployments}
-import magenta.deployment_type.{AmiCloudFormationParameter, CloudFormation, Lambda, SelfDeploy, _}
 
 import scala.concurrent.Future
+
 import router.Routes
 
 class AppComponents(context: Context) extends BuiltInComponentsFromContext(context)

--- a/riff-raff/app/controllers/DeployController.scala
+++ b/riff-raff/app/controllers/DeployController.scala
@@ -7,6 +7,7 @@ import conf.Configuration
 import deployment.{Deployments, PreviewController, PreviewResult}
 import magenta._
 import magenta.artifact._
+import magenta.deployment_type.DeploymentType
 import org.joda.time.{DateTime, DateTimeZone}
 import org.joda.time.format.DateTimeFormat
 import play.api.data.Form
@@ -22,7 +23,7 @@ import scala.util.{Failure, Success}
 case class DeployParameterForm(project:String, build:String, stage:String, recipe: Option[String], action: String, hosts: List[String], stacks: List[String])
 case class UuidForm(uuid:String, action:String)
 
-class DeployController(deployments: Deployments, prismLookup: PrismLookup)
+class DeployController(deployments: Deployments, prismLookup: PrismLookup, deploymentTypes: Seq[DeploymentType])
                       (implicit val messagesApi: MessagesApi, val wsClient: WSClient) extends Controller with Logging with LoginActions with I18nSupport {
 
   lazy val uuidForm = Form[UuidForm](
@@ -97,7 +98,7 @@ class DeployController(deployments: Deployments, prismLookup: PrismLookup)
     val hostList = hosts.split(",").toList.filterNot(_.isEmpty)
     val stackList = stacks.split(",").toList.filterNot(_.isEmpty).map(NamedStack(_))
     val parameters = DeployParameters(Deployer(request.user.fullName), Build(projectName, buildId), Stage(stage), RecipeName(recipe), stackList, hostList)
-    val previewId = PreviewController.startPreview(parameters, prismLookup)
+    val previewId = PreviewController.startPreview(parameters, prismLookup, deploymentTypes)
     Ok(views.html.deploy.preview(request, parameters, previewId.toString))
   }
 

--- a/riff-raff/app/controllers/api.scala
+++ b/riff-raff/app/controllers/api.scala
@@ -16,6 +16,7 @@ import org.joda.time.{DateTime, LocalDate}
 import com.mongodb.casbah.Imports._
 import deployment.{DeployFilter, Deployments, Record}
 import magenta._
+import magenta.deployment_type.DeploymentType
 import magenta.input.RiffRaffYamlReader
 import magenta.input.resolver.{Resolver => YamlResolver}
 import persistence.{MongoFormat, MongoSerialisable, Persistence}
@@ -94,7 +95,7 @@ object ApiKeyGenerator {
 }
 
 
-class Api(deployments: Deployments)(implicit val messagesApi: MessagesApi, val wsClient: WSClient) extends Controller with Logging with LoginActions with I18nSupport {
+class Api(deployments: Deployments, deploymentTypes: Seq[DeploymentType])(implicit val messagesApi: MessagesApi, val wsClient: WSClient) extends Controller with Logging with LoginActions with I18nSupport {
 
   object ApiJsonEndpoint {
     val INTERNAL_KEY = ApiKey("internal", "n/a", "n/a", new DateTime())
@@ -357,7 +358,7 @@ class Api(deployments: Deployments)(implicit val messagesApi: MessagesApi, val w
         )
       )
     }{ body =>
-      val validatedGraph = YamlResolver.resolveDeploymentGraph(body)
+      val validatedGraph = YamlResolver.resolveDeploymentGraph(body, deploymentTypes)
       validatedGraph match {
         case Valid(graph) =>
           Json.obj(

--- a/riff-raff/app/deployment/DeploymentEngine.scala
+++ b/riff-raff/app/deployment/DeploymentEngine.scala
@@ -7,11 +7,12 @@ import akka.agent.Agent
 import com.typesafe.config.ConfigFactory
 import controllers.Logging
 import deployment.actors.{DeployCoordinator, DeployGroupRunner, TasksRunner}
+import magenta.deployment_type.DeploymentType
 import resources.PrismLookup
 
 import scala.collection.JavaConverters._
 
-class DeploymentEngine(prismLookup: PrismLookup) extends Logging {
+class DeploymentEngine(prismLookup: PrismLookup, deploymentTypes: Seq[DeploymentType]) extends Logging {
   import DeploymentEngine._
 
   private lazy val deploymentRunnerFactory = (context: ActorRefFactory, runnerName: String) => context.actorOf(
@@ -21,7 +22,9 @@ class DeploymentEngine(prismLookup: PrismLookup) extends Logging {
 
   private lazy val deployRunnerFactory = (context: ActorRefFactory, record: Record, deployCoordinator: ActorRef) =>
     context.actorOf(
-      props = Props(new DeployGroupRunner(record, deployCoordinator, deploymentRunnerFactory, stopFlagAgent, prismLookup)).withDispatcher("akka.deploy-dispatcher"),
+      props = Props(
+        new DeployGroupRunner(record, deployCoordinator, deploymentRunnerFactory, stopFlagAgent, prismLookup, deploymentTypes)
+      ).withDispatcher("akka.deploy-dispatcher"),
       name = s"deployGroupRunner-${record.uuid.toString}"
     )
 

--- a/riff-raff/test/deployment/actors/DeployGroupRunnerTest.scala
+++ b/riff-raff/test/deployment/actors/DeployGroupRunnerTest.scala
@@ -6,6 +6,7 @@ import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
 import akka.agent.Agent
 import akka.testkit.{TestActorRef, TestKit, TestProbe}
 import deployment.{Fixtures, Record}
+import magenta.deployment_type.DeploymentType
 import magenta.graph.{DeploymentTasks, Graph, ValueNode}
 import magenta.tasks.Task
 import org.scalatest.{FlatSpecLike, ShouldMatchers}
@@ -93,6 +94,8 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
     dr.deployCoordinatorProbe.expectMsgClass(classOf[DeployCoordinator.CleanupDeploy])
   }
 
+  val deploymentTypes = Nil
+
   trait DR {
     def record: Record
     def deployCoordinatorProbe: TestProbe
@@ -109,7 +112,8 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
     val stopFlagAgent = Agent(Map.empty[UUID, String])
     val record = createRecord()
     val ref = system.actorOf(
-      Props(new DeployGroupRunner(record, deployCoordinatorProbe.ref, deploymentRunnerFactory, stopFlagAgent, prismLookup = null)),
+      Props(new DeployGroupRunner(record, deployCoordinatorProbe.ref, deploymentRunnerFactory, stopFlagAgent,
+        prismLookup = null, deploymentTypes)),
       name=s"DeployGroupRunner-${record.uuid.toString}"
     )
     DRImpl(record, deployCoordinatorProbe, deploymentRunnerProbe, ref, stopFlagAgent)
@@ -125,7 +129,8 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
     val stopFlagAgent = Agent(Map.empty[UUID, String])
     val record = createRecord()
     val ref = TestActorRef(
-      new DeployGroupRunner(record, deployCoordinatorProbe.ref, deploymentRunnerFactory, stopFlagAgent, prismLookup = null),
+      new DeployGroupRunner(record, deployCoordinatorProbe.ref, deploymentRunnerFactory, stopFlagAgent,
+        prismLookup = null, deploymentTypes),
       name=s"DeployGroupRunner-${record.uuid.toString}"
     )
     DRwithUnderlying(record, deployCoordinatorProbe, deploymentRunnerProbe, ref, stopFlagAgent, ref.underlyingActor)


### PR DESCRIPTION
Whilst writing the YAML preview pages I realised that eliminating the use of the `DeploymentType.all` global would make the code clearer and (naturally) make it easier to test.

This also ties up a loose end where the code still used `ValidatedNel` instead of `Validated` and the `ConfigErrors` semigroup.