### PR TITLE
Add restrictions for preventing undesirable deploys

### DIFF
--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -50,6 +50,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
   val continuousDeployController = new ContinuousDeployController(prismLookup)
   val previewController = new PreviewController(previewCoordinator)
   val hooksController = new Hooks(prismLookup)
+  val restrictionsController = new Restrictions()
   val loginController = new Login
   val testingController = new Testing(prismLookup)
   val assets = new Assets(httpErrorHandler)
@@ -70,6 +71,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
     apiController,
     continuousDeployController,
     hooksController,
+    restrictionsController,
     loginController,
     testingController,
     assets

--- a/riff-raff/app/ci/ContinuousDeployment.scala
+++ b/riff-raff/app/ci/ContinuousDeployment.scala
@@ -1,14 +1,14 @@
 package ci
 
 import controllers.Logging
-import deployment.Deployments
+import deployment.{ContinuousDeploymentRequestSource, Deployments}
 import lifecycle.Lifecycle
 import magenta.{DeployParameters, Deployer, RecipeName, Stage, Build => MagentaBuild}
 import persistence.ContinuousDeploymentConfigRepository.getContinuousDeploymentList
 import rx.lang.scala.{Observable, Subscription}
 import utils.ChangeFreeze
 
-import scala.util.{Failure, Try}
+import scala.util.Try
 import scala.util.control.NonFatal
 
 class ContinuousDeployment(deployments: Deployments) extends Lifecycle with Logging {
@@ -48,7 +48,10 @@ class ContinuousDeployment(deployments: Deployments) extends Lifecycle with Logg
       if (!ChangeFreeze.frozen(params.stage.name)) {
         log.info(s"Triggering deploy of ${params.toString}")
         try {
-          deployments.deploy(params)
+          deployments.deploy(params, requestSource = ContinuousDeploymentRequestSource) match {
+            case Left(error) => log.error(s"Couldn't continuously deploy $params: $error")
+            case Right(_) => // happy case
+          }
         } catch {
           case NonFatal(e) => log.error(s"Could not deploy $params", e)
         }

--- a/riff-raff/app/ci/ContinuousDeployment.scala
+++ b/riff-raff/app/ci/ContinuousDeployment.scala
@@ -48,9 +48,8 @@ class ContinuousDeployment(deployments: Deployments) extends Lifecycle with Logg
       if (!ChangeFreeze.frozen(params.stage.name)) {
         log.info(s"Triggering deploy of ${params.toString}")
         try {
-          deployments.deploy(params, requestSource = ContinuousDeploymentRequestSource) match {
-            case Left(error) => log.error(s"Couldn't continuously deploy $params: $error")
-            case Right(_) => // happy case
+          deployments.deploy(params, requestSource = ContinuousDeploymentRequestSource).left.foreach { error =>
+            log.error(s"Couldn't continuously deploy $params: ${error.message}")
           }
         } catch {
           case NonFatal(e) => log.error(s"Could not deploy $params", e)

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -78,6 +78,7 @@ class Configuration(val application: String, val webappConfDirectory: String = "
     lazy val redirectUrl: String = configuration.getStringProperty("auth.redirectUrl").getOrElse(s"${urls.publicPrefix}${routes.Login.oauth2Callback().url}")
     lazy val domain: Option[String] = configuration.getStringProperty("auth.domain")
     lazy val googleAuthConfig = GoogleAuthConfig(auth.clientId, auth.clientSecret, auth.redirectUrl, auth.domain)
+    lazy val superusers: List[String] = configuration.getStringPropertiesSplitByComma("auth.superusers")
   }
 
   object concurrency {

--- a/riff-raff/app/controllers/Application.scala
+++ b/riff-raff/app/controllers/Application.scala
@@ -48,7 +48,8 @@ object Menu {
       SingleMenuItem("Continuous Deployment", routes.ContinuousDeployController.list()),
       SingleMenuItem("Hooks", routes.Hooks.list()),
       SingleMenuItem("Authorisation", routes.Login.authList(), enabled = conf.Configuration.auth.whitelist.useDatabase),
-      SingleMenuItem("API keys", routes.Api.listKeys())
+      SingleMenuItem("API keys", routes.Api.listKeys()),
+      SingleMenuItem("Restrictions", routes.Restrictions.list())
     )),
     DropDownMenuItem("Documentation", Seq(
       SingleMenuItem("Deployment Types", routes.Application.documentation("magenta-lib/types")),

--- a/riff-raff/app/controllers/DeployController.scala
+++ b/riff-raff/app/controllers/DeployController.scala
@@ -7,6 +7,7 @@ import conf.Configuration
 import deployment.{Deployments, LegacyPreviewController, LegacyPreviewResult, UserRequestSource}
 import magenta._
 import magenta.artifact._
+import cats.syntax.either._
 import magenta.deployment_type.DeploymentType
 import org.joda.time.{DateTime, DateTimeZone}
 import org.joda.time.format.DateTimeFormat
@@ -73,9 +74,8 @@ class DeployController(deployments: Deployments, prismLookup: PrismLookup, deplo
               "previewStacks" -> parameters.stacks.flatMap(_.nameOption).mkString(",")
             )
           case "deploy" =>
-            val uuid = deployments.deploy(parameters, requestSource = UserRequestSource(request.user)) match {
-              case Right(uuid) => uuid
-              case Left(error) => throw new IllegalStateException(error)
+            val uuid = deployments.deploy(parameters, requestSource = UserRequestSource(request.user)).valueOr{ error =>
+              throw new IllegalStateException(error.message)
             }
             Redirect(routes.DeployController.viewUUID(uuid.toString))
           case _ => throw new RuntimeException("Unknown action")

--- a/riff-raff/app/controllers/Restrictions.scala
+++ b/riff-raff/app/controllers/Restrictions.scala
@@ -1,0 +1,86 @@
+package controllers
+
+import java.util.UUID
+import java.util.regex.PatternSyntaxException
+
+import com.gu.googleauth.UserIdentity
+import deployment.{RequestSource, UserRequestSource}
+import org.joda.time.DateTime
+import persistence.RestrictionConfigDynamoRepository
+import play.api.data.Form
+import play.api.data.Forms._
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.libs.ws.WSClient
+import play.api.mvc.{Controller, Result}
+import restrictions.{RestrictionChecker, RestrictionConfig, RestrictionForm}
+import utils.Forms.uuid
+
+class Restrictions()(implicit val messagesApi: MessagesApi, val wsClient: WSClient) extends Controller with LoginActions
+  with I18nSupport {
+
+  lazy val restrictionsForm = Form[RestrictionForm](
+    mapping(
+      "id" -> uuid,
+      "projectName" -> nonEmptyText,
+      "stage" -> nonEmptyText,
+      "editingLocked" -> boolean,
+      "whitelist" -> optional(text),
+      "continuousDeployment" -> boolean,
+      "note" -> nonEmptyText
+    )((id, projectName, stage, editingLocked, whitelist, cdPermitted, note) =>
+      RestrictionForm(id, projectName, stage, editingLocked,
+        whitelist.map(_.split('\n').toSeq.filter(_.nonEmpty)).getOrElse(Seq.empty), cdPermitted, note)
+    )(f =>
+      Some((f.id, f.projectName, f.stage, f.editingLocked, Some(f.whitelist.mkString("\n")),
+        f.continuousDeployment,  f.note))
+    ).verifying(
+      "Stage is invalid - should be a valid regular expression or contain no special values",
+      form => try { form.stage.r; true } catch { case e:PatternSyntaxException => false }
+    )
+  )
+
+  def list = AuthAction { implicit request =>
+    val configs = RestrictionConfigDynamoRepository.getRestrictionList.toList.sortBy(r => r.projectName + r.stage)
+    Ok(views.html.restrictions.list(configs))
+  }
+
+  def form = AuthAction { implicit request =>
+    val newForm = restrictionsForm.fill(
+      RestrictionForm(UUID.randomUUID(), "", "", editingLocked = false, Seq.empty, continuousDeployment = false, ""))
+    Ok(views.html.restrictions.form(newForm, saveDisabled = false))
+  }
+
+  val editableOrForbidden: (Option[RestrictionConfig], UserIdentity) => (=> Result) => Result =
+    (maybeConfig, identity) => (ifEditable) =>
+    RestrictionChecker.editable[Result](maybeConfig, identity)(ifEditable){ reason =>
+      Forbidden(s"Not possible to edit this restriction: $reason")
+    }
+
+  def save = AuthAction { implicit request =>
+    restrictionsForm.bindFromRequest().fold(
+      formWithErrors => Ok(views.html.restrictions.form(formWithErrors, saveDisabled = false)),
+      f => {
+        editableOrForbidden(RestrictionConfigDynamoRepository.getRestriction(f.id), request.user) {
+          val newConfig = RestrictionConfig(f.id, f.projectName, f.stage, new DateTime(), request.user.fullName,
+            request.user.email, f.editingLocked, f.whitelist, f.continuousDeployment, f.note)
+          RestrictionConfigDynamoRepository.setRestriction(newConfig)
+          Redirect(routes.Restrictions.list())
+        }
+      }
+    )
+  }
+  def edit(id: String) = AuthAction { implicit request =>
+    RestrictionConfigDynamoRepository.getRestriction(UUID.fromString(id)).map{ rc =>
+      val canSave = RestrictionChecker.editable(Some(rc), request.user)(true){_=>false}
+      Ok(views.html.restrictions.form(restrictionsForm.fill(
+        RestrictionForm(rc.id, rc.projectName, rc.stage, rc.editingLocked, rc.whitelist, rc.continuousDeployment, rc.note)
+      ), saveDisabled = !canSave))
+    }.getOrElse(Redirect(routes.Restrictions.list()))
+  }
+  def delete(id: String) = AuthAction { request =>
+    editableOrForbidden(RestrictionConfigDynamoRepository.getRestriction(UUID.fromString(id)), request.user) {
+      RestrictionConfigDynamoRepository.deleteRestriction(UUID.fromString(id))
+      Redirect(routes.Restrictions.list())
+    }
+  }
+}

--- a/riff-raff/app/controllers/api.scala
+++ b/riff-raff/app/controllers/api.scala
@@ -313,7 +313,7 @@ class Api(deployments: Deployments, deploymentTypes: Seq[DeploymentType])(implic
             Json.obj(
               "response" -> Json.obj(
                 "status" -> "error",
-                "errors" -> Json.arr(error)
+                "errors" -> Json.arr(error.message)
               )
             )
         }

--- a/riff-raff/app/controllers/api.scala
+++ b/riff-raff/app/controllers/api.scala
@@ -1,5 +1,16 @@
 package controllers
 
+import java.security.SecureRandom
+import java.util.UUID
+
+import cats.data.Validated.{Invalid, Valid}
+import com.mongodb.casbah.Imports._
+import deployment.{ApiRequestSource, DeployFilter, Deployments, Record}
+import magenta._
+import magenta.deployment_type.DeploymentType
+import magenta.input.resolver.{Resolver => YamlResolver}
+import org.joda.time.{DateTime, LocalDate}
+import persistence.{MongoFormat, MongoSerialisable, Persistence}
 import play.api.data.Forms._
 import play.api.data._
 import play.api.i18n.{I18nSupport, MessagesApi}
@@ -8,18 +19,6 @@ import play.api.libs.json.Json.toJson
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent, BodyParser, Controller, Result}
-import java.security.SecureRandom
-import java.util.UUID
-
-import cats.data.Validated.{Invalid, Valid}
-import org.joda.time.{DateTime, LocalDate}
-import com.mongodb.casbah.Imports._
-import deployment.{DeployFilter, Deployments, Record}
-import magenta._
-import magenta.deployment_type.DeploymentType
-import magenta.input.RiffRaffYamlReader
-import magenta.input.resolver.{Resolver => YamlResolver}
-import persistence.{MongoFormat, MongoSerialisable, Persistence}
 import utils.Json.DefaultJodaDateWrites
 import utils.{ChangeFreeze, Graph}
 
@@ -294,21 +293,30 @@ class Api(deployments: Deployments, deploymentTypes: Seq[DeploymentType])(implic
         )
         assert(!ChangeFreeze.frozen(stage), s"Deployment to $stage is frozen (API disabled, use the web interface if you need to deploy): ${ChangeFreeze.message}")
 
-        val deployId = deployments.deploy(params)
-        Json.obj(
-          "response" -> Json.obj(
-            "status" -> "ok",
-            "request" -> Json.obj(
-              "project" -> project,
-              "build" -> build,
-              "stage" -> stage,
-              "recipe" -> recipe.name,
-              "hosts" -> toJson(hosts)
-            ),
-            "uuid" -> deployId.toString,
-            "logURL" -> routes.DeployController.viewUUID(deployId.toString).absoluteURL()
-          )
-        )
+        deployments.deploy(params, requestSource = ApiRequestSource(request.apiKey)) match {
+          case Right(deployId) =>
+            Json.obj(
+              "response" -> Json.obj(
+                "status" -> "ok",
+                "request" -> Json.obj(
+                  "project" -> project,
+                  "build" -> build,
+                  "stage" -> stage,
+                  "recipe" -> recipe.name,
+                  "hosts" -> toJson(hosts)
+                ),
+                "uuid" -> deployId.toString,
+                "logURL" -> routes.DeployController.viewUUID(deployId.toString).absoluteURL()
+              )
+            )
+          case Left(error) =>
+            Json.obj(
+              "response" -> Json.obj(
+                "status" -> "error",
+                "errors" -> Json.arr(error)
+              )
+            )
+        }
       },
       invalid = { error =>
         Json.obj(

--- a/riff-raff/app/controllers/authentication.scala
+++ b/riff-raff/app/controllers/authentication.scala
@@ -1,25 +1,23 @@
 package controllers
 
-import play.api.mvc.Security.AuthenticatedRequest
-import play.api.mvc._
-import play.api.mvc.Results._
-import play.api.mvc.BodyParsers._
-import conf._
-import conf.Configuration.auth
-import persistence.{MongoFormat, MongoSerialisable, Persistence}
-import org.joda.time.DateTime
-import com.mongodb.casbah.commons.MongoDBObject
-import com.mongodb.casbah.Imports._
-import play.api.data._
-import play.api.data.Forms._
-import deployment.{DeployFilter, Deployments}
-import play.api.libs.concurrent.Execution.Implicits._
 import com.gu.googleauth._
+import com.mongodb.casbah.commons.MongoDBObject
+import conf.Configuration.auth
+import conf._
+import deployment.{DeployFilter, Deployments}
+import org.joda.time.DateTime
+import persistence.{MongoFormat, MongoSerialisable, Persistence}
+import play.api.data.Forms._
+import play.api.data._
 import play.api.i18n.{I18nSupport, MessagesApi}
-
-import scala.concurrent.Future
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
+import play.api.mvc.BodyParsers._
+import play.api.mvc.Results._
+import play.api.mvc._
+
+import scala.concurrent.Future
 
 class ApiRequest[A](val apiKey: ApiKey, request: Request[A]) extends WrappedRequest[A](request) {
   lazy val fullName = s"API:${apiKey.application}"

--- a/riff-raff/app/deployment/model.scala
+++ b/riff-raff/app/deployment/model.scala
@@ -10,11 +10,12 @@ import org.joda.time.{DateTime, Duration, Interval}
 import org.joda.time.format.PeriodFormatterBuilder
 import utils.VCSInfo
 
-trait RequestSource
-
+sealed trait RequestSource
 case class UserRequestSource(user: UserIdentity) extends RequestSource
 case object ContinuousDeploymentRequestSource extends RequestSource
 case class ApiRequestSource(key: ApiKey) extends RequestSource
+
+case class Error(message: String) extends AnyVal
 
 object Record {
   val RIFFRAFF_HOSTNAME = "riffraff-hostname"

--- a/riff-raff/app/deployment/model.scala
+++ b/riff-raff/app/deployment/model.scala
@@ -3,10 +3,18 @@ package deployment
 import java.util.UUID
 
 import ci.{Builds, S3Build}
+import com.gu.googleauth.UserIdentity
+import controllers.ApiKey
 import magenta.{DeployParameters, ReportTree, _}
 import org.joda.time.{DateTime, Duration, Interval}
 import org.joda.time.format.PeriodFormatterBuilder
 import utils.VCSInfo
+
+trait RequestSource
+
+case class UserRequestSource(user: UserIdentity) extends RequestSource
+case object ContinuousDeploymentRequestSource extends RequestSource
+case class ApiRequestSource(key: ApiKey) extends RequestSource
 
 object Record {
   val RIFFRAFF_HOSTNAME = "riffraff-hostname"

--- a/riff-raff/app/persistence/RestrictionConfigDynamoRepository.scala
+++ b/riff-raff/app/persistence/RestrictionConfigDynamoRepository.scala
@@ -1,0 +1,22 @@
+package persistence
+
+import java.util.UUID
+
+import com.gu.scanamo.Table
+import restrictions.{RestrictionConfig, RestrictionsConfigRepository}
+
+object RestrictionConfigDynamoRepository extends DynamoRepository with RestrictionsConfigRepository {
+  def tablePrefix = "riffraff-restriction-config"
+
+  val table = Table[RestrictionConfig](tableName)
+
+  import com.gu.scanamo.syntax._
+
+  def setRestriction(config: RestrictionConfig): Unit = exec(table.put(config))
+  def getRestriction(id: UUID): Option[RestrictionConfig] = exec(table.get('id -> id)).flatMap(_.toOption)
+  def deleteRestriction(id: UUID): Unit = exec(table.delete('id -> id))
+  def getRestrictionList: Iterable[RestrictionConfig] = exec(table.scan()).flatMap(_.toOption)
+
+  def getRestrictions(projectName: String): Seq[RestrictionConfig] =
+    exec(table.index("restriction-config-projectName").query('projectName -> projectName)).flatMap(_.toOption)
+}

--- a/riff-raff/app/restrictions/RestrictionChecker.scala
+++ b/riff-raff/app/restrictions/RestrictionChecker.scala
@@ -1,0 +1,49 @@
+package restrictions
+
+import com.gu.googleauth.UserIdentity
+import deployment.{ContinuousDeploymentRequestSource, RequestSource, UserRequestSource}
+
+object RestrictionChecker {
+  /** Method that runs one function if the supplied config is editable by the supplied source and another if it is not
+    * @param currentConfig The config to check - note that when a config is being checked this must be the original
+    *                      config not the updated config
+    * @param identity The identity of the user trying to make the edit
+    * @param ifEditable The function whose result will be returned if we consider the config to be editable
+    * @param ifNotEditable The function whose result will be returned if the config cannot be edited
+    * @tparam T The function return type
+    * @return The result of either ifEditable or ifNotEditable
+    */
+  def editable[T](currentConfig: Option[RestrictionConfig], identity: UserIdentity)
+    (ifEditable: => T)(ifNotEditable: String => T): T = {
+    currentConfig match {
+      case None =>
+        ifEditable
+      case Some(config) if !config.editingLocked || config.email == identity.email =>
+        ifEditable
+      case Some(config) =>
+        ifNotEditable(s"Locked by ${identity.fullName}")
+    }
+  }
+
+  def configsThatPreventDeployment(restrictions: RestrictionsConfigRepository, projectName: String, stage: String,
+    source: RequestSource): Seq[RestrictionConfig] = {
+    for {
+      restriction <- restrictions.getRestrictions(projectName)
+      if stageMatches(restriction.stage, stage)
+      if !sourceMatches(restriction, source)
+    } yield restriction
+  }
+
+  def sourceMatches(config: RestrictionConfig, source: RequestSource): Boolean = {
+    source match {
+      case ContinuousDeploymentRequestSource => config.continuousDeployment
+      case UserRequestSource(identity) => config.whitelist.contains(identity.email)
+      case _ => false
+    }
+  }
+
+  def stageMatches(configStage: String, stage: String): Boolean =
+    if (configStage.matches(""".*[$^.+*?()\[{|].*""")) {
+      stage.matches(configStage)
+    } else stage == configStage
+}

--- a/riff-raff/app/restrictions/RestrictionConfig.scala
+++ b/riff-raff/app/restrictions/RestrictionConfig.scala
@@ -1,0 +1,32 @@
+package restrictions
+
+import java.util.UUID
+
+import org.joda.time.DateTime
+
+/**
+  * A configuration that restricts which deploys are allowed
+  * @param id Unique ID for CRUD storage and retrival
+  * @param projectName The project name that this applies to
+  * @param stage The stage that this applies to (this can be a regex, but if no special regex characters are found then
+  *              it will be treated as a literal string
+  * @param lastEdited The date time that this was last updated
+  * @param fullName The user that last updated this
+  * @param email The authed email of the user that last updated this
+  * @param editingLocked Whether editing of this record should be locked to the user that created it
+  * @param whitelist A whitelist of users that can deploy
+  * @param continuousDeployment Whether continuous deploys can start this deploy
+  * @param note Note explaining why thie restriction is in place
+  */
+case class RestrictionConfig(
+  id: UUID,
+  projectName: String,
+  stage: String,
+  lastEdited: DateTime,
+  fullName: String,
+  email: String,
+  editingLocked: Boolean,
+  whitelist: Seq[String],
+  continuousDeployment: Boolean,
+  note: String
+)

--- a/riff-raff/app/restrictions/RestrictionForm.scala
+++ b/riff-raff/app/restrictions/RestrictionForm.scala
@@ -1,0 +1,13 @@
+package restrictions
+
+import java.util.UUID
+
+case class RestrictionForm(
+  id: UUID,
+  projectName: String,
+  stage: String,
+  editingLocked: Boolean,
+  whitelist: Seq[String],
+  continuousDeployment: Boolean,
+  note: String
+)

--- a/riff-raff/app/restrictions/RestrictionsConfigRepository.scala
+++ b/riff-raff/app/restrictions/RestrictionsConfigRepository.scala
@@ -1,0 +1,8 @@
+package restrictions
+
+import java.util.UUID
+
+trait RestrictionsConfigRepository {
+  def getRestrictions(projectName: String): Seq[RestrictionConfig]
+  def getRestriction(id: UUID): Option[RestrictionConfig]
+}

--- a/riff-raff/app/views/restrictions/form.scala.html
+++ b/riff-raff/app/views/restrictions/form.scala.html
@@ -10,8 +10,7 @@
 
     <div class="row">
         <div class="col-md-7">
-            @b3.form(action=routes.Restrictions.save) {
-            @CSRF.formField
+            @b3.formCSRF(action=routes.Restrictions.save) {
 
             @snippets.inputHidden(restrictionForm("id"))
 

--- a/riff-raff/app/views/restrictions/form.scala.html
+++ b/riff-raff/app/views/restrictions/form.scala.html
@@ -1,0 +1,58 @@
+@import b3.vertical.fieldConstructor
+@import helper.CSRF
+@import _root_.restrictions.RestrictionForm
+@(restrictionForm: Form[RestrictionForm], saveDisabled: Boolean)(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], messages: Messages)
+
+@main("Create Restriction", request) {
+
+    <h2>Create Restriction</h2>
+    <hr/>
+
+    <div class="row">
+        <div class="col-md-7">
+            @b3.form(action=routes.Restrictions.save) {
+            @CSRF.formField
+
+            @snippets.inputHidden(restrictionForm("id"))
+
+            @b3.text(restrictionForm("projectName"), 'id -> "projectInput", Symbol("data-url") -> "/deployment/request/autoComplete/project", '_label -> "Project Name")
+            @b3.text(
+            restrictionForm("stage"),
+            '_label -> "Stage",
+            '_error -> restrictionForm.globalError.map(_.withMessage("Please enter a deployment stage"))
+            )
+
+            @b3.textarea(restrictionForm("whitelist"), '_label -> "Permitted e-mail addresses whitelist (one per line)",
+                'cols -> 100, 'rows -> 6)
+
+            @b3.checkbox(restrictionForm("continuousDeployment"), '_label -> s"Permit continuous deployment")
+
+            @b3.textarea(restrictionForm("note"), '_label -> "Why does this restriction exist?",
+                'cols -> 100, 'rows -> 6)
+
+            @b3.checkbox(restrictionForm("editingLocked"), '_label -> s"Lock editing of this restriction to ${request.user.fullName}?")
+
+            <div class="actions">
+                <button name="action" type="submit" value="save" class="btn btn-primary" @if(saveDisabled){disabled="disabled"}>Save</button> or
+                <a href="@routes.Restrictions.list()" class="btn btn-danger">Cancel</a>
+            </div>
+        </div>
+    </div>
+}
+<script type="text/javascript">
+    var selectedProject = '';
+    var input = $('#projectInput');
+    input.each( function() {
+        var $input = $(this);
+        var serverUrl = $input.data('url');
+        $input.autocomplete({
+            source:serverUrl,
+            minLength:0
+        });
+    });
+    input.blur( function(e) {
+        selectedProject = encodeURIComponent($(e.target).val())
+    })
+</script>
+
+}

--- a/riff-raff/app/views/restrictions/form.scala.html
+++ b/riff-raff/app/views/restrictions/form.scala.html
@@ -15,22 +15,45 @@
 
             @snippets.inputHidden(restrictionForm("id"))
 
-            @b3.text(restrictionForm("projectName"), 'id -> "projectInput", Symbol("data-url") -> "/deployment/request/autoComplete/project", '_label -> "Project Name")
             @b3.text(
-            restrictionForm("stage"),
-            '_label -> "Stage",
-            '_error -> restrictionForm.globalError.map(_.withMessage("Please enter a deployment stage"))
+                restrictionForm("projectName"),
+                'id -> "projectInput",
+                Symbol("data-url") -> "/deployment/request/autoComplete/project",
+                '_label -> "Project Name"
             )
 
-            @b3.textarea(restrictionForm("whitelist"), '_label -> "Permitted e-mail addresses whitelist (one per line)",
-                'cols -> 100, 'rows -> 6)
+            @b3.text(
+                restrictionForm("stage"),
+                '_label -> "Stage",
+                '_error -> restrictionForm.globalError.map(_.withMessage("Please enter a deployment stage")),
+                '_help -> "Hint: this value will be interpreted as a regex if it has a special character in it - any of $^.+*?()[{|"
+            )
 
-            @b3.checkbox(restrictionForm("continuousDeployment"), '_label -> s"Permit continuous deployment")
+            @b3.textarea(
+                restrictionForm("whitelist"),
+                '_label -> "Deploy whitelist",
+                '_help -> "List of e-mail addresses (one per line) of users who should still be able to deploy whilst the restriction is in place",
+                'cols -> 100, 'rows -> 6
+            )
 
-            @b3.textarea(restrictionForm("note"), '_label -> "Why does this restriction exist?",
-                'cols -> 100, 'rows -> 6)
+            @b3.checkbox(
+                restrictionForm("continuousDeployment"),
+                '_text -> "Permit continuous deployment",
+                '_help -> "If this is checked then deploys triggered by continuous deployment will be allowed to run"
+            )
 
-            @b3.checkbox(restrictionForm("editingLocked"), '_label -> s"Lock editing of this restriction to ${request.user.fullName}?")
+            @b3.textarea(
+                restrictionForm("note"),
+                '_label -> "Why does this restriction exist?",
+                '_help -> "This note will be displayed to users attempting to deploy this project",
+                'cols -> 100, 'rows -> 6
+            )
+
+            @b3.checkbox(
+                restrictionForm("editingLocked"),
+                '_text -> "Lock editing",
+                '_help -> s"When checked, users other than you (${request.user.fullName}) will not be able to edit or delete this restriction - use sparingly!"
+            )
 
             <div class="actions">
                 <button name="action" type="submit" value="save" class="btn btn-primary" @if(saveDisabled){disabled="disabled"}>Save</button> or

--- a/riff-raff/app/views/restrictions/list.scala.html
+++ b/riff-raff/app/views/restrictions/list.scala.html
@@ -1,7 +1,7 @@
 @import _root_.restrictions.RestrictionConfig
 @import _root_.restrictions.RestrictionChecker
 @import helper.CSRF
-@(configs: Seq[RestrictionConfig])(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity])
+@(configs: Seq[RestrictionConfig], superusers: List[String])(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity])
 
 @main("Restrictions", request){
     <h2>Restrictions</h2>
@@ -31,7 +31,7 @@
             </thead>
             <tbody>
             @for(config <- configs) {
-                @defining(RestrictionChecker.editable(Some(config), request.user)(true)(_ => false)) { isEditable =>
+                @defining(RestrictionChecker.isEditable(Some(config), request.user, superusers).isLeft) { deleteDisabled =>
                     <tr>
                         <td>@utils.DateFormats.Short.print(config.lastEdited)
                             by <span class="label label-default">@config.fullName</span></td>
@@ -47,7 +47,7 @@
                         <td>
                         @helper.form(action = routes.Restrictions.delete(config.id.toString), 'class -> "form-make-inline") {
                             @CSRF.formField
-                            <button class="btn btn-xs btn-danger" name="action" value="delete"@if(!isEditable){ disabled="disabled"}><i class="glyphicon glyphicon-trash glyphicon glyphicon-white"></i>
+                            <button class="btn btn-xs btn-danger" name="action" value="delete"@if(deleteDisabled){ disabled="disabled"}><i class="glyphicon glyphicon-trash glyphicon glyphicon-white"></i>
                                 Delete</button>
                         }
                         </td>

--- a/riff-raff/app/views/restrictions/list.scala.html
+++ b/riff-raff/app/views/restrictions/list.scala.html
@@ -1,0 +1,62 @@
+@import _root_.restrictions.RestrictionConfig
+@import _root_.restrictions.RestrictionChecker
+@import helper.CSRF
+@(configs: Seq[RestrictionConfig])(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity])
+
+@main("Restrictions", request){
+    <h2>Restrictions</h2>
+    <hr/>
+    <div class="alert alert-info">
+        <p><strong>Disable or limit deploys of projects</strong></p>
+        <p>Restrictions are principally designed to be used when there is a temporary issue with a project or environment such
+        that deploying would be dangerous or potentially degrade the product. In addition they can be used when
+        infrastructure security could be compromised by allowing any user to rollback or deploy a branch of their
+        choice.</p>
+    </div>
+    <p><a class="btn btn-primary" href="@routes.Restrictions.form()"><i class="glyphicon glyphicon-plus glyphicon glyphicon-white"></i> Add new restriction</a></p>
+    <div class="content">
+    @if(configs.isEmpty) {
+        <div class="alert alert-warning"><strong>No restrictions.</strong></div>
+    } else {
+        <table class="table table-condensed">
+            <thead>
+                <tr>
+                    <th>Last edited</th>
+                    <th>Project Name</th>
+                    <th>Stage</th>
+                    <th>Locked</th>
+                    <th></th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+            @for(config <- configs) {
+                @defining(RestrictionChecker.editable(Some(config), request.user)(true)(_ => false)) { isEditable =>
+                    <tr>
+                        <td>@utils.DateFormats.Short.print(config.lastEdited)
+                            by <span class="label label-default">@config.fullName</span></td>
+                        <td>@config.projectName</td>
+                        <td>@config.stage</td>
+                        <td>@if(config.editingLocked) {
+                            <span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
+                        }</td>
+                        <td>
+                            <a class="btn btn-default btn-xs" href="@routes.Restrictions.edit(config.id.toString)"><i class="glyphicon glyphicon-edit"></i>
+                                Edit</a>
+                        </td>
+                        <td>
+                        @helper.form(action = routes.Restrictions.delete(config.id.toString), 'class -> "form-make-inline") {
+                            @CSRF.formField
+                            <button class="btn btn-xs btn-danger" name="action" value="delete"@if(!isEditable){ disabled="disabled"}><i class="glyphicon glyphicon-trash glyphicon glyphicon-white"></i>
+                                Delete</button>
+                        }
+                        </td>
+                    </tr>
+                }
+            }
+            </tbody>
+        </table>
+    }
+    </div>
+
+}

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -65,6 +65,13 @@ POST        /deployment/hooks/save                          controllers.Hooks.sa
 GET         /deployment/hooks/edit                          controllers.Hooks.edit(id)
 POST        /deployment/hooks/delete                        controllers.Hooks.delete(id)
 
+# Restrictions
+GET         /deployment/restrictions                        controllers.Restrictions.list
+GET         /deployment/restrictions/new                    controllers.Restrictions.form
+POST        /deployment/restrictions/save                   controllers.Restrictions.save
+GET         /deployment/restrictions/edit                   controllers.Restrictions.edit(id)
+POST        /deployment/restrictions/delete                 controllers.Restrictions.delete(id)
+
 # authentication endpoints
 GET         /profile                                        controllers.Login.profile
 GET         /login                                          controllers.Login.login

--- a/riff-raff/test/restrictions/RestrictionCheckerTest.scala
+++ b/riff-raff/test/restrictions/RestrictionCheckerTest.scala
@@ -1,0 +1,168 @@
+package restrictions
+
+import java.util.UUID
+
+import com.gu.googleauth.UserIdentity
+import controllers.ApiKey
+import deployment.{ApiRequestSource, ContinuousDeploymentRequestSource, UserRequestSource}
+import org.joda.time.DateTime
+import org.scalatest.{FlatSpec, Matchers}
+
+class RestrictionCheckerTest extends FlatSpec with Matchers {
+
+  val config = makeConfig("", "")
+  val configs: Seq[RestrictionConfig] = Seq(
+    makeConfig("testProject1", "PROD"),
+    makeConfig("testProject1", "CODE", cd=true, whitelist = Seq("test.user@example.com")),
+    makeConfig("testProject2", ".*")
+  )
+
+  val testRestrictions = new RestrictionsConfigRepository {
+    def getRestrictions(projectName: String) = configs.filter(_.projectName == projectName)
+    def getRestriction(id: UUID) = configs.find(_.id == id)
+  }
+
+  "editable" should "run the editable path when there is no existing config" in {
+    val result = RestrictionChecker.editable(
+      None, makeUser("test.user@example.com")
+    )("editable")(identity)
+    result shouldBe "editable"
+  }
+
+  it should "run the editable path when the config is not locked even if the user is different" in {
+    val someConfig = Some(makeConfig("testProject", "PROD", creator = "test.creator@example.com", editingLocked = false))
+    val result = RestrictionChecker.editable(
+      someConfig, makeUser("test.user@example.com")
+    )("editable")(identity)
+    result shouldBe "editable"
+  }
+
+  it should "run the not editable path when the config is locked when the user is different" in {
+    val someConfig = Some(makeConfig("testProject", "PROD", creator = "test.creator@example.com", editingLocked = true))
+    val result = RestrictionChecker.editable(
+      someConfig, makeUser("test.user@example.com")
+    )("editable")(identity)
+    result shouldBe "Locked by Test User"
+  }
+
+  it should "run the editable path when the config is locked and the user is the creator" in {
+    val someConfig = Some(makeConfig("testProject", "PROD", creator = "test.creator@example.com", editingLocked = true))
+    val result = RestrictionChecker.editable(
+      someConfig, makeUser("test.creator@example.com")
+    )("editable")(identity)
+    result shouldBe "editable"
+  }
+
+  "configsThatPreventDeploy" should "return no configs when deploying to a project with no restrictions" in {
+    val restrictions = RestrictionChecker.configsThatPreventDeployment(
+      testRestrictions, "testProject0", "PROD", UserRequestSource(makeUser("test.user@example.com"))
+    )
+    restrictions.size shouldBe 0
+  }
+
+  it should "return the matching config for a prevented stage" in {
+    val restrictions = RestrictionChecker.configsThatPreventDeployment(
+        testRestrictions, "testProject1", "PROD", UserRequestSource(makeUser("test.user@example.com"))
+    )
+    restrictions.size shouldBe 1
+    restrictions should contain(configs(0))
+  }
+
+  it should "return no configs for a stage that isn't prevented" in {
+    val restrictions = RestrictionChecker.configsThatPreventDeployment(
+      testRestrictions, "testProject1", "TEST", UserRequestSource(makeUser("test.user@example.com"))
+    )
+    restrictions.size shouldBe 0
+  }
+
+  it should "return the matching config for a prevented stage with a non-whitelisted user" in {
+    val restrictions = RestrictionChecker.configsThatPreventDeployment(
+      testRestrictions, "testProject1", "CODE", UserRequestSource(makeUser("bad.user@example.com"))
+    )
+    restrictions.size shouldBe 1
+    restrictions should contain(configs(1))
+  }
+
+  it should "return no configs for a prevented stage with a whitelisted user" in {
+    val restrictions = RestrictionChecker.configsThatPreventDeployment(
+      testRestrictions, "testProject1", "CODE", UserRequestSource(makeUser("test.user@example.com"))
+    )
+    restrictions.size shouldBe 0
+  }
+
+  it should "return no configs for a permitted continuous deployment" in {
+    val restrictions = RestrictionChecker.configsThatPreventDeployment(
+      testRestrictions, "testProject1", "CODE", ContinuousDeploymentRequestSource
+    )
+    restrictions.size shouldBe 0
+  }
+
+  it should "return a config when the stage is a regex" in {
+    val restrictions = RestrictionChecker.configsThatPreventDeployment(
+      testRestrictions, "testProject2", "ANY", ContinuousDeploymentRequestSource
+    )
+    restrictions.size shouldBe 1
+    restrictions should contain(configs(2))
+  }
+
+  "sourceMatches" should "match when a CD and CD is permitted" in {
+    RestrictionChecker.sourceMatches(
+      config.copy(continuousDeployment=true), ContinuousDeploymentRequestSource
+    ) shouldBe true
+  }
+
+  it should "not match when a CD and CD is not permitted" in {
+    RestrictionChecker.sourceMatches(
+      config.copy(continuousDeployment=false), ContinuousDeploymentRequestSource
+    ) shouldBe false
+  }
+
+  it should "not match when an API source" in {
+    RestrictionChecker.sourceMatches(
+      config, ApiRequestSource(ApiKey("", "", "", new DateTime()))
+    ) shouldBe false
+  }
+
+  it should "match when a user request and user is present in whitelist" in {
+    RestrictionChecker.sourceMatches(
+      config.copy(whitelist = Seq("user1@example.com", "test.user@example.com", "user3@example.com")),
+      UserRequestSource(makeUser("test.user@example.com"))
+    ) shouldBe true
+  }
+
+  it should "not match when a user request and user is not present in whitelist" in {
+    RestrictionChecker.sourceMatches(
+      config.copy(whitelist = Seq("user1@example.com", "user3@example.com")),
+      UserRequestSource(makeUser("test.user@example.com"))
+    ) shouldBe false
+  }
+
+  "stageMatches" should "match a literal string" in {
+    RestrictionChecker.stageMatches("CODE", "CODE") shouldBe true
+  }
+
+  it should "not match different literals" in {
+    RestrictionChecker.stageMatches("PROD", "CODE") shouldBe false
+  }
+
+  it should "match a regular expression" in {
+    RestrictionChecker.stageMatches(".*", "CODE") shouldBe true
+  }
+
+  it should "match a prefix regular expression" in {
+    RestrictionChecker.stageMatches("PROD.*", "PROD") shouldBe true
+    RestrictionChecker.stageMatches("PROD.*", "PROD-ZEBRA") shouldBe true
+  }
+
+  it should "not match a mis-matched prefix regular expression" in {
+    RestrictionChecker.stageMatches("PROD.*", "CODE") shouldBe false
+    RestrictionChecker.stageMatches("PROD.*", "CODE-ZEBRA") shouldBe false
+    RestrictionChecker.stageMatches("PROD.*", "ZEBRA-PROD") shouldBe false
+  }
+
+  def makeConfig(projectName: String, stage: String, whitelist: Seq[String] = Seq.empty, cd: Boolean = false,
+    creator:String = "", editingLocked: Boolean = false) =
+  RestrictionConfig(UUID.randomUUID, projectName, stage, new DateTime(), creator, creator, editingLocked, whitelist, cd, "")
+  def makeUser(email: String) = UserIdentity("1234", email, "Test", "User", 123344567845L, None)
+
+}


### PR DESCRIPTION
On of the features of Frontend's `goo` wrapper around riff-raff is the ability to block deploys. In addition @adamnfish has expressed a desire to lock down the ability to deploy Janus. 

This goes someway to achieve both of these and hopefully provide just enough flexibility that it will be useful more widely for temporarily blocking deploys.

Further features could be added (or moved to issues for future consideration):
- Nothing currently stops someone creating a new continuous deploy for a restricted project that permits continuous deployments
- Link from a deploy to create a restriction
- Indication of restriction as soon as you enter the project on the deploy screen
