### PR TITLE
Provide the real deployment type name

### DIFF
--- a/riff-raff/app/docs/DeployTypeDocs.scala
+++ b/riff-raff/app/docs/DeployTypeDocs.scala
@@ -1,0 +1,33 @@
+package docs
+
+import magenta.artifact.S3Path
+import magenta.{App, Build, DeployParameters, DeployTarget, Deployer, DeploymentPackage, NamedStack, RecipeName, Region, Stage}
+import magenta.deployment_type.{DeploymentType, Param}
+
+object DeployTypeDocs {
+  def defaultFromParam(fakePackage: DeploymentPackage, param: Param[_]): Option[String] = {
+    val fakeTarget = DeployTarget(DeployParameters(Deployer("<deployerName>"), Build("<projectName>", "<buildNo>"), Stage("<stage>"), RecipeName("<recipe>"), stacks = Seq(NamedStack("<stack>"))), NamedStack("<stack>"), Region("<region>"))
+    (param.defaultValue, param.defaultValueFromContext.map(_(fakePackage, fakeTarget))) match {
+      case (Some(default), _) => Some(default.toString)
+      case (None, Some(Right(pkgFunction))) => Some(pkgFunction.toString)
+      case (None, Some(Left(error))) => Some(s"ERROR generating default: $error")
+      case (_, _) => None
+    }
+  }
+
+  def generateParamDocs(deploymentTypes: Seq[DeploymentType]): Seq[(DeploymentType, Seq[(String, String, Option[String], Option[String])])] = {
+    deploymentTypes.sortBy(_.name).map { dt =>
+      val legacyPackage = DeploymentPackage("<packageName>",Seq(App("<app>")),Map.empty,dt.name,
+        S3Path("<bucket>", "<prefix>"), legacyConfig = true, deploymentTypes)
+      val newPackage = DeploymentPackage("<packageName>",Seq(App("<app>")),Map.empty,dt.name,
+        S3Path("<bucket>", "<prefix>"), legacyConfig = false, deploymentTypes)
+
+      val paramDocs = dt.params.sortBy(_.name).map { param =>
+        val defaultLegacy = defaultFromParam(legacyPackage, param)
+        val defaultNew = defaultFromParam(newPackage, param)
+        (param.name, param.documentation, defaultLegacy, defaultNew)
+      }.sortBy(_._3.isDefined)
+      dt -> paramDocs
+    }
+  }
+}

--- a/riff-raff/test/docs/DeployTypeDocsTest.scala
+++ b/riff-raff/test/docs/DeployTypeDocsTest.scala
@@ -1,0 +1,43 @@
+package docs
+
+import magenta.deployment_type._
+import org.scalatest.{FlatSpec, Matchers}
+
+class DeployTypeDocsTest extends FlatSpec with Matchers {
+  "generateParamDocs" should "generate documentation for our fake deployment type" in {
+    val testDeploymentType = new DeploymentType {
+      def actions = ???
+      def defaultActions = ???
+
+      def name = "testDeploymentType"
+      def documentation = "This is some documentation"
+
+      val param1 = Param[String]("param1", "first parameter which has no default")
+      val simianType = Param[String]("simianType", "simianType param which has a default").default("monkey")
+      val foodType = Param[String]("foodType", "another param with a contextual default").
+        defaultFromContext((pkg, target) => Right(s"banana${target.stack.nameOption.getOrElse("")}"))
+      val foodCount = Param[Int]("foodCount", "param with different default for legacy and new").
+        defaultFromContext((pkg, target) =>
+          Right(if (pkg.legacyConfig) 1 else 100)
+        )
+    }
+    val result = DeployTypeDocs.generateParamDocs(Seq(testDeploymentType))
+    result.size shouldBe 1
+    val (dt, paramDocs) = result.head
+    dt shouldBe testDeploymentType
+    paramDocs.size shouldBe 4
+    paramDocs should contain (("param1", "first parameter which has no default", None, None))
+    paramDocs should contain (("simianType", "simianType param which has a default", Some("monkey"), Some("monkey")))
+    paramDocs should contain (("foodType", "another param with a contextual default", Some("banana<stack>"), Some("banana<stack>")))
+    paramDocs should contain (("foodCount", "param with different default for legacy and new", Some("1"), Some("100")))
+  }
+
+  it should "successfully generate documentation for the standard set of deployment types" in {
+    // we can't easily check correctness, but we can check exceptions are not thrown
+    val availableDeploymentTypes = Seq(
+      ElasticSearch, S3, AutoScaling, Fastly, CloudFormation, Lambda, AmiCloudFormationParameter, SelfDeploy
+    )
+    val result = DeployTypeDocs.generateParamDocs(availableDeploymentTypes)
+    result.size shouldBe availableDeploymentTypes.size
+  }
+}


### PR DESCRIPTION
Sadly broke the deployment type page earlier. I've fixed this and also extracted the rather gnarly logic into a separate object that can be more easily tested. And written a couple of tests to do exactly that.