### PR TITLE
Extends deployment type documentation to cover actions

### DIFF
--- a/magenta-lib/src/main/scala/magenta/DeploymentPackage.scala
+++ b/magenta-lib/src/main/scala/magenta/DeploymentPackage.scala
@@ -28,6 +28,6 @@ case class DeploymentPackage(
   s3Package: S3Path,
   legacyConfig: Boolean) {
 
-  def mkAction(name: String): ActionResolver = deploymentType.mkActionResolver(name)(this)
+  def mkDeploymentStep(action: String): DeploymentStep = deploymentType.mkDeploymentStep(action)(this)
   val apps = pkgApps
 }

--- a/magenta-lib/src/main/scala/magenta/DeploymentPackage.scala
+++ b/magenta-lib/src/main/scala/magenta/DeploymentPackage.scala
@@ -28,6 +28,6 @@ case class DeploymentPackage(
   s3Package: S3Path,
   legacyConfig: Boolean) {
 
-  def mkAction(name: String): Action = deploymentType.mkAction(name)(this)
+  def mkAction(name: String): ActionResolver = deploymentType.mkActionResolver(name)(this)
   val apps = pkgApps
 }

--- a/magenta-lib/src/main/scala/magenta/Project.scala
+++ b/magenta-lib/src/main/scala/magenta/Project.scala
@@ -78,7 +78,7 @@ case class DeployTarget(parameters: DeployParameters, stack: Stack, region: Regi
  An action represents a step within a recipe. It isn't executable
  until it's resolved against a particular host.
  */
-trait Action {
+trait ActionResolver {
   def apps: Seq[App]
   def description: String
   def resolve(resources: DeploymentResources, target: DeployTarget): List[Task]
@@ -88,7 +88,7 @@ case class App (name: String)
 
 case class Recipe(
   name: String,
-  actions: Iterable[Action] = Nil, //executed once per app (before the host actions are executed)
+  actions: Iterable[ActionResolver] = Nil, //executed once per app (before the host actions are executed)
   dependsOn: List[String] = Nil
 )
 

--- a/magenta-lib/src/main/scala/magenta/Project.scala
+++ b/magenta-lib/src/main/scala/magenta/Project.scala
@@ -74,10 +74,7 @@ case class DeploymentResources(reporter: DeployReporter, lookup: Lookup, artifac
 
 case class DeployTarget(parameters: DeployParameters, stack: Stack, region: Region)
 
-/*
- An action represents a step within a recipe. It isn't executable
- until it's resolved against a particular host.
- */
+/* An ActionResolver represents a step within a deployment. */
 trait ActionResolver {
   def apps: Seq[App]
   def description: String

--- a/magenta-lib/src/main/scala/magenta/Project.scala
+++ b/magenta-lib/src/main/scala/magenta/Project.scala
@@ -7,7 +7,6 @@ import magenta.tasks.Task
 
 import scala.math.Ordering.OptionOrdering
 
-
 case class Host(
     name: String,
     apps: Set[App] = Set.empty,
@@ -74,8 +73,7 @@ case class DeploymentResources(reporter: DeployReporter, lookup: Lookup, artifac
 
 case class DeployTarget(parameters: DeployParameters, stack: Stack, region: Region)
 
-/* An ActionResolver represents a step within a deployment. */
-trait ActionResolver {
+trait DeploymentStep {
   def apps: Seq[App]
   def description: String
   def resolve(resources: DeploymentResources, target: DeployTarget): List[Task]
@@ -85,7 +83,7 @@ case class App (name: String)
 
 case class Recipe(
   name: String,
-  actions: Iterable[ActionResolver] = Nil, //executed once per app (before the host actions are executed)
+  deploymentSteps: Iterable[DeploymentStep] = Nil,
   dependsOn: List[String] = Nil
 )
 

--- a/magenta-lib/src/main/scala/magenta/Resolver.scala
+++ b/magenta-lib/src/main/scala/magenta/Resolver.scala
@@ -50,8 +50,8 @@ object Resolver {
 
     def resolveRecipe(recipe: Recipe, resources: DeploymentResources, target: DeployTarget): RecipeTasks = {
       val tasks = for {
-        action <- recipe.actions
-        tasks <- action.resolve(resources, target)
+        deploymentStep <- recipe.deploymentSteps
+        tasks <- deploymentStep.resolve(resources, target)
       } yield {
         tasks
       }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Action.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Action.scala
@@ -1,0 +1,14 @@
+package magenta.deployment_type
+
+import magenta.{DeployTarget, DeploymentPackage, DeploymentResources}
+import magenta.tasks.Task
+
+trait ActionRegister {
+  def add(action: Action)
+}
+
+case class Action(name: String, documentation: String = "_undocumented_")
+  (val taskGenerator: (DeploymentPackage, DeploymentResources, DeployTarget) => List[Task])
+  (implicit register:ActionRegister) {
+  register.add(this)
+}

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Action.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Action.scala
@@ -4,7 +4,7 @@ import magenta.{DeployTarget, DeploymentPackage, DeploymentResources}
 import magenta.tasks.Task
 
 trait ActionRegister {
-  def add(action: Action)
+  def add(action: Action): Unit
 }
 
 case class Action(name: String, documentation: String = "_undocumented_")

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
@@ -27,10 +27,12 @@ object AmiCloudFormationParameter extends DeploymentType {
     documentation = "The CloudFormation parameter name for the AMI"
   ).default("AMI")
 
-  def defaultActions = List("update")
-
-  override def actions = {
-    case "update" => pkg => (resources, target) => {
+  val update = Action("update",
+    """
+      |Given AMI tags, this will resolve the latest matching AMI and update the AMI parameter
+      | on the provided CloudFormation stack.
+    """.stripMargin
+  ){ (pkg, resources, target) => {
       implicit val keyRing = resources.assembleKeyring(target, pkg)
       val reporter = resources.reporter
 
@@ -52,4 +54,6 @@ object AmiCloudFormationParameter extends DeploymentType {
       )
     }
   }
+
+  def defaultActions = List(update)
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -12,17 +12,7 @@ object AutoScaling  extends DeploymentType {
       |The approach of this deploy type is to:
       |
       | - upload a new application artifact to an S3 bucket (from which new instances download their application)
-      | - tag existing instances in the ASG with a termination tag
-      | - double the size of the auto-scaling group (new instances will have the new application)
-      | - wait for the new instances to enter service
-      | - terminate previously tagged instances
-      |
-      |The action checks whether the auto-scaling group maxsize is big enough before starting the process.
-      |
-      |It also suspends and resumes cloud watch alarms in order to prevent false alarms.
-      |
-      |This deploy type has two actions, `deploy` and `uploadArtifacts`. `uploadArtifacts` simply uploads the files
-      |in the package directory to the specified bucket. `deploy` carries out the auto-scaling group rotation.
+      | - scale up, wait for the new instances to become healthy and ten scale back down
       |
       |The set of AWS permissions needed to let RiffRaff do an autoscaling deploy are:
       |
@@ -89,52 +79,69 @@ object AutoScaling  extends DeploymentType {
     "Whether the uploaded artifacts should be given the PublicRead Canned ACL"
   ).defaultFromContext((pkg, _) => Right(pkg.legacyConfig))
 
-  val defaultActions = List("uploadArtifacts", "deploy")
-
-  def actions = {
-    case "deploy" => (pkg) => (resources, target) => {
-      implicit val keyRing = resources.assembleKeyring(target, pkg)
-      val reporter = resources.reporter
-      val parameters = target.parameters
-      val stack = target.stack
-      List(
-        CheckForStabilization(pkg, parameters.stage, stack, target.region),
-        CheckGroupSize(pkg, parameters.stage, stack, target.region),
-        SuspendAlarmNotifications(pkg, parameters.stage, stack, target.region),
-        TagCurrentInstancesWithTerminationTag(pkg, parameters.stage, stack, target.region),
-        DoubleSize(pkg, parameters.stage, stack, target.region),
-        HealthcheckGrace(healthcheckGrace(pkg, target, reporter) * 1000),
-        WaitForStabilization(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
-        WarmupGrace(warmupGrace(pkg, target, reporter) * 1000),
-        WaitForStabilization(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
-        CullInstancesWithTerminationTag(pkg, parameters.stage, stack, target.region),
-        ResumeAlarmNotifications(pkg, parameters.stage, stack, target.region)
-      )
-    }
-    case "uploadArtifacts" => (pkg) => (resources, target) =>
-      implicit val keyRing = resources.assembleKeyring(target, pkg)
-      implicit val artifactClient = resources.artifactClient
-      val reporter = resources.reporter
-      val prefix = S3Upload.prefixGenerator(
-        stack = if (prefixStack(pkg, target, reporter)) Some(target.stack) else None,
-        stage = if (prefixStage(pkg, target, reporter)) Some(target.parameters.stage) else None,
-        packageName = if (prefixPackage(pkg, target, reporter)) Some(pkg.name) else None
-      )
-      if (pkg.legacyConfig && publicReadAcl.get(pkg).isEmpty)
-        resources.reporter.warning(
-          "DEPRECATED: publicReadAcl should be specified for an autoscaling deploy. Not setting this means that it " +
-            "defaults to true which is insecure and probably not what you want. It is not a good idea for artifacts " +
-            "to be publically available on the internet - it is much better to ensure this is set to false and your " +
-            "instances download the artifact from S3 using IAM instance credentials. If you are CERTAIN that this is" +
-            "what you want you can also get rid of this message by explicitly setting publicReadAcl to true."
-        )
-      List(
-        S3Upload(
-          target.region,
-          bucket(pkg, target, reporter),
-          Seq(pkg.s3Package -> prefix),
-          publicReadAcl = publicReadAcl(pkg, target, reporter)
-        )
-      )
+  val deploy = Action("deploy",
+    """
+      |Carries out the update of instances in an autoscaling group. We carry out the following tasks:
+      | - tag existing instances in the ASG with a termination tag
+      | - double the size of the auto-scaling group (new instances will have the new application)
+      | - wait for the new instances to enter service
+      | - terminate previously tagged instances
+      |
+      |The action checks whether the auto-scaling group maxsize is big enough before starting the process and also
+      |suspends and resumes cloud watch alarms in order to prevent false alarms.
+      |
+      |There are some delays introduced in order to work around consistency issues in the AWS ASG APIs.
+    """.stripMargin
+  ) { (pkg, resources, target) =>
+    implicit val keyRing = resources.assembleKeyring(target, pkg)
+    val reporter = resources.reporter
+    val parameters = target.parameters
+    val stack = target.stack
+    List(
+      CheckForStabilization(pkg, parameters.stage, stack, target.region),
+      CheckGroupSize(pkg, parameters.stage, stack, target.region),
+      SuspendAlarmNotifications(pkg, parameters.stage, stack, target.region),
+      TagCurrentInstancesWithTerminationTag(pkg, parameters.stage, stack, target.region),
+      DoubleSize(pkg, parameters.stage, stack, target.region),
+      HealthcheckGrace(healthcheckGrace(pkg, target, reporter) * 1000),
+      WaitForStabilization(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
+      WarmupGrace(warmupGrace(pkg, target, reporter) * 1000),
+      WaitForStabilization(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
+      CullInstancesWithTerminationTag(pkg, parameters.stage, stack, target.region),
+      ResumeAlarmNotifications(pkg, parameters.stage, stack, target.region)
+    )
   }
+
+  val uploadArtifacts = Action("uploadArtifacts",
+    """
+      |Uploads the files in the deployment's directory to the specified bucket.
+    """.stripMargin
+  ){ (pkg, resources, target) =>
+    implicit val keyRing = resources.assembleKeyring(target, pkg)
+    implicit val artifactClient = resources.artifactClient
+    val reporter = resources.reporter
+    val prefix = S3Upload.prefixGenerator(
+      stack = if (prefixStack(pkg, target, reporter)) Some(target.stack) else None,
+      stage = if (prefixStage(pkg, target, reporter)) Some(target.parameters.stage) else None,
+      packageName = if (prefixPackage(pkg, target, reporter)) Some(pkg.name) else None
+    )
+    if (pkg.legacyConfig && publicReadAcl.get(pkg).isEmpty)
+      resources.reporter.warning(
+        "DEPRECATED: publicReadAcl should be specified for an autoscaling deploy. Not setting this means that it " +
+          "defaults to true which is insecure and probably not what you want. It is not a good idea for artifacts " +
+          "to be publically available on the internet - it is much better to ensure this is set to false and your " +
+          "instances download the artifact from S3 using IAM instance credentials. If you are CERTAIN that this is" +
+          "what you want you can also get rid of this message by explicitly setting publicReadAcl to true."
+      )
+    List(
+      S3Upload(
+        target.region,
+        bucket(pkg, target, reporter),
+        Seq(pkg.s3Package -> prefix),
+        publicReadAcl = publicReadAcl(pkg, target, reporter)
+      )
+    )
+  }
+
+  val defaultActions = List(uploadArtifacts, deploy)
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -12,7 +12,7 @@ object AutoScaling  extends DeploymentType {
       |The approach of this deploy type is to:
       |
       | - upload a new application artifact to an S3 bucket (from which new instances download their application)
-      | - scale up, wait for the new instances to become healthy and ten scale back down
+      | - scale up, wait for the new instances to become healthy and then scale back down
       |
       |The set of AWS permissions needed to let RiffRaff do an autoscaling deploy are:
       |

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -8,17 +8,14 @@ object CloudFormation extends DeploymentType {
   def documentation =
     """Update an AWS CloudFormation template.
       |
-      |It is strongly recommended you do _NOT_ set a desired-capacity on auto-scaling groups, managed
+      |NOTE: It is strongly recommended you do _NOT_ set a desired-capacity on auto-scaling groups, managed
       |with CloudFormation templates deployed in this way, as otherwise any deployment will reset the
       |capacity to this number, even if scaling actions have triggered, changing the capacity, in the
       |mean-time.
       |
       |This deployment type is not currently recommended for continuous deployment, as CloudFormation
       |will fail if you try to update a CloudFormation stack with a configuration that matches its
-      | current state.
-      |
-      |If your CloudFormation template is in YAML format, it will be automatically converted to JSON
-      |before it is used.
+      |current state.
     """.stripMargin
 
   val cloudFormationStackName = Param[String]("cloudFormationStackName",
@@ -60,10 +57,13 @@ object CloudFormation extends DeploymentType {
     documentation = "The CloudFormation parameter name for the AMI"
   ).default("AMI")
 
-  def defaultActions = List("updateStack")
-
-  override def actions = {
-    case "updateStack" => pkg => (resources, target) => {
+  val updateStack = Action("updateStack",
+    """
+      |Apply the specified template to a cloudformation stack. This action runs an asynchronous update task and then
+      |runs another task that _tails_ the stack update events (as well as possible).
+      |
+    """.stripMargin
+  ){ (pkg, resources, target) => {
       implicit val keyRing = resources.assembleKeyring(target, pkg)
       implicit val artifactClient = resources.artifactClient
       val reporter = resources.reporter
@@ -93,4 +93,6 @@ object CloudFormation extends DeploymentType {
       )
     }
   }
+
+  def defaultActions = List(updateStack)
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
@@ -1,7 +1,6 @@
 package magenta.deployment_type
 
 import magenta._
-import magenta.tasks.Task
 
 import scala.collection.mutable
 
@@ -9,26 +8,35 @@ trait DeploymentType {
   def name: String
   def documentation: String
 
-  implicit val register = new ParamRegister {
+  private val registerParamsList = mutable.Map.empty[String, Param[_]]
+  implicit val paramsRegister = new ParamRegister {
     def add(param: Param[_]) = {
-      paramsList += param.name -> param
+      registerParamsList += param.name -> param
     }
   }
-  val paramsList = mutable.Map.empty[String, Param[_]]
-  lazy val params = paramsList.values.toSeq
-  def actions: PartialFunction[String, DeploymentPackage => (DeploymentResources, DeployTarget) => List[Task]]
-  def defaultActions: List[String]
+  def params = registerParamsList.values.toSeq
 
-  def mkAction(actionName: String)(pkg: DeploymentPackage): Action = {
-    actions.lift(actionName).map { action =>
+  private val registerActionsMap = mutable.Map.empty[String, Action]
+  implicit val actionsRegister = new ActionRegister {
+    def add(action: Action) = {
+      registerActionsMap += action.name -> action
+    }
+  }
+  def actionsMap = registerActionsMap.toMap
+
+  def defaultActions: List[Action]
+  def defaultActionNames = defaultActions.map(_.name)
+
+  def mkActionResolver(actionName: String)(pkg: DeploymentPackage): ActionResolver = {
+    actionsMap.lift(actionName).map { action =>
       new PackageAction(pkg, actionName) {
         def resolve(resources: DeploymentResources, target: DeployTarget) =
-          action(pkg)(resources, target)
+          action.taskGenerator(pkg, resources, target)
       }
     } getOrElse sys.error(s"Action $actionName is not supported on package ${pkg.name} of type $name")
   }
 
-  abstract case class PackageAction(pkg: DeploymentPackage, actionName: String) extends Action {
+  abstract case class PackageAction(pkg: DeploymentPackage, actionName: String) extends ActionResolver {
     def apps = pkg.apps
     def description = pkg.name + "." + actionName
   }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
@@ -27,16 +27,16 @@ trait DeploymentType {
   def defaultActions: List[Action]
   def defaultActionNames = defaultActions.map(_.name)
 
-  def mkActionResolver(actionName: String)(pkg: DeploymentPackage): ActionResolver = {
+  def mkDeploymentStep(actionName: String)(pkg: DeploymentPackage): DeploymentStep = {
     actionsMap.lift(actionName).map { action =>
-      new PackageAction(pkg, actionName) {
+      new PackageDeploymentStep(pkg, actionName) {
         def resolve(resources: DeploymentResources, target: DeployTarget) =
           action.taskGenerator(pkg, resources, target)
       }
     } getOrElse sys.error(s"Action $actionName is not supported on package ${pkg.name} of type $name")
   }
 
-  abstract case class PackageAction(pkg: DeploymentPackage, actionName: String) extends ActionResolver {
+  abstract case class PackageDeploymentStep(pkg: DeploymentPackage, actionName: String) extends DeploymentStep {
     def apps = pkg.apps
     def description = pkg.name + "." + actionName
   }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
@@ -22,37 +22,53 @@ object ElasticSearch extends DeploymentType {
       | (also used as the wait time for the instance termination)"""
   ).default(15 * 60)
 
-  def defaultActions = List("uploadArtifacts", "deploy")
-
-  def actions = {
-    case "deploy" => (pkg) => (resources, target) => {
-      implicit val keyRing = resources.assembleKeyring(target, pkg)
-      val reporter = resources.reporter
-      val parameters = target.parameters
-      val stack = target.stack
-      List(
-        CheckGroupSize(pkg, parameters.stage, stack, target.region),
-        WaitForElasticSearchClusterGreen(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
-        SuspendAlarmNotifications(pkg, parameters.stage, stack, target.region),
-        TagCurrentInstancesWithTerminationTag(pkg, parameters.stage, stack, target.region),
-        DoubleSize(pkg, parameters.stage, stack, target.region),
-        WaitForElasticSearchClusterGreen(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
-        CullElasticSearchInstancesWithTerminationTag(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
-        ResumeAlarmNotifications(pkg, parameters.stage, stack, target.region)
-      )
-    }
-    case "uploadArtifacts" => (pkg) => (resources, target) =>
-      implicit val keyRing = resources.assembleKeyring(target, pkg)
-      implicit val artifactClient = resources.artifactClient
-      val reporter = resources.reporter
-      val prefix: String = S3Upload.prefixGenerator(target.stack, target.parameters.stage, pkg.name)
-      List(
-        S3Upload(
-          target.region,
-          bucket(pkg, target, reporter),
-          Seq(pkg.s3Package -> prefix),
-          publicReadAcl = publicReadAcl(pkg, target, reporter)
-        )
-      )
+  val deploy = Action("deploy",
+    """
+      |Carries out the update of instances in an autoscaling group. We carry out the following tasks:
+      | - tag existing instances in the ASG with a termination tag
+      | - double the size of the auto-scaling group (new instances will have the new application)
+      | - wait for the ES cluster to go green
+      | - terminate previously tagged instances one at a time, waiting for the cluster to go green after each
+      |   termination
+      |
+      |The action checks whether the auto-scaling group maxsize is big enough before starting the process and also
+      |suspends and resumes cloud watch alarms in order to prevent false alarms.
+    """.stripMargin
+  ) { (pkg, resources, target) =>
+    implicit val keyRing = resources.assembleKeyring(target, pkg)
+    val reporter = resources.reporter
+    val parameters = target.parameters
+    val stack = target.stack
+    List(
+      CheckGroupSize(pkg, parameters.stage, stack, target.region),
+      WaitForElasticSearchClusterGreen(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
+      SuspendAlarmNotifications(pkg, parameters.stage, stack, target.region),
+      TagCurrentInstancesWithTerminationTag(pkg, parameters.stage, stack, target.region),
+      DoubleSize(pkg, parameters.stage, stack, target.region),
+      WaitForElasticSearchClusterGreen(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
+      CullElasticSearchInstancesWithTerminationTag(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
+      ResumeAlarmNotifications(pkg, parameters.stage, stack, target.region)
+    )
   }
+
+  val uploadArtifacts = Action("uploadArtifacts",
+    """
+      |Uploads the files in the deployment's directory to the specified bucket.
+    """.stripMargin
+  ){ (pkg, resources, target) =>
+    implicit val keyRing = resources.assembleKeyring(target, pkg)
+    implicit val artifactClient = resources.artifactClient
+    val reporter = resources.reporter
+    val prefix: String = S3Upload.prefixGenerator(target.stack, target.parameters.stage, pkg.name)
+    List(
+      S3Upload(
+        target.region,
+        bucket(pkg, target, reporter),
+        Seq(pkg.s3Package -> prefix),
+        publicReadAcl = publicReadAcl(pkg, target, reporter)
+      )
+    )
+  }
+
+  def defaultActions = List(uploadArtifacts, deploy)
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Fastly.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Fastly.scala
@@ -9,14 +9,25 @@ object Fastly  extends DeploymentType {
       |Deploy a new set of VCL configuration files to the [fastly](http://www.fastly.com/) CDN via the fastly API.
     """.stripMargin
 
-  def defaultActions = List("deploy")
-
-  def actions = {
-    case "deploy" => pkg => (resources, target) => {
-      implicit val keyRing = resources.assembleKeyring(target, pkg)
-      implicit val artifactClient = resources.artifactClient
-      resources.reporter.verbose(s"Keyring is $keyRing")
-      List(UpdateFastlyConfig(pkg.s3Package)(keyRing, artifactClient))
-    }
+  val deploy = Action("deploy",
+    """
+      |Undertakes the following using the fastly API:
+      |
+      | - Clone the currently active version
+      | - Deletes all of the existing files from the new clone
+      | - Uploads files from this deployment
+      | - Waits for it to compile
+      | - Validates the config
+      | - Activates the config
+      |
+      | This will set `main.vcl` as the main entrypoint (without checking that this exists) so make sure to structure
+      | your VCL files to facilitate this.
+    """.stripMargin){ (pkg, resources, target) =>
+    implicit val keyRing = resources.assembleKeyring(target, pkg)
+    implicit val artifactClient = resources.artifactClient
+    resources.reporter.verbose(s"Keyring is $keyRing")
+    List(UpdateFastlyConfig(pkg.s3Package)(keyRing, artifactClient))
   }
+
+  def defaultActions = List(deploy)
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -143,7 +143,7 @@ object Lambda extends DeploymentType  {
       |Typically this copies the new function code form S3, but when `bucket` is not provided this directly uploads the
       |file directly into the function.
       |
-      |The fucntion name to update is determined by the `functionName` or `functions` parameters.
+      |The function name to update is determined by the `functionName` or `functions` parameters.
       |
       |It is recommended that you only use the `functionName` parameter (in combination with `fileName`). In this case
       |the `functionName` will be prefixed with the stack (default in YAML) and suffixed with the stage you are

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Param.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Param.scala
@@ -4,7 +4,7 @@ import magenta.{DeployReporter, DeployTarget, DeploymentPackage}
 import play.api.libs.json.{Json, Reads}
 
 trait ParamRegister {
-  def add(param: Param[_])
+  def add(param: Param[_]): Unit
 }
 
 /**

--- a/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentTypeResolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentTypeResolver.scala
@@ -17,8 +17,8 @@ object DeploymentTypeResolver {
   }
 
   private[input] def resolveDeploymentActions(deployment: Deployment, deploymentType: DeploymentType): Validated[ConfigErrors, Deployment] = {
-    val actions = deployment.actions.getOrElse(deploymentType.defaultActions)
-    val invalidActions = actions.filterNot(deploymentType.actions.isDefinedAt)
+    val actions = deployment.actions.getOrElse(deploymentType.defaultActionNames)
+    val invalidActions = actions.filterNot(deploymentType.actionsMap.isDefinedAt)
 
     if (actions.isEmpty)
       Invalid(ConfigErrors(deployment.name, s"Either specify at least one action or omit the actions parameter"))

--- a/magenta-lib/src/main/scala/magenta/input/resolver/TaskResolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/TaskResolver.scala
@@ -19,7 +19,7 @@ object TaskResolver {
         region <- deployment.regions.toList
         stack <- deployment.stacks.toList
         actionName <- deployment.actions.toList.flatten
-        action = deploymentType.mkAction(actionName)(deploymentPackage)
+        action = deploymentType.mkActionResolver(actionName)(deploymentPackage)
         target = DeployTarget(parameters, NamedStack(stack), Region(region))
         task <- action.resolve(deploymentResources, target)
       } yield task

--- a/magenta-lib/src/main/scala/magenta/input/resolver/TaskResolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/TaskResolver.scala
@@ -19,9 +19,9 @@ object TaskResolver {
         region <- deployment.regions.toList
         stack <- deployment.stacks.toList
         actionName <- deployment.actions.toList.flatten
-        action = deploymentType.mkActionResolver(actionName)(deploymentPackage)
+        deploymentStep = deploymentType.mkDeploymentStep(actionName)(deploymentPackage)
         target = DeployTarget(parameters, NamedStack(stack), Region(region))
-        task <- action.resolve(deploymentResources, target)
+        task <- deploymentStep.resolve(deploymentResources, target)
       } yield task
       DeploymentTasks(tasks,
         mkLabel(deploymentPackage.name, deployment.actions.toList.flatten, deployment.regions, deployment.stacks))

--- a/magenta-lib/src/main/scala/magenta/json/JsonInputFile.scala
+++ b/magenta-lib/src/main/scala/magenta/json/JsonInputFile.scala
@@ -62,7 +62,7 @@ object JsonReader {
       actionString.split("\\.") match {
         case Array(pkgName, actionName) =>
           val pkg = availablePackages.get(pkgName).getOrElse(sys.error(s"Package '$pkgName' does not exist; cannot resolve action '$actionString'"))
-          pkg.mkAction(actionName)
+          pkg.mkDeploymentStep(actionName)
 
         case _ => sys.error(s"Badly formed action name: '$actionString' - should be in <packageName>.<actionName> format")
       }
@@ -70,7 +70,7 @@ object JsonReader {
 
     Recipe(
       name = name,
-      actions = (
+      deploymentSteps = (
         jsonRecipe.actionsBeforeApp.getOrElse(Nil)
           ++ jsonRecipe.actionsPerHost.getOrElse(Nil)
           ++ jsonRecipe.actions.getOrElse(Nil)

--- a/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
+++ b/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
@@ -109,7 +109,7 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
 
   val CODE = Stage("CODE")
 
-  case class MockStubPerHostActionResolver(description: String, apps: Seq[App]) extends ActionResolver {
+  case class MockStubPerHostDeploymentStep(description: String, apps: Seq[App]) extends DeploymentStep {
     def resolve(resources: DeploymentResources, target: DeployTarget) = {
       val task = mock[Task]
       when(task.taskHost).thenReturn(Some(resources.lookup.hosts.all.head))
@@ -117,7 +117,7 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
     }
   }
 
-  case class MockStubPerAppActionResolver(description: String, apps: Seq[App]) extends ActionResolver {
+  case class MockStubPerAppDeploymentStep(description: String, apps: Seq[App]) extends DeploymentStep {
     def resolve(resources: DeploymentResources, target: DeployTarget) = {
       val task = mock[Task]
       when(task.taskHost).thenReturn(None)
@@ -133,11 +133,11 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
   val basePackageType = stubDeploymentType(Seq("init_action_one"))
 
   val baseRecipe = Recipe("one",
-    actions = basePackageType.mkActionResolver("init_action_one")(stubPackage(basePackageType)) :: Nil,
+    deploymentSteps = basePackageType.mkDeploymentStep("init_action_one")(stubPackage(basePackageType)) :: Nil,
     dependsOn = Nil)
 
   val baseMockRecipe = Recipe("one",
-    actions = MockStubPerAppActionResolver("init_action_one", Seq(app1)) :: Nil,
+    deploymentSteps = MockStubPerAppDeploymentStep("init_action_one", Seq(app1)) :: Nil,
     dependsOn = Nil)
 
   def project(recipes: Recipe*) = Project(Map.empty, recipes.map(r => r.name -> r).toMap)

--- a/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
+++ b/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
@@ -109,7 +109,7 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
 
   val CODE = Stage("CODE")
 
-  case class MockStubPerHostAction(description: String, apps: Seq[App]) extends Action {
+  case class MockStubPerHostActionResolver(description: String, apps: Seq[App]) extends ActionResolver {
     def resolve(resources: DeploymentResources, target: DeployTarget) = {
       val task = mock[Task]
       when(task.taskHost).thenReturn(Some(resources.lookup.hosts.all.head))
@@ -117,7 +117,7 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
     }
   }
 
-  case class MockStubPerAppAction(description: String, apps: Seq[App]) extends Action {
+  case class MockStubPerAppActionResolver(description: String, apps: Seq[App]) extends ActionResolver {
     def resolve(resources: DeploymentResources, target: DeployTarget) = {
       val task = mock[Task]
       when(task.taskHost).thenReturn(None)
@@ -133,11 +133,11 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
   val basePackageType = stubDeploymentType(Seq("init_action_one"))
 
   val baseRecipe = Recipe("one",
-    actions = basePackageType.mkAction("init_action_one")(stubPackage(basePackageType)) :: Nil,
+    actions = basePackageType.mkActionResolver("init_action_one")(stubPackage(basePackageType)) :: Nil,
     dependsOn = Nil)
 
   val baseMockRecipe = Recipe("one",
-    actions = MockStubPerAppAction("init_action_one", Seq(app1)) :: Nil,
+    actions = MockStubPerAppActionResolver("init_action_one", Seq(app1)) :: Nil,
     dependsOn = Nil)
 
   def project(recipes: Recipe*) = Project(Map.empty, recipes.map(r => r.name -> r).toMap)

--- a/magenta-lib/src/test/scala/magenta/ResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/ResolverTest.scala
@@ -83,7 +83,7 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
     val basePackageType = stubDeploymentType(Seq("main_init_action"))
 
     val mainRecipe = Recipe("main",
-      actions = basePackageType.mkActionResolver("main_init_action")(stubPackage(basePackageType)) :: Nil,
+      deploymentSteps = basePackageType.mkDeploymentStep("main_init_action")(stubPackage(basePackageType)) :: Nil,
       dependsOn = List("one"))
 
     val resources = DeploymentResources(reporter, lookupSingleHost, artifactClient)
@@ -101,10 +101,10 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
     val basePackageType = stubDeploymentType(Seq("main_init_action", "init_action_two"))
 
     val indirectDependencyRecipe = Recipe("two",
-      actions = basePackageType.mkActionResolver("init_action_two")(stubPackage(basePackageType)) :: Nil,
+      deploymentSteps = basePackageType.mkDeploymentStep("init_action_two")(stubPackage(basePackageType)) :: Nil,
       dependsOn = List("one"))
     val mainRecipe = Recipe("main",
-      actions = basePackageType.mkActionResolver("main_init_action")(stubPackage(basePackageType)) :: Nil,
+      deploymentSteps = basePackageType.mkDeploymentStep("main_init_action")(stubPackage(basePackageType)) :: Nil,
       dependsOn = List("two", "one"))
 
     val resources = DeploymentResources(reporter, lookupSingleHost, artifactClient)
@@ -121,7 +121,7 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
 
   it should "not throw an exception if no hosts found and only whole app recipes" in {
     val nonHostRecipe = Recipe("nonHostRecipe",
-      actions =  basePackageType.mkActionResolver("init_action_one")(stubPackage(basePackageType)) :: Nil,
+      deploymentSteps =  basePackageType.mkDeploymentStep("init_action_one")(stubPackage(basePackageType)) :: Nil,
       dependsOn = Nil)
 
     val resources = DeploymentResources(reporter, stubLookup(List()), artifactClient)
@@ -134,7 +134,7 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
       List("deploy")
     )
     val recipe = Recipe("stacked",
-      actions = List(pkgType.mkActionResolver("deploy")(stubPackage(pkgType))))
+      deploymentSteps = List(pkgType.mkDeploymentStep("deploy")(stubPackage(pkgType))))
 
     val proj = project(recipe, NamedStack("foo"), NamedStack("bar"), NamedStack("monkey"), NamedStack("litre"))
     val resources = DeploymentResources(reporter, stubLookup(), artifactClient)
@@ -155,7 +155,7 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
       List("deploy")
     )
     val recipe = Recipe("stacked",
-      actions = List(pkgType.mkActionResolver("deploy")(stubPackage(pkgType))))
+      deploymentSteps = List(pkgType.mkDeploymentStep("deploy")(stubPackage(pkgType))))
 
     val proj = project(recipe, NamedStack("foo"), NamedStack("bar"), NamedStack("monkey"), NamedStack("litre"))
     val resources = DeploymentResources(reporter, stubLookup(), artifactClient)

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -28,7 +28,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
     val p = DeploymentPackage("app", app, data, "autoscaling", S3Path("artifact-bucket", "test/123/app"), true,
       deploymentTypes)
 
-    AutoScaling.actions("deploy")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack, region)) should be (List(
+    AutoScaling.actionsMap("deploy").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack, region)) should be (List(
       CheckForStabilization(p, PROD, UnnamedStack, Region("eu-west-1")),
       CheckGroupSize(p, PROD, UnnamedStack, Region("eu-west-1")),
       SuspendAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1")),
@@ -53,7 +53,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
     val p = DeploymentPackage("app", app, data, "autoscaling", S3Path("artifact-bucket", "test/123/app"), false,
       deploymentTypes)
 
-    AutoScaling.actions("uploadArtifacts")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack, region)) should matchPattern {
+    AutoScaling.actionsMap("uploadArtifacts").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack, region)) should matchPattern {
       case List(S3Upload(_,_,_,_,_,false,_)) =>
     }
   }
@@ -71,7 +71,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
     val p = DeploymentPackage("app", app, data, "autoscaling", S3Path("artifact-bucket", "test/123/app"), true,
       deploymentTypes)
 
-    AutoScaling.actions("deploy")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack, region)) should be (List(
+    AutoScaling.actionsMap("deploy").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack, region)) should be (List(
       CheckForStabilization(p, PROD, UnnamedStack, Region("eu-west-1")),
       CheckGroupSize(p, PROD, UnnamedStack, Region("eu-west-1")),
       SuspendAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1")),

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -27,7 +27,7 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
     val p = DeploymentPackage("app", app, data, "cloud-formation", S3Path("artifact-bucket", "test/123"), true,
       deploymentTypes)
 
-    inside(CloudFormation.actions("updateStack")(p)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), stack, region))) {
+    inside(CloudFormation.actionsMap("updateStack").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), stack, region))) {
       case List(updateTask, checkTask) =>
         inside(updateTask) {
           case UpdateCloudFormationTask(stackName, path, userParams, amiParam, amiTags, _, stage, stack, ifAbsent) =>

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -38,7 +38,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package, true, deploymentTypes)
 
     val thrown = the[NoSuchElementException] thrownBy {
-      S3.actions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)) should be (
+      S3.actionsMap("uploadStaticFiles").taskGenerator(p, DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)) should be (
         List(S3Upload(
           Region("eu-west-1"),
           "bucket-1234",
@@ -62,7 +62,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
 
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package, false, deploymentTypes)
 
-    S3.actions("uploadStaticFiles")(p)(DeploymentResources(mockReporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region))
+    S3.actionsMap("uploadStaticFiles").taskGenerator(p, DeploymentResources(mockReporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region))
 
     verify(mockReporter).warning("Parameter prefixStage is unnecessarily explicitly set to the default value of true")
   }
@@ -78,7 +78,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
 
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package, true, deploymentTypes)
 
-    S3.actions("uploadStaticFiles")(p)(DeploymentResources(mockReporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region))
+    S3.actionsMap("uploadStaticFiles").taskGenerator(p, DeploymentResources(mockReporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region))
 
     verify(mockReporter, never).warning(any())
   }
@@ -92,7 +92,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
 
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package, true, deploymentTypes)
 
-    S3.actions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)) should be (
+    S3.actionsMap("uploadStaticFiles").taskGenerator(p, DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)) should be (
       List(S3Upload(
         Region("eu-west-1"),
         "bucket-1234",
@@ -114,7 +114,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
 
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package, true, deploymentTypes)
 
-    inside(S3.actions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)).head) {
+    inside(S3.actionsMap("uploadStaticFiles").taskGenerator(p, DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)).head) {
       case upload: S3Upload => upload.cacheControlPatterns should be(List(PatternValue("^sub", "no-cache"), PatternValue(".*", "public; max-age:3600")))
     }
   }
@@ -132,7 +132,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
 
     val lookup = stubLookup(List(Host("the_host", stage=CODE.name).app(app1)), Map("s3-path-prefix" -> Seq(Datum(None, app1.name, CODE.name, "testing/2016/05/brexit-companion", None))))
 
-    inside(S3.actions("uploadStaticFiles")(p)(DeploymentResources(reporter, lookup, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)).head) {
+    inside(S3.actionsMap("uploadStaticFiles").taskGenerator(p, DeploymentResources(reporter, lookup, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)).head) {
       case upload: S3Upload => upload.paths should be(Seq(sourceS3Package -> "testing/2016/05/brexit-companion"))
     }
   }
@@ -150,7 +150,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-lambda", S3Path("artifact-bucket", "test/123"), true,
       deploymentTypes)
 
-    Lambda.actions("updateLambda")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)) should be (
+    Lambda.actionsMap("updateLambda").taskGenerator(p, DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)) should be (
       List(UpdateLambda(S3Path("artifact-bucket","test/123/lambda.zip"), "myLambda", defaultRegion)
       ))
   }
@@ -168,7 +168,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
       deploymentTypes)
 
     val thrown = the[FailException] thrownBy {
-      Lambda.actions("updateLambda")(p)(DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)) should be (
+      Lambda.actionsMap("updateLambda").taskGenerator(p, DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)) should be (
         List(UpdateLambda(S3Path("artifact-bucket","test/123/lambda.zip"), "myLambda", defaultRegion)
         ))
     }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
@@ -32,7 +32,7 @@ class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
   val defaultRegion = Region("eu-west-1")
 
   it should "produce an S3 upload task" in {
-    val tasks = Lambda.actions("uploadLambda")(pkg)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("test"), region))
+    val tasks = Lambda.actionsMap("uploadLambda").taskGenerator(pkg, DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("test"), region))
     tasks should be (List(
       S3Upload(
         Region("eu-west-1"),
@@ -43,7 +43,7 @@ class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
   }
 
   it should "produce a lambda update task" in {
-    val tasks = Lambda.actions("updateLambda")(pkg)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("test"), region))
+    val tasks = Lambda.actionsMap("updateLambda").taskGenerator(pkg, DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("test"), region))
     tasks should be (List(
       UpdateS3Lambda(
         functionName = "MyFunction-PROD",
@@ -65,7 +65,7 @@ class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
     val pkg = DeploymentPackage("lambda", app, dataWithStack, "aws-lambda",
       S3Path("artifact-bucket", "test/123/lambda"), true, deploymentTypes)
 
-    val tasks = Lambda.actions("updateLambda")(pkg)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("some-stack"), region))
+    val tasks = Lambda.actionsMap("updateLambda").taskGenerator(pkg, DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("some-stack"), region))
     tasks should be (List(
       UpdateS3Lambda(
         functionName = "some-stackMyFunction-PROD",
@@ -88,7 +88,7 @@ class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
     val pkg = DeploymentPackage("lambda", app, dataWithStack, "aws-lambda",
       S3Path("artifact-bucket", "test/123/lambda"), true, deploymentTypes)
 
-    val tasks = Lambda.actions("updateLambda")(pkg)(DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("some-stack"), region))
+    val tasks = Lambda.actionsMap("updateLambda").taskGenerator(pkg, DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("some-stack"), region))
     tasks should be (List(
       UpdateS3Lambda(
         functionName = "some-stackMyFunction-PROD",

--- a/magenta-lib/src/test/scala/magenta/fixtures/fixtures.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/fixtures.scala
@@ -12,7 +12,7 @@ case class StubTask(description: String, region: Region, stack: Option[Stack] = 
   def keyRing = KeyRing()
 }
 
-case class StubPerAppActionResolver(description: String, apps: Seq[App]) extends ActionResolver {
+case class StubPerAppDeploymentStep(description: String, apps: Seq[App]) extends DeploymentStep {
   def resolve(resources: DeploymentResources, target: DeployTarget) = ???
 }
 

--- a/magenta-lib/src/test/scala/magenta/fixtures/fixtures.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/fixtures.scala
@@ -1,7 +1,7 @@
 package magenta
 package fixtures
 
-import magenta.deployment_type.{DeploymentType, Param, ParamRegister}
+import magenta.deployment_type._
 import magenta.tasks.Task
 
 case class StubTask(description: String, region: Region, stack: Option[Stack] = None,
@@ -12,18 +12,24 @@ case class StubTask(description: String, region: Region, stack: Option[Stack] = 
   def keyRing = KeyRing()
 }
 
-case class StubPerAppAction(description: String, apps: Seq[App]) extends Action {
+case class StubPerAppActionResolver(description: String, apps: Seq[App]) extends ActionResolver {
   def resolve(resources: DeploymentResources, target: DeployTarget) = ???
 }
 
+object StubActionRegister extends ActionRegister {
+  def add(action: Action): Unit = {}
+}
+
 case class StubDeploymentType(
-  override val actions:
-    PartialFunction[String, DeploymentPackage => (DeploymentResources, DeployTarget) => List[Task]] = Map.empty,
-  override val defaultActions: List[String],
+  override val actionsMap: Map[String, Action] = Map.empty,
+  override val defaultActionNames: List[String],
   parameters: ParamRegister => List[Param[_]] = _ => Nil,
   override val name: String = "stub-package-type"
 ) extends DeploymentType {
-  parameters(register)
+  parameters(paramsRegister)
+
+
+  def defaultActions: List[Action] = defaultActionNames.map { name => actionsMap(name) }
 
   val documentation = "Documentation for the testing stub"
 }

--- a/magenta-lib/src/test/scala/magenta/fixtures/package.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/package.scala
@@ -1,6 +1,6 @@
 package magenta
 
-import magenta.deployment_type.{DeploymentType, Param, ParamRegister}
+import magenta.deployment_type._
 import org.joda.time.DateTime
 
 package object fixtures {
@@ -16,7 +16,7 @@ package object fixtures {
   val basePackageType = stubDeploymentType(Seq("init_action_one"))
 
   val baseRecipe = Recipe("one",
-    actions = basePackageType.mkAction("init_action_one")(stubPackage(basePackageType)) :: Nil,
+    actions = basePackageType.mkActionResolver("init_action_one")(stubPackage(basePackageType)) :: Nil,
     dependsOn = Nil)
 
   def project(recipes: Recipe*) = Project(Map.empty, recipes.map(r => r.name -> r).toMap)
@@ -27,17 +27,22 @@ package object fixtures {
     DeploymentPackage("stub project", Seq(app1), Map(), "stub-package-type", null, false, Seq(deploymentType))
 
   def stubDeploymentType(actionNames: Seq[String], params: ParamRegister => List[Param[_]] = _ => Nil,
-    name: String = "stub-package-type") = StubDeploymentType(
-      actions = {
-        case name if actionNames.contains(name) => pkg => (_, target) => List(
-          StubTask(name + " per app task number one", target.region),
-          StubTask(name + " per app task number two", target.region)
-        )
-      },
+    name: String = "stub-package-type") = {
+    StubDeploymentType(
+      actionsMap = actionNames.map { name =>
+        name -> Action(name) { (_, _, target) =>
+          List(
+            StubTask(name + " per app task number one", target.region),
+            StubTask(name + " per app task number two", target.region)
+          )
+        } (StubActionRegister)
+      }.toMap,
       actionNames.toList,
       params,
       name
     )
+  }
+
 
   def testParams() = DeployParameters(
     Deployer("default deployer"),

--- a/magenta-lib/src/test/scala/magenta/fixtures/package.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/package.scala
@@ -16,7 +16,7 @@ package object fixtures {
   val basePackageType = stubDeploymentType(Seq("init_action_one"))
 
   val baseRecipe = Recipe("one",
-    actions = basePackageType.mkActionResolver("init_action_one")(stubPackage(basePackageType)) :: Nil,
+    deploymentSteps = basePackageType.mkDeploymentStep("init_action_one")(stubPackage(basePackageType)) :: Nil,
     dependsOn = Nil)
 
   def project(recipes: Recipe*) = Project(Map.empty, recipes.map(r => r.name -> r).toMap)

--- a/magenta-lib/src/test/scala/magenta/input/resolver/TaskResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/TaskResolverTest.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import cats.data.{NonEmptyList => NEL}
 import com.amazonaws.services.s3.AmazonS3Client
 import magenta.artifact.S3YamlArtifact
-import magenta.deployment_type.AutoScaling
+import magenta.deployment_type.{Action, AutoScaling}
 import magenta.fixtures._
 import magenta.input.Deployment
 import magenta.{Build, DeployParameters, DeployReporter, Deployer, DeploymentResources, NamedStack, Region, Stage, fixtures}
@@ -18,10 +18,14 @@ class TaskResolverTest extends FlatSpec with Matchers with MockitoSugar with Val
   implicit val artifactClient = mock[AmazonS3Client]
 
   val deploymentTypes = List(StubDeploymentType(
-    actions = {
-      case "uploadArtifact" => pkg => (resources, target) => List(StubTask("upload", target.region, stack = Some(target.stack)))
-      case "deploy" => pkg => (resources, target) => List(StubTask("deploy", target.region, stack = Some(target.stack)))
-    },
+    actionsMap = Map(
+      "uploadArtifact" -> Action("uploadArtifact"){
+        (pkg, resources, target) => List(StubTask("upload", target.region, stack = Some(target.stack)))
+      }(StubActionRegister),
+      "deploy" -> Action("deploy"){
+        (pkg, resources, target) => List(StubTask("deploy", target.region, stack = Some(target.stack)))
+      }(StubActionRegister)
+    ),
     List("uploadArtifact", "deploy"))
   )
 

--- a/magenta-lib/src/test/scala/magenta/json/JsonReaderTest.scala
+++ b/magenta-lib/src/test/scala/magenta/json/JsonReaderTest.scala
@@ -81,7 +81,7 @@ class JsonReaderTest extends FlatSpec with Matchers {
 
     val apiCounterRecipe = recipes("api-counter-only")
 
-    apiCounterRecipe.actions.toSeq.length should be (4)
+    apiCounterRecipe.deploymentSteps.toSeq.length should be (4)
   }
 
   val minimalExample = """
@@ -112,7 +112,7 @@ class JsonReaderTest extends FlatSpec with Matchers {
 
     val recipes = parsed.recipes
     recipes.size should be(1)
-    recipes("default") should be (Recipe("default", actions   = parsed.packages.values.map(_.mkAction("deploy"))))
+    recipes("default") should be (Recipe("default", deploymentSteps   = parsed.packages.values.map(_.mkDeploymentStep("deploy"))))
   }
 
   "json parser" should "default to using the package name for the file name" in {

--- a/riff-raff/app/controllers/Application.scala
+++ b/riff-raff/app/controllers/Application.scala
@@ -153,8 +153,8 @@ class Application(prismLookup: PrismLookup, deploymentTypes: Seq[DeploymentType]
 
             resource match {
               case "magenta-lib/types" =>
-                val sections = DeployTypeDocs.generateParamDocs(deploymentTypes).map { case (dt, paramDocs) =>
-                  val typeDocumentation = views.html.documentation.deploymentTypeSnippet(dt.documentation, paramDocs)
+                val sections = DeployTypeDocs.generateDocs(deploymentTypes).map { case (dt, docs) =>
+                  val typeDocumentation = views.html.documentation.deploymentTypeSnippet(docs)
                   (dt.name, typeDocumentation)
                 }
                 Ok(views.html.documentation.markdownBlocks(request, "Deployment Types", breadcrumbs, sections))

--- a/riff-raff/app/views/documentation/deploymentTypeSnippet.scala.html
+++ b/riff-raff/app/views/documentation/deploymentTypeSnippet.scala.html
@@ -1,29 +1,53 @@
-@(typeDescription: String, paramsDescriptions: Seq[(String,String,Option[String],Option[String])])
+@(deployTypeDocs: docs.DeployTypeDocs)
 
-@docs.MarkDown.toHtml(typeDescription)
+@docs.MarkDown.toHtml(deployTypeDocs.documentation)
 
-@if(paramsDescriptions.nonEmpty) {
+
+<h3>Actions</h3>
 <table class="table table-condensed">
     <thead>
         <tr>
-            <th>Parameter</th>
+            <th>Name</th>
+            <th>Description</th>
+            <th>Default action</th>
+        </tr>
+    </thead>
+    <tbody>
+        @deployTypeDocs.actions.map { action =>
+            <tr>
+                <td>@action.name</td>
+                <td>@docs.MarkDown.toHtml(action.documentation)</td>
+                <td>@if(action.isDefault){<span class="glyphicon glyphicon-ok" aria-hidden="true"></span>}</td>
+            </tr>
+        }
+    </tbody>
+</table>
+
+@if(deployTypeDocs.params.nonEmpty) {
+<h3>Parameters</h3>
+<table class="table table-condensed">
+    <thead>
+        <tr>
+            <th>Name</th>
             <th>Description</th>
             <th>Default (riff-raff.yaml)</th>
             <th>Default (legacy deploy.json)</th>
         </tr>
     </thead>
-    @paramsDescriptions.map { case (name, desc, defaultJson, defaultYaml) =>
-    <tr>
-      <td>@name</td>
-      <td>@docs.MarkDown.toHtml(desc)</td>
-        @if(defaultJson != defaultYaml) {
-            <td nowrap="nowrap"><em><strong>@defaultYaml.getOrElse{&lt;no default&gt;}</strong></em></td>
-            <td nowrap="nowrap"><em><strong>@defaultJson.getOrElse{&lt;no default&gt;}</strong></em></td>
-        } else {
-            <td nowrap="nowrap"><em>@defaultYaml.getOrElse{<strong>&lt;no default&gt;</strong>}</em></td>
-            <td nowrap="nowrap"><em>@defaultJson.getOrElse{<strong>&lt;no default&gt;</strong>}</em></td>
+    <tbody>
+        @deployTypeDocs.params.map { param =>
+        <tr>
+          <td>@param.name</td>
+          <td>@docs.MarkDown.toHtml(param.documentation)</td>
+            @if(param.defaultLegacy != param.default) {
+                <td nowrap="nowrap"><em><strong>@param.default.getOrElse{&lt;no default&gt;}</strong></em></td>
+                <td nowrap="nowrap"><em><strong>@param.defaultLegacy.getOrElse{&lt;no default&gt;}</strong></em></td>
+            } else {
+                <td nowrap="nowrap"><em>@param.default.getOrElse{<strong>&lt;no default&gt;</strong>}</em></td>
+                <td nowrap="nowrap"><em>@param.defaultLegacy.getOrElse{<strong>&lt;no default&gt;</strong>}</em></td>
+            }
+        </tr>
         }
-    </tr>
-    }
+    </tbody>
 </table>
 }

--- a/riff-raff/app/views/preview/json/content.scala.html
+++ b/riff-raff/app/views/preview/json/content.scala.html
@@ -5,7 +5,7 @@
     @CSRF.formField
     <table class="table table-hover">
         <tbody>
-        @preview.recipeTasks.filterNot(rt => rt.recipe.actions.isEmpty).map { recipeTasks =>
+        @preview.recipeTasks.filterNot(rt => rt.recipe.deploymentSteps.isEmpty).map { recipeTasks =>
             <tr>
                 <td><span class="no-hyphenation">@recipeTasks.recipeName</span></td>
                 <td>

--- a/riff-raff/test/docs/DeployTypeDocsTest.scala
+++ b/riff-raff/test/docs/DeployTypeDocsTest.scala
@@ -4,13 +4,14 @@ import magenta.deployment_type._
 import org.scalatest.{FlatSpec, Matchers}
 
 class DeployTypeDocsTest extends FlatSpec with Matchers {
-  "generateParamDocs" should "generate documentation for our fake deployment type" in {
+  "generateDocs" should "generate documentation for our fake deployment type" in {
     val testDeploymentType = new DeploymentType {
-      def actions = ???
-      def defaultActions = ???
+      val action = Action("myAction", "some docs for my action")((_, _, _) => Nil)
+      val action2 = Action("myNonDefaultAction", "some docs for my action that doesn't run by default")((_, _, _) => Nil)
+      override def defaultActions = List(action)
 
-      def name = "testDeploymentType"
-      def documentation = "This is some documentation"
+      override def name = "testDeploymentType"
+      override def documentation = "This is some documentation"
 
       val param1 = Param[String]("param1", "first parameter which has no default")
       val simianType = Param[String]("simianType", "simianType param which has a default").default("monkey")
@@ -21,15 +22,22 @@ class DeployTypeDocsTest extends FlatSpec with Matchers {
           Right(if (pkg.legacyConfig) 1 else 100)
         )
     }
-    val result = DeployTypeDocs.generateParamDocs(Seq(testDeploymentType))
+    val result = DeployTypeDocs.generateDocs(Seq(testDeploymentType))
     result.size shouldBe 1
-    val (dt, paramDocs) = result.head
+    val (dt, DeployTypeDocs(docs, actionDocs, paramDocs)) = result.head
     dt shouldBe testDeploymentType
+
+    docs shouldBe testDeploymentType.documentation
+
+    actionDocs.size shouldBe 2
+    actionDocs should contain (ActionDoc("myAction", "some docs for my action", true))
+    actionDocs should contain (ActionDoc("myNonDefaultAction", "some docs for my action that doesn't run by default", false))
+
     paramDocs.size shouldBe 4
-    paramDocs should contain (("param1", "first parameter which has no default", None, None))
-    paramDocs should contain (("simianType", "simianType param which has a default", Some("monkey"), Some("monkey")))
-    paramDocs should contain (("foodType", "another param with a contextual default", Some("banana<stack>"), Some("banana<stack>")))
-    paramDocs should contain (("foodCount", "param with different default for legacy and new", Some("1"), Some("100")))
+    paramDocs should contain (ParamDoc("param1", "first parameter which has no default", None, None))
+    paramDocs should contain (ParamDoc("simianType", "simianType param which has a default", Some("monkey"), Some("monkey")))
+    paramDocs should contain (ParamDoc("foodType", "another param with a contextual default", Some("banana<stack>"), Some("banana<stack>")))
+    paramDocs should contain (ParamDoc("foodCount", "param with different default for legacy and new", Some("1"), Some("100")))
   }
 
   it should "successfully generate documentation for the standard set of deployment types" in {
@@ -37,7 +45,7 @@ class DeployTypeDocsTest extends FlatSpec with Matchers {
     val availableDeploymentTypes = Seq(
       ElasticSearch, S3, AutoScaling, Fastly, CloudFormation, Lambda, AmiCloudFormationParameter, SelfDeploy
     )
-    val result = DeployTypeDocs.generateParamDocs(availableDeploymentTypes)
+    val result = DeployTypeDocs.generateDocs(availableDeploymentTypes)
     result.size shouldBe availableDeploymentTypes.size
   }
 }


### PR DESCRIPTION
This extends the deployment type documentation that currently covers parameters to also cover actions. This has been implemented in exactly the same way as parameters were. Sadly this has not yet stretched to automatic documentation of tasks and I suspect this would be difficult, especially for actions that have parameters without any default.

The overall documentation has also been improved as a result.

<img width="1167" alt="screen shot 2016-11-10 at 13 54 40 1" src="https://cloud.githubusercontent.com/assets/1236466/20179290/55cb3b4e-a74d-11e6-8dca-21d5803fcbaa.png">
