### PR TITLE
Fix relative links in index.md

### DIFF
--- a/magenta-lib/docs/magenta-lib/concepts/index.md
+++ b/magenta-lib/docs/magenta-lib/concepts/index.md
@@ -7,7 +7,7 @@ actually works under the hood and give some details on how it understands the fi
 
 The following concepts are discussed:
 
- - [How Magenta works](how-magenta-works)
- - [The terminology of Magenta](terminology)
- - [The anatomy of the artifacts.zip file](artifacts.zip)
- - [The anatomy of a deploy.json file](deploy.json)
+ - [How Magenta works](how-magenta-works.md)
+ - [The terminology of Magenta](terminology.md)
+ - [The anatomy of the artifacts.zip file](artifacts.zip.md)
+ - [The anatomy of a deploy.json file](deploy.json.md)

--- a/magenta-lib/docs/magenta-lib/howto/index.md
+++ b/magenta-lib/docs/magenta-lib/howto/index.md
@@ -2,6 +2,6 @@
 How-To
 ======
 
- - [How do I make my project deployable?](make-deployable)
- - [How do I make my scala project deployable?](scala-deployable)
- - [How to deploy to the cloud](cloud-deployable)
+ - [How do I make my project deployable?](make-deployable.md)
+ - [How do I make my scala project deployable?](scala-deployable.md)
+ - [How to deploy to the cloud](cloud-deployable.md)

--- a/magenta-lib/docs/magenta-lib/index.md
+++ b/magenta-lib/docs/magenta-lib/index.md
@@ -3,7 +3,7 @@ Magenta Library
 
 If you want to get going quickly check out the [how-to section](./howto/).  In order to get a better understanding of
 how a deploy works you should probably read through the [concepts](./concepts/). The documentation for each of the
-available deployment types and their parameters is available on [this dynamically generated page](./types).
+available deployment types and their parameters is available on [this dynamically generated page](./types.md).
 
-Finally, there are a couple of separate documents talking about the format of the [deployinfo file](deployinfo) and
-the [CLI tool](commandline).
+Finally, there are a couple of separate documents talking about the format of the [deployinfo file](deployinfo.md) and
+the [CLI tool](commandline.md)

--- a/riff-raff/app/controllers/Application.scala
+++ b/riff-raff/app/controllers/Application.scala
@@ -220,10 +220,11 @@ object Application extends Logging {
   }
 
   def getMarkdownLines(resource: String)(implicit environment: Environment): List[String] = {
-    val realResource = if (resource.isEmpty || resource.last == '/') s"${resource}index" else resource
+    val res = if (resource.isEmpty || resource.last == '/') s"${resource}index" else resource
+    val realResource = if(res.endsWith(".md")) res else res + ".md"
     log.info(s"Getting page for $realResource")
     try {
-      withResource(environment.resourceAsStream(s"public/docs/$realResource.md").orElse(environment.resourceAsStream(s"$realResource.md")).get) { url =>
+      withResource(environment.resourceAsStream(s"public/docs/$realResource").orElse(environment.resourceAsStream(s"$realResource")).get) { url =>
         log.info(s"Resolved URL $url")
         Source.fromInputStream(url).getLines().toList
       }

--- a/riff-raff/public/docs/riffraff/administration/index.md
+++ b/riff-raff/public/docs/riffraff/administration/index.md
@@ -1,5 +1,5 @@
 Administrator's guide
 =====================
 
- - [Riff-Raff configuration file (riffraff.properties)](properties)
- - [Authentication and Authorisation](auth)
+ - [Riff-Raff configuration file (riffraff.properties)](properties.md)
+ - [Authentication and Authorisation](auth.md)

--- a/riff-raff/public/docs/riffraff/index.md
+++ b/riff-raff/public/docs/riffraff/index.md
@@ -4,13 +4,13 @@ Riff-Raff
 User guide
 ----------
 
- - [API](api) - how to use the API and a description of the endpoints available
- - [Continuous Integration and Deployment](hooksAndCD) - guide to the Riff-Raff hooks available to make continuous
+ - [API](api.md) - how to use the API and a description of the endpoints available
+ - [Continuous Integration and Deployment](hooksAndCD.md) - guide to the Riff-Raff hooks available to make continuous
  deployment easy
- - [External deploy requests](externalRequest) - how to help a user start a deploy
- - [AWS S3 bucket configuration for uploads](s3buckets)
- - [Dashboards](dashboards) - simple deployment matrix
- - [AWS SNS Topic](aws-sns) - riff-raff can publish notifications to an AWS SNS topic
+ - [External deploy requests](externalRequest.md) - how to help a user start a deploy
+ - [AWS S3 bucket configuration for uploads](s3buckets.md)
+ - [Dashboards](dashboards.md) - simple deployment matrix
+ - [AWS SNS Topic](aws-sns.md) - riff-raff can publish notifications to an AWS SNS topic
 
 Administration
 --------------


### PR DESCRIPTION
The relative links in the `index.md` files don't have the suffix `.md` and return a 404.
Eg.:
![screen shot 2016-11-14 at 15 43 19](https://cloud.githubusercontent.com/assets/3422315/20271015/39716e64-aa81-11e6-82a3-191da5fc98f7.jpg)

This is an attempt to repair the broken links.
cc @sihil 