### PR TITLE
UI improvements

### DIFF
--- a/magenta-lib/src/main/scala/magenta/DeployContext.scala
+++ b/magenta-lib/src/main/scala/magenta/DeployContext.scala
@@ -10,9 +10,7 @@ object DeployContext {
 
     val tasks = {
       resources.reporter.info("Resolving tasks...")
-      val tasks = Resolver.resolve(project, parameters, resources, region)
-      resources.reporter.taskList(DeploymentGraph.toTaskList(tasks))
-      tasks
+      Resolver.resolve(project, parameters, resources, region)
     }
     DeployContext(deployId, parameters, tasks)
   }

--- a/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
+++ b/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
@@ -29,7 +29,7 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
     ))
   }
 
-  it should "send a Info and TaskList message when resolving tasks" in {
+  it should "send a Info message when resolving tasks" in {
     val parameters = DeployParameters(Deployer("tester1"), Build("project","1"), CODE, oneRecipeName)
     val reporter = DeployReporter.startDeployContext(DeployReporter.rootReporterFor(UUID.randomUUID(), parameters))
 
@@ -40,7 +40,6 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
     val context = DeployContext(reporter.messageContext.deployId, parameters, project(baseRecipe), resources, region)
 
     messages.filter(_.getClass == classOf[Info]) should have size (1)
-    messages.filter(_.getClass == classOf[TaskList]) should have size (1)
   }
 
   it should "execute the task" in {

--- a/riff-raff/app/assets/javascripts/auto-refresh.coffee
+++ b/riff-raff/app/assets/javascripts/auto-refresh.coffee
@@ -2,23 +2,24 @@ intervalId = null
 
 callbackList = $.Callbacks()
 
+visibleHeight = ->
+  window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight
+
 bottomInView = (element) ->
   currentScroll = if (document.documentElement.scrollTop) then document.documentElement.scrollTop else document.body.scrollTop
 
   elementHeight = element.offsetHeight
   elementOffset = element.offsetTop
   totalHeight = elementOffset + elementHeight
-  visibleHeight = document.documentElement.clientHeight
 
-  totalHeight - 60 <= currentScroll + visibleHeight
+  totalHeight - 60 <= currentScroll + visibleHeight()
 
 scrollToBottom = (element) ->
   elementHeight = element.offsetHeight
   elementOffset = element.offsetTop
   totalHeight = elementOffset + elementHeight
-  visibleHeight = document.documentElement.clientHeight
 
-  scrollTop = totalHeight - visibleHeight + 60
+  scrollTop = totalHeight - visibleHeight() + 60
 
   $('html, body').animate(
     { scrollTop: scrollTop },


### PR DESCRIPTION
A couple of tweaks for things that I noticed were broken - the running percentage in the history view and the auto scrolling when viewing a deploy. This should make it somewhat more usable.

The percentage was broken as the YAML based deploys didn't report the total number of tasks to undertake so therefore a percentage couldn't be computed. To solve this we move the responsibility of reporting this into the `DeployGroupRunner` rather than a side effect in the legacy resolver.

The auto scrolling was broken due to change in behaviour - possibly only on retina machines? Either way changing the way we compute the height of the browser viewport solved the issue.