### PR TITLE
Add region and tag handling to Cloudformation

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -2,7 +2,7 @@ package magenta.deployment_type
 
 import magenta.artifact.S3Path
 import magenta.tasks.{CheckUpdateEventsTask, UpdateCloudFormationTask}
-import magenta.tasks.UpdateCloudFormationTask.LookupByName
+import magenta.tasks.UpdateCloudFormationTask.{LookupByName, LookupByTags}
 
 object CloudFormation extends DeploymentType {
   val name = "cloud-formation"
@@ -19,6 +19,12 @@ object CloudFormation extends DeploymentType {
       |current state.
     """.stripMargin
 
+  val cloudformationStackByTags = Param[Boolean]("cloudFormationStackByTags",
+    documentation =
+      """When false we derive the stack using the `cloudFormationStackName`, `prependStackToCloudFormationStackName` and
+        |`appendStageToCloudFormationStackName` parameters. When true we find the stack by looking for one with matching
+        |stack, app and stage tags in the same way that autoscaling groups are discovered.""".stripMargin
+  ).defaultFromContext((pkg, _) => Right(!pkg.legacyConfig))
   val cloudFormationStackName = Param[String]("cloudFormationStackName",
     documentation = "The name of the CloudFormation stack to update"
   ).defaultFromContext((pkg, _) => Right(pkg.name))
@@ -69,10 +75,19 @@ object CloudFormation extends DeploymentType {
       implicit val artifactClient = resources.artifactClient
       val reporter = resources.reporter
 
-      val stackName = target.stack.nameOption.filter(_ => prependStackToCloudFormationStackName(pkg, target, reporter))
-      val stageName = Some(target.parameters.stage.name).filter(_ => appendStageToCloudFormationStackName(pkg, target, reporter))
-      val cloudFormationStackNameParts = Seq(stackName, Some(cloudFormationStackName(pkg, target, reporter)), stageName).flatten
-      val fullCloudFormationStackName = cloudFormationStackNameParts.mkString("-")
+      val cloudFormationStackLookupStrategy = {
+        if (cloudformationStackByTags(pkg, target, reporter)) {
+          LookupByTags(pkg, target, reporter)
+        } else {
+          LookupByName(
+            target.stack,
+            target.parameters.stage,
+            cloudFormationStackName(pkg, target, reporter),
+            prependStack = prependStackToCloudFormationStackName(pkg, target, reporter),
+            appendStage = appendStageToCloudFormationStackName(pkg, target, reporter)
+          )
+        }
+      }
 
       val globalParams = templateParameters(pkg, target, reporter)
       val stageParams = templateStageParameters(pkg, target, reporter).lift.apply(target.parameters.stage.name).getOrElse(Map())
@@ -80,7 +95,8 @@ object CloudFormation extends DeploymentType {
 
       List(
         UpdateCloudFormationTask(
-          fullCloudFormationStackName,
+          target.region,
+          cloudFormationStackLookupStrategy,
           S3Path(pkg.s3Package, templatePath(pkg, target, reporter)),
           params,
           amiParameter(pkg, target, reporter),
@@ -90,7 +106,7 @@ object CloudFormation extends DeploymentType {
           target.stack,
           createStackIfAbsent(pkg, target, reporter)
         ),
-        CheckUpdateEventsTask(LookupByName(fullCloudFormationStackName))
+        CheckUpdateEventsTask(target.region, cloudFormationStackLookupStrategy)
       )
     }
   }

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -132,8 +132,9 @@ case class UpdateCloudFormationTask(
       case None =>
         if (createStackIfAbsent) {
           val nameToCallStack = UpdateCloudFormationTask.nameToCallNewStack(cloudFormationStackLookupStrategy)
+          val stackTags = PartialFunction.condOpt(cloudFormationStackLookupStrategy){ case LookupByTags(tags) => tags }
           reporter.info(s"Stack $cloudFormationStackLookupStrategy doesn't exist. Creating stack using name $nameToCallStack.")
-          CloudFormation.createStack(reporter, nameToCallStack, templateString, parameters, cfnClient)
+          CloudFormation.createStack(reporter, nameToCallStack, stackTags, templateString, parameters, cfnClient)
         } else {
           reporter.fail(s"Stack $cloudFormationStackLookupStrategy doesn't exist and createStackIfAbsent is false")
         }

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -1,35 +1,51 @@
 package magenta.tasks
 
 import com.amazonaws.AmazonServiceException
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import magenta.{DeployReporter, KeyRing, Stack, Stage}
-import com.amazonaws.regions.Regions
-import com.amazonaws.services.cloudformation.AmazonCloudFormationAsyncClient
-import com.amazonaws.services.cloudformation.model._
-import com.amazonaws.services.cloudformation.model.{Stack => AmazonStack}
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
-import magenta.artifact.{S3Location, S3Path}
-import org.joda.time.{DateTime, Duration}
+import com.amazonaws.services.cloudformation.model.StackEvent
+import com.amazonaws.services.s3.AmazonS3
+import magenta.artifact.S3Path
+import magenta.tasks.CloudFormation.{ParameterValue, SpecifiedValue, UseExistingValue}
 import magenta.tasks.UpdateCloudFormationTask.CloudFormationStackLookupStrategy
+import magenta.{DeployReporter, DeployTarget, DeploymentPackage, KeyRing, Region, Stack, Stage}
+import org.joda.time.{DateTime, Duration}
 
-import scalax.file.Path
-import collection.convert.wrapAsScala._
-import scala.annotation.tailrec
+import scala.collection.convert.wrapAsScala._
 
 object UpdateCloudFormationTask {
-  sealed trait ParameterValue
-  case class SpecifiedValue(value: String) extends ParameterValue
-  case object UseExistingValue extends ParameterValue
   case class TemplateParameter(key:String, default:Boolean)
 
   sealed trait CloudFormationStackLookupStrategy
   case class LookupByName(cloudFormationStackName: String) extends CloudFormationStackLookupStrategy {
     override def toString = s"called $cloudFormationStackName"
   }
+  object LookupByName {
+    def apply(stack: Stack, stage: Stage, cfnStackName: String, prependStack: Boolean, appendStage: Boolean): LookupByName = {
+      val stackName = stack.nameOption.filter(_ => prependStack)
+      val stageName = Some(stage.name).filter(_ => appendStage)
+      val cloudFormationStackNameParts = Seq(stackName, Some(cfnStackName), stageName).flatten
+      val fullCloudFormationStackName = cloudFormationStackNameParts.mkString("-")
+      LookupByName(fullCloudFormationStackName)
+    }
+  }
   case class LookupByTags(tags: Map[String, String]) extends CloudFormationStackLookupStrategy {
     override def toString = s"with tags $tags"
+  }
+  object LookupByTags {
+    def apply(pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter): LookupByTags = {
+      val lookupByTags = for {
+        stack <- target.stack.nameOption
+        app <- pkg.pkgApps.map(_.name).headOption if pkg.pkgApps.size == 1
+        stage = target.parameters.stage.name
+      } yield LookupByTags(Map(
+        "Stage" -> stage,
+        "Stack" -> stack,
+        "App" -> app
+      ))
+
+      lookupByTags.getOrElse(reporter.fail(
+        s"Tag lookup of cloudformation stacks can only be used when the configuration specifies a stack and exactly one app - you have stack=${target.stack.nameOption} and apps=${pkg.apps.map(_.name).mkString(",")}"
+      ))
+    }
   }
 
   def combineParameters(stack: Stack, stage: Stage, templateParameters: Seq[TemplateParameter], parameters: Map[String, String], amiParam: Option[(String, String)]): Map[String, ParameterValue] = {
@@ -47,10 +63,26 @@ object UpdateCloudFormationTask {
       Seq("Stage" -> stage.name) ++ stack.nameOption.map(name => "Stack" -> name)
     )
   }
+
+  def nameToCallNewStack(strategy: CloudFormationStackLookupStrategy): String = {
+    val intrinsicKeyOrder = List("Stack", "Stage", "App")
+    strategy match {
+      case LookupByName(name) => name
+      case LookupByTags(tags) =>
+        val orderedTags = tags.toList.sortBy{ case (key, value) =>
+          // order by the intrisic ordering and then alphabetically for keys we don't know
+          val order = intrinsicKeyOrder.indexOf(key)
+          val intrinsicOrdering = if (order == -1) Int.MaxValue else order
+          (intrinsicOrdering, key)
+        }
+        orderedTags.map{ case (key, value) => value }.mkString("-")
+    }
+  }
 }
 
 case class UpdateCloudFormationTask(
-  cloudFormationStackName: String,
+  region: Region,
+  cloudFormationStackLookupStrategy: CloudFormationStackLookupStrategy,
   template: S3Path,
   userParameters: Map[String, String],
   amiParamName: String,
@@ -63,45 +95,57 @@ case class UpdateCloudFormationTask(
   import UpdateCloudFormationTask._
 
   override def execute(reporter: DeployReporter, stopFlag: => Boolean) = if (!stopFlag) {
+    val cfnClient = CloudFormation.makeCfnClient(keyRing, region)
+
+    val maybeCfStack = cloudFormationStackLookupStrategy match {
+      case LookupByName(cloudFormationStackName) => CloudFormation.describeStack(cloudFormationStackName, cfnClient)
+      case LookupByTags(tags) => CloudFormation.findStackByTags(tags, reporter, cfnClient)
+    }
+
     val templateString = template.fetchContentAsString match {
       case Some(string) => string
       case None => reporter.fail(s"Unable to locate cloudformation template s3://${template.bucket}/${template.key}")
     }
 
-    val templateParameters = CloudFormation.validateTemplate(templateString).getParameters
+    val templateParameters = CloudFormation.validateTemplate(templateString, cfnClient).getParameters
       .map(tp => TemplateParameter(tp.getParameterKey, Option(tp.getDefaultValue).isDefined))
 
     val amiParam: Option[(String, String)] = if (amiTags.nonEmpty) {
-      latestImage(CloudFormation.region.name)(amiTags).map(amiParamName -> _)
+      latestImage(region.name)(amiTags).map(amiParamName -> _)
     } else None
 
     val parameters: Map[String, ParameterValue] = combineParameters(stack, stage, templateParameters, userParameters, amiParam)
 
     reporter.info(s"Parameters: $parameters")
 
-    if (CloudFormation.describeStack(cloudFormationStackName).isDefined)
-      try {
-        CloudFormation.updateStack(cloudFormationStackName, templateString, parameters)
-      } catch {
-        case ase:AmazonServiceException if ase.getMessage contains "No updates are to be performed." =>
-          reporter.info("Cloudformation update has no changes to template or parameters")
-        case ase:AmazonServiceException if ase.getMessage contains "Template format error: JSON not well-formed" =>
-          reporter.info(s"Cloudformation update failed with the following template content:\n$templateString")
-          throw ase
-      }
-    else if (createStackIfAbsent) {
-      reporter.info(s"Stack $cloudFormationStackName doesn't exist. Creating stack.")
-      CloudFormation.createStack(reporter, cloudFormationStackName, templateString, parameters)
-    } else {
-      reporter.fail(s"Stack $cloudFormationStackName doesn't exist and createStackIfAbsent is false")
+    maybeCfStack match {
+      case Some(cloudFormationStackName) =>
+        try {
+          CloudFormation.updateStack(cloudFormationStackName.getStackName, templateString, parameters, cfnClient)
+        } catch {
+          case ase:AmazonServiceException if ase.getMessage contains "No updates are to be performed." =>
+            reporter.info("Cloudformation update has no changes to template or parameters")
+          case ase:AmazonServiceException if ase.getMessage contains "Template format error: JSON not well-formed" =>
+            reporter.info(s"Cloudformation update failed with the following template content:\n$templateString")
+            throw ase
+        }
+      case None =>
+        if (createStackIfAbsent) {
+          val nameToCallStack = UpdateCloudFormationTask.nameToCallNewStack(cloudFormationStackLookupStrategy)
+          reporter.info(s"Stack $cloudFormationStackLookupStrategy doesn't exist. Creating stack using name $nameToCallStack.")
+          CloudFormation.createStack(reporter, nameToCallStack, templateString, parameters, cfnClient)
+        } else {
+          reporter.fail(s"Stack $cloudFormationStackLookupStrategy doesn't exist and createStackIfAbsent is false")
+        }
     }
   }
 
-  def description = s"Updating CloudFormation stack: $cloudFormationStackName with ${template.fileName}"
+  def description = s"Updating CloudFormation stack $cloudFormationStackLookupStrategy with ${template.fileName}"
   def verbose = description
 }
 
 case class UpdateAmiCloudFormationParameterTask(
+  region: Region,
   cloudFormationStackLookupStrategy: CloudFormationStackLookupStrategy,
   amiParameter: String,
   amiTags: Map[String, String],
@@ -112,9 +156,11 @@ case class UpdateAmiCloudFormationParameterTask(
   import UpdateCloudFormationTask._
 
   override def execute(reporter: DeployReporter, stopFlag: => Boolean) = if (!stopFlag) {
+    val cfnClient = CloudFormation.makeCfnClient(keyRing, region)
+
     val maybeCfStack = cloudFormationStackLookupStrategy match {
-      case LookupByName(cloudFormationStackName) => CloudFormation.describeStack(cloudFormationStackName)
-      case LookupByTags(tags) => CloudFormation.findStackByTags(tags, reporter)
+      case LookupByName(cloudFormationStackName) => CloudFormation.describeStack(cloudFormationStackName, cfnClient)
+      case LookupByTags(tags) => CloudFormation.findStackByTags(tags, reporter, cfnClient)
     }
 
     val (cfStackName, existingParameters, currentAmi) = maybeCfStack match {
@@ -126,14 +172,14 @@ case class UpdateAmiCloudFormationParameterTask(
         reporter.fail(s"Could not find CloudFormation stack $cloudFormationStackLookupStrategy")
     }
 
-    latestImage(CloudFormation.region.name)(amiTags) match {
+    latestImage(region.name)(amiTags) match {
       case Some(sameAmi) if currentAmi == sameAmi =>
         reporter.info(s"Current AMI is the same as the resolved AMI ($sameAmi). No update to perform.")
       case Some(ami) =>
         reporter.info(s"Resolved AMI: $ami")
         val parameters = existingParameters + (amiParameter -> SpecifiedValue(ami))
         reporter.info(s"Updating cloudformation stack params: $parameters")
-        CloudFormation.updateStackParams(cfStackName, parameters)
+        CloudFormation.updateStackParams(cfStackName, parameters, cfnClient)
       case None =>
         val tagsStr = amiTags.map { case (k, v) => s"$k: $v" }.mkString(", ")
         reporter.fail(s"Failed to resolve AMI for $cfStackName with tags: $tagsStr")
@@ -144,35 +190,42 @@ case class UpdateAmiCloudFormationParameterTask(
   def verbose = description
 }
 
-case class CheckUpdateEventsTask(stackLookupStrategy: CloudFormationStackLookupStrategy)(implicit val keyRing: KeyRing) extends Task {
+case class CheckUpdateEventsTask(
+  region: Region,
+  stackLookupStrategy: CloudFormationStackLookupStrategy
+)(implicit val keyRing: KeyRing) extends Task {
 
   import UpdateCloudFormationTask._
 
   override def execute(reporter: DeployReporter, stopFlag: => Boolean): Unit = {
+    val cfnClient = CloudFormation.makeCfnClient(keyRing, region)
+
     import StackEvent._
 
     val stackName = stackLookupStrategy match {
       case LookupByName(name) => name
       case strategy @ LookupByTags(tags) =>
-        val stack = CloudFormation.findStackByTags(tags, reporter).getOrElse(reporter.fail(s"Could not find CloudFormation stack $strategy"))
+        val stack = CloudFormation.findStackByTags(tags, reporter, cfnClient)
+          .getOrElse(reporter.fail(s"Could not find CloudFormation stack $strategy"))
         stack.getStackName
     }
 
     def check(lastSeenEvent: Option[StackEvent]): Unit = {
-      val result = CloudFormation.describeStackEvents(stackName)
+      val result = CloudFormation.describeStackEvents(stackName, cfnClient)
       val events = result.getStackEvents
 
       lastSeenEvent match {
-        case None => events.find(updateStart(stackName)) foreach (e => {
-          val age = new Duration(new DateTime(e.getTimestamp), new DateTime()).getStandardSeconds
-          if (age > 30) {
-            reporter.verbose("No recent IN_PROGRESS events found (nothing within last 30 seconds)")
-          } else {
-            reportEvent(reporter, e)
-            check(Some(e))
-          }
-        })
-        case Some(event) => {
+        case None =>
+          events.find(updateStart(stackName)) foreach (e => {
+            val age = new Duration(new DateTime(e.getTimestamp), new DateTime()).getStandardSeconds
+            if (age > 30) {
+              reporter.verbose("No recent IN_PROGRESS events found (nothing within last 30 seconds)")
+            } else {
+              reportEvent(reporter, e)
+              check(Some(e))
+            }
+          })
+        case Some(event) =>
           val newEvents = events.takeWhile(_.getTimestamp.after(event.getTimestamp))
           newEvents.reverse.foreach(reportEvent(reporter, _))
 
@@ -181,7 +234,6 @@ case class CheckUpdateEventsTask(stackLookupStrategy: CloudFormationStackLookupS
             check(Some(newEvents.headOption.getOrElse(event)))
           }
           newEvents.filter(failed).foreach(fail(reporter, _))
-        }
       }
     }
     check(None)
@@ -206,96 +258,6 @@ case class CheckUpdateEventsTask(stackLookupStrategy: CloudFormationStackLookupS
             |${e.getResourceStatusReason}""".stripMargin)
   }
 
-  def description = s"Checking events on update for: $stackLookupStrategy"
+  def description = s"Checking events on update for stack $stackLookupStrategy"
   def verbose = description
 }
-
-trait CloudFormation extends AWS {
-  import UpdateCloudFormationTask._
-  val CAPABILITY_IAM = "CAPABILITY_IAM"
-
-  val region = Regions.EU_WEST_1
-  def client(implicit keyRing: KeyRing) = {
-    com.amazonaws.regions.Region.getRegion(region).createClient(
-      classOf[AmazonCloudFormationAsyncClient], provider(keyRing), clientConfiguration
-    )
-  }
-
-  def validateTemplate(templateBody: String)(implicit keyRing: KeyRing) =
-    client.validateTemplate(new ValidateTemplateRequest().withTemplateBody(templateBody))
-
-  def updateStack(name: String, templateBody: String, parameters: Map[String, ParameterValue])(implicit keyRing: KeyRing) =
-    client.updateStack(
-      new UpdateStackRequest().withStackName(name).withTemplateBody(templateBody).withCapabilities(CAPABILITY_IAM).withParameters(
-        parameters map {
-          case (k, SpecifiedValue(v)) => new Parameter().withParameterKey(k).withParameterValue(v)
-          case (k, UseExistingValue) => new Parameter().withParameterKey(k).withUsePreviousValue(true)
-        } toSeq: _*
-      )
-    )
-
-  def updateStackParams(name: String, parameters: Map[String, ParameterValue])(implicit keyRing: KeyRing) =
-    client.updateStack(
-      new UpdateStackRequest()
-        .withStackName(name)
-        .withCapabilities(CAPABILITY_IAM)
-        .withUsePreviousTemplate(true)
-        .withParameters(
-        parameters map {
-          case (k, SpecifiedValue(v)) => new Parameter().withParameterKey(k).withParameterValue(v)
-          case (k, UseExistingValue) => new Parameter().withParameterKey(k).withUsePreviousValue(true)
-        } toSeq: _*
-      )
-    )
-
-  def createStack(reporter: DeployReporter, name: String, templateBody: String, parameters: Map[String, ParameterValue])(implicit keyRing: KeyRing) =
-    client.createStack(
-      new CreateStackRequest().withStackName(name).withTemplateBody(templateBody).withCapabilities(CAPABILITY_IAM).withParameters(
-        parameters map {
-          case (k, SpecifiedValue(v)) => new Parameter().withParameterKey(k).withParameterValue(v)
-          case (k, UseExistingValue) => reporter.fail(s"Missing parameter value for parameter $k: all must be specified when creating a stack. Subsequent updates will reuse existing parameter values where possible.")
-         } toSeq: _*
-      )
-    )
-
-  def describeStack(name: String)(implicit keyRing:KeyRing) =
-    client.describeStacks(
-      new DescribeStacksRequest()
-    ).getStacks.find(_.getStackName == name)
-
-  def describeStackEvents(name: String)(implicit keyRing: KeyRing) =
-    client.describeStackEvents(
-      new DescribeStackEventsRequest().withStackName(name)
-    )
-
-  def findStackByTags(tags: Map[String, String], reporter: DeployReporter)(implicit keyRing:KeyRing) = {
-
-    def tagsFilter(stack: AmazonStack): Boolean =
-      tags.forall { case (key, value) => stack.getTags.exists(t => t.getKey == key && t.getValue == value) }
-
-    @tailrec
-    def recur(nextToken: Option[String] = None, existingStacks: List[AmazonStack] = Nil): List[AmazonStack] = {
-      val request = new DescribeStacksRequest().withNextToken(nextToken.orNull)
-      val response = client.describeStacks(request)
-
-      val stacks = response.getStacks.foldLeft(existingStacks) {
-        case (agg, stack) if tagsFilter(stack) => stack :: agg
-        case (agg, _) => agg
-      }
-
-      Option(response.getNextToken) match {
-        case None => stacks
-        case token => recur(token, stacks)
-      }
-    }
-
-    recur() match {
-      case cfnStack :: Nil => Some(cfnStack)
-      case Nil => reporter.fail(s"No matching cloudformation stack match for $tags.")
-      case _ =>
-        reporter.fail(s"More than one cloudformation stack match for $tags. Failing fast since this may be non-deterministic.")
-    }
-  }
-}
-
-object CloudFormation extends CloudFormation


### PR DESCRIPTION
This really follows up on #385 which made it possible to find a cloudformation stack by tags instead of by name in the `AmiCloudFormationParameter` deployment type. This does the same for the `CloudFormation` deployment type as well.

Whilst doing this work I noticed that the cloudformation deployment types ignored the region specification in the new riff-raff.yaml file so I've modified the tasks and client creation to facilitate this. Whilst doing this re-structure I moved the AWS Cloudformation object into same file as the rest of the AWS API wrappers.

In addition I've improved some of the documentation and centralised some logic that creates the lookup strategy.

It will help slightly to view this PR with `w=1` to hide whitespace only changes.