### PR TITLE
Fixes and improved logging for ASG deployments

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
@@ -64,7 +64,7 @@ case class CheckForStabilization(pkg: DeploymentPackage, stage: Stage, stack: St
     implicit val elbClient = ELB.makeElbClient(keyRing, region)
     ASG.isStabilized(asg, asgClient, elbClient) match {
       case Left(reason) => reporter.fail(s"ASG not stable: $reason")
-      case Right(true) =>
+      case Right(()) =>
     }
   }
   lazy val description: String = "Check the desired number of hosts in both the ASG and ELB are up and that the number of hosts match"
@@ -81,7 +81,7 @@ case class WaitForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Sta
           case Left(reason) =>
             reporter.verbose(reason)
             false
-          case Right(result) => result
+          case Right(()) => true
         }
       } catch {
         case e: AmazonServiceException if isRateExceeded(e) => {

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -56,7 +56,7 @@ object ASG extends AWS {
     client.updateAutoScalingGroup(
       new UpdateAutoScalingGroupRequest().withAutoScalingGroupName(name).withMaxSize(capacity))
 
-  def isStabilized(asg: AutoScalingGroup, asgClient: AmazonAutoScalingClient, elbClient: AmazonElasticLoadBalancingClient): Either[String, Boolean] = {
+  def isStabilized(asg: AutoScalingGroup, asgClient: AmazonAutoScalingClient, elbClient: AmazonElasticLoadBalancingClient): Either[String, Unit] = {
     elbName(asg) match {
       case Some(name) => {
         val elbHealth = ELB.instanceHealth(name, elbClient)
@@ -65,7 +65,7 @@ object ASG extends AWS {
         else if (!elbHealth.forall( instance => instance.getState == "InService"))
           Left(s"Only ${elbHealth.count(_.getState == "InService")} of ${elbHealth.size} ELB instances InService")
         else
-          Right(true)
+          Right(())
       }
       case None => {
         val instances = asg.getInstances
@@ -74,7 +74,7 @@ object ASG extends AWS {
         else if (!instances.forall(instance => instance.getLifecycleState == LifecycleState.InService.toString))
           Left(s"Only ${instances.count(_.getLifecycleState == LifecycleState.InService.toString)} of ${instances.size} instances are InService")
         else
-          Right(true)
+          Right(())
       }
     }
   }

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -56,16 +56,25 @@ object ASG extends AWS {
     client.updateAutoScalingGroup(
       new UpdateAutoScalingGroupRequest().withAutoScalingGroupName(name).withMaxSize(capacity))
 
-  def isStabilized(asg: AutoScalingGroup, asgClient: AmazonAutoScalingClient, elbClient: AmazonElasticLoadBalancingClient) = {
+  def isStabilized(asg: AutoScalingGroup, asgClient: AmazonAutoScalingClient, elbClient: AmazonElasticLoadBalancingClient): Either[String, Boolean] = {
     elbName(asg) match {
       case Some(name) => {
         val elbHealth = ELB.instanceHealth(name, elbClient)
-        elbHealth.size == asg.getDesiredCapacity && elbHealth.forall( instance => instance.getState == "InService")
+        if (elbHealth.size != asg.getDesiredCapacity)
+          Left(s"Number of ELB instances (${elbHealth.size}) and ASG desired capacity (${asg.getDesiredCapacity}) don't match")
+        else if (!elbHealth.forall( instance => instance.getState == "InService"))
+          Left(s"Only ${elbHealth.count(_.getState == "InService")} of ${elbHealth.size} ELB instances InService")
+        else
+          Right(true)
       }
       case None => {
         val instances = asg.getInstances
-        instances.size == asg.getDesiredCapacity &&
-          instances.forall(instance => instance.getLifecycleState == LifecycleState.InService.toString)
+        if (instances.size != asg.getDesiredCapacity)
+          Left(s"Number of instances (${instances.size} and ASG desired capacity (${asg.getDesiredCapacity}) don't match")
+        else if (!instances.forall(instance => instance.getLifecycleState == LifecycleState.InService.toString))
+          Left(s"Only ${instances.count(_.getLifecycleState == LifecycleState.InService.toString)} of ${instances.size} instances are InService")
+        else
+          Right(true)
       }
     }
   }
@@ -139,10 +148,10 @@ object ASG extends AWS {
 
     appMatch match {
       case ASGMatch(_, List(singleGroup)) =>
-        reporter.verbose(s"Using group ${singleGroup.getAutoScalingGroupName}")
+        reporter.verbose(s"Using group ${singleGroup.getAutoScalingGroupName} (${singleGroup.getAutoScalingGroupARN})")
         singleGroup
       case ASGMatch(app, groupList) =>
-        reporter.fail(s"More than one autoscaling group match for $app in ${stage.name} (${groupList.map(_.getAutoScalingGroupName).mkString(", ")}). Failing fast since this may be non-deterministic.")
+        reporter.fail(s"More than one autoscaling group match for $app in ${stage.name} (${groupList.map(_.getAutoScalingGroupARN).mkString(", ")}). Failing fast since this may be non-deterministic.")
     }
   }
 }

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
@@ -135,7 +135,7 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
       new DescribeInstanceHealthRequest().withLoadBalancerName("elb")
     )).thenReturn(new DescribeInstanceHealthResult().withInstanceStates(new InstanceState().withState("InService")))
 
-    ASG.isStabilized(group, asgClientMock, elbClientMock) shouldBe Right(true)
+    ASG.isStabilized(group, asgClientMock, elbClientMock) shouldBe Right(())
   }
 
   it should "just check ASG health for stability if there is no ELB" in {
@@ -154,7 +154,7 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
     val updatedGroup = AutoScalingGroup("Role" -> "example", "Stage" -> "PROD")
       .withDesiredCapacity(1).withInstances(new ASGInstance().withLifecycleState(LifecycleState.InService))
 
-    ASG.isStabilized(updatedGroup, asgClientMock, elbClientMock) shouldBe Right(true)
+    ASG.isStabilized(updatedGroup, asgClientMock, elbClientMock) shouldBe Right(())
   }
 
   it should "find the first matching auto-scaling group with Stack and App tags, on the second page of results" in {

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
@@ -129,13 +129,13 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
       new DescribeInstanceHealthRequest().withLoadBalancerName("elb")
     )).thenReturn(new DescribeInstanceHealthResult().withInstanceStates(new InstanceState().withState("")))
 
-    ASG.isStabilized(group, asgClientMock, elbClientMock) should be (false)
+    ASG.isStabilized(group, asgClientMock, elbClientMock) shouldBe Left("Only 0 of 1 ELB instances InService")
 
     when (elbClientMock.describeInstanceHealth(
       new DescribeInstanceHealthRequest().withLoadBalancerName("elb")
     )).thenReturn(new DescribeInstanceHealthResult().withInstanceStates(new InstanceState().withState("InService")))
 
-    ASG.isStabilized(group, asgClientMock, elbClientMock) should be (true)
+    ASG.isStabilized(group, asgClientMock, elbClientMock) shouldBe Right(true)
   }
 
   it should "just check ASG health for stability if there is no ELB" in {
@@ -149,12 +149,12 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
       new DescribeInstanceHealthRequest().withLoadBalancerName("elb")
     )).thenReturn(new DescribeInstanceHealthResult().withInstanceStates(new InstanceState().withState("")))
 
-    ASG.isStabilized(group, asgClientMock, elbClientMock) should be (false)
+    ASG.isStabilized(group, asgClientMock, elbClientMock) shouldBe Left("Only 0 of 1 instances are InService")
 
     val updatedGroup = AutoScalingGroup("Role" -> "example", "Stage" -> "PROD")
       .withDesiredCapacity(1).withInstances(new ASGInstance().withLifecycleState(LifecycleState.InService))
 
-    ASG.isStabilized(updatedGroup, asgClientMock, elbClientMock) should be (true)
+    ASG.isStabilized(updatedGroup, asgClientMock, elbClientMock) shouldBe Right(true)
   }
 
   it should "find the first matching auto-scaling group with Stack and App tags, on the second page of results" in {


### PR DESCRIPTION
@johnduffell had some issues with an ASG deploy the other day. Understanding what happened was difficult due to the lack of information surfaced by Riff-Raff. This PR adds a bunch of extra logging but also fixes a potentially dangerous bug in `CheckForStabilization`.

`CheckForStabilization` previously checked whether the ASG was stable and then allowed the deployment to proceed regardless of the outcome of the check. The deployment will now fail with a helpful error.