### PR TITLE
Support Github HTTPS URLs

### DIFF
--- a/riff-raff/app/utils/VCSInfo.scala
+++ b/riff-raff/app/utils/VCSInfo.scala
@@ -1,6 +1,7 @@
 package utils
 
-import java.net.URL
+import java.net.{URI, URL}
+
 import controllers.Logging
 
 trait VCSInfo {
@@ -8,10 +9,10 @@ trait VCSInfo {
   def revision: String
   def ciVcsUrl: String
   def repo: String
-  def baseUrl: URL
-  def commitUrl: URL
-  def treeUrl: URL
-  def headUrl: URL
+  def baseUrl: URI
+  def commitUrl: URI
+  def treeUrl: URI
+  def headUrl: URI
 
   import VCSInfo._
   def map: Map[String,String] = Map(
@@ -26,19 +27,11 @@ trait VCSInfo {
   )
 }
 
-case class GuGit(ciVcsUrl: String, revision: String, repo: String) extends VCSInfo {
-  lazy val name = "Git.gudev.gnl"
-  lazy val baseUrl = new URL("http://git.gudev.gnl/%s.git" format repo)
-  lazy val commitUrl = new URL("%s/commitdiff/%s" format (baseUrl, revision))
-  lazy val treeUrl = new URL("%s/tree/%s" format (baseUrl, revision))
-  lazy val headUrl = baseUrl
-}
-
 case class GitHub(ciVcsUrl: String, revision: String, repo: String) extends VCSInfo {
   lazy val name = "GitHub"
-  lazy val baseUrl: URL = new URL("https://github.com/%s" format repo)
-  lazy val commitUrl = new URL("%s/commit/%s" format (baseUrl, revision))
-  lazy val treeUrl = new URL("%s/tree/%s" format (baseUrl, revision))
+  lazy val baseUrl = new URI("https://github.com/%s" format repo)
+  lazy val commitUrl = new URI("%s/commit/%s" format (baseUrl, revision))
+  lazy val treeUrl = new URI("%s/tree/%s" format (baseUrl, revision))
   lazy val headUrl = baseUrl
 }
 
@@ -52,16 +45,16 @@ object VCSInfo extends Logging {
   val TREEURL = "vcsTreeUrl"
   val HEADURL = "vcsHeadUrl"
 
-  val GuGitFile = """file:///git/(.*)\.git""".r
   val GitHubProtocol = """git://github\.com/(.*)\.git""".r
   val GitHubUser = """git@github\.com:(.*)\.git""".r
+  val GitHubWeb = """https://github\.com/(.*)""".r
 
   def apply(ciVcsUrl: String, revision: String): Option[VCSInfo] = {
     log.debug("url:%s revision:%s" format(ciVcsUrl, revision))
     ciVcsUrl match {
-      case GuGitFile(repo) => Some(GuGit(ciVcsUrl, revision, repo))
       case GitHubProtocol(repo) => Some(GitHub(ciVcsUrl, revision, repo))
       case GitHubUser(repo) => Some(GitHub(ciVcsUrl, revision, repo))
+      case GitHubWeb(repo) => Some(GitHub(ciVcsUrl, revision, repo))
       case _ => None
     }
   }

--- a/riff-raff/test/utils/VCSInfoTest.scala
+++ b/riff-raff/test/utils/VCSInfoTest.scala
@@ -1,0 +1,18 @@
+package utils
+
+import java.net.URI
+
+import org.scalatest.{FunSuite, ShouldMatchers}
+
+
+class VCSInfoTest extends FunSuite with ShouldMatchers {
+  test("extracts details from Github HTTPS URL") {
+    val info = VCSInfo("https://github.com/guardian/contributions-frontend", "98a1cffadbe564d570b15c2113c07a28cbe835ee")
+    info.get.baseUrl shouldBe new URI("https://github.com/guardian/contributions-frontend")
+  }
+
+  test("extracts details from Github git URL") {
+    val info = VCSInfo("git@github.com:guardian/contributions-frontend.git", "98a1cffadbe564d570b15c2113c07a28cbe835ee")
+    info.get.baseUrl shouldBe new URI("https://github.com/guardian/contributions-frontend")
+  }
+}


### PR DESCRIPTION
Also got rid of support for the ancient realm of `git.gudev.gnl` and moved to URI instead of URL because URL does blocking DNS lookups.