### PR TITLE
Change Riff-Raff to be able to deal with templates over 50kB in size

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -17,6 +17,13 @@ object CloudFormation extends DeploymentType {
       |This deployment type is not currently recommended for continuous deployment, as CloudFormation
       |will fail if you try to update a CloudFormation stack with a configuration that matches its
       |current state.
+      |
+      |Note that if your template is over 51,200 bytes then this task relies on a bucket in your account called
+      |`riff-raff-cfn-templates-<accountNumber>`. If it doesn't exist Riff-Raff will try to create it (it will need
+      |permissions to call S3 create bucket and STS get caller identity. If you don't want this to happen then then you
+      |are welcome to create it yourself. Riff-Raff will create it with a lifecycle rule that deletes objects after one
+      |day. Templates over 51,200 bytes will be uploaded to this bucket and sent to CloudFormation using the template
+      |URL parameter.
     """.stripMargin
 
   val cloudformationStackByTags = Param[Boolean]("cloudFormationStackByTags",

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -18,12 +18,12 @@ object CloudFormation extends DeploymentType {
       |will fail if you try to update a CloudFormation stack with a configuration that matches its
       |current state.
       |
-      |Note that if your template is over 51,200 bytes then this task relies on a bucket in your account called
-      |`riff-raff-cfn-templates-<accountNumber>`. If it doesn't exist Riff-Raff will try to create it (it will need
-      |permissions to call S3 create bucket and STS get caller identity. If you don't want this to happen then then you
-      |are welcome to create it yourself. Riff-Raff will create it with a lifecycle rule that deletes objects after one
-      |day. Templates over 51,200 bytes will be uploaded to this bucket and sent to CloudFormation using the template
-      |URL parameter.
+      |Note that if you are using the riff-raff.yaml configuration format or if your template is over 51,200 bytes then
+      |this task relies on a bucket in your account called `riff-raff-cfn-templates-<accountNumber>-<region>`. If it
+      |doesn't exist Riff-Raff will try to create it (it will need permissions to call S3 create bucket and STS get
+      |caller identity. If you don't want this to happen then then you are welcome to create it yourself. Riff-Raff will
+      |create it with a lifecycle rule that deletes objects after one day. Templates over 51,200 bytes will be uploaded
+      |to this bucket and sent to CloudFormation using the template URL parameter.
     """.stripMargin
 
   val cloudformationStackByTags = Param[Boolean]("cloudFormationStackByTags",
@@ -99,6 +99,7 @@ object CloudFormation extends DeploymentType {
       val globalParams = templateParameters(pkg, target, reporter)
       val stageParams = templateStageParameters(pkg, target, reporter).lift.apply(target.parameters.stage.name).getOrElse(Map())
       val params = globalParams ++ stageParams
+      val alwaysUploadToS3 = !pkg.legacyConfig
 
       List(
         UpdateCloudFormationTask(
@@ -111,7 +112,8 @@ object CloudFormation extends DeploymentType {
           resources.lookup.getLatestAmi,
           target.parameters.stage,
           target.stack,
-          createStackIfAbsent(pkg, target, reporter)
+          createStackIfAbsent(pkg, target, reporter),
+          alwaysUploadToS3
         ),
         CheckUpdateEventsTask(target.region, cloudFormationStackLookupStrategy)
       )

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -3,8 +3,9 @@ package magenta.tasks
 import com.amazonaws.AmazonServiceException
 import com.amazonaws.services.cloudformation.model.StackEvent
 import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient
 import magenta.artifact.S3Path
-import magenta.tasks.CloudFormation.{ParameterValue, SpecifiedValue, UseExistingValue}
+import magenta.tasks.CloudFormation._
 import magenta.tasks.UpdateCloudFormationTask.CloudFormationStackLookupStrategy
 import magenta.{DeployReporter, DeployTarget, DeploymentPackage, KeyRing, Region, Stack, Stage}
 import org.joda.time.{DateTime, Duration}
@@ -78,6 +79,19 @@ object UpdateCloudFormationTask {
         orderedTags.map{ case (key, value) => value }.mkString("-")
     }
   }
+
+  def processTemplate(stackName: String, templateBody: String, s3Client: AmazonS3, stsClient: AWSSecurityTokenServiceClient, region: Region): Template = {
+    val templateTooBigForSdkUpload = templateBody.length > 51200
+
+    if (templateTooBigForSdkUpload) {
+      val bucketName = S3.accountSpecificBucket("riff-raff-cfn-templates", s3Client, stsClient, region, Some(1))
+      val keyName = s"$stackName-${new DateTime().getMillis}"
+      s3Client.putObject(bucketName, keyName, templateBody)
+      TemplateUrl(s"s3://$bucketName/$keyName")
+    } else {
+      TemplateBody(templateBody)
+    }
+  }
 }
 
 case class UpdateCloudFormationTask(
@@ -96,6 +110,8 @@ case class UpdateCloudFormationTask(
 
   override def execute(reporter: DeployReporter, stopFlag: => Boolean) = if (!stopFlag) {
     val cfnClient = CloudFormation.makeCfnClient(keyRing, region)
+    val s3Client = S3.makeS3client(keyRing, region)
+    val stsClient = STS.makeSTSclient(keyRing, region)
 
     val maybeCfStack = cloudFormationStackLookupStrategy match {
       case LookupByName(cloudFormationStackName) => CloudFormation.describeStack(cloudFormationStackName, cfnClient)
@@ -121,7 +137,8 @@ case class UpdateCloudFormationTask(
     maybeCfStack match {
       case Some(cloudFormationStackName) =>
         try {
-          CloudFormation.updateStack(cloudFormationStackName.getStackName, templateString, parameters, cfnClient)
+          val template = processTemplate(cloudFormationStackName.getStackName, templateString, s3Client, stsClient, region)
+          CloudFormation.updateStack(cloudFormationStackName.getStackName, template, parameters, cfnClient)
         } catch {
           case ase:AmazonServiceException if ase.getMessage contains "No updates are to be performed." =>
             reporter.info("Cloudformation update has no changes to template or parameters")
@@ -134,7 +151,8 @@ case class UpdateCloudFormationTask(
           val nameToCallStack = UpdateCloudFormationTask.nameToCallNewStack(cloudFormationStackLookupStrategy)
           val stackTags = PartialFunction.condOpt(cloudFormationStackLookupStrategy){ case LookupByTags(tags) => tags }
           reporter.info(s"Stack $cloudFormationStackLookupStrategy doesn't exist. Creating stack using name $nameToCallStack.")
-          CloudFormation.createStack(reporter, nameToCallStack, stackTags, templateString, parameters, cfnClient)
+          val template = processTemplate(nameToCallStack, templateString, s3Client, stsClient, region)
+          CloudFormation.createStack(reporter, nameToCallStack, stackTags, template, parameters, cfnClient)
         } else {
           reporter.fail(s"Stack $cloudFormationStackLookupStrategy doesn't exist and createStackIfAbsent is false")
         }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -31,7 +31,7 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
     inside(CloudFormation.actionsMap("updateStack").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), stack, region))) {
       case List(updateTask, checkTask) =>
         inside(updateTask) {
-          case UpdateCloudFormationTask(taskRegion, stackName, path, userParams, amiParam, amiTags, _, stage, stack, ifAbsent) =>
+          case UpdateCloudFormationTask(taskRegion, stackName, path, userParams, amiParam, amiTags, _, stage, stack, ifAbsent, alwaysUpload) =>
             taskRegion should be(region)
             stackName should be(LookupByName(cfnStackName))
             path should be(S3Path("artifact-bucket", "test/123/cloud-formation/cfn.json"))
@@ -41,6 +41,7 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
             stage should be(PROD)
             stack should be(NamedStack("cfn"))
             ifAbsent should be(true)
+            alwaysUpload shouldBe false
         }
         inside(checkTask) {
           case CheckUpdateEventsTask(taskRegion, updateStackName) =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,6 +34,7 @@ object Dependencies {
     "com.amazonaws" % "aws-java-sdk-elasticloadbalancing" % Versions.aws,
     "com.amazonaws" % "aws-java-sdk-lambda" % Versions.aws,
     "com.amazonaws" % "aws-java-sdk-cloudformation" % Versions.aws,
+    "com.amazonaws" % "aws-java-sdk-sts" % Versions.aws,
     "com.github.scala-incubator.io" %% "scala-io-core" % "0.4.3",
     "com.github.scala-incubator.io" %% "scala-io-file" % "0.4.3",
     "com.gu" %% "management" % Versions.guardianManagement,


### PR DESCRIPTION
If a template body is larger than 50kB in size (51200 bytes) then we cannot use the CloudFormation SDK's `templateBody`. Instead we must upload the template to S3 and use `templateUrl` instead.

In order to avoid dealing with more bucket configuration my suggestion is that we create a unique bucket for the purpose of temporarily storing these templates. This PR creates buckets with the name: `riff-raff-cfn-templates-<accountNumber>-<region>` (with a lifecycle expiration rule of one day). This can be created by hand if preferred. If it exists (or can be created) then the template will be uploaded to an object key that is named using the stack and current time in milliseconds.

This doesn't alter the SDK path when the template is smaller than 50kB.

/cc @TBonnin 