### PR TITLE
Modify ASG tasks to succeed when operating on ASGs of size zero

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -103,9 +103,9 @@ object AutoScaling  extends DeploymentType {
       SuspendAlarmNotifications(pkg, parameters.stage, stack, target.region),
       TagCurrentInstancesWithTerminationTag(pkg, parameters.stage, stack, target.region),
       DoubleSize(pkg, parameters.stage, stack, target.region),
-      HealthcheckGrace(healthcheckGrace(pkg, target, reporter) * 1000),
+      HealthcheckGrace(pkg, parameters.stage, stack, target.region, healthcheckGrace(pkg, target, reporter) * 1000),
       WaitForStabilization(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
-      WarmupGrace(warmupGrace(pkg, target, reporter) * 1000),
+      WarmupGrace(pkg, parameters.stage, stack, target.region, warmupGrace(pkg, target, reporter) * 1000),
       WaitForStabilization(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
       CullInstancesWithTerminationTag(pkg, parameters.stage, stack, target.region),
       ResumeAlarmNotifications(pkg, parameters.stage, stack, target.region)

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -34,9 +34,9 @@ class AutoScalingTest extends FlatSpec with Matchers {
       SuspendAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1")),
       TagCurrentInstancesWithTerminationTag(p, PROD, UnnamedStack, Region("eu-west-1")),
       DoubleSize(p, PROD, UnnamedStack, Region("eu-west-1")),
-      HealthcheckGrace(20000),
+      HealthcheckGrace(p, PROD, UnnamedStack, Region("eu-west-1"), 20000),
       WaitForStabilization(p, PROD, UnnamedStack, 15 * 60 * 1000, Region("eu-west-1")),
-      WarmupGrace(1000),
+      WarmupGrace(p, PROD, UnnamedStack, Region("eu-west-1"), 1000),
       WaitForStabilization(p, PROD, UnnamedStack, 15 * 60 * 1000, Region("eu-west-1")),
       CullInstancesWithTerminationTag(p, PROD, UnnamedStack, Region("eu-west-1")),
       ResumeAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1"))
@@ -77,9 +77,9 @@ class AutoScalingTest extends FlatSpec with Matchers {
       SuspendAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1")),
       TagCurrentInstancesWithTerminationTag(p, PROD, UnnamedStack, Region("eu-west-1")),
       DoubleSize(p, PROD, UnnamedStack, Region("eu-west-1")),
-      HealthcheckGrace(30000),
+      HealthcheckGrace(p, PROD, UnnamedStack, Region("eu-west-1"), 30000),
       WaitForStabilization(p, PROD, UnnamedStack, 3 * 60 * 1000, Region("eu-west-1")),
-      WarmupGrace(20000),
+      WarmupGrace(p, PROD, UnnamedStack, Region("eu-west-1"), 20000),
       WaitForStabilization(p, PROD, UnnamedStack, 3 * 60 * 1000, Region("eu-west-1")),
       CullInstancesWithTerminationTag(p, PROD, UnnamedStack, Region("eu-west-1")),
       ResumeAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1"))

--- a/magenta-lib/src/test/scala/magenta/graph/DeploymentGraphTest.scala
+++ b/magenta-lib/src/test/scala/magenta/graph/DeploymentGraphTest.scala
@@ -2,7 +2,7 @@ package magenta.graph
 
 import com.amazonaws.services.s3.AmazonS3Client
 import magenta.{Host, KeyRing, Region}
-import magenta.tasks.{HealthcheckGrace, S3Upload, SayHello}
+import magenta.tasks.{ChangeSwitch, HealthcheckGrace, S3Upload, SayHello}
 import org.scalatest.{FlatSpec, ShouldMatchers}
 import org.scalatest.mock.MockitoSugar
 
@@ -21,7 +21,7 @@ class DeploymentGraphTest extends FlatSpec with ShouldMatchers with MockitoSugar
   val threeSimpleTasks = List(
     S3Upload(Region("eu-west-1"), "test-bucket", Seq()),
     SayHello(Host("testHost")),
-    HealthcheckGrace(1000)
+    ChangeSwitch(Host("testHost"), "http", 8080, "switchPath", "bobbinSwitch", desiredState = true)
   )
 
 }

--- a/riff-raff/test/deployment/Fixtures.scala
+++ b/riff-raff/test/deployment/Fixtures.scala
@@ -15,12 +15,12 @@ object Fixtures extends MockitoSugar {
   val threeSimpleTasks: List[Task] = List(
     S3Upload(Region("eu-west-1"), "test-bucket", Seq()),
     SayHello(Host("testHost")),
-    HealthcheckGrace(1000)
+    ChangeSwitch(Host("testHost"), "http", 8080, "switchPath", "bobbinSwitch", desiredState = true)
   )
 
   val twoTasks = List(
     S3Upload(Region("eu-west-1"), "test-bucket", Seq()),
-    HealthcheckGrace(1000)
+    ChangeSwitch(Host("testHost"), "http", 8080, "switchPath", "bobbinSwitch", desiredState = true)
   )
 
   val simpleGraph: Graph[DeploymentTasks] = {


### PR DESCRIPTION
In the frontend application there are a couple of applications that don't exist in CODE (only in PROD). This inconsistency is encoded in the goo tool - but should now be dealt with in the unified deploy.

We neither want to add configuration of stages into the configuration file nor silently fail if no matching ASG is found (a missing ASG might indicate a serious problem). The solution seems to be to have a placeholder ASG with desired size = 0.

Unfortunately Riff-Raff currently fails fast when attempting to deploy an application to an ASG of size zero. This PR modifies the behaviour of a few of the ASG tasks to ensure that this condition is handled gracefully.

See also #244 for previous handling change.