### PR TITLE
Cloudformation deployment type fixes

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -44,16 +44,24 @@ object S3 extends AWS {
     * @return
     */
   def accountSpecificBucket(prefix: String, s3Client: AmazonS3, stsClient: AWSSecurityTokenServiceClient,
-    region: Region, deleteAfterDays: Option[Int] = None): String = {
+    region: Region, reporter: DeployReporter, deleteAfterDays: Option[Int] = None): String = {
     val callerIdentityResponse = stsClient.getCallerIdentity(new GetCallerIdentityRequest())
     val accountNumber = callerIdentityResponse.getAccount
     val bucketName = s"$prefix-$accountNumber-${region.name}"
     if (!s3Client.doesBucketExist(bucketName)) {
+      reporter.info(s"Creating bucket for this account and region: $bucketName")
       s3Client.createBucket(bucketName, region.name)
       deleteAfterDays.foreach { days =>
+        val daysString = s"$days day${if(days==1) "" else "s"}"
+        reporter.info(s"Creating lifecycle rule on bucket that deletes objects after $daysString")
         s3Client.setBucketLifecycleConfiguration(
           bucketName,
-          new BucketLifecycleConfiguration(List(new Rule().withExpirationInDays(days)).asJava)
+          new BucketLifecycleConfiguration().withRules(
+            new Rule()
+              .withId(s"Rule to delete objects after $daysString")
+              .withStatus(BucketLifecycleConfiguration.ENABLED)
+              .withExpirationInDays(days)
+          )
         )
       }
     }

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -247,8 +247,13 @@ object CloudFormation extends AWS {
     new AmazonCloudFormationClient(provider(keyRing), clientConfiguration).withRegion(awsRegion(region))
   }
 
-  def validateTemplate(templateBody: String, client: AmazonCloudFormationClient) =
-    client.validateTemplate(new ValidateTemplateRequest().withTemplateBody(templateBody))
+  def validateTemplate(template: Template, client: AmazonCloudFormationClient) = {
+    val request = template match {
+      case TemplateBody(body) => new ValidateTemplateRequest().withTemplateBody(body)
+      case TemplateUrl(url) => new ValidateTemplateRequest().withTemplateURL(url)
+    }
+    client.validateTemplate(request)
+  }
 
   def updateStack(name: String, template: Template, parameters: Map[String, ParameterValue],
     client: AmazonCloudFormationClient) = {


### PR DESCRIPTION
This fixes a few problems with #397 and adds some helpful logging for visibility.

 1. Make sure that the validate template calls are also included in the "template from URL" party
 1. When creating the S3 bucket the lifecycle rule creation needed an ID and a status
 1. The template URL needed to be a real `http://` url rather than a `s3://` url

