### PR TITLE
Append delimiter to S3 'directories' so that object listings are accurate

### DIFF
--- a/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
+++ b/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
@@ -71,19 +71,22 @@ object S3Location extends Loggable {
 case class S3Path(bucket: String, key: String) extends S3Location
 
 object S3Path {
-  def apply(location: S3Location, key: String): S3Path = S3Path(location.bucket, s"${location.key}/$key")
+  def apply(location: S3Location, key: String): S3Path = {
+    val delimiter = if (location.key.endsWith("/")) "" else "/"
+    S3Path(location.bucket, s"${location.key}$delimiter$key")
+  }
 }
 
 case class S3Object(bucket: String, key: String, size: Long) extends S3Location
 
 trait S3Artifact extends S3Location {
   def deployObjectName: String
-  def deployObject = S3Path(bucket, s"$key/$deployObjectName")
+  def deployObject = S3Path(this, deployObjectName)
 }
 
 object S3Artifact {
   def buildPrefix(build: Build): String = {
-    s"${build.projectName}/${build.id}"
+    s"${build.projectName}/${build.id}/"
   }
 }
 

--- a/magenta-lib/src/main/scala/magenta/input/resolver/TaskResolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/TaskResolver.scala
@@ -36,7 +36,7 @@ object TaskResolver {
       pkgApps = Seq(App(deployment.app)),
       pkgSpecificData = deployment.parameters,
       deploymentTypeName = deployment.`type`,
-      s3Package = S3Path(artifact, deployment.contentDirectory),
+      s3Package = S3Path(artifact, s"${deployment.contentDirectory}/"),
       legacyConfig = false,
       deploymentTypes = deploymentTypes
     )

--- a/magenta-lib/src/main/scala/magenta/json/JsonInputFile.scala
+++ b/magenta-lib/src/main/scala/magenta/json/JsonInputFile.scala
@@ -88,7 +88,7 @@ object JsonReader {
       },
       jsonPackage.safeData,
       jsonPackage.`type`,
-      S3Path(artifact, s"packages/${jsonPackage.fileName.getOrElse(name)}"),
+      S3Path(artifact, s"packages/${jsonPackage.fileName.getOrElse(name)}/"),
       legacyConfig = true,
       deploymentTypes
     )

--- a/magenta-lib/src/test/scala/magenta/ResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/ResolverTest.scala
@@ -57,7 +57,7 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
     val taskList: List[Task] = DeploymentGraph.toTaskList(tasks)
     taskList.size should be (1)
     taskList should be (List(
-      S3Upload(Region("eu-west-1"), "test", Seq((new S3Path("artifact-bucket","tmp/123/packages/htmlapp"), "CODE/htmlapp")), publicReadAcl = true)
+      S3Upload(Region("eu-west-1"), "test", Seq((new S3Path("artifact-bucket","tmp/123/packages/htmlapp/"), "CODE/htmlapp")), publicReadAcl = true)
     ))
   }
 

--- a/magenta-lib/src/test/scala/magenta/artifact/S3ArtifactTest.scala
+++ b/magenta-lib/src/test/scala/magenta/artifact/S3ArtifactTest.scala
@@ -8,6 +8,6 @@ class S3ArtifactTest extends FlatSpec with Matchers {
     val build = Build("testProject", "123")
     val artifact = S3JsonArtifact(build, "myBucket")
     artifact.bucket should be("myBucket")
-    artifact.key should be("testProject/123")
+    artifact.key should be("testProject/123/")
   }
 }

--- a/magenta-lib/src/test/scala/magenta/json/JsonReaderTest.scala
+++ b/magenta-lib/src/test/scala/magenta/json/JsonReaderTest.scala
@@ -69,11 +69,11 @@ class JsonReaderTest extends FlatSpec with Matchers {
 
     parsed.packages.size should be (3)
     parsed.packages("index-builder") shouldBe
-      DeploymentPackage("index-builder", Seq(App("index-builder")), Map.empty, "autoscaling", S3Path("artifact-bucket", "test/123/packages/index-builder"), true, deploymentTypes)
+      DeploymentPackage("index-builder", Seq(App("index-builder")), Map.empty, "autoscaling", S3Path("artifact-bucket", "test/123/packages/index-builder/"), true, deploymentTypes)
     parsed.packages("api") shouldBe
-      DeploymentPackage("api", Seq(App("api")), Map("healthcheck_paths" -> Json.arr("/api/index.json","/api/search.json")), "autoscaling", S3Path("artifact-bucket", "test/123/packages/api"), true, deploymentTypes)
+      DeploymentPackage("api", Seq(App("api")), Map("healthcheck_paths" -> Json.arr("/api/index.json","/api/search.json")), "autoscaling", S3Path("artifact-bucket", "test/123/packages/api/"), true, deploymentTypes)
     parsed.packages("solr") shouldBe
-      DeploymentPackage("solr", Seq(App("solr")), Map("port" -> JsString("8400")), "autoscaling", S3Path("artifact-bucket", "test/123/packages/solr"), true, deploymentTypes)
+      DeploymentPackage("solr", Seq(App("solr")), Map("port" -> JsString("8400")), "autoscaling", S3Path("artifact-bucket", "test/123/packages/solr/"), true, deploymentTypes)
 
     val recipes = parsed.recipes
     recipes.size should be (4)
@@ -118,7 +118,7 @@ class JsonReaderTest extends FlatSpec with Matchers {
   "json parser" should "default to using the package name for the file name" in {
     val parsed = JsonReader.parse(minimalExample, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
 
-    parsed.packages("dinky").s3Package should be(S3Path("artifact-bucket", "test/123/packages/dinky"))
+    parsed.packages("dinky").s3Package should be(S3Path("artifact-bucket", "test/123/packages/dinky/"))
   }
 
   val withExplicitFileName = """
@@ -135,6 +135,6 @@ class JsonReaderTest extends FlatSpec with Matchers {
   "json parser" should "use override file name if specified" in {
     val parsed = JsonReader.parse(withExplicitFileName, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
 
-    parsed.packages("dinky").s3Package should be(S3Path("artifact-bucket", "test/123/packages/awkward"))
+    parsed.packages("dinky").s3Package should be(S3Path("artifact-bucket", "test/123/packages/awkward/"))
   }
 }

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -147,7 +147,7 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
     when(artifactClient.listObjectsV2(any[ListObjectsV2Request])).thenReturn(objectResult)
     when(artifactClient.getObject(any[String], any[String])).thenReturn(mockObject("Some content for this S3 object"))
 
-    val packageRoot = new S3Path("artifact-bucket", "test/123/package")
+    val packageRoot = new S3Path("artifact-bucket", "test/123/package/")
     val s3Client = mock[AmazonS3Client]
     val putObjectResult = {
       val por = new PutObjectResult
@@ -182,7 +182,7 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
     when(artifactClient.listObjectsV2(any[ListObjectsV2Request])).thenReturn(objectResult)
     when(artifactClient.getObject(any[String], any[String])).thenReturn(mockObject("Some content for this S3 object"))
 
-    val packageRoot = new S3Path("artifact-bucket", "test/123/package")
+    val packageRoot = new S3Path("artifact-bucket", "test/123/package/")
     val s3Client = mock[AmazonS3Client]
     val putObjectResult = {
       val por = new PutObjectResult
@@ -217,7 +217,7 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
     when(artifactClient.listObjectsV2(any[ListObjectsV2Request])).thenReturn(objectResult)
 
     val patternValues = List(PatternValue("^keyPrefix/sub/", "public; max-age=3600"), PatternValue(".*", "no-cache"))
-    val packageRoot = new S3Path("artifact-bucket", "test/123/package")
+    val packageRoot = new S3Path("artifact-bucket", "test/123/package/")
     val task = new S3Upload(Region("eu-west-1"), "bucket", Seq(packageRoot -> "keyPrefix"), cacheControlPatterns = patternValues)(fakeKeyRing, artifactClient)
 
     task.requests.find(_.source == fileOne).get.cacheControl should be(Some("no-cache"))
@@ -233,7 +233,7 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
     when(artifactClient.listObjectsV2(any[ListObjectsV2Request])).thenReturn(objectResult)
 
     val mimeTypes = Map("xpi" -> "application/x-xpinstall")
-    val packageRoot = new S3Path("artifact-bucket", "test/123/package")
+    val packageRoot = new S3Path("artifact-bucket", "test/123/package/")
     val task = new S3Upload(Region("eu-west-1"), "bucket", Seq(packageRoot -> ""), extensionToMimeType = mimeTypes)(fakeKeyRing, artifactClient)
 
     task.requests.find(_.source == fileOne).get.contentType should be(None)


### PR DESCRIPTION
Without the delimiter, a listing might include objects from another 'directory' at the same level that happens to share the same prefix.

e.g. Given this bucket layout:
```
`- topLevel
    |- subDir
    |- subDir2
    `- anotherDir
```

Then asking for the contents of `topLevel/subDir` will provide the contents of both `subDir` and `subDir2`. Asking for the contents of `topLevel/subDir/` however will return only the contents of `subDir`.

This PR appends a `/` character in a number of locations such that the listings of artifacts and packages don't unintentionally include files from other artifacts or packages.