### PR TITLE
Add pages to view and download artifact files

### DIFF
--- a/riff-raff/app/views/artifact/listFiles.scala.html
+++ b/riff-raff/app/views/artifact/listFiles.scala.html
@@ -1,0 +1,21 @@
+@import magenta.artifact.S3Object
+@(request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], projectName: String, id: String, objects: Seq[(String, S3Object)])
+
+@main(s"Artifact files for $projectName / $id", request) {
+    <h2>Artifact listing for @projectName build @id</h2>
+    <hr/>
+    <div>
+        @if(objects.isEmpty) {
+            No files
+        } else {
+            <table class="table table-condensed">
+                <thead><tr><td>Key</td><td class="text-right">Object size (bytes)</td></tr></thead>
+                <tbody>
+                @for((path, obj) <- objects) {
+                    <tr><td><a href="@routes.DeployController.getArtifactFile(obj.key)">@path</a></td><td class="text-right">@obj.size</td></tr>
+                }
+                </tbody>
+            </table>
+        }
+    </div>
+}

--- a/riff-raff/app/views/deploy/viewDeploy.scala.html
+++ b/riff-raff/app/views/deploy/viewDeploy.scala.html
@@ -61,8 +61,18 @@
                 </div>
             }
             <div class="actions pull-right"><p>
-                <a class="btn btn-default" href="@routes.DeployController.deployAgainUuid(record.uuid.toString)" role="button">Deploy Again</a>
-                <a class="btn btn-default" href="@routes.DeployController.deployConfig(record.buildName, record.buildId)" role="button">See configuration</a>
+                <div class="btn-group" role="group">
+                    <a class="btn btn-default" href="@routes.DeployController.deployAgainUuid(record.uuid.toString)" role="button">Deploy Again</a>
+                    <div class="btn-group">
+                        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            Show <span class="caret"></span>
+                        </button>
+                        <ul class="dropdown-menu">
+                            <li><a href="@routes.DeployController.deployConfig(record.buildName, record.buildId)">Configuration</a></li>
+                            <li><a href="@routes.DeployController.deployFiles(record.buildName, record.buildId)">Artifact files</a></li>
+                        </ul>
+                    </div>
+                </div>
             </p></div>
         </div>
     </div>

--- a/riff-raff/app/views/preview/yaml/preview.scala.html
+++ b/riff-raff/app/views/preview/yaml/preview.scala.html
@@ -9,18 +9,34 @@
     <h3>Preview of deployments for @parameters.build.projectName</h3>
 
     <div>
-        <dl class="dl-horizontal">
-            <dt>Project</dt><dd>@parameters.build.projectName</dd>
-            <dt>Build</dt><dd>@parameters.build.id</dd>
-            <dt>Stage</dt><dd>@parameters.stage.name</dd>
-            @parameters.selector match {
-                case All => {}
-                case DeploymentKeysSelector(keys) => {
-                    <dt>Deployment selections</dt><dd>@keys.map{ key => <div>@snippets.deploymentInstance(key)</div> }</dd>
+        <div class="pull-left">
+            <dl class="dl-horizontal">
+                <dt>Project</dt><dd>@parameters.build.projectName</dd>
+                <dt>Build</dt><dd>@parameters.build.id</dd>
+                <dt>Stage</dt><dd>@parameters.stage.name</dd>
+                @parameters.selector match {
+                    case All => {}
+                    case DeploymentKeysSelector(keys) => {
+                        <dt>Deployment selections</dt><dd>@keys.map{ key => <div>@snippets.deploymentInstance(key)</div> }</dd>
+                    }
                 }
-            }
-        </dl>
+            </dl>
+        </div>
+
+        <div class="actions pull-right"><p>
+            <div class="btn-group">
+                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    Show <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu">
+                    <li><a href="@routes.DeployController.deployConfig(parameters.build.projectName, parameters.build.id)">Configuration</a></li>
+                    <li><a href="@routes.DeployController.deployFiles(parameters.build.projectName, parameters.build.id)">Files</a></li>
+                </ul>
+            </div>
+        </p></div>
     </div>
+
+    <div class="clearfix"></div>
 
     <div class="content"
       data-ajax-refresh="@routes.PreviewController.showTasks(previewId: String)">

--- a/riff-raff/app/views/snippets/recordTable.scala.html
+++ b/riff-raff/app/views/snippets/recordTable.scala.html
@@ -67,6 +67,7 @@
                         @vcsInfo.map { info => <li><a href="@info.commitUrl">View commit on <strong>@info.name</strong></a></li> }
                         <li><a href="@routes.DeployController.deployAgainUuid(record.uuid.toString)">Deploy again</a></li>
                         <li><a href="@routes.DeployController.deployConfig(record.parameters.build.projectName, record.parameters.build.id)">See configuration</a></li>
+                        <li><a href="@routes.DeployController.deployFiles(record.parameters.build.projectName, record.parameters.build.id)">See files</a></li>
                         @maybeFilter.map { filter =>
                             <li role="separator" class="divider"></li>
                             <li><a href="@{

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -51,6 +51,8 @@ GET         /deployment/dashboard                           controllers.DeployCo
 GET         /deployment/dashboard/content                   controllers.DeployController.dashboardContent(projects:String, search:Boolean?=false)
 
 GET         /deployment/request/deployConfig                controllers.DeployController.deployConfig(projectName:String, id:String)
+GET         /deployment/request/deployFiles                 controllers.DeployController.deployFiles(projectName:String, id:String)
+GET         /deployment/request/artifactFile/*key           controllers.DeployController.getArtifactFile(key:String)
 
 # Continuous deployment
 GET         /deployment/continuous                          controllers.ContinuousDeployController.list


### PR DESCRIPTION
This adds a super simple artifact listing that shows the list of files that are available to riff-raff. This is helpful for debugging why things are not working as expected. It is also possible to download the files directly via Riff-Raff. I don't think this should be a security issue, but it's possible teams are putting secret data in their deployable artifacts.

I've added links to access this from the preview, history and deploy log pages.

Looks like this:

<img width="739" alt="screen shot 2016-12-01 at 18 08 37" src="https://cloud.githubusercontent.com/assets/1236466/20806086/5fe58a44-b7f1-11e6-9e68-be9779e3f0fa.png">


 /cc @adamnfish 