### PR TITLE
Wait again for stabilisation after instance termination

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -64,6 +64,7 @@ object AutoScaling  extends DeploymentType {
   val secondsToWait = Param("secondsToWait", "Number of seconds to wait for instances to enter service").default(15 * 60)
   val healthcheckGrace = Param("healthcheckGrace", "Number of seconds to wait for the AWS api to stabilise").default(20)
   val warmupGrace = Param("warmupGrace", "Number of seconds to wait for the instances in the load balancer to warm up").default(1)
+  val terminationGrace = Param("terminationGrace", "Number of seconds to wait for the AWS api to stabilise after instance termination").default(10)
 
   val prefixStage = Param[Boolean]("prefixStage",
     documentation = "Whether to prefix `stage` to the S3 location"
@@ -108,6 +109,8 @@ object AutoScaling  extends DeploymentType {
       WarmupGrace(pkg, parameters.stage, stack, target.region, warmupGrace(pkg, target, reporter) * 1000),
       WaitForStabilization(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
       CullInstancesWithTerminationTag(pkg, parameters.stage, stack, target.region),
+      TerminationGrace(pkg, parameters.stage, stack, target.region, terminationGrace(pkg, target, reporter) * 1000),
+      WaitForStabilization(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
       ResumeAlarmNotifications(pkg, parameters.stage, stack, target.region)
     )
   }

--- a/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
@@ -63,6 +63,10 @@ case class WarmupGrace(pkg: DeploymentPackage, stage: Stage, stack: Stack, regio
   def description: String = s"Wait extra ${durationMillis}ms to let instances in Load Balancer warm up"
 }
 
+case class TerminationGrace(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region, durationMillis: Long)(implicit keyRing: KeyRing) extends Pause(durationMillis) {
+  def description: String = s"Wait extra ${durationMillis}ms to let Load Balancer report correctly"
+}
+
 case class CheckForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
   override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScalingClient) {
     implicit val elbClient = ELB.makeElbClient(keyRing, region)

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -39,6 +39,8 @@ class AutoScalingTest extends FlatSpec with Matchers {
       WarmupGrace(p, PROD, UnnamedStack, Region("eu-west-1"), 1000),
       WaitForStabilization(p, PROD, UnnamedStack, 15 * 60 * 1000, Region("eu-west-1")),
       CullInstancesWithTerminationTag(p, PROD, UnnamedStack, Region("eu-west-1")),
+      TerminationGrace(p, PROD, UnnamedStack, Region("eu-west-1"), 10000),
+      WaitForStabilization(p, PROD, UnnamedStack, 15 * 60 * 1000, Region("eu-west-1")),
       ResumeAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1"))
     ))
   }
@@ -63,7 +65,8 @@ class AutoScalingTest extends FlatSpec with Matchers {
       "bucket" -> JsString("asg-bucket"),
       "secondsToWait" -> JsNumber(3 * 60),
       "healthcheckGrace" -> JsNumber(30),
-      "warmupGrace" -> JsNumber(20)
+      "warmupGrace" -> JsNumber(20),
+      "terminationGrace" -> JsNumber(11)
     )
 
     val app = Seq(App("app"))
@@ -82,6 +85,8 @@ class AutoScalingTest extends FlatSpec with Matchers {
       WarmupGrace(p, PROD, UnnamedStack, Region("eu-west-1"), 20000),
       WaitForStabilization(p, PROD, UnnamedStack, 3 * 60 * 1000, Region("eu-west-1")),
       CullInstancesWithTerminationTag(p, PROD, UnnamedStack, Region("eu-west-1")),
+      TerminationGrace(p, PROD, UnnamedStack, Region("eu-west-1"), 11000),
+      WaitForStabilization(p, PROD, UnnamedStack, 3 * 60 * 1000, Region("eu-west-1")),
       ResumeAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1"))
     ))
   }


### PR DESCRIPTION
Fixing `CheckForStabilization` in #391 has revealed that an ASG can continue to be unstable after a deploy has completed. This happens because the `CullInstancesWithTerminationTag` task is asynchronous and causes an ASG to become unstable again (the ASG desired number < actual number) whilst the ASG kills off the excess instances. 

This state doesn't last for long, but long enough that the `CheckForStabilization` task of a subsequent deploy can fail if it runs immediately after the initial deploy.

This PR introduces a small pause and then a further execution of the `WaitForStabilization` task to wait for the ASG to become stable again. I believe that this should probably only add the pause (default 10s) to most deploys, but might add another 30s if the check doesn't immediately pass.