### PR TITLE
Add buttons to select / deselect all of the tasks

### DIFF
--- a/riff-raff/app/views/preview/yaml/preview.scala.html
+++ b/riff-raff/app/views/preview/yaml/preview.scala.html
@@ -4,7 +4,7 @@
         parameters: magenta.DeployParameters,
         previewId: String)
 
-@main("Preview", request, List("auto-refresh")) {
+@main("Preview", request, List("auto-refresh", "checkbox-selection")) {
 
     <h3>Preview of deployments for @parameters.build.projectName</h3>
 
@@ -24,14 +24,22 @@
         </div>
 
         <div class="actions pull-right"><p>
-            <div class="btn-group">
-                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                    Show <span class="caret"></span>
+            <div class="btn-group" role="group" aria-label="...">
+                <button type="button" class="btn btn-default" data-checkbox-target=".task-selection" data-checkbox-state="true">
+                    <span class="glyphicon glyphicon-check" aria-hidden="true"></span> Select all
                 </button>
-                <ul class="dropdown-menu">
-                    <li><a href="@routes.DeployController.deployConfig(parameters.build.projectName, parameters.build.id)">Configuration</a></li>
-                    <li><a href="@routes.DeployController.deployFiles(parameters.build.projectName, parameters.build.id)">Files</a></li>
-                </ul>
+                <button type="button" class="btn btn-default" data-checkbox-target=".task-selection" data-checkbox-state="false">
+                    <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span> Deselect all
+                </button>
+                <div class="btn-group">
+                    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        Show <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu">
+                        <li><a href="@routes.DeployController.deployConfig(parameters.build.projectName, parameters.build.id)">Configuration</a></li>
+                        <li><a href="@routes.DeployController.deployFiles(parameters.build.projectName, parameters.build.id)">Files</a></li>
+                    </ul>
+                </div>
             </div>
         </p></div>
     </div>

--- a/riff-raff/app/views/preview/yaml/showTasks.scala.html
+++ b/riff-raff/app/views/preview/yaml/showTasks.scala.html
@@ -41,6 +41,7 @@ to make it fit in the Play idea of forms but it's far from trivial. Be warned!
                         <span>
                             @b3.checkbox(
                                 form("selectedKeys[]"),
+                                'class -> "task-selection",
                                 'value -> DeploymentKey.asString(key),
                                 'checked -> checkedKeys.contains(key),
                                 '_label -> Html("Run tasks")


### PR DESCRIPTION
Deploying only one or tow tasks can be quite painful at the moment. This adds buttons that deselect and select all of the tasks in a YAML preview.

<img width="733" alt="screen shot 2016-12-12 at 12 40 23" src="https://cloud.githubusercontent.com/assets/1236466/21099824/4df63886-c068-11e6-847e-8bad1dd119ed.png">
