### PR TITLE
Better logs

### DIFF
--- a/riff-raff/app/assets/javascripts/deploy-verbose.coffee
+++ b/riff-raff/app/assets/javascripts/deploy-verbose.coffee
@@ -30,10 +30,10 @@ getParamOrElse = (url, param, defaultValue) ->
   if match==null then defaultValue else match[1]
 
 enableVerbose = ->
-  updateCSS("span.message-verbose",{'display':'list-item'})
+  updateCSS(".visibility-verbose",{'display':'inline'})
 
 disableVerbose = ->
-  updateCSS("span.message-verbose",{'display':'none'})
+  updateCSS(".visibility-verbose",{'display':'none'})
 
 setVerbose = (visible) ->
   if (visible)

--- a/riff-raff/app/assets/javascripts/deploy-verbose.coffee
+++ b/riff-raff/app/assets/javascripts/deploy-verbose.coffee
@@ -51,6 +51,7 @@ updateAndPush = ->
   newURL = updateOrAddParam(document.URL, 'verbose', verboseParam)
   window.history.pushState(null,null,newURL)
   mixpanel? && mixpanel.track "Verbose toggled", {"verbose": newState}
+  true
 
 popstate = (event) ->
   verbose = getParamOrElse(document.URL, 'verbose', '0')=='1'

--- a/riff-raff/app/assets/javascripts/report-tree-collapsing.coffee
+++ b/riff-raff/app/assets/javascripts/report-tree-collapsing.coffee
@@ -1,0 +1,18 @@
+setupCallbacks = ->
+  console.log 'setting up'
+  $(".collapsing-node").on 'show.bs.collapse', (e) ->
+    iconId = e.target.id+'-icon'
+    element = $('#'+iconId)
+    element.removeClass('glyphicon-chevron-right')
+    element.addClass('glyphicon-chevron-down')
+  $(".collapsing-node").on 'hide.bs.collapse', (e) ->
+    iconId = e.target.id+'-icon'
+    element = $('#'+iconId)
+    element.removeClass('glyphicon-chevron-down')
+    element.addClass('glyphicon-chevron-right')
+
+
+$ ->
+  if (window.autoRefresh)
+    window.autoRefresh.postRefresh ->
+      setupCallbacks()

--- a/riff-raff/app/assets/stylesheets/magenta.less
+++ b/riff-raff/app/assets/stylesheets/magenta.less
@@ -55,7 +55,8 @@ table.table-auto-width {
 
 ul.magenta-reporttree,
 ul.magenta-list {
-    list-style: none;
+  list-style: none;
+  padding-left: 15px;
 }
 
 .magenta-timestamp {
@@ -63,6 +64,10 @@ ul.magenta-list {
 }
 .magenta-timestamp {
   display:inline
+}
+
+.visibility-tasklist {
+  display: none;
 }
 
 .message-commandoutput,
@@ -199,4 +204,8 @@ div.deployment-target:target {
       }
     }
   }
+}
+
+.display-inline {
+  display: inline;
 }

--- a/riff-raff/app/deployment/model.scala
+++ b/riff-raff/app/deployment/model.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import ci.{Builds, S3Build}
 import com.gu.googleauth.UserIdentity
 import controllers.ApiKey
-import magenta.{DeployParameters, ReportTree, _}
+import magenta._
 import org.joda.time.{DateTime, Duration, Interval}
 import org.joda.time.format.PeriodFormatterBuilder
 import utils.VCSInfo
@@ -44,7 +44,7 @@ trait Record {
   def uuid: UUID
   def parameters: DeployParameters
   def metaData: Map[String, String]
-  def report: ReportTree
+  def report: DeployReport
   def recordState: Option[RunState.Value]
   def recordTotalTasks: Option[Int]
   def recordCompletedTasks: Option[Int]
@@ -147,7 +147,7 @@ case class DeployRecord(time: DateTime,
                            recordTotalTasks: Option[Int] = None,
                            recordCompletedTasks: Option[Int] = None,
                            recordLastActivityTime: Option[DateTime] = None) extends Record {
-  lazy val report = DeployReport(messages, "Deployment Report")
+  lazy val report = DeployReport(messages)
 
   def +(message: MessageWrapper): DeployRecord = {
     this.copy(messages = messages ++ List(message))

--- a/riff-raff/app/views/deploy/logContent.scala.html
+++ b/riff-raff/app/views/deploy/logContent.scala.html
@@ -1,13 +1,23 @@
 @(record: deployment.Record)
+@import magenta.DeployReportTree
+@import magenta.EmptyDeployReport
 
 @logSummary(record)
 
 @if(!record.isSummarised) {
-    <ul class="magenta-reporttree">
-        @snippets.reportTree(record.report)
-    </ul>
+    @record.report match {
+        case report : DeployReportTree => {
+            <ul class="magenta-reporttree">
+                @snippets.reportTree(report, 0)
+            </ul>
+            @logSummary(record)
+        }
+        case EmptyDeployReport => {
+            <p>Deployment log has not yet been written to.</p>
+        }
+    }
 
-    @logSummary(record)
+
 }
 
 @if(record.isDone){

--- a/riff-raff/app/views/deploy/viewDeploy.scala.html
+++ b/riff-raff/app/views/deploy/viewDeploy.scala.html
@@ -13,9 +13,9 @@
         }
 </script>
 
-@main(s"Deploy for ${record.buildName}", request, List("auto-refresh", "deploy-verbose", "stop-deploy", "notifications")) {
+@main(s"Deploy for ${record.buildName}", request, List("auto-refresh", "deploy-verbose", "stop-deploy", "notifications", "report-tree-collapsing")) {
     <style>
-    span.message-verbose {
+    .visibility-verbose {
       display:@if(!verbose) {none} else {list-item};
     }
     </style>

--- a/riff-raff/app/views/html/helper/magenta/MessageHelper.scala
+++ b/riff-raff/app/views/html/helper/magenta/MessageHelper.scala
@@ -4,8 +4,8 @@ import magenta._
 import play.twirl.api.Html
 
 object MessageHelper {
-  def stateClassName(state: RunState.Value): String = {
-    state match {
+  def state(reportNode:DeployReport): String = {
+    reportNode.cascadeState match {
       case RunState.Running => "state-running"
       case RunState.NotRunning => "state-not-running"
       case RunState.ChildRunning => "state-child-running"
@@ -13,11 +13,8 @@ object MessageHelper {
       case RunState.Failed => "state-failed"
     }
   }
-  def messageClassName(message: Message): String = {
-    message.getClass.getName.toLowerCase.replace("magenta.","message-")
-  }
-  def classNames(reportNode:ReportTree): String = {
-    List(stateClassName(reportNode.cascadeState), messageClassName(reportNode.message)).mkString(" ")
+  def messageType(reportNode:DeployReport): String = {
+    reportNode.message.getClass.getName.toLowerCase.replace("magenta.","")
   }
   def trim(html:Html): Html = { Html(html.body.trim) }
 }

--- a/riff-raff/app/views/snippets/reportTree.scala.html
+++ b/riff-raff/app/views/snippets/reportTree.scala.html
@@ -1,14 +1,26 @@
-@(reportTree: magenta.ReportTree)
+@(reportTree: magenta.DeployReportTree, depth: Int)
+@import magenta.RunState
 
 <li>
-<span class="@MessageHelper.classNames(reportTree)"><span class="magenta-timestamp">[@reportTree.messageState.timeOfDay] </span>@MessageHelper.trim{@reportTree.message.text}</span>
-@if(reportTree.children.nonEmpty) {
-  <ul class="magenta-reporttree">
-}
-@reportTree.children.map{ child =>
-    @snippets.reportTree(child)
-}
-@if(reportTree.children.nonEmpty) {
-  </ul>
-}
+    @defining((MessageHelper.messageType(reportTree), MessageHelper.state(reportTree), reportTree.messageState.messageId.toString)){ case (messageType, state, id) =>
+        @defining(reportTree.cascadeState != RunState.Completed || depth < 1) { open =>
+            <span class="visibility-@messageType">
+                <span class="display-inline" role="button" data-toggle="collapse" href="#@id" aria-expanded="false" aria-controls="@id">
+                @if(reportTree.hasChildren) {
+                    <span id="@id-icon" class="glyphicon glyphicon-chevron-@if(open){down}else{right}"></span>
+                } else {
+                    <span class="glyphicon">&nbsp;</span>
+                }
+                </span>
+                <span class="message-@messageType @state">@reportTree.timeString.map{time => <span class="magenta-timestamp">[@time] </span>}@MessageHelper.trim{@reportTree.message.text}</span>
+            </span>
+            @if(reportTree.children.nonEmpty) {
+                <ul id="@id" class="collapsing-node magenta-reporttree collapse@if(open){ in}">
+                    @reportTree.children.map{ child =>
+                        @snippets.reportTree(child, depth + 1)
+                    }
+                </ul>
+            }
+        }
+    }
 </li>

--- a/riff-raff/app/views/test/reportTest.scala.html
+++ b/riff-raff/app/views/test/reportTest.scala.html
@@ -4,7 +4,7 @@
     <!-- verbose @verbose -->
     @if(!verbose) {
         <style>
-        span.message-verbose {
+        .visibility-verbose {
             display:none;
         }
         </style>


### PR DESCRIPTION
Large logs are hard to grok at the moment - especially to find the errors. This change makes the logs collapsible and will automatically collapse successfully completed branches. However if a branch fails then it will by default be unfurled making it easy to identify the problems.

In order to do this the `DeployReport` code has been overhauled so as to expose the UUID of each log entry in the tree (in the process a superfluous top level of the tree has been removed and an `EmptyDeployReport` has been introduced). This provides an easy to use ID for targeting in the DOM using the standard bootstrap collapse feature. On top of this there is a little coffeescript that switches out the chevrons when you furl and unfurl part of the tree.

The dotcom deploy is most improved by this. A successful deploy now looks like this (two pages instead of a dozen):
![screen shot 2016-12-21 at 14 18 32](https://cloud.githubusercontent.com/assets/1236466/21392581/7638df7a-c788-11e6-84b4-92f8599aba68.png)

In much the same way that selecting text can't be done whilst a deploy is running, it is not possible to unfurl parts of a still running deploy. Fixing this will require some smarter update code.