### PR TITLE
Improved exception handling

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -1,6 +1,7 @@
 package magenta.tasks
 
 import java.nio.ByteBuffer
+import javax.xml.stream.XMLStreamException
 
 import com.amazonaws.{AmazonClientException, AmazonWebServiceRequest, ClientConfiguration}
 import com.amazonaws.auth.{AWSCredentialsProvider, AWSCredentialsProviderChain, BasicAWSCredentials}
@@ -431,20 +432,30 @@ trait AWS extends Loggable {
 
   def awsRegion(region: Region): AwsRegion = RegionUtils.getRegion(region.name)
 
-  /* A retry condition that logs errors */
-  class LoggingRetryCondition extends SDKDefaultRetryCondition {
-    def exceptionInfo(e: Throwable): String = {
+  /* A retry condition that logs errors and retries on ParseExceptions.
+   * The parse conditions result under heavy load by all accounts and are not in the default retry policy due to
+   * not knowing whether the query is idempotent or not. There is more discussion about this at
+   * https://github.com/aws/aws-sdk-java/issues/892
+   * */
+  class RiffRaffRetryCondition extends SDKDefaultRetryCondition {
+    private def exceptionInfo(e: Throwable): String = {
       s"${e.getClass.getName} ${e.getMessage} Cause: ${Option(e.getCause).map(e => exceptionInfo(e))}"
     }
+    private def isParseException(exception: AmazonClientException): Boolean = {
+      exception.getCause match {
+        case xse:XMLStreamException if xse.getMessage.startsWith("ParseError at") => true
+        case _ => false
+      }
+    }
     override def shouldRetry(originalRequest: AmazonWebServiceRequest, exception: AmazonClientException, retriesAttempted: Int): Boolean = {
-      val willRetry = super.shouldRetry(originalRequest, exception, retriesAttempted)
+      val willRetry = super.shouldRetry(originalRequest, exception, retriesAttempted) || isParseException(exception)
       if (willRetry) logger.warn(s"AWS SDK retry $retriesAttempted: ${originalRequest.getClass.getName} threw ${exceptionInfo(exception)}")
       willRetry
     }
   }
   val clientConfiguration = new ClientConfiguration().
     withRetryPolicy(new RetryPolicy(
-      new LoggingRetryCondition(),
+      new RiffRaffRetryCondition(),
       PredefinedRetryPolicies.DEFAULT_BACKOFF_STRATEGY,
       20,
       false


### PR DESCRIPTION
This addresses #413 and should also eliminate the *DeploymentRunner unexpectedly terminated* messages.

The first of these is achieved by modifying the custom retry policy to retry on this one specific `XMLStreamException` (when the message starts with `ParseError at`).

The second is caused by `TasksRunner` actors throwing exceptions. The `DeployGroupRunner` actor watches the child `TasksRunner` actors that it creates so it is notified of unexpected terminations. In this case though the exception is expected and it is communicated back via a message. Unfortunately the exception is re-thrown (for the side effect of sending the appropriate error message to the `DeployReporter`). In order to prevent the Actor terminating we re-catch and blackhole NonFatal exceptions. The Actor will then be cleaned up when the `DeployGroupRunner` actor is cleaned up.