### PR TITLE
Restrictions improvements

### DIFF
--- a/riff-raff/app/controllers/Restrictions.scala
+++ b/riff-raff/app/controllers/Restrictions.scala
@@ -29,7 +29,7 @@ class Restrictions()(implicit val messagesApi: MessagesApi, val wsClient: WSClie
       "note" -> nonEmptyText
     )((id, projectName, stage, editingLocked, whitelist, cdPermitted, note) =>
       RestrictionForm(id, projectName, stage, editingLocked,
-        whitelist.map(_.split('\n').toSeq.filter(_.nonEmpty)).getOrElse(Seq.empty), cdPermitted, note)
+        whitelist.map(_.split('\n').map(_.trim).toSeq.filter(_.nonEmpty)).getOrElse(Seq.empty), cdPermitted, note)
     )(f =>
       Some((f.id, f.projectName, f.stage, f.editingLocked, Some(f.whitelist.mkString("\n")),
         f.continuousDeployment,  f.note))

--- a/riff-raff/app/views/deploy/deployHistory.scala.html
+++ b/riff-raff/app/views/deploy/deployHistory.scala.html
@@ -1,5 +1,17 @@
-@(projectName: String, maybeStage: Option[String], records: List[deployment.Record])
+@import _root_.restrictions.RestrictionConfig
+@(projectName: String, maybeStage: Option[String], records: List[deployment.Record], restrictions: Seq[RestrictionConfig])
 
+@if(restrictions.nonEmpty) {
+    <div class="alert alert-warning" role="alert">
+        <p><strong>Deployment restricted</strong></p> <p>There are currently <a href="@routes.Restrictions.list()">restrictions</a>
+            that prevent you from deploying <strong>@projectName</strong>@maybeStage.map{ stage => to <strong>@stage</strong>}:</p>
+        @restrictions.map { restriction =>
+            <p>
+                @restriction.fullName: @restriction.note <a class="alert-link" href="@routes.Restrictions.edit(restriction.id.toString)">View details</a>
+            </p>
+        }
+    </div>
+}
 @if(records.nonEmpty) {
     <h4>Last deploys of <em>@projectName</em> @maybeStage.map{ stage => to @stage }</h4>
     @snippets.recordTable(records, None, allColumns = false)
@@ -9,5 +21,4 @@
         <span class="sr-only">Error:</span>
         Riff Raff has not been used to deploy @projectName @maybeStage.map{ stage => to @stage }
     </div>
-
 }


### PR DESCRIPTION
A minor fix and an improvement for restrictions.

First up, a bug that @TBonnin mentioned - `\r` characters were not correctly stripped from e-mail addresses in the whitelist meaning it would not correctly match users.

Secondly, it makes sense for users to get feedback early that a deploy will not be possible. A message is now shown to the right of the deploy form when a restriction is in force that matches the project and stage.

<img width="924" alt="screen shot 2016-12-23 at 12 25 14" src="https://cloud.githubusercontent.com/assets/1236466/21453821/f3f20f3a-c90a-11e6-99ec-a626a1f56d3c.png">
