### PR TITLE
Allow updates to multiple AMI parameters

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
@@ -1,5 +1,6 @@
 package magenta.deployment_type
 
+import magenta.deployment_type.CloudFormation.{CfnParam, TagCriteria}
 import magenta.tasks.UpdateCloudFormationTask.{LookupByName, LookupByTags}
 import magenta.tasks.{CheckUpdateEventsTask, UpdateAmiCloudFormationParameterTask}
 
@@ -33,7 +34,7 @@ object AmiCloudFormationParameter extends DeploymentType {
   val amiParameter = Param[String]("amiParameter",
     documentation = "The CloudFormation parameter name for the AMI"
   ).default("AMI")
-  val amiParametersToTags = Param[Map[String, Map[String, String]]]("amiParametersToTags",
+  val amiParametersToTags = Param[Map[CfnParam, TagCriteria]]("amiParametersToTags",
     documentation =
       """AMI cloudformation parameter names mapped to the set of tags that should be used to look up an AMI.
       """.stripMargin
@@ -48,7 +49,7 @@ object AmiCloudFormationParameter extends DeploymentType {
       implicit val keyRing = resources.assembleKeyring(target, pkg)
       val reporter = resources.reporter
 
-      val amiParameterMap: Map[String, Map[String, String]] = (amiParametersToTags.get(pkg), amiTags.get(pkg)) match {
+      val amiParameterMap: Map[CfnParam, TagCriteria] = (amiParametersToTags.get(pkg), amiTags.get(pkg)) match {
         case (Some(parametersToTags), Some(tags)) =>
           reporter.warning("Both amiParametersToTags and amiTags supplied. Ignoring amiTags.")
           parametersToTags

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
@@ -33,7 +33,7 @@ object AmiCloudFormationParameter extends DeploymentType {
   val amiParameter = Param[String]("amiParameter",
     documentation = "The CloudFormation parameter name for the AMI"
   ).default("AMI")
-  val amiParametersToTags=Param[Map[String, Map[String, String]]]("amiParametersToTags",
+  val amiParametersToTags = Param[Map[String, Map[String, String]]]("amiParametersToTags",
     documentation =
       """AMI cloudformation parameter names mapped to the set of tags that should be used to look up an AMI.
       """.stripMargin

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -72,7 +72,7 @@ object CloudFormation extends DeploymentType {
   val amiParameter = Param[String]("amiParameter",
     documentation = "The CloudFormation parameter name for the AMI"
   ).default("AMI")
-  val amiParametersToTags=Param[Map[String, Map[String, String]]]("amiParametersToTags",
+  val amiParametersToTags = Param[Map[String, Map[String, String]]]("amiParametersToTags",
     documentation =
       """AMI cloudformation parameter names mapped to the set of tags that should be used to look up an AMI.
       """.stripMargin

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -64,12 +64,19 @@ object CloudFormation extends DeploymentType {
   val createStackIfAbsent = Param[Boolean]("createStackIfAbsent",
     documentation = "If set to true then the cloudformation stack will be created if it doesn't already exist"
   ).default(true)
-  val amiTags = Param[Map[String,String]]("amiTags",
+
+
+  val amiTags = Param[Map[String, String]]("amiTags",
     documentation = "Specify the set of tags to use to find the latest AMI"
-  ).default(Map.empty)
+  )
   val amiParameter = Param[String]("amiParameter",
     documentation = "The CloudFormation parameter name for the AMI"
   ).default("AMI")
+  val amiParametersToTags=Param[Map[String, Map[String, String]]]("amiParametersToTags",
+    documentation =
+      """AMI cloudformation parameter names mapped to the set of tags that should be used to look up an AMI.
+      """.stripMargin
+  )
 
   val updateStack = Action("updateStack",
     """
@@ -81,6 +88,15 @@ object CloudFormation extends DeploymentType {
       implicit val keyRing = resources.assembleKeyring(target, pkg)
       implicit val artifactClient = resources.artifactClient
       val reporter = resources.reporter
+
+      val amiParameterMap: Map[String, Map[String, String]] = (amiParametersToTags.get(pkg), amiTags.get(pkg)) match {
+        case (Some(parametersToTags), Some(tags)) =>
+          reporter.warning("Both amiParametersToTags and amiTags supplied. Ignoring amiTags.")
+          parametersToTags
+        case (Some(parametersToTags), _) => parametersToTags
+        case (None, Some(tags)) => Map(amiParameter(pkg, target, reporter) -> tags)
+        case _ => Map.empty
+      }
 
       val cloudFormationStackLookupStrategy = {
         if (cloudformationStackByTags(pkg, target, reporter)) {
@@ -107,8 +123,7 @@ object CloudFormation extends DeploymentType {
           cloudFormationStackLookupStrategy,
           S3Path(pkg.s3Package, templatePath(pkg, target, reporter)),
           params,
-          amiParameter(pkg, target, reporter),
-          amiTags(pkg, target, reporter),
+          amiParameterMap,
           resources.lookup.getLatestAmi,
           target.parameters.stage,
           target.stack,

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -5,6 +5,10 @@ import magenta.tasks.{CheckUpdateEventsTask, UpdateCloudFormationTask}
 import magenta.tasks.UpdateCloudFormationTask.{LookupByName, LookupByTags}
 
 object CloudFormation extends DeploymentType {
+
+  type TagCriteria = Map[String, String]
+  type CfnParam = String
+
   val name = "cloud-formation"
   def documentation =
     """Update an AWS CloudFormation template.
@@ -72,7 +76,8 @@ object CloudFormation extends DeploymentType {
   val amiParameter = Param[String]("amiParameter",
     documentation = "The CloudFormation parameter name for the AMI"
   ).default("AMI")
-  val amiParametersToTags = Param[Map[String, Map[String, String]]]("amiParametersToTags",
+
+  val amiParametersToTags = Param[Map[CfnParam, TagCriteria]]("amiParametersToTags",
     documentation =
       """AMI cloudformation parameter names mapped to the set of tags that should be used to look up an AMI.
       """.stripMargin
@@ -89,7 +94,7 @@ object CloudFormation extends DeploymentType {
       implicit val artifactClient = resources.artifactClient
       val reporter = resources.reporter
 
-      val amiParameterMap: Map[String, Map[String, String]] = (amiParametersToTags.get(pkg), amiTags.get(pkg)) match {
+      val amiParameterMap: Map[CfnParam, TagCriteria] = (amiParametersToTags.get(pkg), amiTags.get(pkg)) match {
         case (Some(parametersToTags), Some(tags)) =>
           reporter.warning("Both amiParametersToTags and amiTags supplied. Ignoring amiTags.")
           parametersToTags

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -5,6 +5,7 @@ import com.amazonaws.services.cloudformation.model.StackEvent
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient
 import magenta.artifact.S3Path
+import magenta.deployment_type.CloudFormation.{CfnParam, TagCriteria}
 import magenta.tasks.CloudFormation._
 import magenta.tasks.UpdateCloudFormationTask.CloudFormationStackLookupStrategy
 import magenta.{DeployReporter, DeployTarget, DeploymentPackage, KeyRing, Region, Stack, Stage}
@@ -61,7 +62,7 @@ object UpdateCloudFormationTask {
     val userAndDefaultParams = requiredParams ++ parameters.mapValues(SpecifiedValue.apply)
 
     addParametersIfInTemplate(userAndDefaultParams)(
-      Seq("Stage" -> stage.name) ++ stack.nameOption.map(name => "Stack" -> name)
+      Seq("Stage" -> stage.name) ++ stack.nameOption.map("Stack" -> _)
     )
   }
 
@@ -102,7 +103,7 @@ case class UpdateCloudFormationTask(
   cloudFormationStackLookupStrategy: CloudFormationStackLookupStrategy,
   templatePath: S3Path,
   userParameters: Map[String, String],
-  amiParameterMap: Map[String, Map[String, String]],
+  amiParameterMap: Map[CfnParam, TagCriteria],
   latestImage: String => Map[String,String] => Option[String],
   stage: Stage,
   stack: Stack,
@@ -172,7 +173,7 @@ case class UpdateCloudFormationTask(
 case class UpdateAmiCloudFormationParameterTask(
   region: Region,
   cloudFormationStackLookupStrategy: CloudFormationStackLookupStrategy,
-  amiParameterMap: Map[String, Map[String, String]],
+  amiParameterMap: Map[CfnParam, TagCriteria],
   latestImage: String => Map[String, String] => Option[String],
   stage: Stage,
   stack: Stack)(implicit val keyRing: KeyRing) extends Task {

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -49,7 +49,7 @@ object UpdateCloudFormationTask {
     }
   }
 
-  def combineParameters(stack: Stack, stage: Stage, templateParameters: Seq[TemplateParameter], parameters: Map[String, String], amiParam: Option[(String, String)]): Map[String, ParameterValue] = {
+  def combineParameters(stack: Stack, stage: Stage, templateParameters: Seq[TemplateParameter], parameters: Map[String, String]): Map[String, ParameterValue] = {
     def addParametersIfInTemplate(params: Map[String, ParameterValue])(nameValues: Iterable[(String, String)]): Map[String, ParameterValue] = {
       nameValues.foldLeft(params) {
         case (completeParams, (name, value)) if templateParameters.exists(_.key == name) => completeParams + (name -> SpecifiedValue(value))
@@ -58,7 +58,7 @@ object UpdateCloudFormationTask {
     }
 
     val requiredParams: Map[String, ParameterValue] = templateParameters.filterNot(_.default).map(_.key -> UseExistingValue).toMap
-    val userAndDefaultParams = requiredParams ++ (parameters ++ amiParam).mapValues(SpecifiedValue.apply)
+    val userAndDefaultParams = requiredParams ++ parameters.mapValues(SpecifiedValue.apply)
 
     addParametersIfInTemplate(userAndDefaultParams)(
       Seq("Stage" -> stage.name) ++ stack.nameOption.map(name => "Stack" -> name)
@@ -102,8 +102,7 @@ case class UpdateCloudFormationTask(
   cloudFormationStackLookupStrategy: CloudFormationStackLookupStrategy,
   templatePath: S3Path,
   userParameters: Map[String, String],
-  amiParamName: String,
-  amiTags: Map[String, String],
+  amiParameterMap: Map[String, Map[String, String]],
   latestImage: String => Map[String,String] => Option[String],
   stage: Stage,
   stack: Stack,
@@ -134,11 +133,13 @@ case class UpdateCloudFormationTask(
     val templateParameters = CloudFormation.validateTemplate(template, cfnClient).getParameters
       .map(tp => TemplateParameter(tp.getParameterKey, Option(tp.getDefaultValue).isDefined))
 
-    val amiParam: Option[(String, String)] = if (amiTags.nonEmpty) {
-      latestImage(region.name)(amiTags).map(amiParamName -> _)
-    } else None
+    val resolvedAmiParameters: Map[String, String] = amiParameterMap.flatMap { case (name, tags) =>
+      val ami = latestImage(region.name)(tags)
+      ami.map(name ->)
+    }
 
-    val parameters: Map[String, ParameterValue] = combineParameters(stack, stage, templateParameters, userParameters, amiParam)
+    val parameters: Map[String, ParameterValue] =
+        combineParameters(stack, stage, templateParameters, userParameters ++ resolvedAmiParameters)
 
     reporter.info(s"Parameters: $parameters")
 
@@ -171,8 +172,7 @@ case class UpdateCloudFormationTask(
 case class UpdateAmiCloudFormationParameterTask(
   region: Region,
   cloudFormationStackLookupStrategy: CloudFormationStackLookupStrategy,
-  amiParameter: String,
-  amiTags: Map[String, String],
+  amiParameterMap: Map[String, Map[String, String]],
   latestImage: String => Map[String, String] => Option[String],
   stage: Stage,
   stack: Stack)(implicit val keyRing: KeyRing) extends Task {
@@ -187,30 +187,45 @@ case class UpdateAmiCloudFormationParameterTask(
       case LookupByTags(tags) => CloudFormation.findStackByTags(tags, reporter, cfnClient)
     }
 
-    val (cfStackName, existingParameters, currentAmi) = maybeCfStack match {
-      case Some(cfStack) if cfStack.getParameters.exists(_.getParameterKey == amiParameter) =>
-        (cfStack.getStackName, cfStack.getParameters.map(_.getParameterKey -> UseExistingValue).toMap, cfStack.getParameters.find(_.getParameterKey == amiParameter).get.getParameterValue)
-      case Some(cfStack) =>
-        reporter.fail(s"stack ${cfStack.getStackName} does not have an $amiParameter parameter to update")
-      case None =>
-        reporter.fail(s"Could not find CloudFormation stack $cloudFormationStackLookupStrategy")
+    val cfStack = maybeCfStack.getOrElse{
+      reporter.fail(s"Could not find CloudFormation stack $cloudFormationStackLookupStrategy")
     }
 
-    latestImage(region.name)(amiTags) match {
-      case Some(sameAmi) if currentAmi == sameAmi =>
-        reporter.info(s"Current AMI is the same as the resolved AMI ($sameAmi). No update to perform.")
-      case Some(ami) =>
-        reporter.info(s"Resolved AMI: $ami")
-        val parameters = existingParameters + (amiParameter -> SpecifiedValue(ami))
-        reporter.info(s"Updating cloudformation stack params: $parameters")
-        CloudFormation.updateStackParams(cfStackName, parameters, cfnClient)
-      case None =>
-        val tagsStr = amiTags.map { case (k, v) => s"$k: $v" }.mkString(", ")
-        reporter.fail(s"Failed to resolve AMI for $cfStackName with tags: $tagsStr")
+    val existingParameters: Map[String, ParameterValue] = cfStack.getParameters.map(_.getParameterKey -> UseExistingValue).toMap
+
+    val resolvedAmiParameters: Map[String, ParameterValue] = amiParameterMap.flatMap { case(parameterName, amiTags) =>
+      if (!cfStack.getParameters.exists(_.getParameterKey == parameterName)) {
+        reporter.fail(s"stack ${cfStack.getStackName} does not have an $parameterName parameter to update")
+      }
+
+      val currentAmi = cfStack.getParameters.find(_.getParameterKey == parameterName).get.getParameterValue
+      val maybeNewAmi = latestImage(region.name)(amiTags)
+      maybeNewAmi match {
+        case Some(sameAmi) if currentAmi == sameAmi =>
+          reporter.info(s"Current AMI is the same as the resolved AMI for $parameterName ($sameAmi)")
+          None
+        case Some(newAmi) =>
+          reporter.info(s"Resolved AMI for $parameterName: $newAmi")
+          Some(parameterName -> SpecifiedValue(newAmi))
+        case None =>
+          val tagsStr = amiTags.map { case (k, v) => s"$k: $v" }.mkString(", ")
+          reporter.fail(s"Failed to resolve AMI for ${cfStack.getStackName} parameter $parameterName with tags: $tagsStr")
+      }
+    }
+
+    if (resolvedAmiParameters.nonEmpty) {
+      val newParameters = existingParameters ++ resolvedAmiParameters
+      reporter.info(s"Updating cloudformation stack params: $newParameters")
+      CloudFormation.updateStackParams(cfStack.getStackName, newParameters, cfnClient)
+    } else {
+      reporter.info(s"All AMIs the same as current AMIs. No update to perform.")
     }
   }
 
-  def description = s"Update $amiParameter to latest AMI with tags $amiTags in CloudFormation stack: $cloudFormationStackLookupStrategy"
+  def description = {
+    val components = amiParameterMap.map { case(name, tags) => s"$name to latest AMI with tags $tags"}.mkString(", ")
+    s"Update $components in CloudFormation stack: $cloudFormationStackLookupStrategy"
+  }
   def verbose = description
 }
 

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -11,7 +11,7 @@ import magenta.tasks.CloudFormation.{SpecifiedValue, UseExistingValue}
 import magenta.tasks.UpdateCloudFormationTask._
 import magenta.tasks._
 import org.scalatest.{FlatSpec, Inside, Matchers}
-import play.api.libs.json.JsValue
+import play.api.libs.json.{JsString, JsValue, Json}
 
 class CloudFormationTest extends FlatSpec with Matchers with Inside {
   implicit val fakeKeyRing = KeyRing()
@@ -19,16 +19,16 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
   implicit val artifactClient: AmazonS3 = null
   val region = Region("eu-west-1")
   val deploymentTypes = Seq(CloudFormation)
+  val app = Seq(App("app"))
+  val namedStack = NamedStack("cfn")
+  val cfnStackName = s"cfn-app-PROD"
+  def p(data: Map[String, JsValue]) = DeploymentPackage("app", app, data, "cloud-formation", S3Path("artifact-bucket", "test/123"), true,
+    deploymentTypes)
 
   "cloudformation deployment type" should "have an updateStack action" in {
-    val data: Map[String, JsValue] = Map()
-    val app = Seq(App("app"))
-    val stack = NamedStack("cfn")
-    val cfnStackName = s"cfn-app-PROD"
-    val p = DeploymentPackage("app", app, data, "cloud-formation", S3Path("artifact-bucket", "test/123"), true,
-      deploymentTypes)
+    val data: Map[String, JsValue] = Map.empty
 
-    inside(CloudFormation.actionsMap("updateStack").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), stack, region))) {
+    inside(CloudFormation.actionsMap("updateStack").taskGenerator(p(data), DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), namedStack, region))) {
       case List(updateTask, checkTask) =>
         inside(updateTask) {
           case UpdateCloudFormationTask(taskRegion, stackName, path, userParams, amiParamTags, _, stage, stack, ifAbsent, alwaysUpload) =>
@@ -50,6 +50,70 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
     }
   }
 
+  it should "ignore amiTags when amiParametersToTags and amiTags are provided" in {
+    val data: Map[String, JsValue] = Map(
+      "amiTags" -> Json.obj("myApp" -> JsString("fakeApp")),
+      "amiParametersToTags" -> Json.obj(
+        "AMI" -> Json.obj("myApp1" -> JsString("fakeApp1")),
+        "RouterAMI" -> Json.obj("myApp2" -> JsString("fakeApp2"))
+    ))
+
+    inside(CloudFormation.actionsMap("updateStack").taskGenerator(p(data), DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), namedStack, region))) {
+      case List(updateTask, _) =>
+        inside(updateTask) {
+          case UpdateCloudFormationTask(_, _, _, _, amiParamTags, _, _, _, _, _) =>
+            amiParamTags should be(Map("AMI" -> Map("myApp1" -> "fakeApp1"), "RouterAMI" -> Map("myApp2" -> "fakeApp2")))
+        }
+    }
+  }
+
+  it should "use all values on amiParametersToTags" in {
+    val data: Map[String, JsValue] = Map(
+      "amiParametersToTags" -> Json.obj(
+        "AMI" -> Json.obj("myApp1" -> JsString("fakeApp1")),
+        "myAMI" -> Json.obj("myApp2" -> JsString("fakeApp2"))
+    ))
+
+    inside(CloudFormation.actionsMap("updateStack").taskGenerator(p(data), DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), namedStack, region))) {
+      case List(updateTask, _) =>
+        inside(updateTask) {
+          case UpdateCloudFormationTask(_, _, _, _, amiParamTags, _, _, _, _, _) =>
+            amiParamTags should be(Map(
+              "AMI" -> Map("myApp1" -> "fakeApp1"),
+              "myAMI" -> Map("myApp2" -> "fakeApp2")
+            ))
+        }
+    }
+  }
+
+  it should "respect a non-default amiParameter" in {
+    val data: Map[String, JsValue] = Map(
+      "amiParameter" -> JsString("myAMI"),
+      "amiTags" -> Json.obj("myApp" -> JsString("fakeApp"))
+    )
+
+    inside(CloudFormation.actionsMap("updateStack").taskGenerator(p(data), DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), namedStack, region))) {
+      case List(updateTask, _) =>
+        inside(updateTask) {
+          case UpdateCloudFormationTask(_, _, _, _, amiParamTags, _, _, _, _, _) =>
+            amiParamTags should be(Map("myAMI" -> Map("myApp" -> "fakeApp")))
+        }
+    }
+  }
+
+
+  it should "respect the defaults for amiTags and amiParameter" in {
+    val data: Map[String, JsValue] = Map("amiTags" -> Json.obj("myApp" -> JsString("fakeApp")))
+
+    inside(CloudFormation.actionsMap("updateStack").taskGenerator(p(data), DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), namedStack, region))) {
+      case List(updateTask, _) =>
+        inside(updateTask) {
+          case UpdateCloudFormationTask(_, _, _, _, amiParamTags, _, _, _, _, _) =>
+            amiParamTags should be(Map("AMI" -> Map("myApp" -> "fakeApp")))
+        }
+    }
+  }
+
   "UpdateCloudFormationTask" should "substitute stack and stage parameters" in {
     val templateParameters =
       Seq(TemplateParameter("param1", false), TemplateParameter("Stack", false), TemplateParameter("Stage", false))
@@ -60,6 +124,19 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
       "Stack" -> SpecifiedValue("cfn"),
       "Stage" -> SpecifiedValue("PROD")
       ))
+  }
+
+  it should "handle more than one AMI parameter" in {
+    val templateParameters =
+      Seq(TemplateParameter("AMI", false), TemplateParameter("routerAMI", false), TemplateParameter("Stack", false), TemplateParameter("Stage", false))
+    val combined = UpdateCloudFormationTask.combineParameters(NamedStack("cfn"), PROD, templateParameters, Map("AMI" -> "value1", "routerAMI" -> "value2"))
+
+    combined should be(Map(
+      "AMI" -> SpecifiedValue("value1"),
+      "routerAMI" -> SpecifiedValue("value2"),
+      "Stack" -> SpecifiedValue("cfn"),
+      "Stage" -> SpecifiedValue("PROD")
+    ))
   }
 
   it should "default required parameters to use existing parameters" in {

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -31,13 +31,12 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
     inside(CloudFormation.actionsMap("updateStack").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), stack, region))) {
       case List(updateTask, checkTask) =>
         inside(updateTask) {
-          case UpdateCloudFormationTask(taskRegion, stackName, path, userParams, amiParam, amiTags, _, stage, stack, ifAbsent, alwaysUpload) =>
+          case UpdateCloudFormationTask(taskRegion, stackName, path, userParams, amiParamTags, _, stage, stack, ifAbsent, alwaysUpload) =>
             taskRegion should be(region)
             stackName should be(LookupByName(cfnStackName))
             path should be(S3Path("artifact-bucket", "test/123/cloud-formation/cfn.json"))
             userParams should be(Map.empty)
-            amiParam should be("AMI")
-            amiTags should be(Map.empty)
+            amiParamTags should be(Map.empty)
             stage should be(PROD)
             stack should be(NamedStack("cfn"))
             ifAbsent should be(true)
@@ -54,7 +53,7 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
   "UpdateCloudFormationTask" should "substitute stack and stage parameters" in {
     val templateParameters =
       Seq(TemplateParameter("param1", false), TemplateParameter("Stack", false), TemplateParameter("Stage", false))
-    val combined = UpdateCloudFormationTask.combineParameters(NamedStack("cfn"), PROD, templateParameters, Map("param1" -> "value1"), None)
+    val combined = UpdateCloudFormationTask.combineParameters(NamedStack("cfn"), PROD, templateParameters, Map("param1" -> "value1"))
 
     combined should be(Map(
       "param1" -> SpecifiedValue("value1"),
@@ -66,7 +65,7 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
   it should "default required parameters to use existing parameters" in {
     val templateParameters =
       Seq(TemplateParameter("param1", true), TemplateParameter("param3", false), TemplateParameter("Stage", false))
-    val combined = UpdateCloudFormationTask.combineParameters(NamedStack("cfn"), PROD, templateParameters, Map("param1" -> "value1"), None)
+    val combined = UpdateCloudFormationTask.combineParameters(NamedStack("cfn"), PROD, templateParameters, Map("param1" -> "value1"))
 
     combined should be(Map(
       "param1" -> SpecifiedValue("value1"),

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -126,19 +126,6 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
       ))
   }
 
-  it should "handle more than one AMI parameter" in {
-    val templateParameters =
-      Seq(TemplateParameter("AMI", false), TemplateParameter("routerAMI", false), TemplateParameter("Stack", false), TemplateParameter("Stage", false))
-    val combined = UpdateCloudFormationTask.combineParameters(NamedStack("cfn"), PROD, templateParameters, Map("AMI" -> "value1", "routerAMI" -> "value2"))
-
-    combined should be(Map(
-      "AMI" -> SpecifiedValue("value1"),
-      "routerAMI" -> SpecifiedValue("value2"),
-      "Stack" -> SpecifiedValue("cfn"),
-      "Stage" -> SpecifiedValue("PROD")
-    ))
-  }
-
   it should "default required parameters to use existing parameters" in {
     val templateParameters =
       Seq(TemplateParameter("param1", true), TemplateParameter("param3", false), TemplateParameter("Stage", false))


### PR DESCRIPTION
- Add a new parameter call amiParametersToTags to handle multiples amiParameters/tags combinations.
- Add tests to ensure that the old amiTags and amiParameter keep having the same behaviour.

**Note**: changes to AmiCloudFormationParameter are really hard to test without a fundamental refactor therefore I plan to test the change in the CODE env.

@sihil @adamnfish @TBonnin @thomaska 
