### PR TITLE
Policy required for Riff Raff to update AMI of a stack

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
@@ -10,6 +10,33 @@ object AmiCloudFormationParameter extends DeploymentType with CloudFormationDepl
       |
       |Given AMI tags, this will resolve the latest matching AMI and update the AMI parameter
       |on the provided CloudFormation stack.
+      |
+      |The set of AWS permissions needed to let RiffRaff do an AMI updates are:
+      |
+      |    {
+      |      "Statement": [
+      |        {
+      |          "Action": [
+      |             "cloudformation:DescribeStacks",
+      |             "cloudformation:UpdateStack",
+      |             "cloudformation:DescribeStackEvents",
+      |             "ec2:DescribeSecurityGroups",
+      |             "iam:PassRole",
+      |             "autoscaling:CreateLaunchConfiguration",
+      |             "autoscaling:UpdateAutoScalingGroup",
+      |             "autoscaling:DescribeLaunchConfigurations",
+      |             "autoscaling:DescribeScalingActivities",
+      |             "autoscaling:DeleteLaunchConfiguration"
+      |          ],
+      |          "Effect": "Allow",
+      |          "Resource": [
+      |            "*"
+      |          ]
+      |        }
+      |      ]
+      |    }
+      |
+      |You'll need to add this to the Riff-Raff IAM account used for your project.
     """.stripMargin
 
   val update = Action("update",


### PR DESCRIPTION
I think most accounts are allowing riffraff user access to all the things e.g. `"cloudformation:*",` but I went for the hard route and discovered all the individual policies for updating an AMI. I thought it might be nice to document the policies similar to `autoscaling` docs.