### PR TITLE
Add logging in the won't retry case

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -449,7 +449,12 @@ trait AWS extends Loggable {
     }
     override def shouldRetry(originalRequest: AmazonWebServiceRequest, exception: AmazonClientException, retriesAttempted: Int): Boolean = {
       val willRetry = super.shouldRetry(originalRequest, exception, retriesAttempted) || isParseException(exception)
-      if (willRetry) logger.warn(s"AWS SDK retry $retriesAttempted: ${originalRequest.getClass.getName} threw ${exceptionInfo(exception)}")
+      if (willRetry) {
+        logger.warn(s"AWS SDK retry $retriesAttempted: ${originalRequest.getClass.getName} threw ${exceptionInfo(exception)}")
+      } else {
+        logger.warn(s"Encounted fatal exception during AWS API call", exception)
+        Option(exception.getCause).foreach(t => logger.warn(s"Cause of fatal exception", t))
+      }
       willRetry
     }
   }


### PR DESCRIPTION
In the continued quest to vanquish #413 this adds further logging of exceptions that we won't both retrying on (clearly not catching the right thing).