### PR TITLE
Revert "Exceptions => Error values"

### DIFF
--- a/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
+++ b/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
@@ -5,13 +5,12 @@ import java.io.File
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model._
 import com.gu.management.Loggable
-import magenta.json.JsonInputFile
 import magenta.{Build, DeployReporter}
-import play.api.data.validation.ValidationError
-import play.api.libs.json.JsPath
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
+import scala.util.Try
+import scala.util.control.NonFatal
 
 trait S3Location {
   def bucket: String
@@ -60,18 +59,14 @@ object S3Location extends Loggable {
     } yield S3Object(summary.getBucketName, summary.getKey, summary.getSize)
   }
 
-  def fetchContentAsString(location: S3Location)(implicit client:AmazonS3): Either[S3Error, String] = {
-    import cats.syntax.either._
-    Either.catchNonFatal(client.getObjectAsString(location.bucket, location.key)).leftMap {
-      case e: AmazonS3Exception if e.getStatusCode == 404 => EmptyS3Location(location)
-      case e => UnknownS3Error(e)
-    }
+  def fetchContentAsString(location: S3Location)(implicit client:AmazonS3):Option[String] = {
+    Try {
+      Some(client.getObjectAsString(location.bucket, location.key))
+    }.recover {
+      case e: AmazonS3Exception if e.getStatusCode == 404 => None
+    }.get
   }
 }
-
-sealed trait S3Error
-case class EmptyS3Location(location: S3Location) extends S3Error
-case class UnknownS3Error(exception: Throwable) extends S3Error
 
 case class S3Path(bucket: String, key: String) extends S3Location
 
@@ -105,17 +100,13 @@ object S3JsonArtifact extends Loggable {
     S3JsonArtifact(bucket, prefix)
   }
 
-  def fetchInputFile(artifact: S3JsonArtifact)(
-    implicit client: AmazonS3, reporter: DeployReporter): Either[ArtifactResolutionError, JsonInputFile] = {
-
-    import cats.syntax.either._
-    val possibleJson = (artifact.deployObject.fetchContentAsString()(client)).orElse {
-      convertFromZipBundle(artifact)
-      artifact.deployObject.fetchContentAsString()(client)
+  def withZipFallback[T](artifact: S3JsonArtifact)(f: S3JsonArtifact => Try[T])(implicit client: AmazonS3, reporter: DeployReporter): T = {
+    val attempt = f(artifact) recoverWith {
+      case NonFatal(e) =>
+        convertFromZipBundle(artifact)
+        f(artifact)
     }
-    possibleJson.leftMap[ArtifactResolutionError](S3ArtifactError(_)).flatMap(s =>
-      JsonInputFile.parse(s).leftMap(JsonArtifactError(_))
-    )
+    attempt.get
   }
 
   def convertFromZipBundle(artifact: S3JsonArtifact)(implicit client: AmazonS3, reporter: DeployReporter): Unit = {
@@ -151,10 +142,6 @@ object S3JsonArtifact extends Loggable {
     else file.listFiles.toSeq.flatMap(f => resolveFiles(f, subDirectoryPrefix(key, f))).distinct
   }
 }
-
-sealed abstract class ArtifactResolutionError
-case class S3ArtifactError(underlying: S3Error) extends ArtifactResolutionError
-case class JsonArtifactError(underlying: Seq[(JsPath, Seq[ValidationError])]) extends ArtifactResolutionError
 
 case class S3YamlArtifact(bucket: String, key: String) extends S3Artifact {
   val deployObjectName: String = "riff-raff.yaml"

--- a/magenta-lib/src/main/scala/magenta/artifact/S3ZipArtifact.scala
+++ b/magenta-lib/src/main/scala/magenta/artifact/S3ZipArtifact.scala
@@ -35,8 +35,6 @@ object S3ZipArtifact {
 
       reporter.verbose("Extracted files")
     } catch {
-      case e: AmazonS3Exception if e.getStatusCode == 404 =>
-        reporter.fail(s"404 downloading $path\n - have you got the project name and build number correct?")
       case e: ScalaIOException => e.getCause match {
         case e: AmazonS3Exception if e.getStatusCode == 404 =>
           reporter.fail(s"404 downloading $path\n - have you got the project name and build number correct?")

--- a/magenta-lib/src/main/scala/magenta/json/JsonInputFile.scala
+++ b/magenta-lib/src/main/scala/magenta/json/JsonInputFile.scala
@@ -3,8 +3,7 @@ package json
 
 import magenta.artifact.{S3JsonArtifact, S3Path}
 import magenta.deployment_type.DeploymentType
-import play.api.data.validation.ValidationError
-import play.api.libs.json._
+import play.api.libs.json.{JsError, JsSuccess, JsValue, Json}
 
 case class JsonPackage(
   `type`: String,
@@ -35,17 +34,22 @@ case class JsonInputFile(
 )
 object JsonInputFile {
   implicit val reads = Json.reads[JsonInputFile]
-
-  def parse(s: String): Either[Seq[(JsPath, Seq[ValidationError])], JsonInputFile] = Json.fromJson[JsonInputFile](Json.parse(s)).asEither
 }
 
 
 object JsonReader {
+  def parse(s: String, artifact: S3JsonArtifact, deploymentTypes: Seq[DeploymentType]): Project = {
+    val inputFile: JsonInputFile = Json.fromJson[JsonInputFile](Json.parse(s)) match {
+      case JsSuccess(result, _) => result
+      case JsError(errors) => throw new IllegalArgumentException(s"Failed to parse JSON: $errors")
+    }
+    parse(inputFile, artifact, deploymentTypes)
+  }
   
   def defaultRecipes(packages: Map[String, DeploymentPackage]) =
     Map("default" -> JsonRecipe(actions = Some(packages.values.map(_.name + ".deploy").toList)))
 
-  def buildProject(input: JsonInputFile, artifact: S3JsonArtifact, deploymentTypes: Seq[DeploymentType]): Project = {
+  private def parse(input: JsonInputFile, artifact: S3JsonArtifact, deploymentTypes: Seq[DeploymentType]): Project = {
     val packages = input.packages map { case (name, pkg) => name -> parsePackage(name, pkg, artifact, deploymentTypes) }
     val recipes = input.recipes.getOrElse(defaultRecipes(packages))  map { case (name, r) => name -> parseRecipe(name, r, packages) }
 

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -122,9 +122,10 @@ case class UpdateCloudFormationTask(
       case LookupByTags(tags) => CloudFormation.findStackByTags(tags, reporter, cfnClient)
     }
 
-    val templateString = templatePath.fetchContentAsString.right.getOrElse(
-      reporter.fail(s"Unable to locate cloudformation template s3://${templatePath.bucket}/${templatePath.key}")
-    )
+    val templateString = templatePath.fetchContentAsString match {
+      case Some(string) => string
+      case None => reporter.fail(s"Unable to locate cloudformation template s3://${templatePath.bucket}/${templatePath.key}")
+    }
 
     val nameToCallStack = UpdateCloudFormationTask.nameToCallNewStack(cloudFormationStackLookupStrategy)
 

--- a/magenta-lib/src/test/scala/magenta/ResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/ResolverTest.scala
@@ -2,10 +2,11 @@ package magenta
 
 import java.util.UUID
 
+import com.amazonaws.regions.RegionUtils
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.{ListObjectsV2Request, ListObjectsV2Result}
 import magenta.artifact.{S3JsonArtifact, S3Path}
-import magenta.deployment_type.{Action, S3}
+import magenta.deployment_type.{Action, DeploymentType, S3}
 import magenta.fixtures.{StubDeploymentType, StubTask, _}
 import magenta.graph.{DeploymentGraph, DeploymentTasks, StartNode, ValueNode}
 import magenta.json._
@@ -44,8 +45,7 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
                       """
 
   "resolver" should "parse json into actions that can be executed" in {
-    val parsed = JsonReader.buildProject(JsonInputFile.parse(simpleExample).right.get,
-      new S3JsonArtifact("artifact-bucket","tmp/123"), deploymentTypes)
+    val parsed = JsonReader.parse(simpleExample, new S3JsonArtifact("artifact-bucket","tmp/123"), deploymentTypes)
     val deployRecipe = parsed.recipes("htmlapp-only")
 
     val host = Host("host1", stage = CODE.name, tags=Map("group" -> "")).app(App("apache"))

--- a/magenta-lib/src/test/scala/magenta/json/JsonReaderTest.scala
+++ b/magenta-lib/src/test/scala/magenta/json/JsonReaderTest.scala
@@ -2,13 +2,13 @@ package magenta
 package json
 
 import magenta.artifact.{S3JsonArtifact, S3Path}
-import magenta.deployment_type.AutoScaling
+import magenta.deployment_type.{AutoScaling, DeploymentType}
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.{JsString, Json}
 
 class JsonReaderTest extends FlatSpec with Matchers {
   val deploymentTypes = Seq(AutoScaling)
-  val deployJsonExample = parseOrDie("""
+  val deployJsonExample = """
   {
     "stack":"content-api",
     "packages":{
@@ -60,22 +60,22 @@ class JsonReaderTest extends FlatSpec with Matchers {
       }
     }
   }
-  """)
+                          """
 
   "json parser" should "parse json and resolve links" in {
-    val parsedProject = JsonReader.buildProject(deployJsonExample, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
+    val parsed = JsonReader.parse(deployJsonExample, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
 
-    parsedProject.applications should be (Set(App("index-builder"), App("api"), App("solr")))
+    parsed.applications should be (Set(App("index-builder"), App("api"), App("solr")))
 
-    parsedProject.packages.size should be (3)
-    parsedProject.packages("index-builder") shouldBe
+    parsed.packages.size should be (3)
+    parsed.packages("index-builder") shouldBe
       DeploymentPackage("index-builder", Seq(App("index-builder")), Map.empty, "autoscaling", S3Path("artifact-bucket", "test/123/packages/index-builder/"), true, deploymentTypes)
-    parsedProject.packages("api") shouldBe
+    parsed.packages("api") shouldBe
       DeploymentPackage("api", Seq(App("api")), Map("healthcheck_paths" -> Json.arr("/api/index.json","/api/search.json")), "autoscaling", S3Path("artifact-bucket", "test/123/packages/api/"), true, deploymentTypes)
-    parsedProject.packages("solr") shouldBe
+    parsed.packages("solr") shouldBe
       DeploymentPackage("solr", Seq(App("solr")), Map("port" -> JsString("8400")), "autoscaling", S3Path("artifact-bucket", "test/123/packages/solr/"), true, deploymentTypes)
 
-    val recipes = parsedProject.recipes
+    val recipes = parsed.recipes
     recipes.size should be (4)
     recipes("all") should be (Recipe("all", Nil, List("index-build-only", "api-only")))
 
@@ -84,44 +84,44 @@ class JsonReaderTest extends FlatSpec with Matchers {
     apiCounterRecipe.deploymentSteps.toSeq.length should be (4)
   }
 
-  val minimalExample = parseOrDie("""
+  val minimalExample = """
 {
   "packages": {
     "dinky": { "type": "autoscaling" }
   }
 }
-""")
+"""
 
   "json parser" should "infer a single app if none specified" in {
-    val parsedProject = JsonReader.buildProject(minimalExample, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
+    val parsed = JsonReader.parse(minimalExample, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
 
-    parsedProject.applications should be (Set(App("dinky")))
+    parsed.applications should be (Set(App("dinky")))
   }
 
-  val twoPackageExample = parseOrDie("""
+  val twoPackageExample = """
 {
   "packages": {
     "one": { "type": "autoscaling" },
     "two": { "type": "autoscaling" }
   }
 }
-""")
+"""
 
   "json parser" should "infer a default recipe that deploys all packages" in {
-    val parsedProject = JsonReader.buildProject(twoPackageExample, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
+    val parsed = JsonReader.parse(twoPackageExample, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
 
-    val recipes = parsedProject.recipes
+    val recipes = parsed.recipes
     recipes.size should be(1)
-    recipes("default") should be (Recipe("default", deploymentSteps   = parsedProject.packages.values.map(_.mkDeploymentStep("deploy"))))
+    recipes("default") should be (Recipe("default", deploymentSteps   = parsed.packages.values.map(_.mkDeploymentStep("deploy"))))
   }
 
   "json parser" should "default to using the package name for the file name" in {
-    val parsedProject = JsonReader.buildProject(minimalExample, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
+    val parsed = JsonReader.parse(minimalExample, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
 
-    parsedProject.packages("dinky").s3Package should be(S3Path("artifact-bucket", "test/123/packages/dinky/"))
+    parsed.packages("dinky").s3Package should be(S3Path("artifact-bucket", "test/123/packages/dinky/"))
   }
 
-  val withExplicitFileName = parseOrDie("""
+  val withExplicitFileName = """
 {
   "packages": {
     "dinky": {
@@ -130,13 +130,11 @@ class JsonReaderTest extends FlatSpec with Matchers {
     }
   }
 }
-""")
+"""
 
   "json parser" should "use override file name if specified" in {
-    val parsedProject = JsonReader.buildProject(withExplicitFileName, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
+    val parsed = JsonReader.parse(withExplicitFileName, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
 
-    parsedProject.packages("dinky").s3Package should be(S3Path("artifact-bucket", "test/123/packages/awkward/"))
+    parsed.packages("dinky").s3Package should be(S3Path("artifact-bucket", "test/123/packages/awkward/"))
   }
-
-  def parseOrDie(s: String) = JsonInputFile.parse(s).right.get
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.12

--- a/riff-raff/app/ci/CIBuild.scala
+++ b/riff-raff/app/ci/CIBuild.scala
@@ -37,7 +37,7 @@ object CIBuild extends Logging {
   lazy val newBuilds: Observable[CIBuild] = {
     val observable = (for {
       location <- Every(pollingPeriod)(Observable.from(S3Build.buildJsons)).distinct if !initialFiles.contains(location)
-      build <- Observable.from(S3Build.buildAt(location).right.toOption)
+      build <- Observable.from(S3Build.buildAt(location))
     } yield build).publish
     observable.connect // make it a "hot" observable, i.e. it runs even if nobody is subscribed to it
     observable
@@ -54,7 +54,7 @@ object CIBuild extends Logging {
     implicit val ec = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(50))
     log.logger.info(s"Found ${initialFiles.length} builds to parse")
     (Future.traverse(initialFiles) { location =>
-      Future(S3Build.buildAt(location).right.toOption)
+      Future(S3Build.buildAt(location))
     }).map(_.flatten)
   }
 

--- a/riff-raff/app/ci/S3Build.scala
+++ b/riff-raff/app/ci/S3Build.scala
@@ -2,14 +2,12 @@ package ci
 
 import conf.Configuration
 import controllers.Logging
-import magenta.artifact.{S3Error, S3Location, S3Object}
+import magenta.artifact.{S3Location, S3Object}
 import org.joda.time.DateTime
-import play.api.data.validation.ValidationError
 import play.api.libs.json.{JsPath, Json, Reads}
 
 import scala.util.Try
 import scala.util.control.NonFatal
-import cats.syntax.either._
 
 case class S3Build(
   id: Long,
@@ -37,15 +35,20 @@ object S3Build extends Logging {
       Nil
   } get
 
-  def buildAt(location: S3Object): Either[S3BuildError, S3Build] =
-    location.fetchContentAsString().leftMap[S3BuildError](S3BuildRetrievalError(_))
-      .flatMap(s => parse(s).leftMap[S3BuildError](S3BuildParseError(_)))
+  def buildAt(location: S3Object): Option[S3Build] = Try {
+    log.debug(s"Parsing ${location.key}")
+    location.fetchContentAsString().map(parse)
+  } recover {
+    case NonFatal(e) =>
+      log.error(s"Error parsing $location", e)
+      None
+  } get
 
-  def parse(json: String): Either[Seq[(JsPath, Seq[ValidationError])], S3Build] = {
+  def parse(json: String): S3Build = {
     import play.api.libs.functional.syntax._
     import utils.Json.DefaultJodaDateReads
     implicit val reads: Reads[S3Build] = (
-      (JsPath \ "buildNumber").read[Long] and
+      (JsPath \ "buildNumber").read[String].map(_.toLong) and
         (JsPath \ "projectName").read[String] and
         (JsPath \ "projectName").read[String] and
         (JsPath \ "branch").read[String] and
@@ -55,10 +58,6 @@ object S3Build extends Logging {
         (JsPath \ "vcsURL").read[String]
       )(S3Build.apply _)
 
-    Json.parse(json).validate[S3Build].asEither
+    Json.parse(json).as[S3Build]
   }
 }
-
-sealed trait S3BuildError
-final case class S3BuildRetrievalError(s3Error: S3Error) extends S3BuildError
-final case class S3BuildParseError(parseErrors: Seq[(JsPath, Seq[ValidationError])]) extends S3BuildError

--- a/riff-raff/app/ci/S3Tag.scala
+++ b/riff-raff/app/ci/S3Tag.scala
@@ -8,12 +8,10 @@ object S3Tag {
   lazy val bucketName = Configuration.tag.aws.bucketName
   implicit lazy val client = Configuration.tag.aws.client
 
-  import cats.syntax.either._
-
   def of(build: CIBuild): Option[Seq[String]] = {
     for {
       bucket <- bucketName
-      tagContent <- S3Path(bucket, s"${build.jobName}/${build.number}/tags.json").fetchContentAsString().toOption
+      tagContent <- S3Path(bucket, s"${build.jobName}/${build.number}/tags.json").fetchContentAsString()
       tags <- Json.parse(tagContent).asOpt[Seq[String]]
     } yield tags
   }

--- a/riff-raff/app/deployment/actors/DeployGroupRunner.scala
+++ b/riff-raff/app/deployment/actors/DeployGroupRunner.scala
@@ -8,7 +8,7 @@ import akka.agent.Agent
 import cats.data.Validated.{Invalid, Valid}
 import controllers.Logging
 import deployment.Record
-import magenta.artifact._
+import magenta.artifact.{S3JsonArtifact, S3YamlArtifact}
 import magenta.deployment_type.DeploymentType
 import magenta.graph.{DeploymentGraph, DeploymentTasks, Graph, StartNode, ValueNode}
 import magenta.input.resolver.Resolver
@@ -17,6 +17,7 @@ import magenta.{DeployContext, DeployReporter, DeployStoppedException, Deploymen
 import org.joda.time.DateTime
 import resources.PrismLookup
 
+import scala.util.Try
 import scala.util.control.NonFatal
 
 class DeployGroupRunner(
@@ -158,10 +159,8 @@ class DeployGroupRunner(
 
   private def createContext: DeployContext = {
     DeployReporter.withFailureHandling(rootReporter) { implicit safeReporter =>
-      import cats.syntax.either._
       import conf.Configuration._
-
-      implicit val client = artifact.aws.client
+      val client = artifact.aws.client
       val bucketName = artifact.aws.bucketName
 
       safeReporter.info("Reading riff-raff.yaml")
@@ -170,7 +169,7 @@ class DeployGroupRunner(
       val riffRaffYaml = S3YamlArtifact(record.parameters.build, bucketName)
       val riffRaffYamlString = riffRaffYaml.deployObject.fetchContentAsString()(client)
 
-      val context: Either[ArtifactResolutionError, DeployContext] = riffRaffYamlString.map { yaml =>
+      val context: DeployContext = riffRaffYamlString.map { yaml =>
         val graph = Resolver.resolve(yaml, resources, record.parameters, deploymentTypes, riffRaffYaml)
         graph.map(DeployContext(record.uuid, record.parameters, _)) match {
           case Invalid(errors) =>
@@ -178,24 +177,19 @@ class DeployGroupRunner(
             safeReporter.fail(s"Failed to successfully resolve the deployment: ${errors.errors.toList.size} errors")
           case Valid(success) => success
         }
-      } orElse {
+      } getOrElse {
         safeReporter.info("Falling back to deploy.json")
         val s3Artifact = S3JsonArtifact(record.parameters.build, bucketName)
-        val json = S3JsonArtifact.fetchInputFile(s3Artifact)
-        val project = json.map(JsonReader.buildProject(_, s3Artifact, deploymentTypes))
-        project.map(DeployContext(record.uuid, record.parameters, _, resources, Region(target.aws.deployJsonRegionName)))
+        val json = S3JsonArtifact.withZipFallback(s3Artifact) { artifact =>
+          Try(artifact.deployObject.fetchContentAsString()(client).get)
+        }(client, safeReporter)
+        val project = JsonReader.parse(json, s3Artifact, deploymentTypes)
+        DeployContext(record.uuid, record.parameters, project, resources, Region(target.aws.deployJsonRegionName))
       }
 
-      val c = context.recover {
-        case S3ArtifactError(EmptyS3Location(location)) => safeReporter.fail(s"No file found at $location")
-        case S3ArtifactError(UnknownS3Error(e)) => safeReporter.fail("Error while resolving deploy context", e)
-        case JsonArtifactError(parseErrors) => safeReporter.fail(s"Couldn't parse `deploy.json`: $parseErrors")
-      }.getOrElse(safeReporter.fail("Unexpected error while resolving deploy context"))
-
-      if (DeploymentGraph.toTaskList(c.tasks).isEmpty)
+      if (DeploymentGraph.toTaskList(context.tasks).isEmpty)
         safeReporter.fail("No tasks were found to execute. Ensure the app(s) are in the list supported by this stage/host.")
-      
-      c
+      context
     }
   }
 

--- a/riff-raff/app/deployment/preview/PreviewCoordinator.scala
+++ b/riff-raff/app/deployment/preview/PreviewCoordinator.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.ConcurrentHashMap
 import cats.syntax.either._
 import com.gu.management.Loggable
 import conf.Configuration
-import magenta.artifact.{S3Error, S3YamlArtifact}
+import magenta.artifact.S3YamlArtifact
 import magenta.deployment_type.DeploymentType
 import magenta.{DeployParameters, DeployReporter, DeploymentResources}
 import resources.PrismLookup
@@ -25,7 +25,7 @@ class PreviewCoordinator(prismLookup: PrismLookup, deploymentTypes: Seq[Deployme
     }
   }
 
-  def startPreview(parameters: DeployParameters): Either[S3Error, UUID] = {
+  def startPreview(parameters: DeployParameters): Either[String, UUID] = {
     cleanupPreviews()
 
     val previewId = UUID.randomUUID()
@@ -35,12 +35,15 @@ class PreviewCoordinator(prismLookup: PrismLookup, deploymentTypes: Seq[Deployme
     val artifact = S3YamlArtifact.apply(parameters.build, conf.Configuration.artifact.aws.bucketName)
     val maybeConfig = artifact.deployObject.fetchContentAsString()(resources.artifactClient)
 
-    maybeConfig.map(config => {
-      logger.info(s"Got configuration for $previewId - resolving")
-      val eventualPreview = Future(Preview(artifact, config, parameters, resources, deploymentTypes))
-      previews += previewId -> PreviewResult(eventualPreview)
-      previewId
-    })
+    Either.fromOption(
+      maybeConfig.map{ config =>
+        logger.info(s"Got configuration for $previewId - resolving")
+        val eventualPreview = Future(Preview(artifact, config, parameters, resources, deploymentTypes))
+        previews += previewId -> PreviewResult(eventualPreview)
+        previewId
+      },
+      s"YAML configuration file for ${parameters.build.projectName} ${parameters.build.id} not found"
+    )
   }
 
   def getPreviewResult(id: UUID): Option[PreviewResult] = previews.get(id)


### PR DESCRIPTION
Reverts guardian/riff-raff#426

It was noticed this morning that autocomplete and continuous deployment (frontend for example) ceases to function. Restarting riff-raff didn't fix the issues, however deploying the previous version (#662) brought back autocompletion.
Reverting this PR since it could be the cause of the problems.
