### PR TITLE
Ensure region is used to filter images from prism

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -68,7 +68,8 @@ object Dependencies {
     filters,
     ws,
     "com.typesafe.akka" %% "akka-testkit" % "2.4.10" % Test,
-    "org.gnieh" %% "diffson" % "2.0.2" % Test
+    "org.gnieh" %% "diffson" % "2.0.2" % Test,
+    "de.leanovate.play-mockws" %% "play-mockws" % "2.5.1" % Test
   ).map((m: ModuleID) =>
     // don't even ask why I need to do this
     m.excludeAll(ExclusionRule(organization = "com.google.code.findbugs", name = "jsr305"))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -68,8 +68,7 @@ object Dependencies {
     filters,
     ws,
     "com.typesafe.akka" %% "akka-testkit" % "2.4.10" % Test,
-    "org.gnieh" %% "diffson" % "2.0.2" % Test,
-    "de.leanovate.play-mockws" %% "play-mockws" % "2.5.1" % Test
+    "org.gnieh" %% "diffson" % "2.0.2" % Test
   ).map((m: ModuleID) =>
     // don't even ask why I need to do this
     m.excludeAll(ExclusionRule(organization = "com.google.code.findbugs", name = "jsr305"))

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -17,6 +17,7 @@ import resources.PrismLookup
 import utils.HstsFilter
 
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 import router.Routes
 
@@ -32,7 +33,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
   val availableDeploymentTypes = Seq(
     ElasticSearch, S3, AutoScaling, Fastly, CloudFormation, Lambda, AmiCloudFormationParameter, SelfDeploy
   )
-  val prismLookup = new PrismLookup(wsClient)
+  val prismLookup = new PrismLookup(wsClient, conf.Configuration.lookup.prismUrl, conf.Configuration.lookup.timeoutSeconds.seconds)
   val deploymentEngine = new DeploymentEngine(prismLookup, availableDeploymentTypes)
   val deployments = new Deployments(deploymentEngine)
   val continuousDeployment = new ContinuousDeployment(deployments)

--- a/riff-raff/app/resources/PrismLookup.scala
+++ b/riff-raff/app/resources/PrismLookup.scala
@@ -23,7 +23,7 @@ object Image {
   implicit val formats = Json.format[Image]
 }
 
-class PrismLookup(wsClient: WSClient) extends Lookup with Logging {
+class PrismLookup(wsClient: WSClient, url: String, timeout: Duration) extends Lookup with Logging {
 
   def keyRing(stage: Stage, apps: Set[App], stack: Stack): KeyRing = KeyRing(
     apiCredentials = apps.toSeq.flatMap {
@@ -44,9 +44,6 @@ class PrismLookup(wsClient: WSClient) extends Lookup with Logging {
   )
 
   object prism extends Logging {
-    val url = conf.Configuration.lookup.prismUrl
-    val timeout = conf.Configuration.lookup.timeoutSeconds.seconds
-
     def get[T](path: String, retriesLeft: Int = 5)(block: JsValue => T): T = {
       val result = wsClient.url(s"$url$path").get().map(_.json).map { json =>
         block(json)

--- a/riff-raff/app/resources/PrismLookup.scala
+++ b/riff-raff/app/resources/PrismLookup.scala
@@ -18,6 +18,11 @@ import utils.Json._
 
 import scala.util.{Failure, Success, Try}
 
+case class Image(imageId: String, creationDate: DateTime)
+object Image {
+  implicit val formats = Json.format[Image]
+}
+
 class PrismLookup(wsClient: WSClient) extends Lookup with Logging {
 
   def keyRing(stage: Stage, apps: Set[App], stack: Stack): KeyRing = KeyRing(
@@ -178,11 +183,9 @@ class PrismLookup(wsClient: WSClient) extends Lookup with Logging {
       conf.Configuration.credentials.lookupSecret(service, account)
   }
 
-  case class Image(imageId: String, creationDate: DateTime)
-  implicit val imageReads = Json.reads[Image]
   private def get(region: String, tags: Map[String, String]): Seq[Image] = {
     val params = tags.map{ case (key, value) => s"tags.${key.urlEncode}=${value.urlEncode}" }.mkString("&")
-    prism.get(s"/images?$params"){ json =>
+    prism.get(s"/images?region=${region.urlEncode}&$params"){ json =>
       (json \ "data" \ "images").as[Seq[Image]]
     }
   }

--- a/riff-raff/test/lookup/PrismLookupTest.scala
+++ b/riff-raff/test/lookup/PrismLookupTest.scala
@@ -10,6 +10,7 @@ import play.api.test.Helpers._
 import resources.{Image, PrismLookup}
 
 import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.duration._
 
 class PrismLookupTest extends FlatSpec with Matchers {
   "PrismLookup" should "return latest image" in {
@@ -28,7 +29,7 @@ class PrismLookupTest extends FlatSpec with Matchers {
         ))
       }
     }
-    val lookup = new PrismLookup(mockClient)
+    val lookup = new PrismLookup(mockClient, "", 10 seconds)
     val result = lookup.getLatestAmi("bob")(Map.empty)
     result shouldBe Some("test-later-still-ami")
   }
@@ -45,7 +46,7 @@ class PrismLookupTest extends FlatSpec with Matchers {
         ))
       }
     }
-    val lookup = new PrismLookup(mockClient)
+    val lookup = new PrismLookup(mockClient, "", 10 seconds)
     val result = lookup.getLatestAmi("bob")(Map.empty)
     result shouldBe None
     mockRequest.flatMap(_.getQueryString("region")) shouldBe Some("bob")
@@ -63,7 +64,7 @@ class PrismLookupTest extends FlatSpec with Matchers {
         ))
       }
     }
-    val lookup = new PrismLookup(mockClient)
+    val lookup = new PrismLookup(mockClient, "", 10 seconds)
     lookup.getLatestAmi("bob")(Map("tagName" -> "tagValue?", "tagName*" -> "tagValue2"))
     mockRequest.map(_.queryString) shouldBe Some(Map(
       "region" -> ArrayBuffer("bob"),

--- a/riff-raff/test/lookup/PrismLookupTest.scala
+++ b/riff-raff/test/lookup/PrismLookupTest.scala
@@ -1,18 +1,40 @@
 package lookup
 
-import mockws.MockWS
 import org.joda.time.DateTime
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.Json
+import play.api.libs.ws.WSClient
+import play.api.mvc.{Action, AnyContent, Request}
 import play.api.mvc.Results._
-import play.api.mvc.{Action, Request}
-import play.api.test.Helpers._
+import play.api.routing.sird._
+import play.api.test.WsTestClient
+import play.core.server.Server
 import resources.{Image, PrismLookup}
 
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
 
 class PrismLookupTest extends FlatSpec with Matchers {
+
+  def withPrismClient[T](images: List[Image])(block: WSClient => T):(T, Option[Request[AnyContent]]) = {
+    var mockRequest: Option[Request[AnyContent]] = None
+    val result = Server.withRouter() {
+      case GET(p"/images") => Action { request =>
+        mockRequest = Some(request)
+        Ok(Json.obj(
+          "data" -> Json.obj(
+            "images" -> Json.toJson(images)
+          )
+        ))
+      }
+    } { implicit port =>
+      WsTestClient.withClient { client =>
+        block(client)
+      }
+    }
+    (result, mockRequest)
+  }
+
   "PrismLookup" should "return latest image" in {
     val images = List(
       Image("test-ami", new DateTime(2017,3,2,13,32,0)),
@@ -20,53 +42,28 @@ class PrismLookupTest extends FlatSpec with Matchers {
       Image("test-later-still-ami", new DateTime(2017,5,2,13,32,0)),
       Image("test-early-ami", new DateTime(2017,1,2,13,32,0))
     )
-    val mockClient = MockWS{
-      case (GET, _) => Action { request =>
-        Ok(Json.obj(
-          "data" -> Json.obj(
-            "images" -> Json.toJson(images)
-          )
-        ))
-      }
+    withPrismClient(images) { client =>
+      val lookup = new PrismLookup(client, "", 10 seconds)
+      val result = lookup.getLatestAmi("bob")(Map.empty)
+      result shouldBe Some("test-later-still-ami")
     }
-    val lookup = new PrismLookup(mockClient, "", 10 seconds)
-    val result = lookup.getLatestAmi("bob")(Map.empty)
-    result shouldBe Some("test-later-still-ami")
   }
 
   it should "narrows ami query by region" in {
-    var mockRequest: Option[Request[_]] = None
-    val mockClient = MockWS{
-      case (GET, _) => Action { request =>
-        mockRequest = Some(request)
-        Ok(Json.obj(
-          "data" -> Json.obj(
-            "images" -> Json.arr()
-          )
-        ))
-      }
+    val (result, request) = withPrismClient(Nil) { client =>
+      val lookup = new PrismLookup(client, "", 10 seconds)
+      lookup.getLatestAmi("bob")(Map.empty)
     }
-    val lookup = new PrismLookup(mockClient, "", 10 seconds)
-    val result = lookup.getLatestAmi("bob")(Map.empty)
     result shouldBe None
-    mockRequest.flatMap(_.getQueryString("region")) shouldBe Some("bob")
+    request.flatMap(_.getQueryString("region")) shouldBe Some("bob")
   }
 
   it should "correctly query using the tags" in {
-    var mockRequest: Option[Request[_]] = None
-    val mockClient = MockWS{
-      case (GET, _) => Action { request =>
-        mockRequest = Some(request)
-        Ok(Json.obj(
-          "data" -> Json.obj(
-            "images" -> Json.arr()
-          )
-        ))
-      }
+    val (result, request) = withPrismClient(Nil) { client =>
+      val lookup = new PrismLookup(client, "", 10 seconds)
+      lookup.getLatestAmi("bob")(Map("tagName" -> "tagValue?", "tagName*" -> "tagValue2"))
     }
-    val lookup = new PrismLookup(mockClient, "", 10 seconds)
-    lookup.getLatestAmi("bob")(Map("tagName" -> "tagValue?", "tagName*" -> "tagValue2"))
-    mockRequest.map(_.queryString) shouldBe Some(Map(
+    request.map(_.queryString) shouldBe Some(Map(
       "region" -> ArrayBuffer("bob"),
       "tags.tagName" -> ArrayBuffer("tagValue?"),
       "tags.tagName*" -> ArrayBuffer("tagValue2")

--- a/riff-raff/test/lookup/PrismLookupTest.scala
+++ b/riff-raff/test/lookup/PrismLookupTest.scala
@@ -1,0 +1,74 @@
+package lookup
+
+import mockws.MockWS
+import org.joda.time.DateTime
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.libs.json.Json
+import play.api.mvc.Results._
+import play.api.mvc.{Action, Request}
+import play.api.test.Helpers._
+import resources.{Image, PrismLookup}
+
+import scala.collection.mutable.ArrayBuffer
+
+class PrismLookupTest extends FlatSpec with Matchers {
+  "PrismLookup" should "return latest image" in {
+    val images = List(
+      Image("test-ami", new DateTime(2017,3,2,13,32,0)),
+      Image("test-later-ami", new DateTime(2017,4,2,13,32,0)),
+      Image("test-later-still-ami", new DateTime(2017,5,2,13,32,0)),
+      Image("test-early-ami", new DateTime(2017,1,2,13,32,0))
+    )
+    val mockClient = MockWS{
+      case (GET, _) => Action { request =>
+        Ok(Json.obj(
+          "data" -> Json.obj(
+            "images" -> Json.toJson(images)
+          )
+        ))
+      }
+    }
+    val lookup = new PrismLookup(mockClient)
+    val result = lookup.getLatestAmi("bob")(Map.empty)
+    result shouldBe Some("test-later-still-ami")
+  }
+
+  it should "narrows ami query by region" in {
+    var mockRequest: Option[Request[_]] = None
+    val mockClient = MockWS{
+      case (GET, _) => Action { request =>
+        mockRequest = Some(request)
+        Ok(Json.obj(
+          "data" -> Json.obj(
+            "images" -> Json.arr()
+          )
+        ))
+      }
+    }
+    val lookup = new PrismLookup(mockClient)
+    val result = lookup.getLatestAmi("bob")(Map.empty)
+    result shouldBe None
+    mockRequest.flatMap(_.getQueryString("region")) shouldBe Some("bob")
+  }
+
+  it should "correctly query using the tags" in {
+    var mockRequest: Option[Request[_]] = None
+    val mockClient = MockWS{
+      case (GET, _) => Action { request =>
+        mockRequest = Some(request)
+        Ok(Json.obj(
+          "data" -> Json.obj(
+            "images" -> Json.arr()
+          )
+        ))
+      }
+    }
+    val lookup = new PrismLookup(mockClient)
+    lookup.getLatestAmi("bob")(Map("tagName" -> "tagValue?", "tagName*" -> "tagValue2"))
+    mockRequest.map(_.queryString) shouldBe Some(Map(
+      "region" -> ArrayBuffer("bob"),
+      "tags.tagName" -> ArrayBuffer("tagValue?"),
+      "tags.tagName*" -> ArrayBuffer("tagValue2")
+    ))
+  }
+}


### PR DESCRIPTION
Whilst looking at something with @thomaska we noticed that the query to Prism did not use the region that is provided to the `getLatestAmi` call. This has worked as we are only in one region, but will cause confusion when that is no longer the case.

This provides a fix along with a few tests to describe the behaviour.