### PR TITLE
Update AWS SDK to 1.11.106

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,10 @@ import Helpers._
 val commonSettings = Seq(
   organization := "com.gu",
   scalaVersion := "2.11.8",
-  scalacOptions ++= Seq("-deprecation", "-feature", "-language:postfixOps,reflectiveCalls,implicitConversions"),
+  scalacOptions ++= Seq("-deprecation", "-feature","-language:postfixOps,reflectiveCalls,implicitConversions", "-Xfatal-warnings"),
+  scalacOptions in(Compile, doc) ++= Seq(
+    "-no-link-warnings" // Suppresses problems with Scaladoc @throws links
+  ),
   version := "1.0",
   resolvers ++= Seq(
     "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/",

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -8,22 +8,22 @@ import com.amazonaws.auth.{AWSCredentialsProvider, AWSCredentialsProviderChain, 
 import com.amazonaws.regions.{RegionUtils, Region => AwsRegion}
 import com.amazonaws.retry.PredefinedRetryPolicies.SDKDefaultRetryCondition
 import com.amazonaws.retry.{PredefinedRetryPolicies, RetryPolicy}
-import com.amazonaws.services.autoscaling.AmazonAutoScalingClient
-import com.amazonaws.services.autoscaling.model.{Instance => ASGInstance, Tag => AsgTag, _}
-import com.amazonaws.services.cloudformation.AmazonCloudFormationClient
+import com.amazonaws.services.autoscaling.{AmazonAutoScaling, AmazonAutoScalingClientBuilder}
+import com.amazonaws.services.autoscaling.model.{Instance => ASGInstance, _}
+import com.amazonaws.services.cloudformation.{AmazonCloudFormation, AmazonCloudFormationClientBuilder}
 import com.amazonaws.services.cloudformation.model.{Stack => AmazonStack, Tag => CfnTag, _}
-import com.amazonaws.services.ec2.AmazonEC2Client
+import com.amazonaws.services.ec2.{AmazonEC2, AmazonEC2ClientBuilder}
 import com.amazonaws.services.ec2.model.{CreateTagsRequest, DescribeInstancesRequest, Tag => EC2Tag}
-import com.amazonaws.services.elasticloadbalancing.{AmazonElasticLoadBalancingClient => ClassicELBClient}
-import com.amazonaws.services.elasticloadbalancingv2.{AmazonElasticLoadBalancingClient => ApplicationELBClient}
+import com.amazonaws.services.elasticloadbalancing.{AmazonElasticLoadBalancing => ClassicELB, AmazonElasticLoadBalancingClientBuilder => ClassicELBBuilder}
+import com.amazonaws.services.elasticloadbalancingv2.{AmazonElasticLoadBalancing => ApplicationELB, AmazonElasticLoadBalancingClientBuilder => ApplicationELBBuilder}
 import com.amazonaws.services.elasticloadbalancing.model.{Instance => ELBInstance, _}
 import com.amazonaws.services.elasticloadbalancingv2.model.{Tag => _, _}
-import com.amazonaws.services.lambda.AWSLambdaClient
+import com.amazonaws.services.lambda.{AWSLambda, AWSLambdaClientBuilder}
 import com.amazonaws.services.lambda.model.UpdateFunctionCodeRequest
 import com.amazonaws.services.s3.model.{BucketLifecycleConfiguration, CreateBucketRequest}
 import com.amazonaws.services.s3.model.BucketLifecycleConfiguration.Rule
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
-import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import com.amazonaws.services.securitytoken.{AWSSecurityTokenService, AWSSecurityTokenServiceClientBuilder}
 import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest
 import com.gu.management.Loggable
 import magenta.{App, DeployReporter, DeploymentPackage, KeyRing, NamedStack, Region, Stack, Stage, UnnamedStack}
@@ -32,8 +32,12 @@ import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 
 object S3 extends AWS {
-  def makeS3client(keyRing: KeyRing, region: Region, config: ClientConfiguration = clientConfiguration): AmazonS3Client =
-    new AmazonS3Client(provider(keyRing), config).withRegion(awsRegion(region))
+  def makeS3client(keyRing: KeyRing, region: Region, config: ClientConfiguration = clientConfiguration): AmazonS3 =
+    AmazonS3ClientBuilder.standard()
+      .withCredentials(provider(keyRing))
+      .withClientConfiguration(config)
+      .withRegion(region.name)
+      .build()
 
   /**
     * Check (and if necessary create) that an S3 bucket exists for the account and region. Note that it is assumed that
@@ -48,7 +52,7 @@ object S3 extends AWS {
     *
     * @return
     */
-  def accountSpecificBucket(prefix: String, s3Client: AmazonS3, stsClient: AWSSecurityTokenServiceClient,
+  def accountSpecificBucket(prefix: String, s3Client: AmazonS3, stsClient: AWSSecurityTokenService,
     region: Region, reporter: DeployReporter, deleteAfterDays: Option[Int] = None): String = {
     val callerIdentityResponse = stsClient.getCallerIdentity(new GetCallerIdentityRequest())
     val accountNumber = callerIdentityResponse.getAccount
@@ -79,8 +83,12 @@ object S3 extends AWS {
 }
 
 object Lambda extends AWS {
-  def makeLambdaClient(keyRing: KeyRing, region: Region): AWSLambdaClient =
-    new AWSLambdaClient(provider(keyRing), clientConfiguration).withRegion(awsRegion(region))
+  def makeLambdaClient(keyRing: KeyRing, region: Region): AWSLambda =
+    AWSLambdaClientBuilder.standard()
+    .withCredentials(provider(keyRing))
+    .withClientConfiguration(clientConfiguration)
+    .withRegion(region.name)
+    .build()
 
   def lambdaUpdateFunctionCodeRequest(functionName: String, buffer: ByteBuffer): UpdateFunctionCodeRequest = {
     val request = new UpdateFunctionCodeRequest
@@ -98,19 +106,23 @@ object Lambda extends AWS {
 }
 
 object ASG extends AWS {
-  def makeAsgClient(keyRing: KeyRing, region: Region): AmazonAutoScalingClient =
-    new AmazonAutoScalingClient(provider(keyRing), clientConfiguration).withRegion(awsRegion(region))
+  def makeAsgClient(keyRing: KeyRing, region: Region): AmazonAutoScaling =
+    AmazonAutoScalingClientBuilder.standard()
+      .withCredentials(provider(keyRing))
+      .withClientConfiguration(clientConfiguration)
+      .withRegion(region.name)
+      .build()
 
-  def desiredCapacity(name: String, capacity: Int, client: AmazonAutoScalingClient) =
+  def desiredCapacity(name: String, capacity: Int, client: AmazonAutoScaling) =
     client.setDesiredCapacity(
       new SetDesiredCapacityRequest().withAutoScalingGroupName(name).withDesiredCapacity(capacity)
     )
 
-  def maxCapacity(name: String, capacity: Int, client: AmazonAutoScalingClient) =
+  def maxCapacity(name: String, capacity: Int, client: AmazonAutoScaling) =
     client.updateAutoScalingGroup(
       new UpdateAutoScalingGroupRequest().withAutoScalingGroupName(name).withMaxSize(capacity))
 
-  def isStabilized(asg: AutoScalingGroup, asgClient: AmazonAutoScalingClient,
+  def isStabilized(asg: AutoScalingGroup, asgClient: AmazonAutoScaling,
     elbClient: ELB.Client): Either[String, Unit] = {
 
     def matchCapacityAndState(states: List[String], desiredState: String, checkDescription: Option[String]): Either[String, Unit] = {
@@ -145,7 +157,7 @@ object ASG extends AWS {
 
   def elbTargetArn(asg: AutoScalingGroup) = asg.getTargetGroupARNs.asScala.headOption
 
-  def cull(asg: AutoScalingGroup, instance: ASGInstance, asgClient: AmazonAutoScalingClient, elbClient: ELB.Client) = {
+  def cull(asg: AutoScalingGroup, instance: ASGInstance, asgClient: AmazonAutoScaling, elbClient: ELB.Client) = {
     ELB.deregister(elbName(asg), elbTargetArn(asg), instance, elbClient)
 
     asgClient.terminateInstanceInAutoScalingGroup(
@@ -154,20 +166,20 @@ object ASG extends AWS {
     )
   }
 
-  def refresh(asg: AutoScalingGroup, client: AmazonAutoScalingClient) =
+  def refresh(asg: AutoScalingGroup, client: AmazonAutoScaling) =
     client.describeAutoScalingGroups(
       new DescribeAutoScalingGroupsRequest().withAutoScalingGroupNames(asg.getAutoScalingGroupName)
     ).getAutoScalingGroups.asScala.head
 
-  def suspendAlarmNotifications(name: String, client: AmazonAutoScalingClient) = client.suspendProcesses(
+  def suspendAlarmNotifications(name: String, client: AmazonAutoScaling) = client.suspendProcesses(
     new SuspendProcessesRequest().withAutoScalingGroupName(name).withScalingProcesses("AlarmNotification")
   )
 
-  def resumeAlarmNotifications(name: String, client: AmazonAutoScalingClient) = client.resumeProcesses(
+  def resumeAlarmNotifications(name: String, client: AmazonAutoScaling) = client.resumeProcesses(
     new ResumeProcessesRequest().withAutoScalingGroupName(name).withScalingProcesses("AlarmNotification")
   )
 
-  def groupForAppAndStage(pkg: DeploymentPackage, stage: Stage, stack: Stack, client: AmazonAutoScalingClient,
+  def groupForAppAndStage(pkg: DeploymentPackage, stage: Stage, stack: Stack, client: AmazonAutoScaling,
     reporter: DeployReporter): AutoScalingGroup = {
     case class ASGMatch(app:App, matches:List[AutoScalingGroup])
 
@@ -222,22 +234,30 @@ object ASG extends AWS {
 
 object ELB extends AWS {
 
-  case class Client(classic: ClassicELBClient, application: ApplicationELBClient)
+  case class Client(classic: ClassicELB, application: ApplicationELB)
 
   def client(keyRing: KeyRing, region: Region): Client =
     Client(classicClient(keyRing, region), applicationClient(keyRing, region))
 
-  def classicClient(keyRing: KeyRing, region: Region): ClassicELBClient =
-    new ClassicELBClient(provider(keyRing), clientConfiguration).withRegion(awsRegion(region))
+  def classicClient(keyRing: KeyRing, region: Region): ClassicELB =
+    ClassicELBBuilder.standard()
+      .withCredentials(provider(keyRing))
+      .withClientConfiguration(clientConfiguration)
+      .withRegion(region.name)
+      .build()
 
-  def applicationClient(keyRing: KeyRing, region: Region): ApplicationELBClient =
-    new ApplicationELBClient(provider(keyRing), clientConfiguration).withRegion(awsRegion(region))
+  def applicationClient(keyRing: KeyRing, region: Region): ApplicationELB =
+    ApplicationELBBuilder.standard()
+      .withCredentials(provider(keyRing))
+      .withClientConfiguration(clientConfiguration)
+      .withRegion(region.name)
+      .build()
 
-  def targetInstancesHealth(targetARN: String, client: ApplicationELBClient): List[String] =
+  def targetInstancesHealth(targetARN: String, client: ApplicationELB): List[String] =
     client.describeTargetHealth(new DescribeTargetHealthRequest().withTargetGroupArn(targetARN))
       .getTargetHealthDescriptions.asScala.toList.map(_.getTargetHealth.getState)
 
-  def instanceHealth(elbName: String, client: ClassicELBClient): List[String] =
+  def instanceHealth(elbName: String, client: ClassicELB): List[String] =
     client.describeInstanceHealth(new DescribeInstanceHealthRequest(elbName))
       .getInstanceStates.asScala.toList.map(_.getState)
 
@@ -254,11 +274,15 @@ object ELB extends AWS {
 }
 
 object EC2 extends AWS {
-  def makeEc2Client(keyRing: KeyRing, region: Region): AmazonEC2Client = {
-    new AmazonEC2Client(provider(keyRing), clientConfiguration).withRegion(awsRegion(region))
+  def makeEc2Client(keyRing: KeyRing, region: Region): AmazonEC2 = {
+    AmazonEC2ClientBuilder.standard()
+      .withCredentials(provider(keyRing))
+      .withClientConfiguration(clientConfiguration)
+      .withRegion(region.name)
+      .build()
   }
 
-  def setTag(instances: List[ASGInstance], key: String, value: String, client: AmazonEC2Client) {
+  def setTag(instances: List[ASGInstance], key: String, value: String, client: AmazonEC2) {
     val request = new CreateTagsRequest().
       withResources(instances map { _.getInstanceId } asJavaCollection).
       withTags(new EC2Tag(key, value))
@@ -266,17 +290,17 @@ object EC2 extends AWS {
     client.createTags(request)
   }
 
-  def hasTag(instance: ASGInstance, key: String, value: String, client: AmazonEC2Client): Boolean = {
+  def hasTag(instance: ASGInstance, key: String, value: String, client: AmazonEC2): Boolean = {
     describe(instance, client).getTags.asScala exists { tag =>
       tag.getKey == key && tag.getValue == value
     }
   }
 
-  def describe(instance: ASGInstance, client: AmazonEC2Client) = client.describeInstances(
+  def describe(instance: ASGInstance, client: AmazonEC2) = client.describeInstances(
     new DescribeInstancesRequest().withInstanceIds(instance.getInstanceId)
   ).getReservations.asScala.flatMap(_.getInstances.asScala).head
 
-  def apply(instance: ASGInstance, client: AmazonEC2Client) = describe(instance, client)
+  def apply(instance: ASGInstance, client: AmazonEC2) = describe(instance, client)
 }
 
 object CloudFormation extends AWS {
@@ -290,11 +314,15 @@ object CloudFormation extends AWS {
 
   val CAPABILITY_IAM = "CAPABILITY_IAM"
 
-  def makeCfnClient(keyRing: KeyRing, region: Region): AmazonCloudFormationClient = {
-    new AmazonCloudFormationClient(provider(keyRing), clientConfiguration).withRegion(awsRegion(region))
+  def makeCfnClient(keyRing: KeyRing, region: Region): AmazonCloudFormation = {
+    AmazonCloudFormationClientBuilder.standard()
+      .withCredentials(provider(keyRing))
+      .withClientConfiguration(clientConfiguration)
+      .withRegion(region.name)
+      .build()
   }
 
-  def validateTemplate(template: Template, client: AmazonCloudFormationClient) = {
+  def validateTemplate(template: Template, client: AmazonCloudFormation) = {
     val request = template match {
       case TemplateBody(body) => new ValidateTemplateRequest().withTemplateBody(body)
       case TemplateUrl(url) => new ValidateTemplateRequest().withTemplateURL(url)
@@ -303,7 +331,7 @@ object CloudFormation extends AWS {
   }
 
   def updateStack(name: String, template: Template, parameters: Map[String, ParameterValue],
-    client: AmazonCloudFormationClient) = {
+    client: AmazonCloudFormation) = {
 
     val request = new UpdateStackRequest().withStackName(name).withCapabilities(CAPABILITY_IAM).withParameters(
       parameters map {
@@ -318,7 +346,7 @@ object CloudFormation extends AWS {
     client.updateStack(requestWithTemplate)
   }
 
-  def updateStackParams(name: String, parameters: Map[String, ParameterValue], client: AmazonCloudFormationClient) =
+  def updateStackParams(name: String, parameters: Map[String, ParameterValue], client: AmazonCloudFormation) =
     client.updateStack(
       new UpdateStackRequest()
         .withStackName(name)
@@ -333,7 +361,7 @@ object CloudFormation extends AWS {
     )
 
   def createStack(reporter: DeployReporter, name: String, maybeTags: Option[Map[String, String]], template: Template, parameters: Map[String, ParameterValue],
-    client: AmazonCloudFormationClient) = {
+    client: AmazonCloudFormation) = {
 
     val request = new CreateStackRequest()
       .withStackName(name)
@@ -358,17 +386,17 @@ object CloudFormation extends AWS {
     client.createStack(requestWithTemplate)
   }
 
-  def describeStack(name: String, client: AmazonCloudFormationClient) =
+  def describeStack(name: String, client: AmazonCloudFormation) =
     client.describeStacks(
       new DescribeStacksRequest()
     ).getStacks.asScala.find(_.getStackName == name)
 
-  def describeStackEvents(name: String, client: AmazonCloudFormationClient) =
+  def describeStackEvents(name: String, client: AmazonCloudFormation) =
     client.describeStackEvents(
       new DescribeStackEventsRequest().withStackName(name)
     )
 
-  def findStackByTags(tags: Map[String, String], reporter: DeployReporter, client: AmazonCloudFormationClient): Option[AmazonStack] = {
+  def findStackByTags(tags: Map[String, String], reporter: DeployReporter, client: AmazonCloudFormation): Option[AmazonStack] = {
 
     def tagsMatch(stack: AmazonStack): Boolean =
       tags.forall { case (key, value) => stack.getTags.asScala.exists(t => t.getKey == key && t.getValue == value) }
@@ -402,8 +430,12 @@ object CloudFormation extends AWS {
 }
 
 object STS extends AWS {
-  def makeSTSclient(keyRing: KeyRing, region: Region): AWSSecurityTokenServiceClient = {
-    new AWSSecurityTokenServiceClient(provider(keyRing), clientConfiguration).withRegion(awsRegion(region))
+  def makeSTSclient(keyRing: KeyRing, region: Region): AWSSecurityTokenService = {
+    AWSSecurityTokenServiceClientBuilder.standard()
+      .withCredentials(provider(keyRing))
+      .withClientConfiguration(clientConfiguration)
+      .withRegion(region.name)
+      .build()
   }
 }
 
@@ -429,8 +461,6 @@ trait AWS extends Loggable {
       def getCredentials = envCredentials
     }
   )
-
-  def awsRegion(region: Region): AwsRegion = RegionUtils.getRegion(region.name)
 
   /* A retry condition that logs errors and retries on ParseExceptions.
    * The parse conditions result under heavy load by all accounts and are not in the default retry policy due to

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -3,7 +3,7 @@ package magenta.tasks
 import com.amazonaws.AmazonServiceException
 import com.amazonaws.services.cloudformation.model.StackEvent
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService
 import magenta.artifact.S3Path
 import magenta.deployment_type.CloudFormationDeploymentTypeParameters._
 import magenta.tasks.CloudFormation._
@@ -81,7 +81,7 @@ object UpdateCloudFormationTask {
     }
   }
 
-  def processTemplate(stackName: String, templateBody: String, s3Client: AmazonS3, stsClient: AWSSecurityTokenServiceClient,
+  def processTemplate(stackName: String, templateBody: String, s3Client: AmazonS3, stsClient: AWSSecurityTokenService,
     region: Region, alwaysUploadToS3: Boolean, reporter: DeployReporter): Template = {
     val templateTooBigForSdkUpload = templateBody.length > 51200
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val aws = "1.11.67"
+    val aws = "1.11.106"
     val guardianManagement = "5.35"
     val guardianManagementPlay = "8.0"
     val jackson = "2.8.2"


### PR DESCRIPTION
Also fixes all deprecation warnings. (Mostly how the different aws clients are being constructed)

`1.11.106` contains the fix to the `XMLStreamExceptions` issue we have been trying to fixed for a while now. See https://github.com/guardian/riff-raff/issues/413 and https://github.com/guardian/riff-raff/pull/415

https://github.com/aws/aws-sdk-java/blob/799319f670344153d588e7e42095653fabf01673/CHANGELOG.md#bugfixes

