### PR TITLE
Wrap request so we don't NPE when it is null

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -470,9 +470,9 @@ trait AWS extends Loggable {
     override def shouldRetry(originalRequest: AmazonWebServiceRequest, exception: AmazonClientException, retriesAttempted: Int): Boolean = {
       val willRetry = super.shouldRetry(originalRequest, exception, retriesAttempted)
       if (willRetry) {
-        logger.warn(s"AWS SDK retry $retriesAttempted: ${originalRequest.getClass.getName} threw ${exceptionInfo(exception)}")
+        logger.warn(s"AWS SDK retry $retriesAttempted: ${Option(originalRequest).map(_.getClass.getName)} threw ${exceptionInfo(exception)}")
       } else {
-        logger.warn(s"Encounted fatal exception during AWS API call", exception)
+        logger.warn(s"Encountered fatal exception during AWS API call", exception)
         Option(exception.getCause).foreach(t => logger.warn(s"Cause of fatal exception", t))
       }
       willRetry


### PR DESCRIPTION
We saw a deploy that threw an NPE on this line. Aside from the `logger` the only expression that looked like it might throw an NPE is the `originalRequest` so this guards it in an option in the log expression.