### PR TITLE
scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,1 @@
+maxColumn = 120

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,11 @@ import Helpers._
 val commonSettings = Seq(
   organization := "com.gu",
   scalaVersion := "2.11.8",
-  scalacOptions ++= Seq("-deprecation", "-feature","-language:postfixOps,reflectiveCalls,implicitConversions", "-Xfatal-warnings"),
-  scalacOptions in(Compile, doc) ++= Seq(
+  scalacOptions ++= Seq("-deprecation",
+                        "-feature",
+                        "-language:postfixOps,reflectiveCalls,implicitConversions",
+                        "-Xfatal-warnings"),
+  scalacOptions in (Compile, doc) ++= Seq(
     "-no-link-warnings" // Suppresses problems with Scaladoc @throws links
   ),
   version := "1.0",
@@ -15,18 +18,21 @@ val commonSettings = Seq(
   )
 )
 
-lazy val root = project.in(file("."))
+lazy val root = project
+  .in(file("."))
   .aggregate(lib, riffraff)
 
-lazy val lib = project.in(file("magenta-lib"))
+lazy val lib = project
+  .in(file("magenta-lib"))
   .settings(commonSettings)
-  .settings(Seq(
-    libraryDependencies ++= magentaLibDeps,
+  .settings(
+    Seq(
+      libraryDependencies ++= magentaLibDeps,
+      testOptions in Test += Tests.Argument("-oF")
+    ))
 
-    testOptions in Test += Tests.Argument("-oF")
-  ))
-
-lazy val riffraff = project.in(file("riff-raff"))
+lazy val riffraff = project
+  .in(file("riff-raff"))
   .dependsOn(lib % "compile->compile;test->test")
   .enablePlugins(PlayScala, BuildInfoPlugin, RiffRaffArtifact)
   .settings(commonSettings)
@@ -39,27 +45,26 @@ lazy val riffraff = project.in(file("riff-raff"))
       "views.html.helper.magenta._",
       "com.gu.googleauth.AuthenticatedRequest"
     ),
-
     buildInfoKeys := Seq[BuildInfoKey](
-      name, version, scalaVersion, sbtVersion,
+      name,
+      version,
+      scalaVersion,
+      sbtVersion,
       sbtbuildinfo.BuildInfoKey.constant("gitCommitId", System.getProperty("build.vcs.number", "DEV").dequote.trim),
       sbtbuildinfo.BuildInfoKey.constant("buildNumber", System.getProperty("build.number", "DEV").dequote.trim)
     ),
     buildInfoOptions += BuildInfoOption.BuildTime,
     buildInfoPackage := "riffraff",
-
     resolvers += "Brian Clapper Bintray" at "http://dl.bintray.com/bmc/maven",
     libraryDependencies ++= riffRaffDeps,
-
     packageName in Universal := normalizedName.value,
     topLevelDirectory in Universal := Some(normalizedName.value),
     riffRaffPackageType := (packageZipTarball in Universal).value,
-    riffRaffArtifactResources  := Seq(
+    riffRaffArtifactResources := Seq(
       riffRaffPackageType.value -> s"${name.value}/${name.value}.tgz",
       baseDirectory.value / "bootstrap.sh" -> s"${name.value}/bootstrap.sh",
       baseDirectory.value / "riff-raff.yaml" -> "riff-raff.yaml"
     ),
-
     ivyXML := {
       <dependencies>
         <exclude org="commons-logging"><!-- Conflicts with acl-over-slf4j in Play. --> </exclude>
@@ -68,8 +73,6 @@ lazy val riffraff = project.in(file("riff-raff"))
         <exclude org="xpp3"></exclude>
       </dependencies>
     },
-
     fork in Test := false,
-
     includeFilter in (Assets, LessKeys.less) := "*.less"
   ))

--- a/magenta-lib/src/main/scala/magenta/Credentials.scala
+++ b/magenta-lib/src/main/scala/magenta/Credentials.scala
@@ -1,6 +1,5 @@
 package magenta
 
-
 case class KeyRing(apiCredentials: Map[String, ApiCredentials] = Map.empty) {
   override def toString = apiCredentials.values.toList.mkString(", ")
 }

--- a/magenta-lib/src/main/scala/magenta/DeployContext.scala
+++ b/magenta-lib/src/main/scala/magenta/DeployContext.scala
@@ -5,8 +5,11 @@ import java.util.UUID
 import magenta.graph.{DeploymentGraph, DeploymentTasks, Graph}
 
 object DeployContext {
-  def apply(deployId: UUID, parameters: DeployParameters, project: Project,
-    resources: DeploymentResources, region: Region): DeployContext = {
+  def apply(deployId: UUID,
+            parameters: DeployParameters,
+            project: Project,
+            resources: DeploymentResources,
+            region: Region): DeployContext = {
 
     val tasks = {
       resources.reporter.info("Resolving tasks...")
@@ -25,7 +28,8 @@ case class DeployContext(uuid: UUID, parameters: DeployParameters, tasks: Graph[
 
   def execute(reporter: DeployReporter) {
     val taskList = DeploymentGraph.toTaskList(tasks)
-    if (taskList.isEmpty) reporter.fail("No tasks were found to execute. Ensure the app(s) are in the list supported by this stage/host.")
+    if (taskList.isEmpty)
+      reporter.fail("No tasks were found to execute. Ensure the app(s) are in the list supported by this stage/host.")
 
     taskList.foreach { task =>
       reporter.taskContext(task) { taskLogger =>
@@ -35,4 +39,4 @@ case class DeployContext(uuid: UUID, parameters: DeployParameters, tasks: Graph[
   }
 }
 
-case class DeployStoppedException(message:String) extends Exception(message)
+case class DeployStoppedException(message: String) extends Exception(message)

--- a/magenta-lib/src/main/scala/magenta/DeploymentPackage.scala
+++ b/magenta-lib/src/main/scala/magenta/DeploymentPackage.scala
@@ -6,13 +6,12 @@ import play.api.libs.json.JsValue
 
 object DeploymentPackage {
   def apply(name: String,
-    pkgApps: Seq[App],
-    pkgSpecificData: Map[String, JsValue],
-    deploymentTypeName: String,
-    s3Package: S3Path,
-    legacyConfig: Boolean,
-    deploymentTypes: Seq[DeploymentType]
-  ): DeploymentPackage = {
+            pkgApps: Seq[App],
+            pkgSpecificData: Map[String, JsValue],
+            deploymentTypeName: String,
+            s3Package: S3Path,
+            legacyConfig: Boolean,
+            deploymentTypes: Seq[DeploymentType]): DeploymentPackage = {
     val deploymentType = deploymentTypes find (_.name == deploymentTypeName) getOrElse (
       throw new IllegalArgumentException(s"Package type $deploymentTypeName of package $name is unknown")
     )
@@ -20,13 +19,12 @@ object DeploymentPackage {
   }
 }
 
-case class DeploymentPackage(
-  name: String,
-  pkgApps: Seq[App],
-  pkgSpecificData: Map[String, JsValue],
-  deploymentType: DeploymentType,
-  s3Package: S3Path,
-  legacyConfig: Boolean) {
+case class DeploymentPackage(name: String,
+                             pkgApps: Seq[App],
+                             pkgSpecificData: Map[String, JsValue],
+                             deploymentType: DeploymentType,
+                             s3Package: S3Path,
+                             legacyConfig: Boolean) {
 
   def mkDeploymentStep(action: String): DeploymentStep = deploymentType.mkDeploymentStep(action)(this)
   val apps = pkgApps

--- a/magenta-lib/src/main/scala/magenta/Lookup.scala
+++ b/magenta-lib/src/main/scala/magenta/Lookup.scala
@@ -4,14 +4,14 @@ import org.joda.time.DateTime
 
 trait DataLookup {
   def keys: Seq[String]
-  def all: Map[String,Seq[Datum]]
-  def get(key:String): Seq[Datum] = all.getOrElse(key, Nil)
+  def all: Map[String, Seq[Datum]]
+  def get(key: String): Seq[Datum] = all.getOrElse(key, Nil)
   def datum(key: String, app: App, stage: Stage, stack: Stack): Option[Datum]
 }
 
 trait HostLookup {
-  def all:Seq[Host]
-  def get(pkg: DeploymentPackage, app: App, parameters: DeployParameters, stack: Stack):Seq[Host]
+  def all: Seq[Host]
+  def get(pkg: DeploymentPackage, app: App, parameters: DeployParameters, stack: Stack): Seq[Host]
 }
 
 trait Lookup {
@@ -27,4 +27,3 @@ trait Lookup {
 trait SecretProvider {
   def lookup(service: String, account: String): Option[String]
 }
-

--- a/magenta-lib/src/main/scala/magenta/Project.scala
+++ b/magenta-lib/src/main/scala/magenta/Project.scala
@@ -6,14 +6,12 @@ import magenta.tasks.Task
 
 import scala.math.Ordering.OptionOrdering
 
-case class Host(
-    name: String,
-    apps: Set[App] = Set.empty,
-    stage: String = "NO_STAGE",
-    stack: Option[String] = None,
-    connectAs: Option[String] = None,
-    tags: Map[String, String] = Map.empty)
-{
+case class Host(name: String,
+                apps: Set[App] = Set.empty,
+                stage: String = "NO_STAGE",
+                stack: Option[String] = None,
+                connectAs: Option[String] = None,
+                tags: Map[String, String] = Map.empty) {
   def app(app: App) = this.copy(apps = apps + app)
 
   def as(user: String) = this.copy(connectAs = Some(user))
@@ -30,11 +28,11 @@ case class Host(
 }
 
 case class Datum(
-  stack: Option[String],
-  app: String,
-  stage: String,
-  value: String,
-  comment: Option[String]
+    stack: Option[String],
+    app: String,
+    stage: String,
+    value: String,
+    comment: Option[String]
 ) {
   lazy val stackRegex = stack.map(s => s"^$s$$".r)
   lazy val appRegex = ("^%s$" format app).r
@@ -42,10 +40,13 @@ case class Datum(
 }
 
 case class HostList(hosts: Seq[Host]) {
-  def dump = hosts
-    .sortBy { _.name }
-    .map { h => s" ${h.name}: ${h.apps.map(_.toString).mkString(", ")}" }
-    .mkString("\n")
+  def dump =
+    hosts
+      .sortBy { _.name }
+      .map { h =>
+        s" ${h.name}: ${h.apps.map(_.toString).mkString(", ")}"
+      }
+      .mkString("\n")
 
   def filterByStage(stage: Stage): HostList = new HostList(hosts.filter(_.stage == stage.name))
 
@@ -78,25 +79,25 @@ trait DeploymentStep {
   def resolve(resources: DeploymentResources, target: DeployTarget): List[Task]
 }
 
-case class App (name: String)
+case class App(name: String)
 
 case class Recipe(
-  name: String,
-  deploymentSteps: Iterable[DeploymentStep] = Nil,
-  dependsOn: List[String] = Nil
+    name: String,
+    deploymentSteps: Iterable[DeploymentStep] = Nil,
+    dependsOn: List[String] = Nil
 )
 
 case class Project(
-  packages: Map[String, DeploymentPackage] = Map.empty,
-  recipes: Map[String, Recipe] = Map.empty,
-  defaultStacks: Seq[Stack] = Seq()
+    packages: Map[String, DeploymentPackage] = Map.empty,
+    recipes: Map[String, Recipe] = Map.empty,
+    defaultStacks: Seq[Stack] = Seq()
 ) {
   lazy val applications = packages.values.flatMap(_.apps).toSet
 }
 
 case class Stage(name: String)
-case class Build(projectName:String, id:String)
-case class RecipeName(name:String)
+case class Build(projectName: String, id: String)
+case class RecipeName(name: String)
 object DefaultRecipe {
   def apply() = RecipeName("default")
 }
@@ -116,11 +117,11 @@ case class Region(name: String) extends AnyVal
 case class Deployer(name: String)
 
 case class DeployParameters(
-                             deployer: Deployer,
-                             build: Build,
-                             stage: Stage,
-                             recipe: RecipeName = DefaultRecipe(),
-                             stacks: Seq[NamedStack] = Seq(),
-                             hostList: List[String] = Nil,
-                             selector: DeploymentSelector = All
-                             )
+    deployer: Deployer,
+    build: Build,
+    stage: Stage,
+    recipe: RecipeName = DefaultRecipe(),
+    stacks: Seq[NamedStack] = Seq(),
+    hostList: List[String] = Nil,
+    selector: DeploymentSelector = All
+)

--- a/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
+++ b/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
@@ -17,8 +17,8 @@ trait S3Location {
   def bucket: String
   def key: String
   def prefixElements: List[String] = key.split("/").toList
-  def fileName:String = prefixElements.last
-  def extension:Option[String] = if (fileName.contains(".")) Some(fileName.split('.').last) else None
+  def fileName: String = prefixElements.last
+  def extension: Option[String] = if (fileName.contains(".")) Some(fileName.split('.').last) else None
   def relativeTo(path: S3Location): String = {
     key.stripPrefix(path.key).stripPrefix("/")
   }
@@ -35,11 +35,12 @@ object S3Location extends Loggable {
   val maxKeysInBucketListing = 1000 // AWS won't return more than this, even if you set the parameter to a larger value
 
   private def listObjects(bucket: String, prefix: Option[String])(implicit s3Client: AmazonS3): Seq[S3Object] = {
-    def request(continuationToken: Option[String]) = new ListObjectsV2Request()
-      .withBucketName(bucket)
-      .withPrefix(prefix.orNull)
-      .withMaxKeys(maxKeysInBucketListing)
-      .withContinuationToken(continuationToken.orNull)
+    def request(continuationToken: Option[String]) =
+      new ListObjectsV2Request()
+        .withBucketName(bucket)
+        .withPrefix(prefix.orNull)
+        .withMaxKeys(maxKeysInBucketListing)
+        .withContinuationToken(continuationToken.orNull)
 
     @tailrec
     def pageListings(acc: Seq[ListObjectsV2Result], previousListing: ListObjectsV2Result): Seq[ListObjectsV2Result] = {
@@ -60,7 +61,7 @@ object S3Location extends Loggable {
     } yield S3Object(summary.getBucketName, summary.getKey, summary.getSize)
   }
 
-  def fetchContentAsString(location: S3Location)(implicit client:AmazonS3): Either[S3Error, String] = {
+  def fetchContentAsString(location: S3Location)(implicit client: AmazonS3): Either[S3Error, String] = {
     import cats.syntax.either._
     Either.catchNonFatal(client.getObjectAsString(location.bucket, location.key)).leftMap {
       case e: AmazonS3Exception if e.getStatusCode == 404 => EmptyS3Location(location)
@@ -106,30 +107,33 @@ object S3JsonArtifact extends Loggable {
   }
 
   def fetchInputFile(artifact: S3JsonArtifact)(
-    implicit client: AmazonS3, reporter: DeployReporter): Either[ArtifactResolutionError, JsonInputFile] = {
+      implicit client: AmazonS3,
+      reporter: DeployReporter): Either[ArtifactResolutionError, JsonInputFile] = {
 
     import cats.syntax.either._
     val possibleJson = (artifact.deployObject.fetchContentAsString()(client)).orElse {
       convertFromZipBundle(artifact)
       artifact.deployObject.fetchContentAsString()(client)
     }
-    possibleJson.leftMap[ArtifactResolutionError](S3ArtifactError(_)).flatMap(s =>
-      JsonInputFile.parse(s).leftMap(JsonArtifactError(_))
-    )
+    possibleJson
+      .leftMap[ArtifactResolutionError](S3ArtifactError(_))
+      .flatMap(s => JsonInputFile.parse(s).leftMap(JsonArtifactError(_)))
   }
 
   def convertFromZipBundle(artifact: S3JsonArtifact)(implicit client: AmazonS3, reporter: DeployReporter): Unit = {
-    reporter.warning("DEPRECATED: The artifact.zip is now a legacy format - please switch to the new format (if you are using sbt-riffraff-artifact then simply upgrade to >= 0.9.4, if you use the TeamCity upload plugin you'll need to use the riffRaffNotifyTeamcity task instead of the riffRaffArtifact task)")
+    reporter.warning(
+      "DEPRECATED: The artifact.zip is now a legacy format - please switch to the new format (if you are using sbt-riffraff-artifact then simply upgrade to >= 0.9.4, if you use the TeamCity upload plugin you'll need to use the riffRaffNotifyTeamcity task instead of the riffRaffArtifact task)")
     reporter.info("Converting artifact.zip to S3 layout")
     implicit val sourceBucket: Option[String] = Some(artifact.bucket)
-    S3ZipArtifact.withDownload(artifact){ dir =>
+    S3ZipArtifact.withDownload(artifact) { dir =>
       val filesToUpload = resolveFiles(dir, artifact.key)
       reporter.info(s"Uploading contents of artifact (${filesToUpload.size} files) to S3")
-      filesToUpload.foreach{ case (file, key) =>
-        val metadata = new ObjectMetadata()
-        metadata.setContentLength(file.length)
-        val req = new PutObjectRequest(artifact.bucket, key, file).withMetadata(metadata)
-        client.putObject(req)
+      filesToUpload.foreach {
+        case (file, key) =>
+          val metadata = new ObjectMetadata()
+          metadata.setContentLength(file.length)
+          val req = new PutObjectRequest(artifact.bucket, key, file).withMetadata(metadata)
+          client.putObject(req)
       }
       reporter.info(s"Zip artifact converted")
     }(client, reporter)
@@ -138,7 +142,7 @@ object S3JsonArtifact extends Loggable {
     reporter.verbose("Zip artifact deleted")
   }
 
-  private def subDirectoryPrefix(key: String, file:File): String = {
+  private def subDirectoryPrefix(key: String, file: File): String = {
     if (key.isEmpty) {
       file.getName
     } else {

--- a/magenta-lib/src/main/scala/magenta/artifact/S3ZipArtifact.scala
+++ b/magenta-lib/src/main/scala/magenta/artifact/S3ZipArtifact.scala
@@ -14,7 +14,7 @@ import scalax.io.{Resource, ScalaIOException}
 
 object S3ZipArtifact {
   def download(artifact: S3JsonArtifact)(implicit client: AmazonS3, reporter: DeployReporter): File = {
-    val dir = Path.createTempDirectory(prefix="riffraff-", suffix="")
+    val dir = Path.createTempDirectory(prefix = "riffraff-", suffix = "")
     download(artifact, dir)(client, reporter)
     dir
   }
@@ -37,10 +37,11 @@ object S3ZipArtifact {
     } catch {
       case e: AmazonS3Exception if e.getStatusCode == 404 =>
         reporter.fail(s"404 downloading $path\n - have you got the project name and build number correct?")
-      case e: ScalaIOException => e.getCause match {
-        case e: AmazonS3Exception if e.getStatusCode == 404 =>
-          reporter.fail(s"404 downloading $path\n - have you got the project name and build number correct?")
-      }
+      case e: ScalaIOException =>
+        e.getCause match {
+          case e: AmazonS3Exception if e.getStatusCode == 404 =>
+            reporter.fail(s"404 downloading $path\n - have you got the project name and build number correct?")
+        }
     } finally {
       artifactPath.delete()
     }
@@ -51,8 +52,7 @@ object S3ZipArtifact {
     client.deleteObject(path.bucket, path.key)
   }
 
-  def withDownload[T](artifact: S3JsonArtifact)(block: File => T)
-    (client: AmazonS3, reporter: DeployReporter): T = {
+  def withDownload[T](artifact: S3JsonArtifact)(block: File => T)(client: AmazonS3, reporter: DeployReporter): T = {
     val tempDir = Try { download(artifact)(client, reporter) }
     val result = tempDir.map(block)
     tempDir.map(dir => Path(dir).deleteRecursively(continueOnFailure = true))

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Action.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Action.scala
@@ -7,8 +7,8 @@ trait ActionRegister {
   def add(action: Action): Unit
 }
 
-case class Action(name: String, documentation: String = "_undocumented_")
-  (val taskGenerator: (DeploymentPackage, DeploymentResources, DeployTarget) => List[Task])
-  (implicit register:ActionRegister) {
+case class Action(name: String, documentation: String = "_undocumented_")(
+    val taskGenerator: (DeploymentPackage, DeploymentResources, DeployTarget) => List[Task])(
+    implicit register: ActionRegister) {
   register.add(this)
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
@@ -39,12 +39,14 @@ object AmiCloudFormationParameter extends DeploymentType with CloudFormationDepl
       |You'll need to add this to the Riff-Raff IAM account used for your project.
     """.stripMargin
 
-  val update = Action("update",
+  val update = Action(
+    "update",
     """
       |Given AMI tags, this will resolve the latest matching AMI and update the AMI parameter
       | on the provided CloudFormation stack.
     """.stripMargin
-  ){ (pkg, resources, target) => {
+  ) { (pkg, resources, target) =>
+    {
       implicit val keyRing = resources.assembleKeyring(target, pkg)
       val reporter = resources.reporter
 

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -3,7 +3,7 @@ package magenta.deployment_type
 import magenta.tasks._
 import java.io.File
 
-object AutoScaling  extends DeploymentType {
+object AutoScaling extends DeploymentType {
   val name = "autoscaling"
   val documentation =
     """
@@ -53,34 +53,42 @@ object AutoScaling  extends DeploymentType {
       |You'll need to add this to the Riff-Raff IAM account used for your project.
     """.stripMargin
 
-  val bucket = Param[String]("bucket",
+  val bucket = Param[String](
+    "bucket",
     """
       |S3 bucket name to upload artifact into.
       |
       |The path in the bucket is `<stack>/<stage>/<packageName>/<fileName>`.
     """.stripMargin,
     optionalInYaml = true
-  ).defaultFromContext((_, target) => target.stack.nameOption.map(stackName => s"$stackName-dist").toRight("You must specify bucket explicitly when not using stacks"))
-  val secondsToWait = Param("secondsToWait", "Number of seconds to wait for instances to enter service").default(15 * 60)
-  val healthcheckGrace = Param("healthcheckGrace", "Number of seconds to wait for the AWS api to stabilise").default(20)
-  val warmupGrace = Param("warmupGrace", "Number of seconds to wait for the instances in the load balancer to warm up").default(1)
-  val terminationGrace = Param("terminationGrace", "Number of seconds to wait for the AWS api to stabilise after instance termination").default(10)
+  ).defaultFromContext(
+    (_, target) =>
+      target.stack.nameOption
+        .map(stackName => s"$stackName-dist")
+        .toRight("You must specify bucket explicitly when not using stacks"))
+  val secondsToWait =
+    Param("secondsToWait", "Number of seconds to wait for instances to enter service").default(15 * 60)
+  val healthcheckGrace =
+    Param("healthcheckGrace", "Number of seconds to wait for the AWS api to stabilise").default(20)
+  val warmupGrace =
+    Param("warmupGrace", "Number of seconds to wait for the instances in the load balancer to warm up").default(1)
+  val terminationGrace =
+    Param("terminationGrace", "Number of seconds to wait for the AWS api to stabilise after instance termination")
+      .default(10)
 
-  val prefixStage = Param[Boolean]("prefixStage",
-    documentation = "Whether to prefix `stage` to the S3 location"
-  ).default(true)
-  val prefixPackage = Param[Boolean]("prefixPackage",
-    documentation = "Whether to prefix `package` to the S3 location"
-  ).default(true)
-  val prefixStack = Param[Boolean]("prefixStack",
-    documentation = "Whether to prefix `stack` to the S3 location"
-  ).default(true)
+  val prefixStage =
+    Param[Boolean]("prefixStage", documentation = "Whether to prefix `stage` to the S3 location").default(true)
+  val prefixPackage =
+    Param[Boolean]("prefixPackage", documentation = "Whether to prefix `package` to the S3 location").default(true)
+  val prefixStack =
+    Param[Boolean]("prefixStack", documentation = "Whether to prefix `stack` to the S3 location").default(true)
 
-  val publicReadAcl = Param[Boolean]("publicReadAcl",
-    "Whether the uploaded artifacts should be given the PublicRead Canned ACL"
-  ).defaultFromContext((pkg, _) => Right(pkg.legacyConfig))
+  val publicReadAcl =
+    Param[Boolean]("publicReadAcl", "Whether the uploaded artifacts should be given the PublicRead Canned ACL")
+      .defaultFromContext((pkg, _) => Right(pkg.legacyConfig))
 
-  val deploy = Action("deploy",
+  val deploy = Action(
+    "deploy",
     """
       |Carries out the update of instances in an autoscaling group. We carry out the following tasks:
       | - tag existing instances in the ASG with a termination tag
@@ -116,10 +124,9 @@ object AutoScaling  extends DeploymentType {
   }
 
   val uploadArtifacts = Action("uploadArtifacts",
-    """
+                               """
       |Uploads the files in the deployment's directory to the specified bucket.
-    """.stripMargin
-  ){ (pkg, resources, target) =>
+    """.stripMargin) { (pkg, resources, target) =>
     implicit val keyRing = resources.assembleKeyring(target, pkg)
     implicit val artifactClient = resources.artifactClient
     val reporter = resources.reporter

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -32,11 +32,13 @@ object CloudFormation extends DeploymentType with CloudFormationDeploymentTypePa
     documentation =
       "Location of template to use within package. If it has a standard YAML file extension (`.yml` or `.yaml`), the template will be converted from YAML to JSON."
   ).default("""cloud-formation/cfn.json""")
+
   val templateParameters = Param[Map[String, String]](
     "templateParameters",
     documentation =
       "Map of parameter names and values to be passed into template. `Stage` and `Stack` (if `defaultStacks` are specified) will be appropriately set automatically."
   ).default(Map.empty)
+
   val templateStageParameters = Param[Map[String, Map[String, String]]](
     "templateStageParameters",
     documentation = """Like templateParameters, a map of parameter names and values, but in this case keyed by stage to
@@ -51,11 +53,11 @@ object CloudFormation extends DeploymentType with CloudFormationDeploymentTypePa
         |templateParameters parameters, with stage-specific values overriding general parameters
         |when in conflict.""".stripMargin
   ).default(Map.empty)
-  val createStackIfAbsent =
-    Param[Boolean]("createStackIfAbsent",
-                   documentation =
-                     "If set to true then the cloudformation stack will be created if it doesn't already exist")
-      .default(true)
+  val createStackIfAbsent = Param[Boolean](
+    "createStackIfAbsent",
+    documentation =
+      "If set to true then the cloudformation stack will be created if it doesn't already exist")
+  .default(true)
 
   val updateStack = Action(
     "updateStack",

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -27,15 +27,19 @@ object CloudFormation extends DeploymentType with CloudFormationDeploymentTypePa
       |to this bucket and sent to CloudFormation using the template URL parameter.
     """.stripMargin
 
-  val templatePath = Param[String]("templatePath",
-    documentation = "Location of template to use within package. If it has a standard YAML file extension (`.yml` or `.yaml`), the template will be converted from YAML to JSON."
-  ).default("""cloud-formation/cfn.json""")
-  val templateParameters = Param[Map[String, String]]("templateParameters",
-    documentation = "Map of parameter names and values to be passed into template. `Stage` and `Stack` (if `defaultStacks` are specified) will be appropriately set automatically."
-  ).default(Map.empty)
-  val templateStageParameters = Param[Map[String, Map[String, String]]]("templateStageParameters",
+  val templatePath = Param[String](
+    "templatePath",
     documentation =
-      """Like templateParameters, a map of parameter names and values, but in this case keyed by stage to
+      "Location of template to use within package. If it has a standard YAML file extension (`.yml` or `.yaml`), the template will be converted from YAML to JSON."
+  ).default("""cloud-formation/cfn.json""")
+  val templateParameters = Param[Map[String, String]](
+    "templateParameters",
+    documentation =
+      "Map of parameter names and values to be passed into template. `Stage` and `Stack` (if `defaultStacks` are specified) will be appropriately set automatically."
+  ).default(Map.empty)
+  val templateStageParameters = Param[Map[String, Map[String, String]]](
+    "templateStageParameters",
+    documentation = """Like templateParameters, a map of parameter names and values, but in this case keyed by stage to
         |support stage-specific configuration. E.g.
         |
         |    {
@@ -47,17 +51,21 @@ object CloudFormation extends DeploymentType with CloudFormationDeploymentTypePa
         |templateParameters parameters, with stage-specific values overriding general parameters
         |when in conflict.""".stripMargin
   ).default(Map.empty)
-  val createStackIfAbsent = Param[Boolean]("createStackIfAbsent",
-    documentation = "If set to true then the cloudformation stack will be created if it doesn't already exist"
-  ).default(true)
+  val createStackIfAbsent =
+    Param[Boolean]("createStackIfAbsent",
+                   documentation =
+                     "If set to true then the cloudformation stack will be created if it doesn't already exist")
+      .default(true)
 
-  val updateStack = Action("updateStack",
+  val updateStack = Action(
+    "updateStack",
     """
       |Apply the specified template to a cloudformation stack. This action runs an asynchronous update task and then
       |runs another task that _tails_ the stack update events (as well as possible).
       |
     """.stripMargin
-  ){ (pkg, resources, target) => {
+  ) { (pkg, resources, target) =>
+    {
       implicit val keyRing = resources.assembleKeyring(target, pkg)
       implicit val artifactClient = resources.artifactClient
       val reporter = resources.reporter
@@ -67,7 +75,8 @@ object CloudFormation extends DeploymentType with CloudFormationDeploymentTypePa
       val cloudFormationStackLookupStrategy = getCloudFormationStackLookupStrategy(pkg, target, reporter)
 
       val globalParams = templateParameters(pkg, target, reporter)
-      val stageParams = templateStageParameters(pkg, target, reporter).lift.apply(target.parameters.stage.name).getOrElse(Map())
+      val stageParams =
+        templateStageParameters(pkg, target, reporter).lift.apply(target.parameters.stage.name).getOrElse(Map())
       val params = globalParams ++ stageParams
       val alwaysUploadToS3 = !pkg.legacyConfig
 

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormationDeploymentTypeParameters.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormationDeploymentTypeParameters.scala
@@ -8,43 +8,48 @@ object CloudFormationDeploymentTypeParameters {
   type CfnParam = String
 }
 
-trait CloudFormationDeploymentTypeParameters {
-  this: DeploymentType =>
+trait CloudFormationDeploymentTypeParameters { this: DeploymentType =>
   import CloudFormationDeploymentTypeParameters._
 
-  val cloudformationStackByTags = Param[Boolean]("cloudFormationStackByTags",
+  val cloudformationStackByTags = Param[Boolean](
+    "cloudFormationStackByTags",
     documentation =
       """When false we derive the stack using the `cloudFormationStackName`, `prependStackToCloudFormationStackName` and
         |`appendStageToCloudFormationStackName` parameters. When true we find the stack by looking for one with matching
         |stack, app and stage tags in the same way that autoscaling groups are discovered.""".stripMargin
   ).defaultFromContext((pkg, _) => Right(!pkg.legacyConfig))
-  val cloudFormationStackName = Param[String]("cloudFormationStackName",
-    documentation = "The name of the CloudFormation stack to update"
-  ).defaultFromContext((pkg, _) => Right(pkg.name))
-  val prependStackToCloudFormationStackName = Param[Boolean]("prependStackToCloudFormationStackName",
-    documentation = "Whether to prepend '`stack`-' to the `cloudFormationStackName`, e.g. MyApp => service-preview-MyApp"
+  val cloudFormationStackName =
+    Param[String]("cloudFormationStackName", documentation = "The name of the CloudFormation stack to update")
+      .defaultFromContext((pkg, _) => Right(pkg.name))
+  val prependStackToCloudFormationStackName = Param[Boolean](
+    "prependStackToCloudFormationStackName",
+    documentation =
+      "Whether to prepend '`stack`-' to the `cloudFormationStackName`, e.g. MyApp => service-preview-MyApp"
   ).default(true)
-  val appendStageToCloudFormationStackName = Param[Boolean]("appendStageToCloudFormationStackName",
-    documentation = "Whether to add '-`stage`' to the `cloudFormationStackName`, e.g. MyApp => MyApp-PROD"
-  ).default(true)
+  val appendStageToCloudFormationStackName =
+    Param[Boolean]("appendStageToCloudFormationStackName",
+                   documentation =
+                     "Whether to add '-`stage`' to the `cloudFormationStackName`, e.g. MyApp => MyApp-PROD")
+      .default(true)
 
   val amiTags = Param[TagCriteria]("amiTags",
-    optionalInYaml = true,
-    documentation = "Specify the set of tags to use to find the latest AMI"
-  )
+                                   optionalInYaml = true,
+                                   documentation = "Specify the set of tags to use to find the latest AMI")
 
-  val amiParameter = Param[CfnParam]("amiParameter",
-    documentation = "The CloudFormation parameter name for the AMI"
-  ).default("AMI")
+  val amiParameter =
+    Param[CfnParam]("amiParameter", documentation = "The CloudFormation parameter name for the AMI").default("AMI")
 
-  val amiParametersToTags = Param[Map[CfnParam, TagCriteria]]("amiParametersToTags",
+  val amiParametersToTags = Param[Map[CfnParam, TagCriteria]](
+    "amiParametersToTags",
     optionalInYaml = true,
     documentation =
       """AMI cloudformation parameter names mapped to the set of tags that should be used to look up an AMI.
       """.stripMargin
   )
 
-  def getCloudFormationStackLookupStrategy(pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter): CloudFormationStackLookupStrategy = {
+  def getCloudFormationStackLookupStrategy(pkg: DeploymentPackage,
+                                           target: DeployTarget,
+                                           reporter: DeployReporter): CloudFormationStackLookupStrategy = {
     if (cloudformationStackByTags(pkg, target, reporter)) {
       LookupByTags(pkg, target, reporter)
     } else {
@@ -58,7 +63,9 @@ trait CloudFormationDeploymentTypeParameters {
     }
   }
 
-  def getAmiParameterMap(pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter): Map[CfnParam, TagCriteria] = {
+  def getAmiParameterMap(pkg: DeploymentPackage,
+                         target: DeployTarget,
+                         reporter: DeployReporter): Map[CfnParam, TagCriteria] = {
     (amiParametersToTags.get(pkg), amiTags.get(pkg)) match {
       case (Some(parametersToTags), Some(tags)) =>
         reporter.warning("Both amiParametersToTags and amiTags supplied. Ignoring amiTags.")

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormationDeploymentTypeParameters.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormationDeploymentTypeParameters.scala
@@ -18,26 +18,34 @@ trait CloudFormationDeploymentTypeParameters { this: DeploymentType =>
         |`appendStageToCloudFormationStackName` parameters. When true we find the stack by looking for one with matching
         |stack, app and stage tags in the same way that autoscaling groups are discovered.""".stripMargin
   ).defaultFromContext((pkg, _) => Right(!pkg.legacyConfig))
-  val cloudFormationStackName =
-    Param[String]("cloudFormationStackName", documentation = "The name of the CloudFormation stack to update")
-      .defaultFromContext((pkg, _) => Right(pkg.name))
+
+  val cloudFormationStackName = Param[String](
+    "cloudFormationStackName",
+    documentation = "The name of the CloudFormation stack to update"
+  ).defaultFromContext((pkg, _) => Right(pkg.name))
+
   val prependStackToCloudFormationStackName = Param[Boolean](
     "prependStackToCloudFormationStackName",
     documentation =
       "Whether to prepend '`stack`-' to the `cloudFormationStackName`, e.g. MyApp => service-preview-MyApp"
   ).default(true)
-  val appendStageToCloudFormationStackName =
-    Param[Boolean]("appendStageToCloudFormationStackName",
-                   documentation =
-                     "Whether to add '-`stage`' to the `cloudFormationStackName`, e.g. MyApp => MyApp-PROD")
-      .default(true)
 
-  val amiTags = Param[TagCriteria]("amiTags",
-                                   optionalInYaml = true,
-                                   documentation = "Specify the set of tags to use to find the latest AMI")
+  val appendStageToCloudFormationStackName = Param[Boolean](
+    "appendStageToCloudFormationStackName",
+    documentation =
+      "Whether to add '-`stage`' to the `cloudFormationStackName`, e.g. MyApp => MyApp-PROD"
+  ).default(true)
 
-  val amiParameter =
-    Param[CfnParam]("amiParameter", documentation = "The CloudFormation parameter name for the AMI").default("AMI")
+  val amiTags = Param[TagCriteria](
+    "amiTags",
+     optionalInYaml = true,
+     documentation = "Specify the set of tags to use to find the latest AMI"
+  )
+
+  val amiParameter = Param[CfnParam](
+    "amiParameter",
+    documentation = "The CloudFormation parameter name for the AMI"
+  ).default("AMI")
 
   val amiParametersToTags = Param[Map[CfnParam, TagCriteria]](
     "amiParametersToTags",

--- a/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
@@ -13,16 +13,19 @@ object ElasticSearch extends DeploymentType {
 
   val bucket = Param[String]("bucket", "S3 bucket that the artifact should be uploaded into")
 
-  val publicReadAcl = Param[Boolean]("publicReadAcl",
-    "Whether the uploaded artifacts should be given the PublicRead Canned ACL. (Default is true!)"
-  ).defaultFromContext((pkg, _) => Right(pkg.legacyConfig))
+  val publicReadAcl =
+    Param[Boolean]("publicReadAcl",
+                   "Whether the uploaded artifacts should be given the PublicRead Canned ACL. (Default is true!)")
+      .defaultFromContext((pkg, _) => Right(pkg.legacyConfig))
 
-  val secondsToWait = Param("secondsToWait",
+  val secondsToWait = Param(
+    "secondsToWait",
     """Number of seconds to wait for the ElasticSearch cluster to become green
       | (also used as the wait time for the instance termination)"""
   ).default(15 * 60)
 
-  val deploy = Action("deploy",
+  val deploy = Action(
+    "deploy",
     """
       |Carries out the update of instances in an autoscaling group. We carry out the following tasks:
       | - tag existing instances in the ASG with a termination tag
@@ -41,21 +44,32 @@ object ElasticSearch extends DeploymentType {
     val stack = target.stack
     List(
       CheckGroupSize(pkg, parameters.stage, stack, target.region),
-      WaitForElasticSearchClusterGreen(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
+      WaitForElasticSearchClusterGreen(pkg,
+                                       parameters.stage,
+                                       stack,
+                                       secondsToWait(pkg, target, reporter) * 1000,
+                                       target.region),
       SuspendAlarmNotifications(pkg, parameters.stage, stack, target.region),
       TagCurrentInstancesWithTerminationTag(pkg, parameters.stage, stack, target.region),
       DoubleSize(pkg, parameters.stage, stack, target.region),
-      WaitForElasticSearchClusterGreen(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
-      CullElasticSearchInstancesWithTerminationTag(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
+      WaitForElasticSearchClusterGreen(pkg,
+                                       parameters.stage,
+                                       stack,
+                                       secondsToWait(pkg, target, reporter) * 1000,
+                                       target.region),
+      CullElasticSearchInstancesWithTerminationTag(pkg,
+                                                   parameters.stage,
+                                                   stack,
+                                                   secondsToWait(pkg, target, reporter) * 1000,
+                                                   target.region),
       ResumeAlarmNotifications(pkg, parameters.stage, stack, target.region)
     )
   }
 
   val uploadArtifacts = Action("uploadArtifacts",
-    """
+                               """
       |Uploads the files in the deployment's directory to the specified bucket.
-    """.stripMargin
-  ){ (pkg, resources, target) =>
+    """.stripMargin) { (pkg, resources, target) =>
     implicit val keyRing = resources.assembleKeyring(target, pkg)
     implicit val artifactClient = resources.artifactClient
     val reporter = resources.reporter

--- a/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
@@ -13,10 +13,10 @@ object ElasticSearch extends DeploymentType {
 
   val bucket = Param[String]("bucket", "S3 bucket that the artifact should be uploaded into")
 
-  val publicReadAcl =
-    Param[Boolean]("publicReadAcl",
-                   "Whether the uploaded artifacts should be given the PublicRead Canned ACL. (Default is true!)")
-      .defaultFromContext((pkg, _) => Right(pkg.legacyConfig))
+  val publicReadAcl = Param[Boolean](
+    "publicReadAcl",
+     "Whether the uploaded artifacts should be given the PublicRead Canned ACL. (Default is true!)"
+  ).defaultFromContext((pkg, _) => Right(pkg.legacyConfig))
 
   val secondsToWait = Param(
     "secondsToWait",

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Fastly.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Fastly.scala
@@ -2,14 +2,15 @@ package magenta.deployment_type
 
 import magenta.tasks.UpdateFastlyConfig
 
-object Fastly  extends DeploymentType {
+object Fastly extends DeploymentType {
   val name = "fastly"
   val documentation =
     """
       |Deploy a new set of VCL configuration files to the [fastly](http://www.fastly.com/) CDN via the fastly API.
     """.stripMargin
 
-  val deploy = Action("deploy",
+  val deploy = Action(
+    "deploy",
     """
       |Undertakes the following using the fastly API:
       |
@@ -22,7 +23,8 @@ object Fastly  extends DeploymentType {
       |
       | This will set `main.vcl` as the main entrypoint (without checking that this exists) so make sure to structure
       | your VCL files to facilitate this.
-    """.stripMargin){ (pkg, resources, target) =>
+    """.stripMargin
+  ) { (pkg, resources, target) =>
     implicit val keyRing = resources.assembleKeyring(target, pkg)
     implicit val artifactClient = resources.artifactClient
     resources.reporter.verbose(s"Keyring is $keyRing")

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -7,7 +7,7 @@ import magenta.{DeployParameters, DeployReporter, DeployTarget, DeploymentPackag
 
 import scala.util.Try
 
-object Lambda extends DeploymentType  {
+object Lambda extends DeploymentType {
   val name = "aws-lambda"
   val documentation =
     """
@@ -18,15 +18,17 @@ object Lambda extends DeploymentType  {
       |cloudformation.
       """.stripMargin
 
-  val regionsParam = Param[List[String]]("regions",
-    documentation = 
+  val regionsParam = Param[List[String]](
+    "regions",
+    documentation =
       """
       |One or more AWS region name where the lambda should be deployed - If this is not specified then the default region will be used (typically set to eu-west-1).
       """.stripMargin,
     optionalInYaml = true
   )
 
-  val bucketParam = Param[String]("bucket",
+  val bucketParam = Param[String](
+    "bucket",
     documentation =
       """
         |Name of the S3 bucket where the lambda archive should be uploaded - if this is not specified then the zip file
@@ -35,19 +37,24 @@ object Lambda extends DeploymentType  {
     optionalInYaml = false
   )
 
-  val functionNamesParam = Param[List[String]]("functionNames",
+  val functionNamesParam = Param[List[String]](
+    "functionNames",
     """One or more function names to update with the code from fileNameParam.
       |Each function name will be suffixed with the stage, e.g. MyFunction- becomes MyFunction-CODE""".stripMargin,
     optionalInYaml = true
   )
 
-  val prefixStackParam = Param[Boolean]("prefixStack",
-    "If true then the values in the functionNames param will be prefixed with the name of the stack being deployed").defaultFromContext((pkg, _) => Right(!pkg.legacyConfig))
+  val prefixStackParam =
+    Param[Boolean](
+      "prefixStack",
+      "If true then the values in the functionNames param will be prefixed with the name of the stack being deployed")
+      .defaultFromContext((pkg, _) => Right(!pkg.legacyConfig))
 
   val fileNameParam = Param[String]("fileName", "The name of the archive of the function")
     .defaultFromContext((pkg, _) => Right(s"${pkg.name}.zip"))
 
-  val functionsParam = Param[Map[String, Map[String, String]]]("functions",
+  val functionsParam = Param[Map[String, Map[String, String]]](
+    "functions",
     documentation =
       """
         |In order for this to work, magenta must have credentials that are able to perform `lambda:UpdateFunctionCode`
@@ -75,14 +82,19 @@ object Lambda extends DeploymentType  {
     val bucketOption = bucketParam.get(pkg)
     if (bucketOption.isEmpty) {
       if (pkg.legacyConfig)
-        reporter.warning(s"DEPRECATED: Uploading directly to lambda is deprecated (it is dangerous for CloudFormed lambdas). Specify the bucket parameter and call both uploadLambda and updateLambda to upload via S3.")
+        reporter.warning(
+          s"DEPRECATED: Uploading directly to lambda is deprecated (it is dangerous for CloudFormed lambdas). Specify the bucket parameter and call both uploadLambda and updateLambda to upload via S3.")
       else
-        reporter.fail("Uploading directly to lambda is not supported in a riff-raff.yaml file (it is dangerous for CloudFormed lambdas). Specify the bucket parameter and call both uploadLambda and updateLambda to upload via S3.")
+        reporter.fail(
+          "Uploading directly to lambda is not supported in a riff-raff.yaml file (it is dangerous for CloudFormed lambdas). Specify the bucket parameter and call both uploadLambda and updateLambda to upload via S3.")
     }
 
     val regionsOption = regionsParam.get(pkg)
-    if (!pkg.legacyConfig && regionsOption.isDefined) reporter.fail(s"The regions parameter for the aws-lambda deployment type should not be used in the riff-raff.yaml format. Use the global, template or deployment regions fields of the riff-raff.yaml format instead.")
-    val regions: List[Region] = regionsOption.map(_.filter(regionExists(_)(reporter)).map(Region)).getOrElse(List(target.region))
+    if (!pkg.legacyConfig && regionsOption.isDefined)
+      reporter.fail(
+        s"The regions parameter for the aws-lambda deployment type should not be used in the riff-raff.yaml format. Use the global, template or deployment regions fields of the riff-raff.yaml format instead.")
+    val regions: List[Region] =
+      regionsOption.map(_.filter(regionExists(_)(reporter)).map(Region)).getOrElse(List(target.region))
     val stage = target.parameters.stage.name
 
     (functionNamesParam.get(pkg), functionsParam.get(pkg), prefixStackParam(pkg, target, reporter)) match {
@@ -91,11 +103,13 @@ object Lambda extends DeploymentType  {
         for {
           name <- functionNames
           region <- regions
-        } yield LambdaFunction(s"$stackNamePrefix$name$stage", fileNameParam(pkg, target, reporter), region, bucketOption)
-        
+        } yield
+          LambdaFunction(s"$stackNamePrefix$name$stage", fileNameParam(pkg, target, reporter), region, bucketOption)
+
       case (None, Some(functionsMap), _) =>
         val functionDefinition = functionsMap.getOrElse(stage, reporter.fail(s"Function not defined for stage $stage"))
-        val functionName = functionDefinition.getOrElse("name", reporter.fail(s"Function name not defined for stage $stage"))
+        val functionName =
+          functionDefinition.getOrElse("name", reporter.fail(s"Function name not defined for stage $stage"))
         val fileName = functionDefinition.getOrElse("filename", "lambda.zip")
         for {
           region <- regions
@@ -114,29 +128,32 @@ object Lambda extends DeploymentType  {
     exists
   }
 
-  def makeS3Key(stack: Stack, params:DeployParameters, pkg:DeploymentPackage, fileName: String): String = {
+  def makeS3Key(stack: Stack, params: DeployParameters, pkg: DeploymentPackage, fileName: String): String = {
     List(stack.nameOption, Some(params.stage.name), Some(pkg.name), Some(fileName)).flatten.mkString("/")
   }
 
-  val uploadLambda = Action("uploadLambda",
-    """
+  val uploadLambda =
+    Action("uploadLambda",
+           """
       |Uploads the lambda code to S3. This is a no-op when the `bucket` parameter is not provided.
-    """.stripMargin){ (pkg, resources, target) =>
-    implicit val keyRing = resources.assembleKeyring(target, pkg)
-    implicit val artifactClient = resources.artifactClient
-    lambdaToProcess(pkg, target, resources.reporter).flatMap {
-      case LambdaFunctionFromZip(_,_, _) => None
+    """.stripMargin) { (pkg, resources, target) =>
+      implicit val keyRing = resources.assembleKeyring(target, pkg)
+      implicit val artifactClient = resources.artifactClient
+      lambdaToProcess(pkg, target, resources.reporter).flatMap {
+        case LambdaFunctionFromZip(_, _, _) => None
 
-      case LambdaFunctionFromS3(functionName, fileName, region, s3Bucket) =>
-        val s3Key = makeS3Key(target.stack, target.parameters, pkg, fileName)
-        Some(S3Upload(
-          target.region,
-          s3Bucket,
-          Seq(S3Path(pkg.s3Package, fileName) -> s3Key)
-        ))
-    }.distinct
-  }
-  val updateLambda = Action("updateLambda",
+        case LambdaFunctionFromS3(functionName, fileName, region, s3Bucket) =>
+          val s3Key = makeS3Key(target.stack, target.parameters, pkg, fileName)
+          Some(
+            S3Upload(
+              target.region,
+              s3Bucket,
+              Seq(S3Path(pkg.s3Package, fileName) -> s3Key)
+            ))
+      }.distinct
+    }
+  val updateLambda = Action(
+    "updateLambda",
     """
       |Updates the lambda to use new code using the UpdateFunctionCode API.
       |
@@ -152,22 +169,23 @@ object Lambda extends DeploymentType  {
       |Due to the current limitations in AWS (particularly the lack of configuration mechanisms) there is a more
       |powerful `functions` parameter. This lets you bind a specific file to a specific function for any given stage.
       |As a result you can bundle stage specific configuration into the respective files.
-    """.stripMargin){ (pkg, resources, target) =>
+    """.stripMargin
+  ) { (pkg, resources, target) =>
     implicit val keyRing = resources.assembleKeyring(target, pkg)
     implicit val artifactClient = resources.artifactClient
     lambdaToProcess(pkg, target, resources.reporter).flatMap {
       case LambdaFunctionFromZip(functionName, fileName, region) =>
-        Some(UpdateLambda(S3Path(pkg.s3Package,fileName), functionName, region))
+        Some(UpdateLambda(S3Path(pkg.s3Package, fileName), functionName, region))
 
       case LambdaFunctionFromS3(functionName, fileName, region, s3Bucket) =>
         val s3Key = makeS3Key(target.stack, target.parameters, pkg, fileName)
         Some(
-        UpdateS3Lambda(
-          functionName,
-          s3Bucket,
-          s3Key,
-          region
-        ))
+          UpdateS3Lambda(
+            functionName,
+            s3Bucket,
+            s3Key,
+            region
+          ))
     }.distinct
   }
 
@@ -180,14 +198,15 @@ sealed trait LambdaFunction {
   def region: Region
 }
 
-case class LambdaFunctionFromS3(functionName: String, fileName: String, region: Region, s3Bucket: String) extends LambdaFunction
+case class LambdaFunctionFromS3(functionName: String, fileName: String, region: Region, s3Bucket: String)
+    extends LambdaFunction
 case class LambdaFunctionFromZip(functionName: String, fileName: String, region: Region) extends LambdaFunction
 
 object LambdaFunction {
   def apply(functionName: String, fileName: String, region: Region, s3Bucket: Option[String] = None): LambdaFunction = {
-    s3Bucket.fold[LambdaFunction]{
+    s3Bucket.fold[LambdaFunction] {
       LambdaFunctionFromZip(functionName, fileName, region)
-    }{ bucket =>
+    } { bucket =>
       LambdaFunctionFromS3(functionName, fileName, region, bucket)
     }
   }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -44,14 +44,15 @@ object Lambda extends DeploymentType {
     optionalInYaml = true
   )
 
-  val prefixStackParam =
-    Param[Boolean](
-      "prefixStack",
-      "If true then the values in the functionNames param will be prefixed with the name of the stack being deployed")
-      .defaultFromContext((pkg, _) => Right(!pkg.legacyConfig))
+  val prefixStackParam = Param[Boolean](
+    "prefixStack",
+    "If true then the values in the functionNames param will be prefixed with the name of the stack being deployed"
+  ).defaultFromContext((pkg, _) => Right(!pkg.legacyConfig))
 
-  val fileNameParam = Param[String]("fileName", "The name of the archive of the function")
-    .defaultFromContext((pkg, _) => Right(s"${pkg.name}.zip"))
+  val fileNameParam = Param[String](
+    "fileName",
+    "The name of the archive of the function"
+  ).defaultFromContext((pkg, _) => Right(s"${pkg.name}.zip"))
 
   val functionsParam = Param[Map[String, Map[String, String]]](
     "functions",

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Param.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Param.scala
@@ -23,21 +23,22 @@ trait ParamRegister {
   * @tparam T The type of the parameter to extract
   */
 case class Param[T](
-  name: String,
-  documentation: String = "_undocumented_",
-  optionalInYaml: Boolean = false,
-  defaultValue: Option[T] = None,
-  defaultValueFromContext: Option[(DeploymentPackage, DeployTarget) => Either[String,T]] = None
-)(implicit register:ParamRegister) {
+    name: String,
+    documentation: String = "_undocumented_",
+    optionalInYaml: Boolean = false,
+    defaultValue: Option[T] = None,
+    defaultValueFromContext: Option[(DeploymentPackage, DeployTarget) => Either[String, T]] = None
+)(implicit register: ParamRegister) {
   register.add(this)
 
   val requiredInYaml = !optionalInYaml && defaultValue.isEmpty && defaultValueFromContext.isEmpty
 
   def get(pkg: DeploymentPackage)(implicit reads: Reads[T]): Option[T] =
     pkg.pkgSpecificData.get(name).flatMap(jsValue => Json.fromJson[T](jsValue).asOpt)
-  def apply(pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter)(implicit reads: Reads[T], manifest: Manifest[T]): T = {
+  def apply(pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter)(implicit reads: Reads[T],
+                                                                                    manifest: Manifest[T]): T = {
     val maybeValue = get(pkg)
-    val defaultFromContext = defaultValueFromContext.map(_ (pkg, target))
+    val defaultFromContext = defaultValueFromContext.map(_(pkg, target))
 
     val maybeDefault = defaultValue.orElse(defaultFromContext.flatMap(_.right.toOption))
     (pkg.legacyConfig, maybeDefault, maybeValue) match {
@@ -64,7 +65,7 @@ case class Param[T](
   def default(default: T) = {
     this.copy(defaultValue = Some(default))
   }
-  def defaultFromContext(defaultFromContext: (DeploymentPackage, DeployTarget) => Either[String,T]) = {
+  def defaultFromContext(defaultFromContext: (DeploymentPackage, DeployTarget) => Either[String, T]) = {
     this.copy(defaultValueFromContext = Some(defaultFromContext))
   }
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
@@ -8,13 +8,11 @@ object S3 extends DeploymentType {
   val name = "aws-s3"
   val documentation = "For uploading files into an S3 bucket."
 
-  val prefixStage = Param("prefixStage",
-    "Prefix the S3 bucket key with the target stage").default(true)
-  val prefixPackage = Param("prefixPackage",
-    "Prefix the S3 bucket key with the package name").default(true)
-  val prefixStack = Param("prefixStack",
-    "Prefix the S3 bucket key with the target stack").default(true)
-  val pathPrefixResource = Param[String]("pathPrefixResource",
+  val prefixStage = Param("prefixStage", "Prefix the S3 bucket key with the target stage").default(true)
+  val prefixPackage = Param("prefixPackage", "Prefix the S3 bucket key with the package name").default(true)
+  val prefixStack = Param("prefixStack", "Prefix the S3 bucket key with the target stack").default(true)
+  val pathPrefixResource = Param[String](
+    "pathPrefixResource",
     """Deploy Info resource key to use to look up an additional prefix for the path key. Note that this will override
        the `prefixStage`, `prefixPackage` and `prefixStack` keys - none of those prefixes will be applied, as you have
        full control over the path with the resource lookup.
@@ -23,8 +21,10 @@ object S3 extends DeploymentType {
   )
 
   //required configuration, you cannot upload without setting these
-  val bucket = Param[String]("bucket", "S3 bucket to upload package files to (see also `bucketResource`)", optionalInYaml = true)
-  val bucketResource = Param[String]("bucketResource",
+  val bucket =
+    Param[String]("bucket", "S3 bucket to upload package files to (see also `bucketResource`)", optionalInYaml = true)
+  val bucketResource = Param[String](
+    "bucketResource",
     """Deploy Info resource key to use to look up the S3 bucket to which the package files should be uploaded.
       |
       |This parameter is mutually exclusive with `bucket`, which can be used instead if you upload to the same bucket
@@ -33,11 +33,13 @@ object S3 extends DeploymentType {
     optionalInYaml = true
   )
 
-  val publicReadAcl = Param[Boolean]("publicReadAcl",
-    "Whether the uploaded artifacts should be given the PublicRead Canned ACL. (Default is true!)"
-  ).default(true)
+  val publicReadAcl =
+    Param[Boolean](
+      "publicReadAcl",
+      "Whether the uploaded artifacts should be given the PublicRead Canned ACL. (Default is true!)").default(true)
 
-  val cacheControl = Param[List[PatternValue]]("cacheControl",
+  val cacheControl = Param[List[PatternValue]](
+    "cacheControl",
     """
       |Set the cache control header for the uploaded files. This can take two forms, but in either case the format of
       |the cache control value itself must be a valid HTTP `Cache-Control` value such as `public, max-age=315360000`.
@@ -72,7 +74,8 @@ object S3 extends DeploymentType {
     """.stripMargin
   )
 
-  val mimeTypes = Param[Map[String,String]]("mimeTypes",
+  val mimeTypes = Param[Map[String, String]](
+    "mimeTypes",
     """
       |A map of file extension to MIME type.
       |
@@ -101,16 +104,22 @@ object S3 extends DeploymentType {
         |Alternatively, you can specify a pathPrefixResource (eg `s3-path-prefix`) to lookup the path prefix, giving you
         |greater control. The generated key looks like: `/<pathPrefix>/<filePathAndName>`.
         """.stripMargin
-  ){ (pkg, resources, target) => {
+  ) { (pkg, resources, target) =>
+    {
       def resourceLookupFor(resource: Param[String]): Option[Datum] = {
         resource.get(pkg).flatMap { resourceName =>
-          assert(pkg.apps.size == 1, s"The $name package type, in conjunction with ${resource.name}, only be used when exactly one app is specified - you have [${pkg.apps.map(_.name).mkString(",")}]")
+          assert(
+            pkg.apps.size == 1,
+            s"The $name package type, in conjunction with ${resource.name}, only be used when exactly one app is specified - you have [${pkg.apps.map(_.name).mkString(",")}]"
+          )
           val dataLookup = resources.lookup.data
           val app = pkg.apps.head
           val datumOpt = dataLookup.datum(resourceName, app, target.parameters.stage, target.stack)
           if (datumOpt.isEmpty) {
             def str(f: Datum => String) = s"[${dataLookup.get(resourceName).map(f).toSet.mkString(", ")}]"
-            resources.reporter.verbose(s"No datum found for resource=$resourceName app=$app stage=${target.parameters.stage} stack=${target.stack} - values *are* defined for app=${str(_.app)} stage=${str(_.stage)} stack=${str(_.stack.mkString)}")
+            resources.reporter.verbose(
+              s"No datum found for resource=$resourceName app=$app stage=${target.parameters.stage} stack=${target.stack} - values *are* defined for app=${str(
+                _.app)} stage=${str(_.stage)} stack=${str(_.stack.mkString)}")
           }
           datumOpt
         }
@@ -120,18 +129,23 @@ object S3 extends DeploymentType {
       implicit val artifactClient = resources.artifactClient
       val reporter = resources.reporter
 
-      assert(bucket.get(pkg).isDefined != bucketResource.get(pkg).isDefined, "One, and only one, of bucket or bucketResource must be specified")
+      assert(bucket.get(pkg).isDefined != bucketResource.get(pkg).isDefined,
+             "One, and only one, of bucket or bucketResource must be specified")
       val bucketName = bucket.get(pkg) getOrElse {
         val data = resourceLookupFor(bucketResource)
-        assert(data.isDefined, s"Cannot find resource value for ${bucketResource(pkg, target, reporter)} (${pkg.apps.head} in ${target.parameters.stage.name})")
+        assert(
+          data.isDefined,
+          s"Cannot find resource value for ${bucketResource(pkg, target, reporter)} (${pkg.apps.head} in ${target.parameters.stage.name})")
         data.get.value
       }
 
-      val prefix:String = resourceLookupFor(pathPrefixResource).map(_.value).getOrElse(S3Upload.prefixGenerator(
-        stack = if (prefixStack(pkg, target, reporter)) Some(target.stack) else None,
-        stage = if (prefixStage(pkg, target, reporter)) Some(target.parameters.stage) else None,
-        packageName = if (prefixPackage(pkg, target, reporter)) Some(pkg.name) else None
-      ))
+      val prefix: String = resourceLookupFor(pathPrefixResource)
+        .map(_.value)
+        .getOrElse(S3Upload.prefixGenerator(
+          stack = if (prefixStack(pkg, target, reporter)) Some(target.stack) else None,
+          stage = if (prefixStage(pkg, target, reporter)) Some(target.parameters.stage) else None,
+          packageName = if (prefixPackage(pkg, target, reporter)) Some(pkg.name) else None
+        ))
       List(
         S3Upload(
           target.region,

--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
@@ -21,8 +21,12 @@ object S3 extends DeploymentType {
   )
 
   //required configuration, you cannot upload without setting these
-  val bucket =
-    Param[String]("bucket", "S3 bucket to upload package files to (see also `bucketResource`)", optionalInYaml = true)
+  val bucket = Param[String](
+    "bucket",
+    "S3 bucket to upload package files to (see also `bucketResource`)",
+    optionalInYaml = true
+  )
+
   val bucketResource = Param[String](
     "bucketResource",
     """Deploy Info resource key to use to look up the S3 bucket to which the package files should be uploaded.
@@ -33,10 +37,10 @@ object S3 extends DeploymentType {
     optionalInYaml = true
   )
 
-  val publicReadAcl =
-    Param[Boolean](
-      "publicReadAcl",
-      "Whether the uploaded artifacts should be given the PublicRead Canned ACL. (Default is true!)").default(true)
+  val publicReadAcl = Param[Boolean](
+    "publicReadAcl",
+    "Whether the uploaded artifacts should be given the PublicRead Canned ACL. (Default is true!)"
+  ).default(true)
 
   val cacheControl = Param[List[PatternValue]](
     "cacheControl",

--- a/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
@@ -13,32 +13,42 @@ object SelfDeploy extends DeploymentType {
       |opportunity (when it has finished deploys).
     """.stripMargin
 
-  val bucket = Param[String]("bucket",
+  val bucket = Param[String](
+    "bucket",
     """
       |S3 bucket name to upload artifact into.
       |
       |The path in the bucket is `<stack>/<stage>/<packageName>/<fileName>`.
     """.stripMargin
-  ).defaultFromContext{ case (_, target) =>
-    target.stack.nameOption.map(stackName => s"$stackName-dist").toRight("You must specify bucket explicitly when not using stacks")
+  ).defaultFromContext {
+    case (_, target) =>
+      target.stack.nameOption
+        .map(stackName => s"$stackName-dist")
+        .toRight("You must specify bucket explicitly when not using stacks")
   }
 
-  val publicReadAcl = Param[Boolean]("publicReadAcl",
-    "Whether the uploaded artifacts should be given the PublicRead Canned ACL. (Default is true!)"
-  ).defaultFromContext((pkg, _) => Right(pkg.legacyConfig))
+  val publicReadAcl =
+    Param[Boolean]("publicReadAcl",
+                   "Whether the uploaded artifacts should be given the PublicRead Canned ACL. (Default is true!)")
+      .defaultFromContext((pkg, _) => Right(pkg.legacyConfig))
 
-  val managementPort = Param[Int]("managementPort",
-    "For deferred deployment only: The port of the management pages containing the location of the switchboard"
-  ).default(18080)
-  val managementProtocol = Param[String]("managementProtocol",
-    "For deferred deployment only: The protocol of the management pages containing the location of the switchboard"
-  ).default("http")
-  val switchboardPath = Param[String]("switchboardPath",
-    "For deferred deployment only: The URL path on the host to the switchboard management page"
-  ).default("/management/switchboard")
+  val managementPort =
+    Param[Int](
+      "managementPort",
+      "For deferred deployment only: The port of the management pages containing the location of the switchboard")
+      .default(18080)
+  val managementProtocol =
+    Param[String](
+      "managementProtocol",
+      "For deferred deployment only: The protocol of the management pages containing the location of the switchboard")
+      .default("http")
+  val switchboardPath =
+    Param[String]("switchboardPath",
+                  "For deferred deployment only: The URL path on the host to the switchboard management page")
+      .default("/management/switchboard")
 
   val uploadArtifacts = Action("uploadArtifacts",
-    """
+                               """
       |Uploads the files in the deployment's directory to the specified bucket.
     """.stripMargin) { (pkg, resources, target) =>
     implicit val keyRing = resources.assembleKeyring(target, pkg)
@@ -53,28 +63,29 @@ object SelfDeploy extends DeploymentType {
       )
     )
   }
-  val selfDeploy = Action("selfDeploy",
+  val selfDeploy = Action(
+    "selfDeploy",
     """
       |Switches the `shutdown-when-inactive` switch to true on the target hosts (discovered using Prism to lookup
       |hosts according to the stack, app and stage of the deployment).
       |
       |The switch is expected to be a [guardian management](https://github.com/guardian/guardian-management) switch.
-    """.stripMargin){ (pkg, resources, target) =>
+    """.stripMargin
+  ) { (pkg, resources, target) =>
     implicit val keyRing = resources.assembleKeyring(target, pkg)
     val reporter = resources.reporter
     val hosts = pkg.apps.toList.flatMap(app => resources.lookup.hosts.get(pkg, app, target.parameters, target.stack))
-    hosts.map{ host =>
+    hosts.map { host =>
       ChangeSwitch(
         host,
         managementProtocol(pkg, target, reporter),
         managementPort(pkg, target, reporter),
         switchboardPath(pkg, target, reporter),
         "shutdown-when-inactive",
-        desiredState=true
+        desiredState = true
       )
     }
   }
 
   def defaultActions = List(uploadArtifacts, selfDeploy)
 }
-

--- a/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
@@ -27,25 +27,25 @@ object SelfDeploy extends DeploymentType {
         .toRight("You must specify bucket explicitly when not using stacks")
   }
 
-  val publicReadAcl =
-    Param[Boolean]("publicReadAcl",
-                   "Whether the uploaded artifacts should be given the PublicRead Canned ACL. (Default is true!)")
-      .defaultFromContext((pkg, _) => Right(pkg.legacyConfig))
+  val publicReadAcl = Param[Boolean](
+    "publicReadAcl",
+    "Whether the uploaded artifacts should be given the PublicRead Canned ACL. (Default is true!)"
+  ).defaultFromContext((pkg, _) => Right(pkg.legacyConfig))
 
-  val managementPort =
-    Param[Int](
-      "managementPort",
-      "For deferred deployment only: The port of the management pages containing the location of the switchboard")
-      .default(18080)
-  val managementProtocol =
-    Param[String](
-      "managementProtocol",
-      "For deferred deployment only: The protocol of the management pages containing the location of the switchboard")
-      .default("http")
-  val switchboardPath =
-    Param[String]("switchboardPath",
-                  "For deferred deployment only: The URL path on the host to the switchboard management page")
-      .default("/management/switchboard")
+  val managementPort = Param[Int](
+    "managementPort",
+    "For deferred deployment only: The port of the management pages containing the location of the switchboard"
+  ).default(18080)
+
+  val managementProtocol = Param[String](
+    "managementProtocol",
+    "For deferred deployment only: The protocol of the management pages containing the location of the switchboard"
+  ).default("http")
+
+  val switchboardPath = Param[String](
+    "switchboardPath",
+    "For deferred deployment only: The URL path on the host to the switchboard management page"
+  ).default("/management/switchboard")
 
   val uploadArtifacts = Action("uploadArtifacts",
                                """

--- a/magenta-lib/src/main/scala/magenta/graph/package.scala
+++ b/magenta-lib/src/main/scala/magenta/graph/package.scala
@@ -2,17 +2,18 @@ package magenta
 
 package object graph {
   implicit class RichNodeSet[T](nodes: Set[Node[T]]) {
-    def filterValueNodes: Set[ValueNode[T]] = nodes.collect{ case valueNode:ValueNode[T] => valueNode }
+    def filterValueNodes: Set[ValueNode[T]] = nodes.collect { case valueNode: ValueNode[T] => valueNode }
     def values: Set[T] = filterValueNodes.map(_.value)
   }
   implicit class RichNodeList[T](nodes: List[Node[T]]) {
-    def filterValueNodes: List[ValueNode[T]] = nodes.collect{ case valueNode:ValueNode[T] => valueNode }
+    def filterValueNodes: List[ValueNode[T]] = nodes.collect { case valueNode: ValueNode[T] => valueNode }
     def values: List[T] = filterValueNodes.map(_.value)
   }
   implicit class RichEdgeList[T](edges: List[Edge[T]]) {
     def replace(old: Edge[T], newEdges: List[Edge[T]]): List[Edge[T]] = edges.patch(edges.indexOf(old), newEdges, 1)
-    def reprioritise: List[Edge[T]] = edges.zipWithIndex.map {case (edge, index) =>
-      edge.copy(priority = index + 1)
+    def reprioritise: List[Edge[T]] = edges.zipWithIndex.map {
+      case (edge, index) =>
+        edge.copy(priority = index + 1)
     }
   }
 }

--- a/magenta-lib/src/main/scala/magenta/input/RiffRaffYamlReader.scala
+++ b/magenta-lib/src/main/scala/magenta/input/RiffRaffYamlReader.scala
@@ -18,14 +18,17 @@ object RiffRaffYamlReader {
         type Errors = Seq[(JsPath, Seq[ValidationError])]
         def locate(e: Errors, key: String) = e.map { case (p, valerr) => (JsPath \ key) ++ p -> valerr }
 
-        linkedMap.foldLeft(Right(Nil): Either[Errors, List[(String, V)]]) {
-          case (acc, (key, value)) => (acc, Json.fromJson[V](value)(fmtv)) match {
-            case (Right(vs), JsSuccess(v, _)) => Right(vs :+ (key -> v))
-            case (Right(_), JsError(e)) => Left(locate(e, key))
-            case (Left(e), _: JsSuccess[_]) => Left(e)
-            case (Left(e1), JsError(e2)) => Left(e1 ++ locate(e2, key))
+        linkedMap
+          .foldLeft(Right(Nil): Either[Errors, List[(String, V)]]) {
+            case (acc, (key, value)) =>
+              (acc, Json.fromJson[V](value)(fmtv)) match {
+                case (Right(vs), JsSuccess(v, _)) => Right(vs :+ (key -> v))
+                case (Right(_), JsError(e)) => Left(locate(e, key))
+                case (Left(e), _: JsSuccess[_]) => Left(e)
+                case (Left(e1), JsError(e2)) => Left(e1 ++ locate(e2, key))
+              }
           }
-        }.fold(JsError.apply, res => JsSuccess(res))
+          .fold(JsError.apply, res => JsSuccess(res))
       case _ => JsError(Seq(JsPath() -> Seq(ValidationError("error.expected.jsobject"))))
     }
   }
@@ -42,9 +45,10 @@ object RiffRaffYamlReader {
       case JsSuccess(config, _) => Valid(config)
       case JsError(errors :: tail) =>
         val nelErrors = NEL(errors, tail)
-        Invalid(ConfigErrors(nelErrors.map{ case (path, validationErrors) =>
-          val pathName = if (path.path.isEmpty) "YAML" else path.toString
-          ConfigError(s"Parsing $pathName", validationErrors.map(ve => ve.message).mkString(", "))
+        Invalid(ConfigErrors(nelErrors.map {
+          case (path, validationErrors) =>
+            val pathName = if (path.path.isEmpty) "YAML" else path.toString
+            ConfigError(s"Parsing $pathName", validationErrors.map(ve => ve.message).mkString(", "))
         }))
       case JsError(_) => `wtf?`
     }

--- a/magenta-lib/src/main/scala/magenta/input/models.scala
+++ b/magenta-lib/src/main/scala/magenta/input/models.scala
@@ -21,6 +21,7 @@ object ConfigErrors {
   */
 case class DeploymentKey(name: String, action: String, stack: String, region: String)
 object DeploymentKey {
+
   /** Turn a deployment into a deployment key - WARNING: this doesn't make any checks about the number of elements
     * but will only work predictably with one element in each of actions, stacks and regions */
   def apply(deployment: Deployment): DeploymentKey = {
@@ -49,10 +50,10 @@ case object All extends DeploymentSelector
 case class DeploymentKeysSelector(keys: List[DeploymentKey]) extends DeploymentSelector
 
 case class RiffRaffDeployConfig(
-  stacks: Option[List[String]],
-  regions: Option[List[String]],
-  templates: Option[Map[String, DeploymentOrTemplate]],
-  deployments: List[(String, DeploymentOrTemplate)]
+    stacks: Option[List[String]],
+    regions: Option[List[String]],
+    templates: Option[Map[String, DeploymentOrTemplate]],
+    deployments: List[(String, DeploymentOrTemplate)]
 )
 object RiffRaffDeployConfig {
   import RiffRaffYamlReader.readObjectAsList
@@ -74,15 +75,15 @@ object RiffRaffDeployConfig {
   * @param parameters       Provides additional parameters to the deployment type. Refer to the deployment types to see what is required.
   */
 case class DeploymentOrTemplate(
-  `type`: Option[String],
-  template: Option[String],
-  stacks: Option[List[String]],
-  regions: Option[List[String]],
-  actions: Option[List[String]],
-  app: Option[String],
-  contentDirectory: Option[String],
-  dependencies: Option[List[String]],
-  parameters: Option[Map[String, JsValue]]
+    `type`: Option[String],
+    template: Option[String],
+    stacks: Option[List[String]],
+    regions: Option[List[String]],
+    actions: Option[List[String]],
+    app: Option[String],
+    contentDirectory: Option[String],
+    dependencies: Option[List[String]],
+    parameters: Option[Map[String, JsValue]]
 )
 object DeploymentOrTemplate {
   implicit val reads: Reads[DeploymentOrTemplate] = checkedReads(Json.reads)
@@ -92,13 +93,13 @@ object DeploymentOrTemplate {
   * A deployment that has been parsed and validated out of a riff-raff.yml file.
   */
 case class Deployment(
-  name: String,
-  `type`: String,
-  stacks: NEL[String],
-  regions: NEL[String],
-  actions: NEL[String],
-  app: String,
-  contentDirectory: String,
-  dependencies: List[String],
-  parameters: Map[String, JsValue]
+    name: String,
+    `type`: String,
+    stacks: NEL[String],
+    regions: NEL[String],
+    actions: NEL[String],
+    app: String,
+    contentDirectory: String,
+    dependencies: List[String],
+    parameters: Map[String, JsValue]
 )

--- a/magenta-lib/src/main/scala/magenta/input/package.scala
+++ b/magenta-lib/src/main/scala/magenta/input/package.scala
@@ -6,9 +6,10 @@ import scala.reflect.runtime.universe._
 
 package object input {
   def checkedReads[T](underlyingReads: Reads[T])(implicit typeTag: TypeTag[T]): Reads[T] = new Reads[T] {
-    def classFields[T: TypeTag]: Set[String] = typeOf[T].members.collect {
-      case m: MethodSymbol if m.isCaseAccessor => m.name.decodedName.toString
-    }.toSet
+    def classFields[T: TypeTag]: Set[String] =
+      typeOf[T].members.collect {
+        case m: MethodSymbol if m.isCaseAccessor => m.name.decodedName.toString
+      }.toSet
     def reads(json: JsValue): JsResult[T] = {
       val caseClassFields = classFields[T]
       json match {

--- a/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentGraphActionFlattening.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentGraphActionFlattening.scala
@@ -6,7 +6,7 @@ import magenta.input.Deployment
 
 object DeploymentGraphActionFlattening {
   def flattenActions(deploymentGraph: Graph[Deployment]): Graph[Deployment] = {
-    deploymentGraph.flatMap{
+    deploymentGraph.flatMap {
       case ValueNode(deployment) =>
         val deploymentPerAction = for {
           action <- deployment.actions

--- a/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentPruner.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentPruner.scala
@@ -33,6 +33,7 @@ object DeploymentPruner {
     else
       None
   }
+
   /** This prunes a deployment against the list of selected keys.
     * If none of the keys match the deployment then None will be returned.
     * If there are keys that match all the actions, regions and stacks then the deployment will be returned unmodified.
@@ -47,9 +48,9 @@ object DeploymentPruner {
 
     def matchKey(key: DeploymentKey): Boolean =
       deployment.name == key.name &&
-      deployment.actions.contains(key.action) &&
-      deployment.regions.contains(key.region) &&
-      deployment.stacks.contains(key.stack)
+        deployment.actions.contains(key.action) &&
+        deployment.regions.contains(key.region) &&
+        deployment.stacks.contains(key.stack)
 
     for {
       matchingKeys <- NEL.fromList(keys.filter(matchKey))

--- a/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentResolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentResolver.scala
@@ -10,12 +10,13 @@ import play.api.libs.json.JsValue
 
 object DeploymentResolver {
   def resolve(config: RiffRaffDeployConfig): Validated[ConfigErrors, List[PartiallyResolvedDeployment]] = {
-    config.deployments.traverseU[Validated[ConfigErrors, PartiallyResolvedDeployment]] { case (label, rawDeployment) =>
-      for {
-        templated <- applyTemplates(label, rawDeployment, config.templates)
-        deployment <- resolveDeployment(label, templated, config.stacks, config.regions)
-        validatedDeployment <- validateDependencies(label, deployment, config.deployments)
-      } yield validatedDeployment
+    config.deployments.traverseU[Validated[ConfigErrors, PartiallyResolvedDeployment]] {
+      case (label, rawDeployment) =>
+        for {
+          templated <- applyTemplates(label, rawDeployment, config.templates)
+          deployment <- resolveDeployment(label, templated, config.stacks, config.regions)
+          validatedDeployment <- validateDependencies(label, deployment, config.deployments)
+        } yield validatedDeployment
     }
   }
 
@@ -23,10 +24,16 @@ object DeploymentResolver {
     * Validates and resolves a templated deployment by merging its
     * deployment attributes with any globally defined properties.
     */
-  private[input] def resolveDeployment(label: String, templated: DeploymentOrTemplate, globalStacks: Option[List[String]], globalRegions: Option[List[String]]): Validated[ConfigErrors, PartiallyResolvedDeployment] = {
+  private[input] def resolveDeployment(
+      label: String,
+      templated: DeploymentOrTemplate,
+      globalStacks: Option[List[String]],
+      globalRegions: Option[List[String]]): Validated[ConfigErrors, PartiallyResolvedDeployment] = {
     (Validated.fromOption(templated.`type`, ConfigErrors(label, "No type field provided")) |@|
-      Validated.fromOption(templated.stacks.orElse(globalStacks).flatMap(NEL.fromList), ConfigErrors(label, "No stacks provided")) |@|
-      Validated.fromOption(templated.regions.orElse(globalRegions).flatMap(NEL.fromList), ConfigErrors(label, "No regions provided"))) map { (deploymentType, stacks, regions) =>
+      Validated.fromOption(templated.stacks.orElse(globalStacks).flatMap(NEL.fromList),
+                           ConfigErrors(label, "No stacks provided")) |@|
+      Validated.fromOption(templated.regions.orElse(globalRegions).flatMap(NEL.fromList),
+                           ConfigErrors(label, "No regions provided"))) map { (deploymentType, stacks, regions) =>
       PartiallyResolvedDeployment(
         name = label,
         `type` = deploymentType,
@@ -45,8 +52,10 @@ object DeploymentResolver {
     * Recursively apply named templates by merging the provided
     * deployment template with named parent templates.
     */
-  private[input] def applyTemplates(templateName: String, template: DeploymentOrTemplate,
-    templates: Option[Map[String, DeploymentOrTemplate]]): Validated[ConfigErrors, DeploymentOrTemplate] = {
+  private[input] def applyTemplates(
+      templateName: String,
+      template: DeploymentOrTemplate,
+      templates: Option[Map[String, DeploymentOrTemplate]]): Validated[ConfigErrors, DeploymentOrTemplate] = {
 
     template.template match {
       case None =>
@@ -55,7 +64,7 @@ object DeploymentResolver {
         for {
           parentTemplate <- {
             Validated.fromOption(templates.flatMap(_.get(parentTemplateName)),
-              ConfigErrors(templateName, s"Template with name $parentTemplateName does not exist"))
+                                 ConfigErrors(templateName, s"Template with name $parentTemplateName does not exist"))
           }
           resolvedParent <- applyTemplates(parentTemplateName, parentTemplate, templates)
         } yield {
@@ -68,7 +77,8 @@ object DeploymentResolver {
             app = template.app.orElse(resolvedParent.app),
             contentDirectory = template.contentDirectory.orElse(resolvedParent.contentDirectory),
             dependencies = template.dependencies.orElse(resolvedParent.dependencies),
-            parameters = Some(resolvedParent.parameters.getOrElse(Map.empty) ++ template.parameters.getOrElse(Map.empty))
+            parameters =
+              Some(resolvedParent.parameters.getOrElse(Map.empty) ++ template.parameters.getOrElse(Map.empty))
           )
         }
     }
@@ -77,7 +87,10 @@ object DeploymentResolver {
   /**
     * Ensures that when deployments have named dependencies, deployments with those names exists.
     */
-  private[input] def validateDependencies(label: String, deployment: PartiallyResolvedDeployment, allDeployments: List[(String, DeploymentOrTemplate)]): Validated[ConfigErrors, PartiallyResolvedDeployment] = {
+  private[input] def validateDependencies(
+      label: String,
+      deployment: PartiallyResolvedDeployment,
+      allDeployments: List[(String, DeploymentOrTemplate)]): Validated[ConfigErrors, PartiallyResolvedDeployment] = {
     val allDeploymentNames = allDeployments.map { case (name, _) => name }
     deployment.dependencies.filterNot(allDeploymentNames.contains) match {
       case Nil =>
@@ -88,14 +101,14 @@ object DeploymentResolver {
   }
 }
 
-private [resolver] case class PartiallyResolvedDeployment(
-  name: String,
-  `type`: String,
-  stacks: NEL[String],
-  regions: NEL[String],
-  actions: Option[NEL[String]],
-  app: String,
-  contentDirectory: String,
-  dependencies: List[String],
-  parameters: Map[String, JsValue]
+private[resolver] case class PartiallyResolvedDeployment(
+    name: String,
+    `type`: String,
+    stacks: NEL[String],
+    regions: NEL[String],
+    actions: Option[NEL[String]],
+    app: String,
+    contentDirectory: String,
+    dependencies: List[String],
+    parameters: Map[String, JsValue]
 )

--- a/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentTypeResolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentTypeResolver.scala
@@ -7,30 +7,39 @@ import magenta.input.{ConfigErrors, Deployment}
 
 object DeploymentTypeResolver {
 
-  def validateDeploymentType(deployment: PartiallyResolvedDeployment, availableTypes: Seq[DeploymentType]): Validated[ConfigErrors, Deployment] = {
+  def validateDeploymentType(deployment: PartiallyResolvedDeployment,
+                             availableTypes: Seq[DeploymentType]): Validated[ConfigErrors, Deployment] = {
     for {
       deploymentType <- Validated.fromOption(availableTypes.find(_.name == deployment.`type`),
-        ConfigErrors(deployment.name, s"Unknown type ${deployment.`type`}"))
+                                             ConfigErrors(deployment.name, s"Unknown type ${deployment.`type`}"))
       deploymentWithActions <- resolveDeploymentActions(deployment, deploymentType)
       deployment <- verifyDeploymentParameters(deploymentWithActions, deploymentType)
     } yield deployment
   }
 
-  private[input] def resolveDeploymentActions(deployment: PartiallyResolvedDeployment, deploymentType: DeploymentType): Validated[ConfigErrors, Deployment] = {
+  private[input] def resolveDeploymentActions(deployment: PartiallyResolvedDeployment,
+                                              deploymentType: DeploymentType): Validated[ConfigErrors, Deployment] = {
     val actions = deployment.actions.orElse(NonEmptyList.fromList(deploymentType.defaultActionNames))
-    val invalidActions = actions.flatMap(as => NonEmptyList.fromList(as.filter(!deploymentType.actionsMap.isDefinedAt(_))))
+    val invalidActions =
+      actions.flatMap(as => NonEmptyList.fromList(as.filter(!deploymentType.actionsMap.isDefinedAt(_))))
 
-    invalidActions.map(invalids => Invalid(
-      ConfigErrors(deployment.name, s"Invalid action ${invalids.toList.mkString(", ")} for type ${deployment.`type`}"))
-    ).getOrElse {
-      import automagic._
-      Validated.fromOption(actions.map(as =>
-        transform[PartiallyResolvedDeployment, Deployment](deployment, "actions" -> as)
-      ), ConfigErrors(deployment.name, s"Either specify at least one action or omit the actions parameter"))
-    }
+    invalidActions
+      .map(
+        invalids =>
+          Invalid(ConfigErrors(deployment.name,
+                               s"Invalid action ${invalids.toList.mkString(", ")} for type ${deployment.`type`}")))
+      .getOrElse {
+        import automagic._
+        Validated.fromOption(
+          actions.map(as => transform[PartiallyResolvedDeployment, Deployment](deployment, "actions" -> as)),
+          ConfigErrors(deployment.name, s"Either specify at least one action or omit the actions parameter")
+        )
+      }
   }
 
-  private[input] def verifyDeploymentParameters(deployment: Deployment, deploymentType: DeploymentType): Validated[ConfigErrors, Deployment] = {
+  private[input] def verifyDeploymentParameters(
+      deployment: Deployment,
+      deploymentType: DeploymentType): Validated[ConfigErrors, Deployment] = {
     val validParameterNames = deploymentType.params.map(_.name)
     val requiredParameterNames =
       deploymentType.params.filter(_.requiredInYaml).map(_.name).toSet
@@ -39,9 +48,13 @@ object DeploymentTypeResolver {
     val missingParameters = requiredParameterNames -- actualParamNames
     val unusedParameters = actualParamNames -- validParameterNames
     if (missingParameters.nonEmpty)
-      Invalid(ConfigErrors(deployment.name, s"Parameters required for ${deploymentType.name} deployments not provided: ${missingParameters.mkString(", ")}"))
+      Invalid(ConfigErrors(
+        deployment.name,
+        s"Parameters required for ${deploymentType.name} deployments not provided: ${missingParameters.mkString(", ")}"))
     else if (unusedParameters.nonEmpty)
-      Invalid(ConfigErrors(deployment.name, s"Parameters provided but not used by ${deploymentType.name} deployments: ${unusedParameters.mkString(", ")}"))
+      Invalid(ConfigErrors(
+        deployment.name,
+        s"Parameters provided but not used by ${deploymentType.name} deployments: ${unusedParameters.mkString(", ")}"))
     else
       Valid(deployment)
   }

--- a/magenta-lib/src/main/scala/magenta/input/resolver/Resolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/Resolver.scala
@@ -12,8 +12,11 @@ import magenta.input._
 import magenta.{DeployParameters, DeploymentResources}
 
 object Resolver {
-  def resolve(yamlConfig: String, deploymentResources: DeploymentResources, parameters: DeployParameters,
-    deploymentTypes: Seq[DeploymentType], artifact: S3Artifact): Validated[ConfigErrors, Graph[DeploymentTasks]] = {
+  def resolve(yamlConfig: String,
+              deploymentResources: DeploymentResources,
+              parameters: DeployParameters,
+              deploymentTypes: Seq[DeploymentType],
+              artifact: S3Artifact): Validated[ConfigErrors, Graph[DeploymentTasks]] = {
 
     for {
       deploymentGraph <- resolveDeploymentGraph(yamlConfig, deploymentTypes, parameters.selector)
@@ -21,13 +24,14 @@ object Resolver {
     } yield taskGraph
   }
 
-  def resolveDeploymentGraph(yamlConfig: String, deploymentTypes: Seq[DeploymentType],
-    selector: DeploymentSelector): Validated[ConfigErrors, Graph[Deployment]] = {
+  def resolveDeploymentGraph(yamlConfig: String,
+                             deploymentTypes: Seq[DeploymentType],
+                             selector: DeploymentSelector): Validated[ConfigErrors, Graph[Deployment]] = {
 
     for {
       config <- RiffRaffYamlReader.fromString(yamlConfig)
       deployments <- DeploymentResolver.resolve(config)
-      validatedDeployments <- deployments.traverseU[Validated[ConfigErrors, Deployment]]{deployment =>
+      validatedDeployments <- deployments.traverseU[Validated[ConfigErrors, Deployment]] { deployment =>
         DeploymentTypeResolver.validateDeploymentType(deployment, deploymentTypes)
       }
       prunedDeployments = DeploymentPruner.prune(validatedDeployments, DeploymentPruner.create(selector))
@@ -35,8 +39,11 @@ object Resolver {
     } yield graph
   }
 
-  private[resolver] def buildTaskGraph(deploymentResources: DeploymentResources, parameters: DeployParameters,
-    deploymentTypes: Seq[DeploymentType], artifact: S3Artifact, graph: Graph[Deployment]): Validated[ConfigErrors, Graph[DeploymentTasks]] = {
+  private[resolver] def buildTaskGraph(deploymentResources: DeploymentResources,
+                                       parameters: DeployParameters,
+                                       deploymentTypes: Seq[DeploymentType],
+                                       artifact: S3Artifact,
+                                       graph: Graph[Deployment]): Validated[ConfigErrors, Graph[DeploymentTasks]] = {
 
     val flattenedGraph = DeploymentGraphActionFlattening.flattenActions(graph)
     val deploymentTaskGraph = flattenedGraph.map { deployment =>
@@ -59,7 +66,7 @@ object Resolver {
       stack <- stacks
       region <- regions
       deploymentsForStackAndRegion = DeploymentPruner.prune(userSelectedDeployments,
-        DeploymentPruner.StackAndRegion(stack, region))
+                                                            DeploymentPruner.StackAndRegion(stack, region))
       graphForStackAndRegion = DeploymentGraphBuilder.buildGraph(deploymentsForStackAndRegion)
     } yield graphForStackAndRegion
 

--- a/magenta-lib/src/main/scala/magenta/input/resolver/TaskResolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/TaskResolver.scala
@@ -8,10 +8,14 @@ import magenta.input.{ConfigErrors, Deployment}
 import magenta.{App, DeployParameters, DeployTarget, DeploymentPackage, DeploymentResources, NamedStack, Region}
 
 object TaskResolver {
-  def resolve(deployment: Deployment, deploymentResources: DeploymentResources, parameters: DeployParameters,
-    deploymentTypes: Seq[DeploymentType], artifact: S3Artifact): Validated[ConfigErrors, DeploymentTasks] = {
-    val validatedDeploymentType = Validated.fromOption(deploymentTypes.find(_.name == deployment.`type`),
-      ConfigErrors(deployment.name, s"Deployment type ${deployment.`type`} not found"))
+  def resolve(deployment: Deployment,
+              deploymentResources: DeploymentResources,
+              parameters: DeployParameters,
+              deploymentTypes: Seq[DeploymentType],
+              artifact: S3Artifact): Validated[ConfigErrors, DeploymentTasks] = {
+    val validatedDeploymentType =
+      Validated.fromOption(deploymentTypes.find(_.name == deployment.`type`),
+                           ConfigErrors(deployment.name, s"Deployment type ${deployment.`type`} not found"))
 
     validatedDeploymentType.map { deploymentType =>
       val deploymentPackage = createDeploymentPackage(deployment, artifact, deploymentTypes)
@@ -24,12 +28,13 @@ object TaskResolver {
         task <- deploymentStep.resolve(deploymentResources, target)
       } yield task
       DeploymentTasks(tasks,
-        mkLabel(deploymentPackage.name, deployment.actions, deployment.regions, deployment.stacks))
+                      mkLabel(deploymentPackage.name, deployment.actions, deployment.regions, deployment.stacks))
     }
   }
 
-  private[resolver] def createDeploymentPackage(deployment: Deployment, artifact: S3Artifact,
-    deploymentTypes: Seq[DeploymentType]): DeploymentPackage = {
+  private[resolver] def createDeploymentPackage(deployment: Deployment,
+                                                artifact: S3Artifact,
+                                                deploymentTypes: Seq[DeploymentType]): DeploymentPackage = {
 
     DeploymentPackage(
       name = deployment.name,
@@ -43,7 +48,7 @@ object TaskResolver {
   }
 
   private def mkLabel(name: String, actions: NEL[String], regions: NEL[String], stacks: NEL[String]): String = {
-    val bracketList = (list: List[String]) => if (list.size <= 1) list.mkString else list.mkString("{",",","}")
+    val bracketList = (list: List[String]) => if (list.size <= 1) list.mkString else list.mkString("{", ",", "}")
     s"$name [${actions.toList.mkString(", ")}] => ${bracketList(regions.toList)}/${bracketList(stacks.toList)}"
   }
 }

--- a/magenta-lib/src/main/scala/magenta/metrics/metrics.scala
+++ b/magenta-lib/src/main/scala/magenta/metrics/metrics.scala
@@ -5,7 +5,11 @@ import com.gu.management.TimingMetric
 object MagentaMetrics {
   val all = Seq(MessageBrokerMessages)
 
-  object MessageBrokerMessages extends TimingMetric(
-    "messages", "message_broker_messages", "Message Broker messages", "messages dispatched by the internal MessageBroker"
-  )
+  object MessageBrokerMessages
+      extends TimingMetric(
+        "messages",
+        "message_broker_messages",
+        "Message Broker messages",
+        "messages dispatched by the internal MessageBroker"
+      )
 }

--- a/magenta-lib/src/main/scala/magenta/package.scala
+++ b/magenta-lib/src/main/scala/magenta/package.scala
@@ -11,11 +11,11 @@ import scala.util.{Failure, Success, Try}
 object `package` extends Loggable {
   def transpose[A](xs: Seq[Seq[A]]): Seq[Seq[A]] = xs.filter(_.nonEmpty) match {
     case Nil => Nil
-    case ys: Seq[Seq[A]] => ys.map{ _.head } +: transpose(ys.map{ _.tail })
+    case ys: Seq[Seq[A]] => ys.map { _.head } +: transpose(ys.map { _.tail })
   }
 
   implicit class Seq2TransposeBy[A](seq: Seq[A]) {
-    def transposeBy[K](f: A => K)(implicit ord:Ordering[K]): Seq[A] = {
+    def transposeBy[K](f: A => K)(implicit ord: Ordering[K]): Seq[A] = {
       val listOfGroups = seq.groupBy(f).toList.sortBy(_._1).map(_._2)
       transpose(listOfGroups).fold(Nil)(_ ++ _)
     }
@@ -39,7 +39,7 @@ object `package` extends Loggable {
 
     Try(f) match {
       case Success(result) => result
-      case Failure(exception:AmazonClientException) if currentAttempt <= retries && shouldRetryFor(exception) =>
+      case Failure(exception: AmazonClientException) if currentAttempt <= retries && shouldRetryFor(exception) =>
         // use client config to calculate delay - pass in null for request as no SDK implementations actually use it
         val delay = policy.getBackoffStrategy.delayBeforeNextRetry(null, exception, currentAttempt)
         logger.warn(s"Client exception encountered, retrying in ${delay}ms")

--- a/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
@@ -7,8 +7,13 @@ import magenta.{KeyRing, Stage, _}
 
 import scala.collection.JavaConversions._
 
-case class CheckGroupSize(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling) {
+case class CheckGroupSize(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(
+    implicit val keyRing: KeyRing)
+    extends ASGTask {
+  override def execute(asg: AutoScalingGroup,
+                       reporter: DeployReporter,
+                       stopFlag: => Boolean,
+                       asgClient: AmazonAutoScaling) {
     val doubleCapacity = asg.getDesiredCapacity * 2
     reporter.verbose(s"ASG desired = ${asg.getDesiredCapacity}; ASG max = ${asg.getMaxSize}; Target = $doubleCapacity")
     if (asg.getMaxSize < doubleCapacity) {
@@ -21,8 +26,13 @@ case class CheckGroupSize(pkg: DeploymentPackage, stage: Stage, stack: Stack, re
   lazy val description = "Checking there is enough capacity to deploy"
 }
 
-case class TagCurrentInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling) {
+case class TagCurrentInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(
+    implicit val keyRing: KeyRing)
+    extends ASGTask {
+  override def execute(asg: AutoScalingGroup,
+                       reporter: DeployReporter,
+                       stopFlag: => Boolean,
+                       asgClient: AmazonAutoScaling) {
     if (asg.getInstances.nonEmpty) {
       implicit val ec2Client = EC2.makeEc2Client(keyRing, region)
       reporter.verbose(s"Tagging ${asg.getInstances.toList.map(_.getInstanceId).mkString(", ")}")
@@ -35,19 +45,28 @@ case class TagCurrentInstancesWithTerminationTag(pkg: DeploymentPackage, stage: 
   lazy val description = "Tag existing instances of the auto-scaling group for termination"
 }
 
-case class DoubleSize(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
+case class DoubleSize(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(
+    implicit val keyRing: KeyRing)
+    extends ASGTask {
 
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling) {
+  override def execute(asg: AutoScalingGroup,
+                       reporter: DeployReporter,
+                       stopFlag: => Boolean,
+                       asgClient: AmazonAutoScaling) {
     val targetCapacity = asg.getDesiredCapacity * 2
     reporter.verbose(s"Doubling capacity to $targetCapacity")
     ASG.desiredCapacity(asg.getAutoScalingGroupName, targetCapacity, asgClient)
   }
 
-  lazy val description = s"Double the size of the auto-scaling group in $stage, $stack for apps ${pkg.apps.mkString(", ")}"
+  lazy val description =
+    s"Double the size of the auto-scaling group in $stage, $stack for apps ${pkg.apps.mkString(", ")}"
 }
 
 sealed abstract class Pause(durationMillis: Long)(implicit val keyRing: KeyRing) extends ASGTask {
-  def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling): Unit = {
+  def execute(asg: AutoScalingGroup,
+              reporter: DeployReporter,
+              stopFlag: => Boolean,
+              asgClient: AmazonAutoScaling): Unit = {
     if (asg.getDesiredCapacity == 0 && asg.getInstances.isEmpty)
       reporter.verbose("Skipping pause as there are no instances and desired capacity is zero")
     else
@@ -55,33 +74,50 @@ sealed abstract class Pause(durationMillis: Long)(implicit val keyRing: KeyRing)
   }
 }
 
-case class HealthcheckGrace(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region, durationMillis: Long)(implicit keyRing: KeyRing) extends Pause(durationMillis) {
+case class HealthcheckGrace(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region, durationMillis: Long)(
+    implicit keyRing: KeyRing)
+    extends Pause(durationMillis) {
   def description: String = s"Wait extra ${durationMillis}ms to let Load Balancer report correctly"
 }
 
-case class WarmupGrace(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region, durationMillis: Long)(implicit keyRing: KeyRing) extends Pause(durationMillis) {
+case class WarmupGrace(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region, durationMillis: Long)(
+    implicit keyRing: KeyRing)
+    extends Pause(durationMillis) {
   def description: String = s"Wait extra ${durationMillis}ms to let instances in Load Balancer warm up"
 }
 
-case class TerminationGrace(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region, durationMillis: Long)(implicit keyRing: KeyRing) extends Pause(durationMillis) {
+case class TerminationGrace(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region, durationMillis: Long)(
+    implicit keyRing: KeyRing)
+    extends Pause(durationMillis) {
   def description: String = s"Wait extra ${durationMillis}ms to let Load Balancer report correctly"
 }
 
-case class CheckForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling) {
+case class CheckForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(
+    implicit val keyRing: KeyRing)
+    extends ASGTask {
+  override def execute(asg: AutoScalingGroup,
+                       reporter: DeployReporter,
+                       stopFlag: => Boolean,
+                       asgClient: AmazonAutoScaling) {
     val elbClient = ELB.client(keyRing, region)
     ASG.isStabilized(asg, asgClient, elbClient) match {
       case Left(reason) => reporter.fail(s"ASG not stable: $reason")
       case Right(()) =>
     }
   }
-  lazy val description: String = "Check the desired number of hosts in both the ASG and ELB are up and that the number of hosts match"
+  lazy val description: String =
+    "Check the desired number of hosts in both the ASG and ELB are up and that the number of hosts match"
 }
 
-case class WaitForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Stack, duration: Long, region: Region)(implicit val keyRing: KeyRing) extends ASGTask
+case class WaitForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Stack, duration: Long, region: Region)(
+    implicit val keyRing: KeyRing)
+    extends ASGTask
     with SlowRepeatedPollingCheck {
 
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling) {
+  override def execute(asg: AutoScalingGroup,
+                       reporter: DeployReporter,
+                       stopFlag: => Boolean,
+                       asgClient: AmazonAutoScaling) {
     val elbClient = ELB.client(keyRing, region)
     check(reporter, stopFlag) {
       try {
@@ -103,11 +139,17 @@ case class WaitForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Sta
     def isRateExceeded(e: AmazonServiceException) = e.getStatusCode == 400 && e.getErrorCode == "Throttling"
   }
 
-  lazy val description: String = "Check the desired number of hosts in both the ASG and ELB are up and that the number of hosts match"
+  lazy val description: String =
+    "Check the desired number of hosts in both the ASG and ELB are up and that the number of hosts match"
 }
 
-case class CullInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling) {
+case class CullInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(
+    implicit val keyRing: KeyRing)
+    extends ASGTask {
+  override def execute(asg: AutoScalingGroup,
+                       reporter: DeployReporter,
+                       stopFlag: => Boolean,
+                       asgClient: AmazonAutoScaling) {
     implicit val ec2Client = EC2.makeEc2Client(keyRing, region)
     implicit val elbClient = ELB.client(keyRing, region)
     val instancesToKill = asg.getInstances.filter(instance => EC2.hasTag(instance, "Magenta", "Terminate", ec2Client))
@@ -119,18 +161,28 @@ case class CullInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage,
   lazy val description = "Terminate instances with the termination tag for this deploy"
 }
 
-case class SuspendAlarmNotifications(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
+case class SuspendAlarmNotifications(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(
+    implicit val keyRing: KeyRing)
+    extends ASGTask {
 
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling) {
+  override def execute(asg: AutoScalingGroup,
+                       reporter: DeployReporter,
+                       stopFlag: => Boolean,
+                       asgClient: AmazonAutoScaling) {
     ASG.suspendAlarmNotifications(asg.getAutoScalingGroupName, asgClient)
   }
 
   lazy val description = "Suspending Alarm Notifications - group will no longer scale on any configured alarms"
 }
 
-case class ResumeAlarmNotifications(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
+case class ResumeAlarmNotifications(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(
+    implicit val keyRing: KeyRing)
+    extends ASGTask {
 
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling) {
+  override def execute(asg: AutoScalingGroup,
+                       reporter: DeployReporter,
+                       stopFlag: => Boolean,
+                       asgClient: AmazonAutoScaling) {
     ASG.resumeAlarmNotifications(asg.getAutoScalingGroupName, asgClient)
   }
 

--- a/magenta-lib/src/main/scala/magenta/tasks/CommandLine.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/CommandLine.scala
@@ -7,16 +7,17 @@ case class CommandLine(commandLine: List[String], successCodes: List[Int] = List
   lazy val quoted = (commandLine) map quoteIfNeeded mkString " "
   private def quoteIfNeeded(s: String) = if (s.contains(" ")) "\"" + s + "\"" else s
 
-  def suppressor(filteredOut: String => Unit) = { line:String =>
-    if ( !line.startsWith("tcgetattr") &&
-      !line.startsWith("Warning: Permanently added") )
-        filteredOut(line)
+  def suppressor(filteredOut: String => Unit) = { line: String =>
+    if (!line.startsWith("tcgetattr") &&
+        !line.startsWith("Warning: Permanently added"))
+      filteredOut(line)
   }
 
   def run(reporter: DeployReporter) {
     import sys.process._
     reporter.infoContext(s"$$ $quoted") { infoContext =>
-      val returnValue = commandLine ! ProcessLogger(infoContext.commandOutput(_), suppressor(infoContext.commandError(_)))
+      val returnValue = commandLine ! ProcessLogger(infoContext.commandOutput(_),
+                                                    suppressor(infoContext.commandError(_)))
       infoContext.verbose("return value " + returnValue)
       if (!successCodes.contains(returnValue)) {
         infoContext.fail("Exit code %d from command: %s" format (returnValue, quoted))

--- a/magenta-lib/src/main/scala/magenta/tasks/ElasticSearchTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ElasticSearchTasks.scala
@@ -11,9 +11,13 @@ import play.api.libs.json.Json
 
 import scala.collection.JavaConversions._
 
-case class WaitForElasticSearchClusterGreen(pkg: DeploymentPackage, stage: Stage, stack: Stack, duration: Long, region: Region)
-                                           (implicit val keyRing: KeyRing)
-  extends ASGTask with RepeatedPollingCheck {
+case class WaitForElasticSearchClusterGreen(pkg: DeploymentPackage,
+                                            stage: Stage,
+                                            stack: Stack,
+                                            duration: Long,
+                                            region: Region)(implicit val keyRing: KeyRing)
+    extends ASGTask
+    with RepeatedPollingCheck {
 
   val description = "Wait for the elasticsearch cluster status to be green"
   override val verbose =
@@ -21,7 +25,10 @@ case class WaitForElasticSearchClusterGreen(pkg: DeploymentPackage, stage: Stage
       |Requires access to port 9200 on cluster members.
     """.stripMargin
 
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling) {
+  override def execute(asg: AutoScalingGroup,
+                       reporter: DeployReporter,
+                       stopFlag: => Boolean,
+                       asgClient: AmazonAutoScaling) {
     implicit val ec2Client = EC2.makeEc2Client(keyRing, region)
     val instance = EC2(asg.getInstances.headOption.getOrElse {
       throw new IllegalArgumentException("Auto-scaling group: %s had no instances" format (asg))
@@ -33,28 +40,35 @@ case class WaitForElasticSearchClusterGreen(pkg: DeploymentPackage, stage: Stage
   }
 }
 
-case class CullElasticSearchInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage, stack: Stack, duration: Long, region: Region)
-                                                       (implicit val keyRing: KeyRing)
-  extends ASGTask with RepeatedPollingCheck{
+case class CullElasticSearchInstancesWithTerminationTag(pkg: DeploymentPackage,
+                                                        stage: Stage,
+                                                        stack: Stack,
+                                                        duration: Long,
+                                                        region: Region)(implicit val keyRing: KeyRing)
+    extends ASGTask
+    with RepeatedPollingCheck {
 
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling) {
+  override def execute(asg: AutoScalingGroup,
+                       reporter: DeployReporter,
+                       stopFlag: => Boolean,
+                       asgClient: AmazonAutoScaling) {
     implicit val ec2Client = EC2.makeEc2Client(keyRing, region)
     implicit val elbClient = ELB.client(keyRing, region)
     val newNode = asg.getInstances.filterNot(EC2.hasTag(_, "Magenta", "Terminate", ec2Client)).head
     val newESNode = ElasticSearchNode(EC2(newNode, ec2Client).getPublicDnsName)
 
     def cullInstance(instance: Instance) {
-        val node = ElasticSearchNode(EC2(instance, ec2Client).getPublicDnsName)
+      val node = ElasticSearchNode(EC2(instance, ec2Client).getPublicDnsName)
+      check(reporter, stopFlag) {
+        newESNode.inHealthyClusterOfSize(ASG.refresh(asg, asgClient).getDesiredCapacity)
+      }
+      if (!stopFlag) {
+        node.shutdown()
         check(reporter, stopFlag) {
-          newESNode.inHealthyClusterOfSize(ASG.refresh(asg, asgClient).getDesiredCapacity)
+          newESNode.inHealthyClusterOfSize(ASG.refresh(asg, asgClient).getDesiredCapacity - 1)
         }
-        if (!stopFlag) {
-          node.shutdown()
-          check(reporter, stopFlag) {
-            newESNode.inHealthyClusterOfSize(ASG.refresh(asg, asgClient).getDesiredCapacity - 1)
-          }
-        }
-        if (!stopFlag) ASG.cull(asg, instance, asgClient, elbClient)
+      }
+      if (!stopFlag) ASG.cull(asg, instance, asgClient, elbClient)
     }
 
     val instancesToKill = asg.getInstances.filter(instance => EC2.hasTag(instance, "Magenta", "Terminate", ec2Client))
@@ -69,9 +83,10 @@ case class ElasticSearchNode(address: String) {
   implicit val format = DefaultFormats
 
   val http = new Http()
-  private def clusterHealth = http(:/(address, 9200) / "_cluster" / "health" >- {json =>
-    Json.parse(json)
-  })
+  private def clusterHealth =
+    http(:/(address, 9200) / "_cluster" / "health" >- { json =>
+      Json.parse(json)
+    })
 
   def dataNodesInCluster = (clusterHealth \ "number_of_data_nodes").as[Int]
   def clusterIsHealthy = (clusterHealth \ "status").as[String] == "green"
@@ -85,5 +100,3 @@ case class ElasticSearchNode(address: String) {
 
   def shutdown() = http((:/(address, 9200) / "_cluster" / "nodes" / "_local" / "_shutdown").POST >|)
 }
-
-

--- a/magenta-lib/src/main/scala/magenta/tasks/TaskGraph.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/TaskGraph.scala
@@ -11,4 +11,3 @@ case class TaskReference(task: Task, index: Int, name: String) extends TaskNode 
 }
 case object StartMarker extends TaskNode
 case object EndMarker extends TaskNode
-

--- a/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
+++ b/magenta-lib/src/test/scala/magenta/DeployContextTest.scala
@@ -20,17 +20,18 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
 
   it should "resolve a set of tasks" in {
     val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
-    val parameters = DeployParameters(Deployer("tester"), Build("project","1"), CODE, oneRecipeName)
+    val parameters = DeployParameters(Deployer("tester"), Build("project", "1"), CODE, oneRecipeName)
     val resources = DeploymentResources(reporter, lookupSingleHost, artifactClient)
     val context = DeployContext(UUID.randomUUID(), parameters, project(baseRecipe), resources, region)
-    DeploymentGraph.toTaskList(context.tasks) should be(List(
-      StubTask("init_action_one per app task number one", Region("eu-west-1")),
-      StubTask("init_action_one per app task number two", Region("eu-west-1"))
-    ))
+    DeploymentGraph.toTaskList(context.tasks) should be(
+      List(
+        StubTask("init_action_one per app task number one", Region("eu-west-1")),
+        StubTask("init_action_one per app task number two", Region("eu-west-1"))
+      ))
   }
 
   it should "send a Info message when resolving tasks" in {
-    val parameters = DeployParameters(Deployer("tester1"), Build("project","1"), CODE, oneRecipeName)
+    val parameters = DeployParameters(Deployer("tester1"), Build("project", "1"), CODE, oneRecipeName)
     val reporter = DeployReporter.startDeployContext(DeployReporter.rootReporterFor(UUID.randomUUID(), parameters))
 
     val messages = Buffer[Message]()
@@ -43,10 +44,11 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
   }
 
   it should "execute the task" in {
-    val parameters = DeployParameters(Deployer("tester"), Build("prooecjt","1"), CODE, oneRecipeName)
+    val parameters = DeployParameters(Deployer("tester"), Build("prooecjt", "1"), CODE, oneRecipeName)
     val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), parameters)
     val resources = DeploymentResources(reporter, lookupSingleHost, artifactClient)
-    val context = DeployContext(reporter.messageContext.deployId, parameters, project(baseMockRecipe), resources, region)
+    val context =
+      DeployContext(reporter.messageContext.deployId, parameters, project(baseMockRecipe), resources, region)
     context.execute(reporter)
     val task = DeploymentGraph.toTaskList(context.tasks).head
 
@@ -54,17 +56,18 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
   }
 
   it should "send taskStart and taskFinish messages for each task" in {
-    val parameters = DeployParameters(Deployer("tester2"), Build("project","1"), CODE, oneRecipeName)
+    val parameters = DeployParameters(Deployer("tester2"), Build("project", "1"), CODE, oneRecipeName)
 
     val start = Buffer[Message]()
     val finished = Buffer[Message]()
-    DeployReporter.messages.filter(_.stack.deployParameters == Some(parameters)).subscribe(wrapper =>
-      wrapper.stack.top match {
-        case FinishContext(finishMessage) => finished += finishMessage
-        case StartContext(startMessage) => start += startMessage
-        case _ =>
-      }
-    )
+    DeployReporter.messages
+      .filter(_.stack.deployParameters == Some(parameters))
+      .subscribe(wrapper =>
+        wrapper.stack.top match {
+          case FinishContext(finishMessage) => finished += finishMessage
+          case StartContext(startMessage) => start += startMessage
+          case _ =>
+      })
 
     val reporter = DeployReporter.startDeployContext(DeployReporter.rootReporterFor(UUID.randomUUID(), parameters))
     val resources = DeploymentResources(reporter, lookupSingleHost, artifactClient)
@@ -81,17 +84,18 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
   }
 
   it should "bookend the messages with startdeploy and finishdeploy messages" in {
-    val parameters = DeployParameters(Deployer("tester3"), Build("Project","1"), CODE, oneRecipeName)
+    val parameters = DeployParameters(Deployer("tester3"), Build("Project", "1"), CODE, oneRecipeName)
 
     val start = Buffer[Message]()
     val finished = Buffer[Message]()
-    DeployReporter.messages.filter(_.stack.deployParameters == Some(parameters)).subscribe(wrapper =>
-      wrapper.stack.top match {
-        case FinishContext(finishMessage) => finished += finishMessage
-        case StartContext(startMessage) => start += startMessage
-        case _ =>
-      }
-    )
+    DeployReporter.messages
+      .filter(_.stack.deployParameters == Some(parameters))
+      .subscribe(wrapper =>
+        wrapper.stack.top match {
+          case FinishContext(finishMessage) => finished += finishMessage
+          case StartContext(startMessage) => start += startMessage
+          case _ =>
+      })
 
     val reporter = DeployReporter.startDeployContext(DeployReporter.rootReporterFor(UUID.randomUUID(), parameters))
     val resources = DeploymentResources(reporter, lookupSingleHost, artifactClient)
@@ -104,7 +108,6 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
     start.head.getClass should be(classOf[Deploy])
     finished.last.getClass should be(classOf[Deploy])
   }
-
 
   val CODE = Stage("CODE")
 
@@ -131,13 +134,13 @@ class DeployContextTest extends FlatSpec with Matchers with MockitoSugar {
 
   val basePackageType = stubDeploymentType(Seq("init_action_one"))
 
-  val baseRecipe = Recipe("one",
+  val baseRecipe = Recipe(
+    "one",
     deploymentSteps = basePackageType.mkDeploymentStep("init_action_one")(stubPackage(basePackageType)) :: Nil,
     dependsOn = Nil)
 
-  val baseMockRecipe = Recipe("one",
-    deploymentSteps = MockStubPerAppDeploymentStep("init_action_one", Seq(app1)) :: Nil,
-    dependsOn = Nil)
+  val baseMockRecipe =
+    Recipe("one", deploymentSteps = MockStubPerAppDeploymentStep("init_action_one", Seq(app1)) :: Nil, dependsOn = Nil)
 
   def project(recipes: Recipe*) = Project(Map.empty, recipes.map(r => r.name -> r).toMap)
 

--- a/magenta-lib/src/test/scala/magenta/HostListTests.scala
+++ b/magenta-lib/src/test/scala/magenta/HostListTests.scala
@@ -4,9 +4,9 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class HostListTests extends FlatSpec with Matchers {
   import magenta.HostList._
-  
+
   it should "provide an alphabetical list of all hosts and supported apps" in {
     val hostList = List(Host("z.z.z.z", Set(App("z"))), Host("x.x.x.x", Set(App("x"))))
-    hostList.dump should be (" x.x.x.x: App(x)\n z.z.z.z: App(z)")
+    hostList.dump should be(" x.x.x.x: App(x)\n z.z.z.z: App(z)")
   }
 }

--- a/magenta-lib/src/test/scala/magenta/PackageTest.scala
+++ b/magenta-lib/src/test/scala/magenta/PackageTest.scala
@@ -8,8 +8,8 @@ import org.scalatest.mock.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}
 
 class PackageTest extends FlatSpec with Matchers with MockitoSugar {
-  val clientConfiguration = new ClientConfiguration().
-    withRetryPolicy(new RetryPolicy(
+  val clientConfiguration = new ClientConfiguration().withRetryPolicy(
+    new RetryPolicy(
       PredefinedRetryPolicies.DEFAULT_RETRY_CONDITION,
       PredefinedRetryPolicies.DEFAULT_BACKOFF_STRATEGY,
       3,
@@ -18,7 +18,7 @@ class PackageTest extends FlatSpec with Matchers with MockitoSugar {
 
   "retryOnException" should "work when no exception is thrown" in {
     var calls = 0
-    def block:String = {
+    def block: String = {
       calls += 1
       "banana"
     }
@@ -30,7 +30,7 @@ class PackageTest extends FlatSpec with Matchers with MockitoSugar {
 
   "retryOnException" should "work when an exception is thrown" in {
     var calls = 0
-    def block:String = {
+    def block: String = {
       calls += 1
       if (calls == 1)
         throw new AmazonClientException("failure message", new IOException("IO cause"))
@@ -45,24 +45,24 @@ class PackageTest extends FlatSpec with Matchers with MockitoSugar {
 
   "retryOnException" should "throw an exception if it fails consistently" in {
     var calls = 0
-    def block:String = {
+    def block: String = {
       calls += 1
       throw new AmazonClientException("failure message", new IOException("IO cause"))
     }
 
-    an [AmazonClientException] should be thrownBy retryOnException(clientConfiguration)(block)
+    an[AmazonClientException] should be thrownBy retryOnException(clientConfiguration)(block)
 
     calls should be(4)
   }
 
   "retryOnException" should "throw an exception immediately if not retryable" in {
     var calls = 0
-    def block:String = {
+    def block: String = {
       calls += 1
       throw new AmazonClientException("failure message")
     }
 
-    an [AmazonClientException] should be thrownBy retryOnException(clientConfiguration)(block)
+    an[AmazonClientException] should be thrownBy retryOnException(clientConfiguration)(block)
 
     calls should be(1)
   }

--- a/magenta-lib/src/test/scala/magenta/ReporterTest.scala
+++ b/magenta-lib/src/test/scala/magenta/ReporterTest.scala
@@ -38,7 +38,8 @@ class ReporterTest extends FlatSpec with Matchers {
     wrappers.size should be(3)
     wrappers(0).context should be(reporter.messageContext)
     wrappers(0).stack.messages should be(List(StartContext(Deploy(parameters))))
-    wrappers(1).context should be(MessageContext(reporter.messageContext.deployId, parameters, Some(wrappers(0).messageId)))
+    wrappers(1).context should be(
+      MessageContext(reporter.messageContext.deployId, parameters, Some(wrappers(0).messageId)))
     wrappers(1).stack.messages should be(List(Info("this should work"), Deploy(parameters)))
     wrappers(2).stack.messages should be(List(FinishContext(Deploy(parameters)), Deploy(parameters)))
   }

--- a/magenta-lib/src/test/scala/magenta/ReportingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/ReportingTest.scala
@@ -18,116 +18,114 @@ class ReportingTest extends FlatSpec with Matchers {
   it should "build a no-op deploy report" in {
     val stacks = startDeployWrapper :: finishDeployWrapper :: Nil
     val report = DeployReport(stacks)
-    report.isRunning should be (false)
+    report.isRunning should be(false)
     report shouldBe tree(deployMessageId, startDeploy, finishDep)
   }
-
 
   it should "build a one-op deploy report" in {
     val stacks = startDeployWrapper :: wrapper(infoMessageId, Some(deployMessageId), stack(infoMsg, deploy)) :: finishDeployWrapper :: Nil
     val report = DeployReport(stacks)
 
-    report.isRunning should be (false)
-    report.size should be (2)
+    report.isRunning should be(false)
+    report.size should be(2)
     report shouldBe tree(deployMessageId, startDeploy, finishDep, tree(infoMessageId, infoMsg))
   }
 
   it should "build a complex report" in {
     val report = DeployReport(messageWrappers)
 
-    report.size should be (4)
+    report.size should be(4)
 
-    report.isRunning should be (false)
+    report.isRunning should be(false)
     report shouldBe
-      tree(deployMessageId, startDeploy, finishDep,
-        tree(infoMessageId, startInfo, finishInfo,
-          tree(cmdOutId, cmdOut),
-          tree(verboseId, verbose)
-        )
-      )
+      tree(deployMessageId,
+           startDeploy,
+           finishDep,
+           tree(infoMessageId, startInfo, finishInfo, tree(cmdOutId, cmdOut), tree(verboseId, verbose)))
   }
 
   it should "build a partial report" in {
     val partialStacks = messageWrappers.take(5)
     val report = DeployReport(partialStacks)
-    report.size should be (4)
+    report.size should be(4)
 
-    report.isRunning should be (true)
+    report.isRunning should be(true)
     report shouldBe
-      tree(deployMessageId, startDeploy,
-        tree(infoMessageId, startInfo, finishInfo,
-          tree(cmdOutId, cmdOut),
-          tree(verboseId, verbose)
-        )
-      )
+      tree(deployMessageId,
+           startDeploy,
+           tree(infoMessageId, startInfo, finishInfo, tree(cmdOutId, cmdOut), tree(verboseId, verbose)))
   }
 
   it should "build a nested partial report" in {
     val partialStacks = messageWrappers.take(4)
     val report = DeployReport(partialStacks)
-    report.size should be (4)
+    report.size should be(4)
 
-    report.isRunning should be (true)
+    report.isRunning should be(true)
     report shouldBe
-      tree(deployMessageId, startDeploy,
-        tree(infoMessageId, startInfo,
-          tree(cmdOutId, cmdOut),
-          tree(verboseId, verbose)
-        )
-      )
+      tree(deployMessageId,
+           startDeploy,
+           tree(infoMessageId, startInfo, tree(cmdOutId, cmdOut), tree(verboseId, verbose)))
   }
 
   it should "render a report as text" in {
     val report = DeployReport(messageWrappers)
-    report should matchPattern { case drt:DeployReportTree => }
+    report should matchPattern { case drt: DeployReportTree => }
     val tree = report.asInstanceOf[DeployReportTree]
 
-    tree.size should be (4)
+    tree.size should be(4)
 
-    tree.render.mkString(", ") should be (""":Deploy(DeployParameters(Deployer(Test reports),Build(test-project,1),Stage(CODE),RecipeName(default),List(),List(),All)) [Completed], 1:Info($ echo hello) [Completed], 1.1:CommandOutput(hello) [Not running], 1.2:Verbose(return value 0) [Not running]""")
+    tree.render.mkString(", ") should be(
+      """:Deploy(DeployParameters(Deployer(Test reports),Build(test-project,1),Stage(CODE),RecipeName(default),List(),List(),All)) [Completed], 1:Info($ echo hello) [Completed], 1.1:CommandOutput(hello) [Not running], 1.2:Verbose(return value 0) [Not running]""")
   }
 
   it should "know it has failed" in {
-    val failStacks = messageWrappers.take(4) ::: List(wrapper(UUID.randomUUID(), Some(infoMessageId), stack(failInfo, infoMsg, deploy)), wrapper(UUID.randomUUID(), Some(deployMessageId), stack(failDep, deploy)))
+    val failStacks = messageWrappers.take(4) ::: List(
+      wrapper(UUID.randomUUID(), Some(infoMessageId), stack(failInfo, infoMsg, deploy)),
+      wrapper(UUID.randomUUID(), Some(deployMessageId), stack(failDep, deploy)))
     val report = DeployReport(failStacks)
-    report.size should be (4)
+    report.size should be(4)
 
     report shouldBe
-      tree(deployMessageId, startDeploy, failDep,
-        tree(infoMessageId, startInfo, failInfo,
-          tree(cmdOutId, cmdOut),
-          tree(verboseId, verbose)
-        )
-      )
-    report.isRunning should be (false)
+      tree(deployMessageId,
+           startDeploy,
+           failDep,
+           tree(infoMessageId, startInfo, failInfo, tree(cmdOutId, cmdOut), tree(verboseId, verbose)))
+    report.isRunning should be(false)
     report.cascadeState should be(RunState.Failed)
   }
 
   val testTime = new DateTime()
 
-  def stack( messages: Message * ): MessageStack = {
+  def stack(messages: Message*): MessageStack = {
     stack(testTime, messages: _*)
   }
 
-  def stack( time: DateTime, messages: Message * ): MessageStack = {
+  def stack(time: DateTime, messages: Message*): MessageStack = {
     MessageStack(messages.toList, time)
   }
 
-  def wrapper( id: UUID, parentId: Option[UUID], stack: MessageStack ): MessageWrapper = {
+  def wrapper(id: UUID, parentId: Option[UUID], stack: MessageStack): MessageWrapper = {
     MessageWrapper(MessageContext(deployId, parameters, parentId), id, stack)
   }
 
-  def tree( id: UUID, message: Message, trees: DeployReportTree * ): DeployReportTree = {
-    DeployReportTree( MessageState(message, testTime, id), trees.toList )
+  def tree(id: UUID, message: Message, trees: DeployReportTree*): DeployReportTree = {
+    DeployReportTree(MessageState(message, testTime, id), trees.toList)
   }
-  def tree( id: UUID, startMessage: StartContext, finishMessage: FinishContext, trees: DeployReportTree * ): DeployReportTree = {
-    DeployReportTree( MessageState(startMessage, finishMessage, testTime, id), trees.toList )
+  def tree(id: UUID,
+           startMessage: StartContext,
+           finishMessage: FinishContext,
+           trees: DeployReportTree*): DeployReportTree = {
+    DeployReportTree(MessageState(startMessage, finishMessage, testTime, id), trees.toList)
   }
-  def tree( id: UUID, startMessage: StartContext, failMessage: FailContext, trees: DeployReportTree * ): DeployReportTree = {
-    DeployReportTree( MessageState(startMessage, failMessage, testTime, id), trees.toList )
+  def tree(id: UUID,
+           startMessage: StartContext,
+           failMessage: FailContext,
+           trees: DeployReportTree*): DeployReportTree = {
+    DeployReportTree(MessageState(startMessage, failMessage, testTime, id), trees.toList)
   }
 
-  val parameters = DeployParameters(Deployer("Test reports"),Build("test-project","1"),Stage("CODE"))
+  val parameters = DeployParameters(Deployer("Test reports"), Build("test-project", "1"), Stage("CODE"))
 
   val deploy = Deploy(parameters)
   val startDeploy = StartContext(deploy)
@@ -162,11 +160,11 @@ class ReportingTest extends FlatSpec with Matchers {
 
   val messageWrappers: List[MessageWrapper] =
     startDeployWrapper ::
-    wrapper(infoMessageId, Some(deployMessageId), stack(startInfo, deploy)) ::
-    wrapper(cmdOutId, Some(infoMessageId), stack(cmdOut, infoMsg, deploy)) ::
-    wrapper(verboseId, Some(infoMessageId), stack(verbose, infoMsg, deploy)) ::
-    wrapper(finishInfoId, Some(infoMessageId), stack(finishInfo, infoMsg, deploy)) ::
-    finishDeployWrapper ::
-    Nil
+      wrapper(infoMessageId, Some(deployMessageId), stack(startInfo, deploy)) ::
+      wrapper(cmdOutId, Some(infoMessageId), stack(cmdOut, infoMsg, deploy)) ::
+      wrapper(verboseId, Some(infoMessageId), stack(verbose, infoMsg, deploy)) ::
+      wrapper(finishInfoId, Some(infoMessageId), stack(finishInfo, infoMsg, deploy)) ::
+      finishDeployWrapper ::
+      Nil
 
 }

--- a/magenta-lib/src/test/scala/magenta/ResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/ResolverTest.scala
@@ -45,20 +45,25 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
 
   "resolver" should "parse json into actions that can be executed" in {
     val parsed = JsonReader.buildProject(JsonInputFile.parse(simpleExample).right.get,
-      new S3JsonArtifact("artifact-bucket","tmp/123"), deploymentTypes)
+                                         new S3JsonArtifact("artifact-bucket", "tmp/123"),
+                                         deploymentTypes)
     val deployRecipe = parsed.recipes("htmlapp-only")
 
-    val host = Host("host1", stage = CODE.name, tags=Map("group" -> "")).app(App("apache"))
+    val host = Host("host1", stage = CODE.name, tags = Map("group" -> "")).app(App("apache"))
     val lookup = stubLookup(host :: Nil)
 
     val resources = DeploymentResources(reporter, lookup, artifactClient)
     val tasks = Resolver.resolve(project(deployRecipe), parameters(deployRecipe), resources, region)
 
     val taskList: List[Task] = DeploymentGraph.toTaskList(tasks)
-    taskList.size should be (1)
-    taskList should be (List(
-      S3Upload(Region("eu-west-1"), "test", Seq((new S3Path("artifact-bucket","tmp/123/packages/htmlapp/"), "CODE/htmlapp")), publicReadAcl = true)
-    ))
+    taskList.size should be(1)
+    taskList should be(
+      List(
+        S3Upload(Region("eu-west-1"),
+                 "test",
+                 Seq((new S3Path("artifact-bucket", "tmp/123/packages/htmlapp/"), "CODE/htmlapp")),
+                 publicReadAcl = true)
+      ))
   }
 
   val app2 = App("the_2nd_role")
@@ -73,56 +78,69 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
 
   it should "generate the tasks from the actions supplied" in {
     val taskGraph = Resolver.resolve(project(baseRecipe), parameters(baseRecipe), resources, region)
-    DeploymentGraph.toTaskList(taskGraph) should be (List(
-      StubTask("init_action_one per app task number one", Region("eu-west-1")),
-      StubTask("init_action_one per app task number two", Region("eu-west-1"))
-    ))
+    DeploymentGraph.toTaskList(taskGraph) should be(
+      List(
+        StubTask("init_action_one per app task number one", Region("eu-west-1")),
+        StubTask("init_action_one per app task number two", Region("eu-west-1"))
+      ))
   }
 
   it should "prepare dependsOn actions correctly" in {
     val basePackageType = stubDeploymentType(Seq("main_init_action"))
 
-    val mainRecipe = Recipe("main",
-      deploymentSteps = basePackageType.mkDeploymentStep("main_init_action")(stubPackage(basePackageType)) :: Nil,
-      dependsOn = List("one"))
+    val mainRecipe =
+      Recipe(
+        "main",
+        deploymentSteps = basePackageType.mkDeploymentStep("main_init_action")(stubPackage(basePackageType)) :: Nil,
+        dependsOn = List("one"))
 
     val resources = DeploymentResources(reporter, lookupSingleHost, artifactClient)
     val taskGraph = Resolver.resolve(project(mainRecipe, baseRecipe), parameters(mainRecipe), resources, region)
-    DeploymentGraph.toTaskList(taskGraph) should be (List(
-      StubTask("init_action_one per app task number one", Region("eu-west-1")),
-      StubTask("init_action_one per app task number two", Region("eu-west-1")),
-      StubTask("main_init_action per app task number one", Region("eu-west-1")),
-      StubTask("main_init_action per app task number two", Region("eu-west-1"))
-    ))
+    DeploymentGraph.toTaskList(taskGraph) should be(
+      List(
+        StubTask("init_action_one per app task number one", Region("eu-west-1")),
+        StubTask("init_action_one per app task number two", Region("eu-west-1")),
+        StubTask("main_init_action per app task number one", Region("eu-west-1")),
+        StubTask("main_init_action per app task number two", Region("eu-west-1"))
+      ))
 
   }
 
   it should "only include dependencies once" in {
     val basePackageType = stubDeploymentType(Seq("main_init_action", "init_action_two"))
 
-    val indirectDependencyRecipe = Recipe("two",
-      deploymentSteps = basePackageType.mkDeploymentStep("init_action_two")(stubPackage(basePackageType)) :: Nil,
-      dependsOn = List("one"))
-    val mainRecipe = Recipe("main",
+    val indirectDependencyRecipe =
+      Recipe(
+        "two",
+        deploymentSteps = basePackageType.mkDeploymentStep("init_action_two")(stubPackage(basePackageType)) :: Nil,
+        dependsOn = List("one"))
+    val mainRecipe = Recipe(
+      "main",
       deploymentSteps = basePackageType.mkDeploymentStep("main_init_action")(stubPackage(basePackageType)) :: Nil,
       dependsOn = List("two", "one"))
 
     val resources = DeploymentResources(reporter, lookupSingleHost, artifactClient)
-    val taskGraph = Resolver.resolve(project(mainRecipe, indirectDependencyRecipe, baseRecipe), parameters(mainRecipe), resources, region)
-    DeploymentGraph.toTaskList(taskGraph) should be (List(
-      StubTask("init_action_one per app task number one", Region("eu-west-1")),
-      StubTask("init_action_one per app task number two", Region("eu-west-1")),
-      StubTask("init_action_two per app task number one", Region("eu-west-1")),
-      StubTask("init_action_two per app task number two", Region("eu-west-1")),
-      StubTask("main_init_action per app task number one", Region("eu-west-1")),
-      StubTask("main_init_action per app task number two", Region("eu-west-1"))
-    ))
+    val taskGraph = Resolver.resolve(project(mainRecipe, indirectDependencyRecipe, baseRecipe),
+                                     parameters(mainRecipe),
+                                     resources,
+                                     region)
+    DeploymentGraph.toTaskList(taskGraph) should be(
+      List(
+        StubTask("init_action_one per app task number one", Region("eu-west-1")),
+        StubTask("init_action_one per app task number two", Region("eu-west-1")),
+        StubTask("init_action_two per app task number one", Region("eu-west-1")),
+        StubTask("init_action_two per app task number two", Region("eu-west-1")),
+        StubTask("main_init_action per app task number one", Region("eu-west-1")),
+        StubTask("main_init_action per app task number two", Region("eu-west-1"))
+      ))
   }
 
   it should "not throw an exception if no hosts found and only whole app recipes" in {
-    val nonHostRecipe = Recipe("nonHostRecipe",
-      deploymentSteps =  basePackageType.mkDeploymentStep("init_action_one")(stubPackage(basePackageType)) :: Nil,
-      dependsOn = Nil)
+    val nonHostRecipe =
+      Recipe(
+        "nonHostRecipe",
+        deploymentSteps = basePackageType.mkDeploymentStep("init_action_one")(stubPackage(basePackageType)) :: Nil,
+        dependsOn = Nil)
 
     val resources = DeploymentResources(reporter, stubLookup(List()), artifactClient)
     Resolver.resolve(project(nonHostRecipe), parameters(nonHostRecipe), resources, region)
@@ -130,32 +148,32 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
 
   it should "resolve tasks from multiple stacks" in {
     val pkgType = StubDeploymentType(
-      actionsMap = Map("deploy" -> Action("deploy")((pkg, resources, target) => List(StubTask("stacked", Region("eu-west-1"), stack = Some(target.stack))))(StubActionRegister)),
+      actionsMap = Map("deploy" -> Action("deploy")((pkg, resources, target) =>
+        List(StubTask("stacked", Region("eu-west-1"), stack = Some(target.stack))))(StubActionRegister)),
       List("deploy")
     )
-    val recipe = Recipe("stacked",
-      deploymentSteps = List(pkgType.mkDeploymentStep("deploy")(stubPackage(pkgType))))
+    val recipe = Recipe("stacked", deploymentSteps = List(pkgType.mkDeploymentStep("deploy")(stubPackage(pkgType))))
 
     val proj = project(recipe, NamedStack("foo"), NamedStack("bar"), NamedStack("monkey"), NamedStack("litre"))
     val resources = DeploymentResources(reporter, stubLookup(), artifactClient)
     val taskGraph = Resolver.resolve(proj, parameters(recipe), resources, region)
-    DeploymentGraph.toTaskList(taskGraph) should be (List(
-      StubTask("stacked", Region("eu-west-1"), stack = Some(NamedStack("foo"))),
-      StubTask("stacked", Region("eu-west-1"), stack = Some(NamedStack("bar"))),
-      StubTask("stacked", Region("eu-west-1"), stack = Some(NamedStack("monkey"))),
-      StubTask("stacked", Region("eu-west-1"), stack = Some(NamedStack("litre")))
-    ))
+    DeploymentGraph.toTaskList(taskGraph) should be(
+      List(
+        StubTask("stacked", Region("eu-west-1"), stack = Some(NamedStack("foo"))),
+        StubTask("stacked", Region("eu-west-1"), stack = Some(NamedStack("bar"))),
+        StubTask("stacked", Region("eu-west-1"), stack = Some(NamedStack("monkey"))),
+        StubTask("stacked", Region("eu-west-1"), stack = Some(NamedStack("litre")))
+      ))
   }
 
   it should "resolve tasks from multiple stacks into a parallel task graph" in {
     val pkgType = StubDeploymentType(
-      actionsMap = Map("deploy" -> Action("deploy"){ (pkg, resources, target) =>
+      actionsMap = Map("deploy" -> Action("deploy") { (pkg, resources, target) =>
         List(StubTask("stacked", Region("eu-west-1"), stack = Some(target.stack)))
       }(StubActionRegister)),
       List("deploy")
     )
-    val recipe = Recipe("stacked",
-      deploymentSteps = List(pkgType.mkDeploymentStep("deploy")(stubPackage(pkgType))))
+    val recipe = Recipe("stacked", deploymentSteps = List(pkgType.mkDeploymentStep("deploy")(stubPackage(pkgType))))
 
     val proj = project(recipe, NamedStack("foo"), NamedStack("bar"), NamedStack("monkey"), NamedStack("litre"))
     val resources = DeploymentResources(reporter, stubLookup(), artifactClient)
@@ -163,12 +181,17 @@ class ResolverTest extends FlatSpec with Matchers with MockitoSugar {
     val successors = taskGraph.orderedSuccessors(StartNode)
     successors.size should be(4)
 
-    successors should be(List(
-      ValueNode(DeploymentTasks(List(StubTask("stacked", Region("eu-west-1"), stack = Some(NamedStack("foo")))), "project -> foo")),
-      ValueNode(DeploymentTasks(List(StubTask("stacked", Region("eu-west-1"), stack = Some(NamedStack("bar")))), "project -> bar")),
-      ValueNode(DeploymentTasks(List(StubTask("stacked", Region("eu-west-1"), stack = Some(NamedStack("monkey")))), "project -> monkey")),
-      ValueNode(DeploymentTasks(List(StubTask("stacked", Region("eu-west-1"), stack = Some(NamedStack("litre")))), "project -> litre"))
-    ))
+    successors should be(
+      List(
+        ValueNode(DeploymentTasks(List(StubTask("stacked", Region("eu-west-1"), stack = Some(NamedStack("foo")))),
+                                  "project -> foo")),
+        ValueNode(DeploymentTasks(List(StubTask("stacked", Region("eu-west-1"), stack = Some(NamedStack("bar")))),
+                                  "project -> bar")),
+        ValueNode(DeploymentTasks(List(StubTask("stacked", Region("eu-west-1"), stack = Some(NamedStack("monkey")))),
+                                  "project -> monkey")),
+        ValueNode(DeploymentTasks(List(StubTask("stacked", Region("eu-west-1"), stack = Some(NamedStack("litre")))),
+                                  "project -> litre"))
+      ))
   }
 
   def parameters(recipe: Recipe) =

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -25,24 +25,34 @@ class AutoScalingTest extends FlatSpec with Matchers {
 
     val app = Seq(App("app"))
 
-    val p = DeploymentPackage("app", app, data, "autoscaling", S3Path("artifact-bucket", "test/123/app"), true,
-      deploymentTypes)
+    val p = DeploymentPackage("app",
+                              app,
+                              data,
+                              "autoscaling",
+                              S3Path("artifact-bucket", "test/123/app"),
+                              true,
+                              deploymentTypes)
 
-    AutoScaling.actionsMap("deploy").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack, region)) should be (List(
-      CheckForStabilization(p, PROD, UnnamedStack, Region("eu-west-1")),
-      CheckGroupSize(p, PROD, UnnamedStack, Region("eu-west-1")),
-      SuspendAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1")),
-      TagCurrentInstancesWithTerminationTag(p, PROD, UnnamedStack, Region("eu-west-1")),
-      DoubleSize(p, PROD, UnnamedStack, Region("eu-west-1")),
-      HealthcheckGrace(p, PROD, UnnamedStack, Region("eu-west-1"), 20000),
-      WaitForStabilization(p, PROD, UnnamedStack, 15 * 60 * 1000, Region("eu-west-1")),
-      WarmupGrace(p, PROD, UnnamedStack, Region("eu-west-1"), 1000),
-      WaitForStabilization(p, PROD, UnnamedStack, 15 * 60 * 1000, Region("eu-west-1")),
-      CullInstancesWithTerminationTag(p, PROD, UnnamedStack, Region("eu-west-1")),
-      TerminationGrace(p, PROD, UnnamedStack, Region("eu-west-1"), 10000),
-      WaitForStabilization(p, PROD, UnnamedStack, 15 * 60 * 1000, Region("eu-west-1")),
-      ResumeAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1"))
-    ))
+    AutoScaling
+      .actionsMap("deploy")
+      .taskGenerator(p,
+                     DeploymentResources(reporter, lookupEmpty, artifactClient),
+                     DeployTarget(parameters(), UnnamedStack, region)) should be(
+      List(
+        CheckForStabilization(p, PROD, UnnamedStack, Region("eu-west-1")),
+        CheckGroupSize(p, PROD, UnnamedStack, Region("eu-west-1")),
+        SuspendAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1")),
+        TagCurrentInstancesWithTerminationTag(p, PROD, UnnamedStack, Region("eu-west-1")),
+        DoubleSize(p, PROD, UnnamedStack, Region("eu-west-1")),
+        HealthcheckGrace(p, PROD, UnnamedStack, Region("eu-west-1"), 20000),
+        WaitForStabilization(p, PROD, UnnamedStack, 15 * 60 * 1000, Region("eu-west-1")),
+        WarmupGrace(p, PROD, UnnamedStack, Region("eu-west-1"), 1000),
+        WaitForStabilization(p, PROD, UnnamedStack, 15 * 60 * 1000, Region("eu-west-1")),
+        CullInstancesWithTerminationTag(p, PROD, UnnamedStack, Region("eu-west-1")),
+        TerminationGrace(p, PROD, UnnamedStack, Region("eu-west-1"), 10000),
+        WaitForStabilization(p, PROD, UnnamedStack, 15 * 60 * 1000, Region("eu-west-1")),
+        ResumeAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1"))
+      ))
   }
 
   it should "default publicReadAcl to false when a new style package" in {
@@ -52,11 +62,20 @@ class AutoScalingTest extends FlatSpec with Matchers {
 
     val app = Seq(App("app"))
 
-    val p = DeploymentPackage("app", app, data, "autoscaling", S3Path("artifact-bucket", "test/123/app"), false,
-      deploymentTypes)
+    val p = DeploymentPackage("app",
+                              app,
+                              data,
+                              "autoscaling",
+                              S3Path("artifact-bucket", "test/123/app"),
+                              false,
+                              deploymentTypes)
 
-    AutoScaling.actionsMap("uploadArtifacts").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack, region)) should matchPattern {
-      case List(S3Upload(_,_,_,_,_,false,_)) =>
+    AutoScaling
+      .actionsMap("uploadArtifacts")
+      .taskGenerator(p,
+                     DeploymentResources(reporter, lookupEmpty, artifactClient),
+                     DeployTarget(parameters(), UnnamedStack, region)) should matchPattern {
+      case List(S3Upload(_, _, _, _, _, false, _)) =>
     }
   }
 
@@ -71,23 +90,33 @@ class AutoScalingTest extends FlatSpec with Matchers {
 
     val app = Seq(App("app"))
 
-    val p = DeploymentPackage("app", app, data, "autoscaling", S3Path("artifact-bucket", "test/123/app"), true,
-      deploymentTypes)
+    val p = DeploymentPackage("app",
+                              app,
+                              data,
+                              "autoscaling",
+                              S3Path("artifact-bucket", "test/123/app"),
+                              true,
+                              deploymentTypes)
 
-    AutoScaling.actionsMap("deploy").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack, region)) should be (List(
-      CheckForStabilization(p, PROD, UnnamedStack, Region("eu-west-1")),
-      CheckGroupSize(p, PROD, UnnamedStack, Region("eu-west-1")),
-      SuspendAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1")),
-      TagCurrentInstancesWithTerminationTag(p, PROD, UnnamedStack, Region("eu-west-1")),
-      DoubleSize(p, PROD, UnnamedStack, Region("eu-west-1")),
-      HealthcheckGrace(p, PROD, UnnamedStack, Region("eu-west-1"), 30000),
-      WaitForStabilization(p, PROD, UnnamedStack, 3 * 60 * 1000, Region("eu-west-1")),
-      WarmupGrace(p, PROD, UnnamedStack, Region("eu-west-1"), 20000),
-      WaitForStabilization(p, PROD, UnnamedStack, 3 * 60 * 1000, Region("eu-west-1")),
-      CullInstancesWithTerminationTag(p, PROD, UnnamedStack, Region("eu-west-1")),
-      TerminationGrace(p, PROD, UnnamedStack, Region("eu-west-1"), 11000),
-      WaitForStabilization(p, PROD, UnnamedStack, 3 * 60 * 1000, Region("eu-west-1")),
-      ResumeAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1"))
-    ))
+    AutoScaling
+      .actionsMap("deploy")
+      .taskGenerator(p,
+                     DeploymentResources(reporter, lookupEmpty, artifactClient),
+                     DeployTarget(parameters(), UnnamedStack, region)) should be(
+      List(
+        CheckForStabilization(p, PROD, UnnamedStack, Region("eu-west-1")),
+        CheckGroupSize(p, PROD, UnnamedStack, Region("eu-west-1")),
+        SuspendAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1")),
+        TagCurrentInstancesWithTerminationTag(p, PROD, UnnamedStack, Region("eu-west-1")),
+        DoubleSize(p, PROD, UnnamedStack, Region("eu-west-1")),
+        HealthcheckGrace(p, PROD, UnnamedStack, Region("eu-west-1"), 30000),
+        WaitForStabilization(p, PROD, UnnamedStack, 3 * 60 * 1000, Region("eu-west-1")),
+        WarmupGrace(p, PROD, UnnamedStack, Region("eu-west-1"), 20000),
+        WaitForStabilization(p, PROD, UnnamedStack, 3 * 60 * 1000, Region("eu-west-1")),
+        CullInstancesWithTerminationTag(p, PROD, UnnamedStack, Region("eu-west-1")),
+        TerminationGrace(p, PROD, UnnamedStack, Region("eu-west-1"), 11000),
+        WaitForStabilization(p, PROD, UnnamedStack, 3 * 60 * 1000, Region("eu-west-1")),
+        ResumeAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1"))
+      ))
   }
 }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -22,16 +22,36 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
   val app = Seq(App("app"))
   val namedStack = NamedStack("cfn")
   val cfnStackName = s"cfn-app-PROD"
-  def p(data: Map[String, JsValue]) = DeploymentPackage("app", app, data, "cloud-formation", S3Path("artifact-bucket", "test/123"), true,
-    deploymentTypes)
+  def p(data: Map[String, JsValue]) =
+    DeploymentPackage("app",
+                      app,
+                      data,
+                      "cloud-formation",
+                      S3Path("artifact-bucket", "test/123"),
+                      true,
+                      deploymentTypes)
 
   "cloudformation deployment type" should "have an updateStack action" in {
     val data: Map[String, JsValue] = Map.empty
 
-    inside(CloudFormation.actionsMap("updateStack").taskGenerator(p(data), DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), namedStack, region))) {
+    inside(
+      CloudFormation
+        .actionsMap("updateStack")
+        .taskGenerator(p(data),
+                       DeploymentResources(reporter, lookupEmpty, artifactClient),
+                       DeployTarget(parameters(), namedStack, region))) {
       case List(updateTask, checkTask) =>
         inside(updateTask) {
-          case UpdateCloudFormationTask(taskRegion, stackName, path, userParams, amiParamTags, _, stage, stack, ifAbsent, alwaysUpload) =>
+          case UpdateCloudFormationTask(taskRegion,
+                                        stackName,
+                                        path,
+                                        userParams,
+                                        amiParamTags,
+                                        _,
+                                        stage,
+                                        stack,
+                                        ifAbsent,
+                                        alwaysUpload) =>
             taskRegion should be(region)
             stackName should be(LookupByName(cfnStackName))
             path should be(S3Path("artifact-bucket", "test/123/cloud-formation/cfn.json"))
@@ -56,13 +76,20 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
       "amiParametersToTags" -> Json.obj(
         "AMI" -> Json.obj("myApp1" -> JsString("fakeApp1")),
         "RouterAMI" -> Json.obj("myApp2" -> JsString("fakeApp2"))
-    ))
+      )
+    )
 
-    inside(CloudFormation.actionsMap("updateStack").taskGenerator(p(data), DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), namedStack, region))) {
+    inside(
+      CloudFormation
+        .actionsMap("updateStack")
+        .taskGenerator(p(data),
+                       DeploymentResources(reporter, lookupEmpty, artifactClient),
+                       DeployTarget(parameters(), namedStack, region))) {
       case List(updateTask, _) =>
         inside(updateTask) {
           case UpdateCloudFormationTask(_, _, _, _, amiParamTags, _, _, _, _, _) =>
-            amiParamTags should be(Map("AMI" -> Map("myApp1" -> "fakeApp1"), "RouterAMI" -> Map("myApp2" -> "fakeApp2")))
+            amiParamTags should be(
+              Map("AMI" -> Map("myApp1" -> "fakeApp1"), "RouterAMI" -> Map("myApp2" -> "fakeApp2")))
         }
     }
   }
@@ -72,16 +99,22 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
       "amiParametersToTags" -> Json.obj(
         "AMI" -> Json.obj("myApp1" -> JsString("fakeApp1")),
         "myAMI" -> Json.obj("myApp2" -> JsString("fakeApp2"))
-    ))
+      ))
 
-    inside(CloudFormation.actionsMap("updateStack").taskGenerator(p(data), DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), namedStack, region))) {
+    inside(
+      CloudFormation
+        .actionsMap("updateStack")
+        .taskGenerator(p(data),
+                       DeploymentResources(reporter, lookupEmpty, artifactClient),
+                       DeployTarget(parameters(), namedStack, region))) {
       case List(updateTask, _) =>
         inside(updateTask) {
           case UpdateCloudFormationTask(_, _, _, _, amiParamTags, _, _, _, _, _) =>
-            amiParamTags should be(Map(
-              "AMI" -> Map("myApp1" -> "fakeApp1"),
-              "myAMI" -> Map("myApp2" -> "fakeApp2")
-            ))
+            amiParamTags should be(
+              Map(
+                "AMI" -> Map("myApp1" -> "fakeApp1"),
+                "myAMI" -> Map("myApp2" -> "fakeApp2")
+              ))
         }
     }
   }
@@ -92,7 +125,12 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
       "amiTags" -> Json.obj("myApp" -> JsString("fakeApp"))
     )
 
-    inside(CloudFormation.actionsMap("updateStack").taskGenerator(p(data), DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), namedStack, region))) {
+    inside(
+      CloudFormation
+        .actionsMap("updateStack")
+        .taskGenerator(p(data),
+                       DeploymentResources(reporter, lookupEmpty, artifactClient),
+                       DeployTarget(parameters(), namedStack, region))) {
       case List(updateTask, _) =>
         inside(updateTask) {
           case UpdateCloudFormationTask(_, _, _, _, amiParamTags, _, _, _, _, _) =>
@@ -101,11 +139,15 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
     }
   }
 
-
   it should "respect the defaults for amiTags and amiParameter" in {
     val data: Map[String, JsValue] = Map("amiTags" -> Json.obj("myApp" -> JsString("fakeApp")))
 
-    inside(CloudFormation.actionsMap("updateStack").taskGenerator(p(data), DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), namedStack, region))) {
+    inside(
+      CloudFormation
+        .actionsMap("updateStack")
+        .taskGenerator(p(data),
+                       DeploymentResources(reporter, lookupEmpty, artifactClient),
+                       DeployTarget(parameters(), namedStack, region))) {
       case List(updateTask, _) =>
         inside(updateTask) {
           case UpdateCloudFormationTask(_, _, _, _, amiParamTags, _, _, _, _, _) =>
@@ -117,25 +159,33 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
   "UpdateCloudFormationTask" should "substitute stack and stage parameters" in {
     val templateParameters =
       Seq(TemplateParameter("param1", false), TemplateParameter("Stack", false), TemplateParameter("Stage", false))
-    val combined = UpdateCloudFormationTask.combineParameters(NamedStack("cfn"), PROD, templateParameters, Map("param1" -> "value1"))
+    val combined = UpdateCloudFormationTask.combineParameters(NamedStack("cfn"),
+                                                              PROD,
+                                                              templateParameters,
+                                                              Map("param1" -> "value1"))
 
-    combined should be(Map(
-      "param1" -> SpecifiedValue("value1"),
-      "Stack" -> SpecifiedValue("cfn"),
-      "Stage" -> SpecifiedValue("PROD")
+    combined should be(
+      Map(
+        "param1" -> SpecifiedValue("value1"),
+        "Stack" -> SpecifiedValue("cfn"),
+        "Stage" -> SpecifiedValue("PROD")
       ))
   }
 
   it should "default required parameters to use existing parameters" in {
     val templateParameters =
       Seq(TemplateParameter("param1", true), TemplateParameter("param3", false), TemplateParameter("Stage", false))
-    val combined = UpdateCloudFormationTask.combineParameters(NamedStack("cfn"), PROD, templateParameters, Map("param1" -> "value1"))
+    val combined = UpdateCloudFormationTask.combineParameters(NamedStack("cfn"),
+                                                              PROD,
+                                                              templateParameters,
+                                                              Map("param1" -> "value1"))
 
-    combined should be(Map(
-      "param1" -> SpecifiedValue("value1"),
-      "param3" -> UseExistingValue,
-      "Stage" -> SpecifiedValue(PROD.name)
-    ))
+    combined should be(
+      Map(
+        "param1" -> SpecifiedValue("value1"),
+        "param3" -> UseExistingValue,
+        "Stage" -> SpecifiedValue(PROD.name)
+      ))
   }
 
   it should "create new CFN stack names" in {
@@ -143,7 +193,8 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
     nameToCallNewStack(LookupByName("name-of-stack")) shouldBe "name-of-stack"
     nameToCallNewStack(LookupByTags(Map("Stack" -> "stackName", "App" -> "appName", "Stage" -> "STAGE"))) shouldBe
       "stackName-STAGE-appName"
-    nameToCallNewStack(LookupByTags(Map("Stack" -> "stackName", "App" -> "appName", "Stage" -> "STAGE", "Extra" -> "extraBit"))) shouldBe
+    nameToCallNewStack(LookupByTags(
+      Map("Stack" -> "stackName", "App" -> "appName", "Stage" -> "STAGE", "Extra" -> "extraBit"))) shouldBe
       "stackName-STAGE-appName-extraBit"
   }
 
@@ -161,8 +212,13 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
     val app = Seq(App("app"))
     val stack = NamedStack("cfn")
     val cfnStackName = s"cfn-app-PROD"
-    val pkg = DeploymentPackage("app", app, data, "cloud-formation", S3Path("artifact-bucket", "test/123"), true,
-      deploymentTypes)
+    val pkg = DeploymentPackage("app",
+                                app,
+                                data,
+                                "cloud-formation",
+                                S3Path("artifact-bucket", "test/123"),
+                                true,
+                                deploymentTypes)
     val target = DeployTarget(parameters(), stack, region)
     LookupByTags(pkg, target, reporter) shouldBe LookupByTags(Map("Stack" -> "cfn", "Stage" -> "PROD", "App" -> "app"))
   }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -23,7 +23,16 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
 
   "Deployment types" should "automatically register params in the params Seq" in {
     S3.params should have size 9
-    S3.params.map(_.name).toSet should be(Set("prefixStage","prefixPackage","prefixStack", "pathPrefixResource","bucket","publicReadAcl","bucketResource","cacheControl","mimeTypes"))
+    S3.params.map(_.name).toSet should be(
+      Set("prefixStage",
+          "prefixPackage",
+          "prefixStack",
+          "pathPrefixResource",
+          "bucket",
+          "publicReadAcl",
+          "bucketResource",
+          "cacheControl",
+          "mimeTypes"))
   }
 
   private val sourceS3Package = S3Path("artifact-bucket", "test/123/static-files")
@@ -38,17 +47,21 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package, true, deploymentTypes)
 
     val thrown = the[NoSuchElementException] thrownBy {
-      S3.actionsMap("uploadStaticFiles").taskGenerator(p, DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)) should be (
-        List(S3Upload(
-          Region("eu-west-1"),
-          "bucket-1234",
-          Seq(sourceS3Package -> "CODE/myapp"),
-          List(PatternValue(".*", "no-cache"))
-        ))
+      S3.actionsMap("uploadStaticFiles")
+        .taskGenerator(p,
+                       DeploymentResources(reporter, lookupSingleHost, artifactClient),
+                       DeployTarget(parameters(CODE), UnnamedStack, region)) should be(
+        List(
+          S3Upload(
+            Region("eu-west-1"),
+            "bucket-1234",
+            Seq(sourceS3Package -> "CODE/myapp"),
+            List(PatternValue(".*", "no-cache"))
+          ))
       )
     }
 
-    thrown.getMessage should equal ("Package myapp [aws-s3] requires parameter cacheControl of type List")
+    thrown.getMessage should equal("Package myapp [aws-s3] requires parameter cacheControl of type List")
   }
 
   it should "log a warning when a default is explictly set in a riff-raff.yaml" in {
@@ -62,7 +75,10 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
 
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package, false, deploymentTypes)
 
-    S3.actionsMap("uploadStaticFiles").taskGenerator(p, DeploymentResources(mockReporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region))
+    S3.actionsMap("uploadStaticFiles")
+      .taskGenerator(p,
+                     DeploymentResources(mockReporter, lookupSingleHost, artifactClient),
+                     DeployTarget(parameters(CODE), UnnamedStack, region))
 
     verify(mockReporter).warning("Parameter prefixStage is unnecessarily explicitly set to the default value of true")
   }
@@ -78,7 +94,10 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
 
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package, true, deploymentTypes)
 
-    S3.actionsMap("uploadStaticFiles").taskGenerator(p, DeploymentResources(mockReporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region))
+    S3.actionsMap("uploadStaticFiles")
+      .taskGenerator(p,
+                     DeploymentResources(mockReporter, lookupSingleHost, artifactClient),
+                     DeployTarget(parameters(CODE), UnnamedStack, region))
 
     verify(mockReporter, never).warning(any())
   }
@@ -92,14 +111,18 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
 
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package, true, deploymentTypes)
 
-    S3.actionsMap("uploadStaticFiles").taskGenerator(p, DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)) should be (
-      List(S3Upload(
-        Region("eu-west-1"),
-        "bucket-1234",
-        Seq(sourceS3Package -> "CODE/myapp"),
-        List(PatternValue(".*", "no-cache")),
-        publicReadAcl = true
-      ))
+    S3.actionsMap("uploadStaticFiles")
+      .taskGenerator(p,
+                     DeploymentResources(reporter, lookupSingleHost, artifactClient),
+                     DeployTarget(parameters(CODE), UnnamedStack, region)) should be(
+      List(
+        S3Upload(
+          Region("eu-west-1"),
+          "bucket-1234",
+          Seq(sourceS3Package -> "CODE/myapp"),
+          List(PatternValue(".*", "no-cache")),
+          publicReadAcl = true
+        ))
     )
   }
 
@@ -114,8 +137,15 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
 
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", sourceS3Package, true, deploymentTypes)
 
-    inside(S3.actionsMap("uploadStaticFiles").taskGenerator(p, DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)).head) {
-      case upload: S3Upload => upload.cacheControlPatterns should be(List(PatternValue("^sub", "no-cache"), PatternValue(".*", "public; max-age:3600")))
+    inside(
+      S3.actionsMap("uploadStaticFiles")
+        .taskGenerator(p,
+                       DeploymentResources(reporter, lookupSingleHost, artifactClient),
+                       DeployTarget(parameters(CODE), UnnamedStack, region))
+        .head) {
+      case upload: S3Upload =>
+        upload.cacheControlPatterns should be(
+          List(PatternValue("^sub", "no-cache"), PatternValue(".*", "public; max-age:3600")))
     }
   }
 
@@ -130,9 +160,16 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
 
     val p = DeploymentPackage("myapp", Seq(app1), data, "aws-s3", sourceS3Package, true, deploymentTypes)
 
-    val lookup = stubLookup(List(Host("the_host", stage=CODE.name).app(app1)), Map("s3-path-prefix" -> Seq(Datum(None, app1.name, CODE.name, "testing/2016/05/brexit-companion", None))))
+    val lookup = stubLookup(
+      List(Host("the_host", stage = CODE.name).app(app1)),
+      Map("s3-path-prefix" -> Seq(Datum(None, app1.name, CODE.name, "testing/2016/05/brexit-companion", None))))
 
-    inside(S3.actionsMap("uploadStaticFiles").taskGenerator(p, DeploymentResources(reporter, lookup, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)).head) {
+    inside(
+      S3.actionsMap("uploadStaticFiles")
+        .taskGenerator(p,
+                       DeploymentResources(reporter, lookup, artifactClient),
+                       DeployTarget(parameters(CODE), UnnamedStack, region))
+        .head) {
       case upload: S3Upload => upload.paths should be(Seq(sourceS3Package -> "testing/2016/05/brexit-companion"))
     }
   }
@@ -147,12 +184,20 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
       )
     )
 
-    val p = DeploymentPackage("myapp", Seq.empty, data, "aws-lambda", S3Path("artifact-bucket", "test/123"), true,
-      deploymentTypes)
+    val p = DeploymentPackage("myapp",
+                              Seq.empty,
+                              data,
+                              "aws-lambda",
+                              S3Path("artifact-bucket", "test/123"),
+                              true,
+                              deploymentTypes)
 
-    Lambda.actionsMap("updateLambda").taskGenerator(p, DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)) should be (
-      List(UpdateLambda(S3Path("artifact-bucket","test/123/lambda.zip"), "myLambda", defaultRegion)
-      ))
+    Lambda
+      .actionsMap("updateLambda")
+      .taskGenerator(p,
+                     DeploymentResources(reporter, lookupSingleHost, artifactClient),
+                     DeployTarget(parameters(CODE), UnnamedStack, region)) should be(
+      List(UpdateLambda(S3Path("artifact-bucket", "test/123/lambda.zip"), "myLambda", defaultRegion)))
   }
 
   it should "throw an exception if a required mapping is missing" in {
@@ -164,16 +209,24 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
       )
     )
 
-    val p = DeploymentPackage("myapp", Seq.empty, badData, "aws-lambda", S3Path("artifact-bucket", "test/123"), true,
-      deploymentTypes)
+    val p = DeploymentPackage("myapp",
+                              Seq.empty,
+                              badData,
+                              "aws-lambda",
+                              S3Path("artifact-bucket", "test/123"),
+                              true,
+                              deploymentTypes)
 
     val thrown = the[FailException] thrownBy {
-      Lambda.actionsMap("updateLambda").taskGenerator(p, DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), UnnamedStack, region)) should be (
-        List(UpdateLambda(S3Path("artifact-bucket","test/123/lambda.zip"), "myLambda", defaultRegion)
-        ))
+      Lambda
+        .actionsMap("updateLambda")
+        .taskGenerator(p,
+                       DeploymentResources(reporter, lookupSingleHost, artifactClient),
+                       DeployTarget(parameters(CODE), UnnamedStack, region)) should be(
+        List(UpdateLambda(S3Path("artifact-bucket", "test/123/lambda.zip"), "myLambda", defaultRegion)))
     }
 
-    thrown.getMessage should equal ("Function not defined for stage CODE")
+    thrown.getMessage should equal("Function not defined for stage CODE")
   }
 
   def parameters(stage: Stage) = DeployParameters(Deployer("tester"), Build("project", "version"), stage)

--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
@@ -6,7 +6,17 @@ import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
 import magenta.artifact.S3Path
 import magenta.fixtures._
 import magenta.tasks.{S3Upload, UpdateS3Lambda}
-import magenta.{App, DeployReporter, DeployTarget, DeploymentPackage, DeploymentResources, KeyRing, NamedStack, Region, fixtures}
+import magenta.{
+  App,
+  DeployReporter,
+  DeployTarget,
+  DeploymentPackage,
+  DeploymentResources,
+  KeyRing,
+  NamedStack,
+  Region,
+  fixtures
+}
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.{JsBoolean, JsString, JsValue, Json}
@@ -27,31 +37,46 @@ class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
   )
 
   val app = Seq(App("lambda"))
-  val pkg = DeploymentPackage("lambda", app, data, "aws-lambda", S3Path("artifact-bucket", "test/123/lambda"), true,
-    deploymentTypes)
+  val pkg = DeploymentPackage("lambda",
+                              app,
+                              data,
+                              "aws-lambda",
+                              S3Path("artifact-bucket", "test/123/lambda"),
+                              true,
+                              deploymentTypes)
   val defaultRegion = Region("eu-west-1")
 
   it should "produce an S3 upload task" in {
-    val tasks = Lambda.actionsMap("uploadLambda").taskGenerator(pkg, DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("test"), region))
-    tasks should be (List(
-      S3Upload(
-        Region("eu-west-1"),
-        bucket = "lambda-bucket",
-        paths = Seq(S3Path("artifact-bucket", "test/123/lambda/test-file.zip") -> s"test/PROD/lambda/test-file.zip")
-      )
-    ))
+    val tasks = Lambda
+      .actionsMap("uploadLambda")
+      .taskGenerator(pkg,
+                     DeploymentResources(reporter, lookupEmpty, artifactClient),
+                     DeployTarget(parameters(PROD), NamedStack("test"), region))
+    tasks should be(
+      List(
+        S3Upload(
+          Region("eu-west-1"),
+          bucket = "lambda-bucket",
+          paths = Seq(S3Path("artifact-bucket", "test/123/lambda/test-file.zip") -> s"test/PROD/lambda/test-file.zip")
+        )
+      ))
   }
 
   it should "produce a lambda update task" in {
-    val tasks = Lambda.actionsMap("updateLambda").taskGenerator(pkg, DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("test"), region))
-    tasks should be (List(
-      UpdateS3Lambda(
-        functionName = "MyFunction-PROD",
-        s3Bucket = "lambda-bucket",
-        s3Key = "test/PROD/lambda/test-file.zip",
-        region = defaultRegion
-      )
-    ))
+    val tasks = Lambda
+      .actionsMap("updateLambda")
+      .taskGenerator(pkg,
+                     DeploymentResources(reporter, lookupEmpty, artifactClient),
+                     DeployTarget(parameters(PROD), NamedStack("test"), region))
+    tasks should be(
+      List(
+        UpdateS3Lambda(
+          functionName = "MyFunction-PROD",
+          s3Bucket = "lambda-bucket",
+          s3Key = "test/PROD/lambda/test-file.zip",
+          region = defaultRegion
+        )
+      ))
   }
 
   it should "prefix stack name to function name" in {
@@ -62,18 +87,28 @@ class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
       "functionNames" -> Json.arr("MyFunction-")
     )
     val app = Seq(App("lambda"))
-    val pkg = DeploymentPackage("lambda", app, dataWithStack, "aws-lambda",
-      S3Path("artifact-bucket", "test/123/lambda"), true, deploymentTypes)
+    val pkg = DeploymentPackage("lambda",
+                                app,
+                                dataWithStack,
+                                "aws-lambda",
+                                S3Path("artifact-bucket", "test/123/lambda"),
+                                true,
+                                deploymentTypes)
 
-    val tasks = Lambda.actionsMap("updateLambda").taskGenerator(pkg, DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("some-stack"), region))
-    tasks should be (List(
-      UpdateS3Lambda(
-        functionName = "some-stackMyFunction-PROD",
-        s3Bucket = "lambda-bucket",
-        s3Key = "some-stack/PROD/lambda/test-file.zip",
-        region = defaultRegion
-      )
-    ))
+    val tasks = Lambda
+      .actionsMap("updateLambda")
+      .taskGenerator(pkg,
+                     DeploymentResources(reporter, lookupEmpty, artifactClient),
+                     DeployTarget(parameters(PROD), NamedStack("some-stack"), region))
+    tasks should be(
+      List(
+        UpdateS3Lambda(
+          functionName = "some-stackMyFunction-PROD",
+          s3Bucket = "lambda-bucket",
+          s3Key = "some-stack/PROD/lambda/test-file.zip",
+          region = defaultRegion
+        )
+      ))
   }
 
   it should "create an update lambda for each region" in {
@@ -85,23 +120,33 @@ class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
       "regions" -> Json.arr("us-east-1", "ap-southeast-2")
     )
     val app = Seq(App("lambda"))
-    val pkg = DeploymentPackage("lambda", app, dataWithStack, "aws-lambda",
-      S3Path("artifact-bucket", "test/123/lambda"), true, deploymentTypes)
+    val pkg = DeploymentPackage("lambda",
+                                app,
+                                dataWithStack,
+                                "aws-lambda",
+                                S3Path("artifact-bucket", "test/123/lambda"),
+                                true,
+                                deploymentTypes)
 
-    val tasks = Lambda.actionsMap("updateLambda").taskGenerator(pkg, DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(PROD), NamedStack("some-stack"), region))
-    tasks should be (List(
-      UpdateS3Lambda(
-        functionName = "some-stackMyFunction-PROD",
-        s3Bucket = "lambda-bucket",
-        s3Key = "some-stack/PROD/lambda/test-file.zip",
-        region = Region("us-east-1")
-      ),
-      UpdateS3Lambda(
-        functionName = "some-stackMyFunction-PROD",
-        s3Bucket = "lambda-bucket",
-        s3Key = "some-stack/PROD/lambda/test-file.zip",
-        region = Region("ap-southeast-2")
-      )
-    ))
+    val tasks = Lambda
+      .actionsMap("updateLambda")
+      .taskGenerator(pkg,
+                     DeploymentResources(reporter, lookupEmpty, artifactClient),
+                     DeployTarget(parameters(PROD), NamedStack("some-stack"), region))
+    tasks should be(
+      List(
+        UpdateS3Lambda(
+          functionName = "some-stackMyFunction-PROD",
+          s3Bucket = "lambda-bucket",
+          s3Key = "some-stack/PROD/lambda/test-file.zip",
+          region = Region("us-east-1")
+        ),
+        UpdateS3Lambda(
+          functionName = "some-stackMyFunction-PROD",
+          s3Bucket = "lambda-bucket",
+          s3Key = "some-stack/PROD/lambda/test-file.zip",
+          region = Region("ap-southeast-2")
+        )
+      ))
   }
 }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/ParamTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/ParamTest.scala
@@ -21,7 +21,7 @@ class TestRegister extends ParamRegister {
 class ParamTest extends FlatSpec with Matchers with MockitoSugar {
   val target = DeployTarget(fixtures.parameters(), NamedStack("testStack"), Region("testRegion"))
   val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), target.parameters)
-  val deploymentTypes = Seq(stubDeploymentType(name="testDeploymentType", actionNames = Seq("testAction")))
+  val deploymentTypes = Seq(stubDeploymentType(name = "testDeploymentType", actionNames = Seq("testAction")))
 
   "Param" should "register itself with a register" in {
     implicit val register = new TestRegister
@@ -34,8 +34,13 @@ class ParamTest extends FlatSpec with Matchers with MockitoSugar {
 
   it should "extract a value from a package using get" in {
     implicit val register = new TestRegister
-    val pkg = DeploymentPackage("testPackage", Nil, Map("key" -> JsString("myValue")), "testDeploymentType",
-      S3Path("test", "test"), legacyConfig = true, deploymentTypes)
+    val pkg = DeploymentPackage("testPackage",
+                                Nil,
+                                Map("key" -> JsString("myValue")),
+                                "testDeploymentType",
+                                S3Path("test", "test"),
+                                legacyConfig = true,
+                                deploymentTypes)
     val key = Param[String]("key").default("valueDefault")
     val paramValue = key.get(pkg)
     paramValue shouldBe Some("myValue")
@@ -43,8 +48,13 @@ class ParamTest extends FlatSpec with Matchers with MockitoSugar {
 
   it should "extract None using get when the value isn't in a package" in {
     implicit val register = new TestRegister
-    val pkg = DeploymentPackage("testPackage", Nil, Map.empty, "testDeploymentType", S3Path("test", "test"),
-      legacyConfig = true, deploymentTypes)
+    val pkg = DeploymentPackage("testPackage",
+                                Nil,
+                                Map.empty,
+                                "testDeploymentType",
+                                S3Path("test", "test"),
+                                legacyConfig = true,
+                                deploymentTypes)
     val key = Param[String]("key").default("valueDefault")
     val paramValue = key.get(pkg)
     paramValue shouldBe None
@@ -52,8 +62,13 @@ class ParamTest extends FlatSpec with Matchers with MockitoSugar {
 
   it should "extract a value using apply" in {
     implicit val register = new TestRegister
-    val pkg = DeploymentPackage("testPackage", Nil, Map("key" -> JsString("myValue")), "testDeploymentType",
-      S3Path("test", "test"), legacyConfig = true, deploymentTypes)
+    val pkg = DeploymentPackage("testPackage",
+                                Nil,
+                                Map("key" -> JsString("myValue")),
+                                "testDeploymentType",
+                                S3Path("test", "test"),
+                                legacyConfig = true,
+                                deploymentTypes)
     val key = Param[String]("key").default("valueDefault")
     val paramValue = key.apply(pkg, target, reporter)
     paramValue shouldBe "myValue"
@@ -61,10 +76,15 @@ class ParamTest extends FlatSpec with Matchers with MockitoSugar {
 
   it should "throw an exception if a value is not specified and has no default" in {
     implicit val register = new TestRegister
-    val pkg = DeploymentPackage("testPackage", Nil, Map.empty, "testDeploymentType", S3Path("test", "test"),
-      legacyConfig = true, deploymentTypes)
+    val pkg = DeploymentPackage("testPackage",
+                                Nil,
+                                Map.empty,
+                                "testDeploymentType",
+                                S3Path("test", "test"),
+                                legacyConfig = true,
+                                deploymentTypes)
     val key = Param[String]("key")
-    val thrown = the [NoSuchElementException] thrownBy {
+    val thrown = the[NoSuchElementException] thrownBy {
       key.apply(pkg, target, reporter)
     }
     thrown.getMessage shouldBe "Package testPackage [testDeploymentType] requires parameter key of type String"
@@ -72,8 +92,13 @@ class ParamTest extends FlatSpec with Matchers with MockitoSugar {
 
   it should "return the param default from apply when no value is specified" in {
     implicit val register = new TestRegister
-    val pkg = DeploymentPackage("testPackage", Nil, Map.empty, "testDeploymentType", S3Path("test", "test"),
-      legacyConfig = true, deploymentTypes)
+    val pkg = DeploymentPackage("testPackage",
+                                Nil,
+                                Map.empty,
+                                "testDeploymentType",
+                                S3Path("test", "test"),
+                                legacyConfig = true,
+                                deploymentTypes)
     val key = Param[String]("key").default("valueDefault")
     val paramValue = key.apply(pkg, target, reporter)
     paramValue shouldBe "valueDefault"
@@ -81,19 +106,30 @@ class ParamTest extends FlatSpec with Matchers with MockitoSugar {
 
   it should "return the param context default from apply when no value is specified" in {
     implicit val register = new TestRegister
-    val pkg = DeploymentPackage("testPackage", Nil, Map.empty, "testDeploymentType", S3Path("test", "test"),
-      legacyConfig = true, deploymentTypes)
-    val key = Param[String]("key").defaultFromContext((pkg, target) => Right(s"${target.region.name} and ${pkg.legacyConfig}"))
+    val pkg = DeploymentPackage("testPackage",
+                                Nil,
+                                Map.empty,
+                                "testDeploymentType",
+                                S3Path("test", "test"),
+                                legacyConfig = true,
+                                deploymentTypes)
+    val key =
+      Param[String]("key").defaultFromContext((pkg, target) => Right(s"${target.region.name} and ${pkg.legacyConfig}"))
     val paramValue = key.apply(pkg, target, reporter)
     paramValue shouldBe "testRegion and true"
   }
 
   it should "throw an exception if defaultFromContext returns a Left value" in {
     implicit val register = new TestRegister
-    val pkg = DeploymentPackage("testPackage", Nil, Map.empty, "testDeploymentType", S3Path("test", "test"),
-      legacyConfig = true, deploymentTypes)
+    val pkg = DeploymentPackage("testPackage",
+                                Nil,
+                                Map.empty,
+                                "testDeploymentType",
+                                S3Path("test", "test"),
+                                legacyConfig = true,
+                                deploymentTypes)
     val key = Param[String]("key").defaultFromContext((pkg, target) => Left("something was wrong"))
-    val thrown = the [NoSuchElementException] thrownBy {
+    val thrown = the[NoSuchElementException] thrownBy {
       key.apply(pkg, target, reporter)
     }
     thrown.getMessage shouldBe "Error whilst generating default for parameter key in package testPackage [testDeploymentType]: something was wrong"
@@ -102,8 +138,13 @@ class ParamTest extends FlatSpec with Matchers with MockitoSugar {
   it should "log a warning if the value you've specified is the same as the default" in {
     val mockReporter = mock[DeployReporter]
     implicit val register = new TestRegister
-    val pkg = DeploymentPackage("testPackage", Nil, Map("key" -> JsString("sameValue")), "testDeploymentType",
-      S3Path("test", "test"), legacyConfig = false, deploymentTypes)
+    val pkg = DeploymentPackage("testPackage",
+                                Nil,
+                                Map("key" -> JsString("sameValue")),
+                                "testDeploymentType",
+                                S3Path("test", "test"),
+                                legacyConfig = false,
+                                deploymentTypes)
     val key = Param[String]("key").default("sameValue")
     val paramValue = key.apply(pkg, target, mockReporter)
     paramValue shouldBe "sameValue"
@@ -113,8 +154,13 @@ class ParamTest extends FlatSpec with Matchers with MockitoSugar {
   it should "log a warning if the value you've specified is the same as the default from context" in {
     val mockReporter = mock[DeployReporter]
     implicit val register = new TestRegister
-    val pkg = DeploymentPackage("testPackage", Nil, Map("key" -> JsString("sameValue")), "testDeploymentType",
-      S3Path("test", "test"), legacyConfig = false, deploymentTypes)
+    val pkg = DeploymentPackage("testPackage",
+                                Nil,
+                                Map("key" -> JsString("sameValue")),
+                                "testDeploymentType",
+                                S3Path("test", "test"),
+                                legacyConfig = false,
+                                deploymentTypes)
     val key = Param[String]("key").defaultFromContext((_, _) => Right("sameValue"))
     val paramValue = key.apply(pkg, target, mockReporter)
     paramValue shouldBe "sameValue"
@@ -124,8 +170,13 @@ class ParamTest extends FlatSpec with Matchers with MockitoSugar {
   it should "not log warning if the value you've specified is the same as the default but it is a legacy config" in {
     val mockReporter = mock[DeployReporter]
     implicit val register = new TestRegister
-    val pkg = DeploymentPackage("testPackage", Nil, Map("key" -> JsString("sameValue")), "testDeploymentType",
-      S3Path("test", "test"), legacyConfig = true, deploymentTypes)
+    val pkg = DeploymentPackage("testPackage",
+                                Nil,
+                                Map("key" -> JsString("sameValue")),
+                                "testDeploymentType",
+                                S3Path("test", "test"),
+                                legacyConfig = true,
+                                deploymentTypes)
     val key = Param[String]("key").default("sameValue")
     val paramValue = key.apply(pkg, target, mockReporter)
     paramValue shouldBe "sameValue"

--- a/magenta-lib/src/test/scala/magenta/deployment_type/param_reads/PatternValueTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/param_reads/PatternValueTest.scala
@@ -49,7 +49,7 @@ class PatternValueTest extends FlatSpec with Matchers with Inside {
       )
     )
     val jsResult = Json.fromJson[List[PatternValue]](json)
-    jsResult should matchPattern{
+    jsResult should matchPattern {
       case JsError(_) =>
     }
   }

--- a/magenta-lib/src/test/scala/magenta/fixtures/fixtures.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/fixtures.scala
@@ -4,10 +4,13 @@ package fixtures
 import magenta.deployment_type._
 import magenta.tasks.Task
 
-case class StubTask(description: String, region: Region, stack: Option[Stack] = None,
-  override val taskHost: Option[Host] = None) extends Task {
+case class StubTask(description: String,
+                    region: Region,
+                    stack: Option[Stack] = None,
+                    override val taskHost: Option[Host] = None)
+    extends Task {
 
-  def execute(reporter: DeployReporter, stopFlag: => Boolean) { }
+  def execute(reporter: DeployReporter, stopFlag: => Boolean) {}
   def verbose = "stub(%s)" format description
   def keyRing = KeyRing()
 }
@@ -21,15 +24,16 @@ object StubActionRegister extends ActionRegister {
 }
 
 case class StubDeploymentType(
-  override val actionsMap: Map[String, Action] = Map.empty,
-  override val defaultActionNames: List[String],
-  parameters: ParamRegister => List[Param[_]] = _ => Nil,
-  override val name: String = "stub-package-type"
+    override val actionsMap: Map[String, Action] = Map.empty,
+    override val defaultActionNames: List[String],
+    parameters: ParamRegister => List[Param[_]] = _ => Nil,
+    override val name: String = "stub-package-type"
 ) extends DeploymentType {
   parameters(paramsRegister)
 
-
-  def defaultActions: List[Action] = defaultActionNames.map { name => actionsMap(name) }
+  def defaultActions: List[Action] = defaultActionNames.map { name =>
+    actionsMap(name)
+  }
 
   val documentation = "Documentation for the testing stub"
 }

--- a/magenta-lib/src/test/scala/magenta/fixtures/package.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/package.scala
@@ -11,11 +11,12 @@ package object fixtures {
 
   val lookupEmpty = stubLookup()
 
-  val lookupSingleHost = stubLookup(List(Host("the_host", stage=CODE.name).app(app1)))
+  val lookupSingleHost = stubLookup(List(Host("the_host", stage = CODE.name).app(app1)))
 
   val basePackageType = stubDeploymentType(Seq("init_action_one"))
 
-  val baseRecipe = Recipe("one",
+  val baseRecipe = Recipe(
+    "one",
     deploymentSteps = basePackageType.mkDeploymentStep("init_action_one")(stubPackage(basePackageType)) :: Nil,
     dependsOn = Nil)
 
@@ -26,8 +27,9 @@ package object fixtures {
   def stubPackage(deploymentType: DeploymentType) =
     DeploymentPackage("stub project", Seq(app1), Map(), "stub-package-type", null, false, Seq(deploymentType))
 
-  def stubDeploymentType(actionNames: Seq[String], params: ParamRegister => List[Param[_]] = _ => Nil,
-    name: String = "stub-package-type") = {
+  def stubDeploymentType(actionNames: Seq[String],
+                         params: ParamRegister => List[Param[_]] = _ => Nil,
+                         name: String = "stub-package-type") = {
     StubDeploymentType(
       actionsMap = actionNames.map { name =>
         name -> Action(name) { (_, _, target) =>
@@ -35,14 +37,13 @@ package object fixtures {
             StubTask(name + " per app task number one", target.region),
             StubTask(name + " per app task number two", target.region)
           )
-        } (StubActionRegister)
+        }(StubActionRegister)
       }.toMap,
       actionNames.toList,
       params,
       name
     )
   }
-
 
   def testParams() = DeployParameters(
     Deployer("default deployer"),
@@ -62,12 +63,12 @@ package object fixtures {
           val matchingList = resourceData.getOrElse(key, List.empty)
           stack match {
             case UnnamedStack =>
-              matchingList.filter(_.stack.isEmpty).find{data =>
+              matchingList.filter(_.stack.isEmpty).find { data =>
                 data.appRegex.findFirstMatchIn(app.name).isDefined &&
                 data.stageRegex.findFirstMatchIn(stage.name).isDefined
               }
             case NamedStack(stackName) =>
-              matchingList.filter(_.stack.isDefined).find{data =>
+              matchingList.filter(_.stack.isDefined).find { data =>
                 data.stackRegex.exists(_.findFirstMatchIn(stackName).isDefined) &&
                 data.appRegex.findFirstMatchIn(app.name).isDefined &&
                 data.stageRegex.findFirstMatchIn(stage.name).isDefined
@@ -84,7 +85,7 @@ package object fixtures {
 
       def hosts: HostLookup = new HostLookup {
         def get(pkg: DeploymentPackage, app: App, params: DeployParameters, stack: Stack): Seq[Host] = {
-          hostsSeq.filter{ host =>
+          hostsSeq.filter { host =>
             host.stage == params.stage.name &&
             host.apps.contains(app) &&
             host.isValidForStack(stack)

--- a/magenta-lib/src/test/scala/magenta/graph/GraphTest.scala
+++ b/magenta-lib/src/test/scala/magenta/graph/GraphTest.scala
@@ -33,8 +33,8 @@ class GraphTest extends FlatSpec with ShouldMatchers {
     val successors = mergedGraph.orderedSuccessors(StartNode)
     successors.size should be(2)
     val nodes = successors.filterValueNodes
-    nodes.head should matchPattern{case ValueNode("one") =>}
-    nodes(1) should matchPattern{case ValueNode("two") =>}
+    nodes.head should matchPattern { case ValueNode("one") => }
+    nodes(1) should matchPattern { case ValueNode("two") => }
   }
 
   it should "parallel join two complex graphs together" in {
@@ -61,34 +61,41 @@ class GraphTest extends FlatSpec with ShouldMatchers {
     val graph = Graph(start ~> one, one ~> two, two ~> end)
     val graph2 = Graph(start ~> two, two ~> three, three ~> end)
     val joinedGraph = graph.joinParallel(graph2)
-    joinedGraph should be(Graph(
-      start ~> one, start ~2~> two,
-      one ~> two,
-      two ~> end, two ~2~> three,
-      three ~> end
-    ))
+    joinedGraph should be(
+      Graph(
+        start ~> one,
+        start ~ 2 ~> two,
+        one ~> two,
+        two ~> end,
+        two ~ 2 ~> three,
+        three ~> end
+      ))
   }
 
   it should "parallel join two dis-similar graphs together" in {
     val graph = Graph(StartNode ~> one, one ~> two, two ~> EndNode)
     val graph2 = Graph(StartNode ~> one, one ~> EndNode)
     val joinedGraph = graph joinParallel graph2
-    joinedGraph should be(Graph(
-      StartNode ~> one,
-      one ~> two, one ~2~> EndNode,
-      two ~> EndNode
-    ))
+    joinedGraph should be(
+      Graph(
+        StartNode ~> one,
+        one ~> two,
+        one ~ 2 ~> EndNode,
+        two ~> EndNode
+      ))
   }
 
   it should "parallel join a one node graph to a shared two node graph" in {
     val graph = Graph(start ~> one, one ~> two, two ~> end)
     val graph2 = Graph(start ~> one, one ~> end)
     val joinedGraph = graph.joinParallel(graph2)
-    joinedGraph should be(Graph(
-      start ~> one,
-      one ~> two, one ~2~> end,
-      two ~> end
-    ))
+    joinedGraph should be(
+      Graph(
+        start ~> one,
+        one ~> two,
+        one ~ 2 ~> end,
+        two ~> end
+      ))
   }
 
   it should "join two graphs together in series" in {
@@ -101,34 +108,47 @@ class GraphTest extends FlatSpec with ShouldMatchers {
   }
 
   it should "retain priorities when merging non-trivial graphs in series" in {
-    val graph = Graph(start ~> one, one ~> two, one ~2~> end, two ~> end)
-    val graph2 = Graph(start ~> three, start ~2~> four, three ~> end, four ~> end)
-    val joinedGraph = graph joinSeries(graph2)
-    joinedGraph should be(Graph(
-      start ~> one,
-      one ~> two, one ~2~> three, one ~3~> four,
-      two ~> three, two ~2~> four,
-      three ~> end,
-      four ~> end
-    ))
+    val graph = Graph(start ~> one, one ~> two, one ~ 2 ~> end, two ~> end)
+    val graph2 = Graph(start ~> three, start ~ 2 ~> four, three ~> end, four ~> end)
+    val joinedGraph = graph joinSeries (graph2)
+    joinedGraph should be(
+      Graph(
+        start ~> one,
+        one ~> two,
+        one ~ 2 ~> three,
+        one ~ 3 ~> four,
+        two ~> three,
+        two ~ 2 ~> four,
+        three ~> end,
+        four ~> end
+      ))
   }
 
   it should "retain priorities when merging more complex examples in series" in {
     val graph = Graph(
       start ~> one,
-      one ~> two, one ~2~> end, one ~3~> three,
-      two ~> end, three ~> end
+      one ~> two,
+      one ~ 2 ~> end,
+      one ~ 3 ~> three,
+      two ~> end,
+      three ~> end
     )
-    val graph2 = Graph(start ~> four, start ~2~> five, four ~> end, five ~> end)
+    val graph2 = Graph(start ~> four, start ~ 2 ~> five, four ~> end, five ~> end)
     val joinedGraph = graph joinSeries graph2
-    joinedGraph should be(Graph(
-      start ~> one,
-      one ~> two, one ~2~> four, one ~3~> five, one ~4~> three,
-      two ~> four, two ~2~> five,
-      three ~> four, three ~2~> five,
-      four ~> end,
-      five ~> end
-    ))
+    joinedGraph should be(
+      Graph(
+        start ~> one,
+        one ~> two,
+        one ~ 2 ~> four,
+        one ~ 3 ~> five,
+        one ~ 4 ~> three,
+        two ~> four,
+        two ~ 2 ~> five,
+        three ~> four,
+        three ~ 2 ~> five,
+        four ~> end,
+        five ~> end
+      ))
   }
 
   it should "join two complex graphs together in series" in {
@@ -141,12 +161,17 @@ class GraphTest extends FlatSpec with ShouldMatchers {
     val mergedGraph = joinedGraph.joinSeries(joinedGraph2)
     mergedGraph.nodes.size should be(6)
     mergedGraph.edges should contain(one ~> three)
-    mergedGraph should be(Graph(
-      start ~> one, start ~2~> two,
-      one ~> three, one ~2~> four,
-      two ~> three, two ~2~> four,
-      three ~> end, four ~> end
-    ))
+    mergedGraph should be(
+      Graph(
+        start ~> one,
+        start ~ 2 ~> two,
+        one ~> three,
+        one ~ 2 ~> four,
+        two ~> three,
+        two ~ 2 ~> four,
+        three ~> end,
+        four ~> end
+      ))
   }
 
   it should "noop when parallel joining to an empty graph" in {
@@ -178,12 +203,13 @@ class GraphTest extends FlatSpec with ShouldMatchers {
     val transformedGraph = mergedGraph.map(s => List(s, s))
     transformedGraph.nodes.size should be(6)
     transformedGraph.edges.size should be(mergedGraph.edges.size)
-    transformedGraph.orderedSuccessors(StartNode) should be (List(
-      ValueNode(List("one", "one")),
-      ValueNode(List("two", "two")),
-      ValueNode(List("three", "three")),
-      ValueNode(List("four", "four"))
-    ))
+    transformedGraph.orderedSuccessors(StartNode) should be(
+      List(
+        ValueNode(List("one", "one")),
+        ValueNode(List("two", "two")),
+        ValueNode(List("three", "three")),
+        ValueNode(List("four", "four"))
+      ))
   }
 
   "flatMap" should "work with empty graphs" in {
@@ -204,40 +230,52 @@ class GraphTest extends FlatSpec with ShouldMatchers {
     } shouldBe Graph(4)
   }
 
-
   it should "allow nodes to be flatMapped to a series graph" in {
     val graph = Graph(start ~> one, one ~> end).joinParallel(Graph(start ~> two, two ~> end))
-    val mappedGraph = graph.flatMap{
-      case ValueNode(node) => Graph(start ~> ValueNode((node, 1)), ValueNode((node, 1)) ~> ValueNode((node, 2)), ValueNode((node, 2)) ~> end)
+    val mappedGraph = graph.flatMap {
+      case ValueNode(node) =>
+        Graph(start ~> ValueNode((node, 1)), ValueNode((node, 1)) ~> ValueNode((node, 2)), ValueNode((node, 2)) ~> end)
       case _ => Graph.empty[(String, Int)]
     }
-    mappedGraph should be(Graph(
-      start ~> ValueNode(("one", 1)), ValueNode(("one", 1)) ~> ValueNode(("one", 2)), ValueNode(("one", 2)) ~> end,
-      start ~2~> ValueNode(("two", 1)), ValueNode(("two", 1)) ~> ValueNode(("two", 2)), ValueNode(("two", 2)) ~> end
-    ))
+    mappedGraph should be(
+      Graph(
+        start ~> ValueNode(("one", 1)),
+        ValueNode(("one", 1)) ~> ValueNode(("one", 2)),
+        ValueNode(("one", 2)) ~> end,
+        start ~ 2 ~> ValueNode(("two", 1)),
+        ValueNode(("two", 1)) ~> ValueNode(("two", 2)),
+        ValueNode(("two", 2)) ~> end
+      ))
   }
 
   it should "allow nodes to be flatMapped to a parallel graph" in {
     val graph = Graph(start ~> one, one ~> end).joinParallel(Graph(start ~> two, two ~> end))
-    val mappedGraph = graph.flatMap{
+    val mappedGraph = graph.flatMap {
       case ValueNode(node) =>
         Graph(
-          start ~> ValueNode((node, 1)), ValueNode((node, 1)) ~> end,
-          start ~2~> ValueNode((node, 2)), ValueNode((node, 2)) ~> end
+          start ~> ValueNode((node, 1)),
+          ValueNode((node, 1)) ~> end,
+          start ~ 2 ~> ValueNode((node, 2)),
+          ValueNode((node, 2)) ~> end
         )
       case _ => Graph.empty[(String, Int)]
     }
-    mappedGraph should be(Graph(
-      start ~> ValueNode(("one", 1)), ValueNode(("one", 1)) ~> end,
-      start ~2~> ValueNode(("one", 2)), ValueNode(("one", 2)) ~> end,
-      start ~3~> ValueNode(("two", 1)), ValueNode(("two", 1)) ~> end,
-      start ~4~> ValueNode(("two", 2)), ValueNode(("two", 2)) ~> end
-    ))
+    mappedGraph should be(
+      Graph(
+        start ~> ValueNode(("one", 1)),
+        ValueNode(("one", 1)) ~> end,
+        start ~ 2 ~> ValueNode(("one", 2)),
+        ValueNode(("one", 2)) ~> end,
+        start ~ 3 ~> ValueNode(("two", 1)),
+        ValueNode(("two", 1)) ~> end,
+        start ~ 4 ~> ValueNode(("two", 2)),
+        ValueNode(("two", 2)) ~> end
+      ))
   }
 
   it should "not allow a mid node to be replaced with an empty graph" in {
     // this is because sowing up the hole that is left is far harder than replacing nodes or even adding multiple nodes
-    an [AssertionError] should be thrownBy {
+    an[AssertionError] should be thrownBy {
       Graph(4) flatMap {
         case _ => Graph.empty[Int]
       }
@@ -256,7 +294,10 @@ class GraphTest extends FlatSpec with ShouldMatchers {
     val graph = Graph(start ~> one, one ~> end).joinParallel(Graph(start ~> two, two ~> end))
     val graph2 = Graph(start ~> three, three ~> end).joinParallel(Graph(start ~> four, four ~> end))
     Graph.joiningEdges(graph, graph2) shouldBe Set(
-      one ~> three, one ~2~> four, two ~> three, two ~2~> four
+      one ~> three,
+      one ~ 2 ~> four,
+      two ~> three,
+      two ~ 2 ~> four
     )
   }
 }

--- a/magenta-lib/src/test/scala/magenta/input/RiffRaffYamlReaderTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/RiffRaffYamlReaderTest.scala
@@ -19,7 +19,8 @@ class RiffRaffYamlReaderTest extends FlatSpec with ShouldMatchers with Validated
     input.stacks.get.size should be(1)
     input.stacks.get should be(List("banana"))
     input.deployments.size should be(1)
-    input.deployments.head should be("monkey" -> DeploymentOrTemplate(Some("autoscaling"), None, None, None, None, None, None, None, None))
+    input.deployments.head should be(
+      "monkey" -> DeploymentOrTemplate(Some("autoscaling"), None, None, None, None, None, None, None, None))
   }
 
   it should "parse a more complex yaml example" in {
@@ -57,19 +58,51 @@ class RiffRaffYamlReaderTest extends FlatSpec with ShouldMatchers with Validated
     input.stacks.get.size should be(2)
     input.stacks.get should be(List("banana", "cabbage"))
     input.templates.isDefined should be(true)
-    input.templates.get should be(Map("custom-auto" -> DeploymentOrTemplate(Some("autoscaling"),None, None, None, None, None, None, None, Some(Map(
-      "paramString" -> JsString("value1"),
-      "paramNumber" -> JsNumber(2000),
-      "paramList" -> JsArray(Seq(JsString("valueOne"), JsString("valueTwo"))),
-      "paramMap" -> Json.obj("txt" -> "text/plain", "json" -> "application/json")
-    )))))
+    input.templates.get should be(
+      Map("custom-auto" -> DeploymentOrTemplate(
+        Some("autoscaling"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(Map(
+          "paramString" -> JsString("value1"),
+          "paramNumber" -> JsNumber(2000),
+          "paramList" -> JsArray(Seq(JsString("valueOne"), JsString("valueTwo"))),
+          "paramMap" -> Json.obj("txt" -> "text/plain", "json" -> "application/json")
+        ))
+      )))
     input.deployments.size should be(3)
-    input.deployments should contain("human" ->
-      DeploymentOrTemplate(None, Some("custom-auto"), Some(List("carrot")), None, Some(List("overridden")), None, None, Some(List("elephant")), Some(Map("paramString" -> JsString("value2")))))
-    input.deployments should contain("monkey" ->
-      DeploymentOrTemplate(Some("autoscaling"), None, None, None, None, Some("ook"), None, Some(List("elephant")), None))
-    input.deployments should contain("elephant" ->
-      DeploymentOrTemplate(Some("dung"), None, None, None, None, None, None, None, None))
+    input.deployments should contain(
+      "human" ->
+        DeploymentOrTemplate(
+          None,
+          Some("custom-auto"),
+          Some(List("carrot")),
+          None,
+          Some(List("overridden")),
+          None,
+          None,
+          Some(List("elephant")),
+          Some(Map("paramString" -> JsString("value2")))
+        ))
+    input.deployments should contain(
+      "monkey" ->
+        DeploymentOrTemplate(Some("autoscaling"),
+                             None,
+                             None,
+                             None,
+                             None,
+                             Some("ook"),
+                             None,
+                             Some(List("elephant")),
+                             None))
+    input.deployments should contain(
+      "elephant" ->
+        DeploymentOrTemplate(Some("dung"), None, None, None, None, None, None, None, None))
     input.deployments.map(_._1) should be(List("human", "monkey", "elephant"))
   }
 

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentGraphActionFlatteningTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentGraphActionFlatteningTest.scala
@@ -8,14 +8,24 @@ import org.scalatest.{FlatSpec, Matchers}
 class DeploymentGraphActionFlatteningTest extends FlatSpec with Matchers {
   "flattenActions" should "flatten out the actions in a deployment graph" in {
     val deployment =
-      Deployment("bob", "autoscaling", NEL.of("stackName"), NEL.of("eu-west-1"), NEL.of("action1", "action2"), "bob", "bob", Nil, Map.empty)
+      Deployment("bob",
+                 "autoscaling",
+                 NEL.of("stackName"),
+                 NEL.of("eu-west-1"),
+                 NEL.of("action1", "action2"),
+                 "bob",
+                 "bob",
+                 Nil,
+                 Map.empty)
     val graph = Graph(deployment)
     val flattenedGraph = DeploymentGraphActionFlattening.flattenActions(graph)
 
-    val action1 = deployment.copy(actions=NEL.of("action1"))
-    val action2 = deployment.copy(actions=NEL.of("action2"))
+    val action1 = deployment.copy(actions = NEL.of("action1"))
+    val action2 = deployment.copy(actions = NEL.of("action2"))
     flattenedGraph shouldBe Graph(
-      StartNode ~> ValueNode(action1), ValueNode(action1) ~> ValueNode(action2), ValueNode(action2) ~> EndNode
+      StartNode ~> ValueNode(action1),
+      ValueNode(action1) ~> ValueNode(action2),
+      ValueNode(action2) ~> EndNode
     )
   }
 }

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentPrunerTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentPrunerTest.scala
@@ -6,14 +6,23 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class DeploymentPrunerTest extends FlatSpec with Matchers {
   import DeploymentPruner._
-  val testDeployment = Deployment("testName", "testType", NEL.of("testStack"), NEL.of("testRegion"),
-    NEL.of("testAction"), "testName", "testName", Nil, Map.empty)
+  val testDeployment =
+    Deployment("testName",
+               "testType",
+               NEL.of("testStack"),
+               NEL.of("testRegion"),
+               NEL.of("testAction"),
+               "testName",
+               "testName",
+               Nil,
+               Map.empty)
   val testStackAndRegionPruner = StackAndRegion("testStack", "testRegion")
 
   "StackAndRegion pruner" should "return None when either the region or stack isn't specified" in {
     testStackAndRegionPruner(testDeployment.copy(stacks = NEL.of("differentStack"))) shouldBe None
     testStackAndRegionPruner(testDeployment.copy(regions = NEL.of("differentRegion"))) shouldBe None
-    testStackAndRegionPruner(testDeployment.copy(stacks = NEL.of("differentStack"), regions = NEL.of("differentRegion"))) shouldBe None
+    testStackAndRegionPruner(
+      testDeployment.copy(stacks = NEL.of("differentStack"), regions = NEL.of("differentRegion"))) shouldBe None
   }
 
   it should "return the unmodified deployment when it has only the specified stack and region" in {
@@ -21,19 +30,20 @@ class DeploymentPrunerTest extends FlatSpec with Matchers {
   }
 
   it should "return a modified deployment containing just the specified region and stack when there are multiple stacks and regions" in {
-    testStackAndRegionPruner(testDeployment.copy(
-      stacks = NEL.of("testStack1", "testStack", "testStack2"),
-      regions = NEL.of("testRegion1", "testRegion", "testRegion2")
-    )) shouldBe Some(testDeployment)
+    testStackAndRegionPruner(
+      testDeployment.copy(
+        stacks = NEL.of("testStack1", "testStack", "testStack2"),
+        regions = NEL.of("testRegion1", "testRegion", "testRegion2")
+      )) shouldBe Some(testDeployment)
   }
 
   val testKeysPruner = Keys(List(DeploymentKey(testDeployment)))
 
   "Keys pruner" should "return None when the name, action, region or stack doesn't match" in {
-    testKeysPruner(testDeployment.copy(name="differentName")) shouldBe None
-    testKeysPruner(testDeployment.copy(actions=NEL.of("differentAction"))) shouldBe None
-    testKeysPruner(testDeployment.copy(stacks=NEL.of("differentStack"))) shouldBe None
-    testKeysPruner(testDeployment.copy(regions=NEL.of("differentRegion"))) shouldBe None
+    testKeysPruner(testDeployment.copy(name = "differentName")) shouldBe None
+    testKeysPruner(testDeployment.copy(actions = NEL.of("differentAction"))) shouldBe None
+    testKeysPruner(testDeployment.copy(stacks = NEL.of("differentStack"))) shouldBe None
+    testKeysPruner(testDeployment.copy(regions = NEL.of("differentRegion"))) shouldBe None
   }
 
   it should "return the unmodified deployment when it matches" in {
@@ -41,19 +51,21 @@ class DeploymentPrunerTest extends FlatSpec with Matchers {
   }
 
   it should "return a subset of actions, regions and stacks when multiple are specified" in {
-    testKeysPruner(testDeployment.copy(
-      actions = NEL.of("testAction1", "testAction"),
-      stacks = NEL.of("testStack1", "testStack", "testStack2"),
-      regions = NEL.of("testRegion1", "testRegion", "testRegion2")
-    )) shouldBe Some(testDeployment)
+    testKeysPruner(
+      testDeployment.copy(
+        actions = NEL.of("testAction1", "testAction"),
+        stacks = NEL.of("testStack1", "testStack", "testStack2"),
+        regions = NEL.of("testRegion1", "testRegion", "testRegion2")
+      )) shouldBe Some(testDeployment)
   }
 
-  val testMultipleKeysPruner = Keys(List(
-    DeploymentKey("testName", "testAction", "testStack", "testRegion"),
-    DeploymentKey("testName", "testAction1", "testStack1", "testRegion1"),
-    DeploymentKey("testName100", "testAction", "testStack2", "testRegion2"),
-    DeploymentKey("testName", "bobbins", "bobbins", "bobbins")
-  ))
+  val testMultipleKeysPruner = Keys(
+    List(
+      DeploymentKey("testName", "testAction", "testStack", "testRegion"),
+      DeploymentKey("testName", "testAction1", "testStack1", "testRegion1"),
+      DeploymentKey("testName100", "testAction", "testStack2", "testRegion2"),
+      DeploymentKey("testName", "bobbins", "bobbins", "bobbins")
+    ))
 
   it should "return a subset of actions, regions and stacks that match multiple deployment keys" in {
     val testComplexDeployment = testDeployment.copy(
@@ -61,10 +73,11 @@ class DeploymentPrunerTest extends FlatSpec with Matchers {
       stacks = NEL.of("testStack1", "testStack", "testStack2"),
       regions = NEL.of("testRegion1", "testRegion", "testRegion2")
     )
-    testMultipleKeysPruner(testComplexDeployment) shouldBe Some(testDeployment.copy(
-      actions = NEL.of("testAction1", "testAction"),
-      stacks = NEL.of("testStack1", "testStack"),
-      regions = NEL.of("testRegion1", "testRegion")
-    ))
+    testMultipleKeysPruner(testComplexDeployment) shouldBe Some(
+      testDeployment.copy(
+        actions = NEL.of("testAction1", "testAction"),
+        stacks = NEL.of("testStack1", "testStack"),
+        regions = NEL.of("testRegion1", "testRegion")
+      ))
   }
 }

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentResolverTest.scala
@@ -20,8 +20,8 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (1)
-    deployments.head should have (
+    deployments.size should be(1)
+    deployments.head should have(
       'type ("testType"),
       'stacks (NEL.of("testStack")),
       'regions (NEL.of("eu-west-1")),
@@ -46,8 +46,8 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (1)
-    deployments.head should have (
+    deployments.size should be(1)
+    deployments.head should have(
       'type ("testType"),
       'stacks (NEL.of("stack1", "stack2")),
       'regions (NEL.of("oceania-south-1")),
@@ -75,8 +75,8 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (1)
-    deployments.head should have (
+    deployments.size should be(1)
+    deployments.head should have(
       'type ("testType"),
       'stacks (NEL.of("testStack")),
       'regions (NEL.of("eurasia-north-1")),
@@ -106,8 +106,8 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (1)
-    deployments.head should have (
+    deployments.size should be(1)
+    deployments.head should have(
       'type ("testType"),
       'stacks (NEL.of("testStack")),
       'regions (NEL.of("eu-west-1")),
@@ -136,7 +136,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (1)
+    deployments.size should be(1)
     deployments.head should have(
       'stacks (NEL.of("deployment-stack")),
       'regions (NEL.of("deployment-region"))
@@ -159,7 +159,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (1)
+    deployments.size should be(1)
     deployments.head should have(
       'stacks (NEL.of("template-stack")),
       'regions (NEL.of("template-region"))
@@ -180,7 +180,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (1)
+    deployments.size should be(1)
     deployments.head should have(
       'stacks (NEL.of("global-stack")),
       'regions (NEL.of("global-region"))
@@ -206,7 +206,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (1)
+    deployments.size should be(1)
     deployments.head should have(
       'stacks (NEL.of("nested-template-stack")),
       'regions (NEL.of("template-region"))
@@ -242,7 +242,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (1)
+    deployments.size should be(1)
     val deployment = deployments.head
     deployment.parameters.size should be(6)
     deployment.parameters should contain("nestedParameter" -> JsNumber(1984))
@@ -270,7 +270,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (1)
+    deployments.size should be(1)
     deployments.head should have(
       'app ("templateApp"),
       'actions (Some(NEL.of("templateAction"))),
@@ -303,7 +303,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (4)
+    deployments.size should be(4)
     val deployment = deployments.find(_.name == "test").get
     deployment.dependencies should be(List("deployment-dep"))
   }
@@ -330,7 +330,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (3)
+    deployments.size should be(3)
     val deployment = deployments.find(_.name == "test").get
     deployment.dependencies should be(List("template-dep"))
   }
@@ -354,7 +354,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (2)
+    deployments.size should be(2)
     val deployment = deployments.find(_.name == "test").get
     deployment.dependencies should be(List("nested-dep"))
   }
@@ -376,7 +376,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val configErrors = yaml.andThen(DeploymentResolver.resolve).invalid
-    configErrors.errors.toList.size should be (1)
+    configErrors.errors.toList.size should be(1)
     configErrors.errors.head should be(ConfigError("test", "Template with name nonExistentTemplate does not exist"))
   }
 
@@ -392,7 +392,7 @@ class DeploymentResolverTest extends FlatSpec with ShouldMatchers with Validated
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val configErrors = yaml.andThen(DeploymentResolver.resolve).invalid
-    configErrors.errors.toList.size should be (1)
+    configErrors.errors.toList.size should be(1)
     configErrors.errors.head should be(ConfigError("test", "Missing deployment dependencies missing-dep"))
 
   }

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTypeResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTypeResolverTest.scala
@@ -8,19 +8,29 @@ import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.JsNumber
 
 class DeploymentTypeResolverTest extends FlatSpec with Matchers with ValidatedValues {
-  val deployment = PartiallyResolvedDeployment("bob", "stub-package-type", NEL.of("stack"), NEL.of("eu-west-1"), actions=None, "bob", "bob", Nil, Map.empty)
+  val deployment = PartiallyResolvedDeployment("bob",
+                                               "stub-package-type",
+                                               NEL.of("stack"),
+                                               NEL.of("eu-west-1"),
+                                               actions = None,
+                                               "bob",
+                                               "bob",
+                                               Nil,
+                                               Map.empty)
   val deploymentTypes = List(stubDeploymentType(Seq("upload", "deploy")))
 
   "validateDeploymentType" should "fail on invalid deployment type" in {
     val deploymentWithInvalidType = deployment.copy(`type` = "invalidType")
-    val configErrors = DeploymentTypeResolver.validateDeploymentType(deploymentWithInvalidType, deploymentTypes).invalid
+    val configErrors =
+      DeploymentTypeResolver.validateDeploymentType(deploymentWithInvalidType, deploymentTypes).invalid
     configErrors.errors.head.context shouldBe "bob"
     configErrors.errors.head.message should include(s"Unknown type invalidType")
   }
 
   it should "fail if given an invalid action" in {
     val deploymentWithInvalidAction = deployment.copy(actions = Some(NEL.of("invalidAction")))
-    val configErrors = DeploymentTypeResolver.validateDeploymentType(deploymentWithInvalidAction, deploymentTypes).invalid
+    val configErrors =
+      DeploymentTypeResolver.validateDeploymentType(deploymentWithInvalidAction, deploymentTypes).invalid
     configErrors.errors.head.context shouldBe "bob"
     configErrors.errors.head.message should include(s"Invalid action invalidAction for type stub-package-type")
   }
@@ -32,7 +42,8 @@ class DeploymentTypeResolverTest extends FlatSpec with Matchers with ValidatedVa
 
   it should "use specified actions if they are provided" in {
     val deploymentWithSpecifiedActions = deployment.copy(actions = Some(NEL.of("upload")))
-    val validatedDeployment = DeploymentTypeResolver.validateDeploymentType(deploymentWithSpecifiedActions, deploymentTypes).valid
+    val validatedDeployment =
+      DeploymentTypeResolver.validateDeploymentType(deploymentWithSpecifiedActions, deploymentTypes).valid
     validatedDeployment.actions shouldBe NEL.of("upload")
   }
 
@@ -53,7 +64,9 @@ class DeploymentTypeResolverTest extends FlatSpec with Matchers with ValidatedVa
   it should "fail if given an invalid parameter" in {
     val deploymentWithParameters = deployment.copy(parameters = Map("param1" -> JsNumber(1234)))
     val configErrors = DeploymentTypeResolver.validateDeploymentType(deploymentWithParameters, deploymentTypes).invalid
-    configErrors.errors.head shouldBe ConfigError("bob", "Parameters provided but not used by stub-package-type deployments: param1")
+    configErrors.errors.head shouldBe ConfigError(
+      "bob",
+      "Parameters provided but not used by stub-package-type deployments: param1")
   }
 
   it should "fail if a parameter with no default is not provided" in {
@@ -64,7 +77,9 @@ class DeploymentTypeResolverTest extends FlatSpec with Matchers with ValidatedVa
       )
     )
     val configErrors = DeploymentTypeResolver.validateDeploymentType(deployment, deploymentTypesWithParams).invalid
-    configErrors.errors.head shouldBe ConfigError("bob", "Parameters required for stub-package-type deployments not provided: param1")
+    configErrors.errors.head shouldBe ConfigError(
+      "bob",
+      "Parameters required for stub-package-type deployments not provided: param1")
   }
 
   it should "succeed if an optional parameter is not provided" in {
@@ -91,7 +106,8 @@ class DeploymentTypeResolverTest extends FlatSpec with Matchers with ValidatedVa
     val deploymentTypesWithParams = List(
       stubDeploymentType(
         Seq("upload", "deploy"),
-        register => List(Param[String]("param1", defaultValueFromContext = Some((pkg, _) => Right(pkg.name)))(register))
+        register =>
+          List(Param[String]("param1", defaultValueFromContext = Some((pkg, _) => Right(pkg.name)))(register))
       )
     )
     DeploymentTypeResolver.validateDeploymentType(deployment, deploymentTypesWithParams).valid

--- a/magenta-lib/src/test/scala/magenta/input/resolver/TaskResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/TaskResolverTest.scala
@@ -8,7 +8,17 @@ import magenta.artifact.S3YamlArtifact
 import magenta.deployment_type.{Action, AutoScaling}
 import magenta.fixtures._
 import magenta.input.Deployment
-import magenta.{Build, DeployParameters, DeployReporter, Deployer, DeploymentResources, NamedStack, Region, Stage, fixtures}
+import magenta.{
+  Build,
+  DeployParameters,
+  DeployReporter,
+  Deployer,
+  DeploymentResources,
+  NamedStack,
+  Region,
+  Stage,
+  fixtures
+}
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.JsString
@@ -17,22 +27,32 @@ class TaskResolverTest extends FlatSpec with Matchers with MockitoSugar with Val
   implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
   implicit val artifactClient = mock[AmazonS3Client]
 
-  val deploymentTypes = List(StubDeploymentType(
-    actionsMap = Map(
-      "uploadArtifact" -> Action("uploadArtifact"){
-        (pkg, resources, target) => List(StubTask("upload", target.region, stack = Some(target.stack)))
-      }(StubActionRegister),
-      "deploy" -> Action("deploy"){
-        (pkg, resources, target) => List(StubTask("deploy", target.region, stack = Some(target.stack)))
-      }(StubActionRegister)
-    ),
-    List("uploadArtifact", "deploy"))
-  )
+  val deploymentTypes = List(
+    StubDeploymentType(
+      actionsMap = Map(
+        "uploadArtifact" -> Action("uploadArtifact") { (pkg, resources, target) =>
+          List(StubTask("upload", target.region, stack = Some(target.stack)))
+        }(StubActionRegister),
+        "deploy" -> Action("deploy") { (pkg, resources, target) =>
+          List(StubTask("deploy", target.region, stack = Some(target.stack)))
+        }(StubActionRegister)
+      ),
+      List("uploadArtifact", "deploy")
+    ))
 
   "resolve" should "produce a deployment task" in {
     val deploymentTask = TaskResolver.resolve(
-      deployment = Deployment("test", "stub-package-type", NEL.of("stack"), NEL.of("region"),
-        NEL.of("uploadArtifact", "deploy"), "app", "directory", Nil, Map("bucket" -> JsString("bucketName"))),
+      deployment = Deployment(
+        "test",
+        "stub-package-type",
+        NEL.of("stack"),
+        NEL.of("region"),
+        NEL.of("uploadArtifact", "deploy"),
+        "app",
+        "directory",
+        Nil,
+        Map("bucket" -> JsString("bucketName"))
+      ),
       deploymentResources = DeploymentResources(reporter, stubLookup(), artifactClient),
       parameters = DeployParameters(Deployer("Test user"), Build("test-project", "1"), Stage("PROD")),
       deploymentTypes = deploymentTypes,
@@ -48,8 +68,17 @@ class TaskResolverTest extends FlatSpec with Matchers with MockitoSugar with Val
 
   "resolve" should "produce a deployment task with multiple regions" in {
     val deploymentTask = TaskResolver.resolve(
-      deployment = Deployment("test", "stub-package-type", NEL.of("stack"), NEL.of("region-one", "region-two"),
-        NEL.of("uploadArtifact", "deploy"), "app", "directory", Nil, Map("bucket" -> JsString("bucketName"))),
+      deployment = Deployment(
+        "test",
+        "stub-package-type",
+        NEL.of("stack"),
+        NEL.of("region-one", "region-two"),
+        NEL.of("uploadArtifact", "deploy"),
+        "app",
+        "directory",
+        Nil,
+        Map("bucket" -> JsString("bucketName"))
+      ),
       deploymentResources = DeploymentResources(reporter, stubLookup(), artifactClient),
       parameters = DeployParameters(Deployer("Test user"), Build("test-project", "1"), Stage("PROD")),
       deploymentTypes = deploymentTypes,
@@ -67,7 +96,15 @@ class TaskResolverTest extends FlatSpec with Matchers with MockitoSugar with Val
 
   "resolve" should "produce an error when the deployment type isn't found" in {
     val deploymentTask = TaskResolver.resolve(
-      deployment = Deployment("test", "autoscaling", NEL.of("stack"), NEL.of("region"), NEL.of("uploadArtifact", "deploy"), "app", "directory", Nil, Map("bucket" -> JsString("bucketName"))),
+      deployment = Deployment("test",
+                              "autoscaling",
+                              NEL.of("stack"),
+                              NEL.of("region"),
+                              NEL.of("uploadArtifact", "deploy"),
+                              "app",
+                              "directory",
+                              Nil,
+                              Map("bucket" -> JsString("bucketName"))),
       deploymentResources = DeploymentResources(reporter, stubLookup(), artifactClient),
       parameters = DeployParameters(Deployer("Test user"), Build("test-project", "1"), Stage("PROD")),
       deploymentTypes = Nil,

--- a/magenta-lib/src/test/scala/magenta/json/JsonReaderTest.scala
+++ b/magenta-lib/src/test/scala/magenta/json/JsonReaderTest.scala
@@ -63,25 +63,46 @@ class JsonReaderTest extends FlatSpec with Matchers {
   """)
 
   "json parser" should "parse json and resolve links" in {
-    val parsedProject = JsonReader.buildProject(deployJsonExample, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
+    val parsedProject =
+      JsonReader.buildProject(deployJsonExample, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
 
-    parsedProject.applications should be (Set(App("index-builder"), App("api"), App("solr")))
+    parsedProject.applications should be(Set(App("index-builder"), App("api"), App("solr")))
 
-    parsedProject.packages.size should be (3)
+    parsedProject.packages.size should be(3)
     parsedProject.packages("index-builder") shouldBe
-      DeploymentPackage("index-builder", Seq(App("index-builder")), Map.empty, "autoscaling", S3Path("artifact-bucket", "test/123/packages/index-builder/"), true, deploymentTypes)
+      DeploymentPackage("index-builder",
+                        Seq(App("index-builder")),
+                        Map.empty,
+                        "autoscaling",
+                        S3Path("artifact-bucket", "test/123/packages/index-builder/"),
+                        true,
+                        deploymentTypes)
     parsedProject.packages("api") shouldBe
-      DeploymentPackage("api", Seq(App("api")), Map("healthcheck_paths" -> Json.arr("/api/index.json","/api/search.json")), "autoscaling", S3Path("artifact-bucket", "test/123/packages/api/"), true, deploymentTypes)
+      DeploymentPackage(
+        "api",
+        Seq(App("api")),
+        Map("healthcheck_paths" -> Json.arr("/api/index.json", "/api/search.json")),
+        "autoscaling",
+        S3Path("artifact-bucket", "test/123/packages/api/"),
+        true,
+        deploymentTypes
+      )
     parsedProject.packages("solr") shouldBe
-      DeploymentPackage("solr", Seq(App("solr")), Map("port" -> JsString("8400")), "autoscaling", S3Path("artifact-bucket", "test/123/packages/solr/"), true, deploymentTypes)
+      DeploymentPackage("solr",
+                        Seq(App("solr")),
+                        Map("port" -> JsString("8400")),
+                        "autoscaling",
+                        S3Path("artifact-bucket", "test/123/packages/solr/"),
+                        true,
+                        deploymentTypes)
 
     val recipes = parsedProject.recipes
-    recipes.size should be (4)
-    recipes("all") should be (Recipe("all", Nil, List("index-build-only", "api-only")))
+    recipes.size should be(4)
+    recipes("all") should be(Recipe("all", Nil, List("index-build-only", "api-only")))
 
     val apiCounterRecipe = recipes("api-counter-only")
 
-    apiCounterRecipe.deploymentSteps.toSeq.length should be (4)
+    apiCounterRecipe.deploymentSteps.toSeq.length should be(4)
   }
 
   val minimalExample = parseOrDie("""
@@ -93,9 +114,10 @@ class JsonReaderTest extends FlatSpec with Matchers {
 """)
 
   "json parser" should "infer a single app if none specified" in {
-    val parsedProject = JsonReader.buildProject(minimalExample, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
+    val parsedProject =
+      JsonReader.buildProject(minimalExample, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
 
-    parsedProject.applications should be (Set(App("dinky")))
+    parsedProject.applications should be(Set(App("dinky")))
   }
 
   val twoPackageExample = parseOrDie("""
@@ -108,15 +130,18 @@ class JsonReaderTest extends FlatSpec with Matchers {
 """)
 
   "json parser" should "infer a default recipe that deploys all packages" in {
-    val parsedProject = JsonReader.buildProject(twoPackageExample, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
+    val parsedProject =
+      JsonReader.buildProject(twoPackageExample, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
 
     val recipes = parsedProject.recipes
     recipes.size should be(1)
-    recipes("default") should be (Recipe("default", deploymentSteps   = parsedProject.packages.values.map(_.mkDeploymentStep("deploy"))))
+    recipes("default") should be(
+      Recipe("default", deploymentSteps = parsedProject.packages.values.map(_.mkDeploymentStep("deploy"))))
   }
 
   "json parser" should "default to using the package name for the file name" in {
-    val parsedProject = JsonReader.buildProject(minimalExample, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
+    val parsedProject =
+      JsonReader.buildProject(minimalExample, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
 
     parsedProject.packages("dinky").s3Package should be(S3Path("artifact-bucket", "test/123/packages/dinky/"))
   }
@@ -133,7 +158,8 @@ class JsonReaderTest extends FlatSpec with Matchers {
 """)
 
   "json parser" should "use override file name if specified" in {
-    val parsedProject = JsonReader.buildProject(withExplicitFileName, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
+    val parsedProject =
+      JsonReader.buildProject(withExplicitFileName, S3JsonArtifact("artifact-bucket", "test/123"), deploymentTypes)
 
     parsedProject.packages("dinky").s3Package should be(S3Path("artifact-bucket", "test/123/packages/awkward/"))
   }

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
@@ -15,14 +15,19 @@ import org.scalatest.{FlatSpec, Matchers}
 class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing = KeyRing()
   val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
-  val deploymentTypes = Seq(stubDeploymentType(name="testDeploymentType", actionNames = Seq("testAction")))
+  val deploymentTypes = Seq(stubDeploymentType(name = "testDeploymentType", actionNames = Seq("testAction")))
 
   it should "double the size of the autoscaling group" in {
     val asg = new AutoScalingGroup().withDesiredCapacity(3).withAutoScalingGroupName("test").withMaxSize(10)
     val asgClientMock = mock[AmazonAutoScalingClient]
 
-    val p = DeploymentPackage("test", Seq(App("app")), Map.empty, "testDeploymentType", S3Path("artifact-bucket", "project/123/test"),
-      true, deploymentTypes)
+    val p = DeploymentPackage("test",
+                              Seq(App("app")),
+                              Map.empty,
+                              "testDeploymentType",
+                              S3Path("artifact-bucket", "project/123/test"),
+                              true,
+                              deploymentTypes)
 
     val task = new DoubleSize(p, Stage("PROD"), UnnamedStack, Region("eu-west-1"))
 
@@ -34,18 +39,26 @@ class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
   }
 
   it should "fail if you do not have the capacity to deploy" in {
-    val asg = new AutoScalingGroup().withAutoScalingGroupName("test")
-      .withMinSize(1).withDesiredCapacity(1).withMaxSize(1)
+    val asg = new AutoScalingGroup()
+      .withAutoScalingGroupName("test")
+      .withMinSize(1)
+      .withDesiredCapacity(1)
+      .withMaxSize(1)
 
     val asgClientMock = mock[AmazonAutoScalingClient]
 
-    val p = DeploymentPackage("test", Seq(App("app")), Map.empty, "testDeploymentType", S3Path("artifact-bucket", "project/123/test"),
-      true, deploymentTypes)
+    val p = DeploymentPackage("test",
+                              Seq(App("app")),
+                              Map.empty,
+                              "testDeploymentType",
+                              S3Path("artifact-bucket", "project/123/test"),
+                              true,
+                              deploymentTypes)
 
     val task = new CheckGroupSize(p, Stage("PROD"), UnnamedStack, Region("eu-west-1"))
 
     val thrown = intercept[FailException](task.execute(asg, reporter, false, asgClientMock))
 
-    thrown.getMessage should startWith ("Autoscaling group does not have the capacity")
+    thrown.getMessage should startWith("Autoscaling group does not have the capacity")
   }
 }

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
@@ -6,7 +6,12 @@ import com.amazonaws.services.autoscaling.AmazonAutoScalingClient
 import com.amazonaws.services.autoscaling.model.{Instance => ASGInstance, _}
 import com.amazonaws.services.elasticloadbalancing.{AmazonElasticLoadBalancingClient => ClassicELBClient}
 import com.amazonaws.services.elasticloadbalancingv2.{AmazonElasticLoadBalancingClient => ApplicationELBClient}
-import com.amazonaws.services.elasticloadbalancing.model.{DescribeInstanceHealthRequest, DescribeInstanceHealthResult, InstanceState, Instance => ELBInstance}
+import com.amazonaws.services.elasticloadbalancing.model.{
+  DescribeInstanceHealthRequest,
+  DescribeInstanceHealthResult,
+  InstanceState,
+  Instance => ELBInstance
+}
 import com.amazonaws.services.elasticloadbalancingv2.model.{TagDescription => _, _}
 import magenta.artifact.S3Path
 import magenta.deployment_type.DeploymentType
@@ -28,16 +33,21 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
 
     val desiredGroup = AutoScalingGroup("App" -> "example", "Stage" -> "PROD")
 
-    when (asgClientMock.describeAutoScalingGroups(any[DescribeAutoScalingGroupsRequest])) thenReturn
-      new DescribeAutoScalingGroupsResult().withAutoScalingGroups(List(
-        desiredGroup,
-        AutoScalingGroup("App" -> "other", "Stage" -> "PROD"),
-        AutoScalingGroup("App" -> "example", "Stage" -> "TEST")
-      ))
+    when(asgClientMock.describeAutoScalingGroups(any[DescribeAutoScalingGroupsRequest])) thenReturn
+      new DescribeAutoScalingGroupsResult().withAutoScalingGroups(
+        List(
+          desiredGroup,
+          AutoScalingGroup("App" -> "other", "Stage" -> "PROD"),
+          AutoScalingGroup("App" -> "example", "Stage" -> "TEST")
+        ))
 
-    val p = DeploymentPackage("example", Seq(App("app")), Map.empty, deploymentType = null,
-      S3Path("artifact-bucket", "project/123/example"), true)
-    ASG.groupForAppAndStage(p, Stage("PROD"), UnnamedStack, asgClientMock, reporter) should be (desiredGroup)
+    val p = DeploymentPackage("example",
+                              Seq(App("app")),
+                              Map.empty,
+                              deploymentType = null,
+                              S3Path("artifact-bucket", "project/123/example"),
+                              true)
+    ASG.groupForAppAndStage(p, Stage("PROD"), UnnamedStack, asgClientMock, reporter) should be(desiredGroup)
   }
 
   it should "find the matching auto-scaling group with Role tagging" in {
@@ -45,16 +55,21 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
 
     val desiredGroup = AutoScalingGroup("Role" -> "example", "Stage" -> "PROD")
 
-    when (asgClientMock.describeAutoScalingGroups(any[DescribeAutoScalingGroupsRequest])) thenReturn
-      new DescribeAutoScalingGroupsResult().withAutoScalingGroups(List(
-        desiredGroup,
-        AutoScalingGroup(("Role" -> "other"), ("Stage" -> "PROD")),
-        AutoScalingGroup(("Role" -> "example"), ("Stage" -> "TEST"))
-      ))
+    when(asgClientMock.describeAutoScalingGroups(any[DescribeAutoScalingGroupsRequest])) thenReturn
+      new DescribeAutoScalingGroupsResult().withAutoScalingGroups(
+        List(
+          desiredGroup,
+          AutoScalingGroup(("Role" -> "other"), ("Stage" -> "PROD")),
+          AutoScalingGroup(("Role" -> "example"), ("Stage" -> "TEST"))
+        ))
 
-    val p = DeploymentPackage("example", Seq(App("app")), Map.empty, deploymentType = null,
-      S3Path("artifact-bucket", "project/123/example"), true)
-    ASG.groupForAppAndStage(p, Stage("PROD"), UnnamedStack, asgClientMock, reporter) should be (desiredGroup)
+    val p = DeploymentPackage("example",
+                              Seq(App("app")),
+                              Map.empty,
+                              deploymentType = null,
+                              S3Path("artifact-bucket", "project/123/example"),
+                              true)
+    ASG.groupForAppAndStage(p, Stage("PROD"), UnnamedStack, asgClientMock, reporter) should be(desiredGroup)
   }
 
   it should "find the matching auto-scaling group with Stack and App tags" in {
@@ -62,7 +77,7 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
 
     val desiredGroup = AutoScalingGroup("Stack" -> "contentapi", "App" -> "logcabin", "Stage" -> "PROD")
 
-    when (asgClientMock.describeAutoScalingGroups(any[DescribeAutoScalingGroupsRequest])) thenReturn
+    when(asgClientMock.describeAutoScalingGroups(any[DescribeAutoScalingGroupsRequest])) thenReturn
       new DescribeAutoScalingGroupsResult().withAutoScalingGroups(List(
         desiredGroup,
         AutoScalingGroup("Role" -> "other", "Stage" -> "PROD"),
@@ -72,9 +87,14 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         AutoScalingGroup("Stack" -> "monkey", "App" -> "logcabin", "Stage" -> "PROD")
       ))
 
-    val p = DeploymentPackage("example", Seq(App("logcabin")), Map.empty, deploymentType = null,
-      S3Path("artifact-bucket", "project/123/example"), true)
-    ASG.groupForAppAndStage(p, Stage("PROD"), NamedStack("contentapi"), asgClientMock, reporter) should be (desiredGroup)
+    val p = DeploymentPackage("example",
+                              Seq(App("logcabin")),
+                              Map.empty,
+                              deploymentType = null,
+                              S3Path("artifact-bucket", "project/123/example"),
+                              true)
+    ASG.groupForAppAndStage(p, Stage("PROD"), NamedStack("contentapi"), asgClientMock, reporter) should be(
+      desiredGroup)
   }
 
   it should "find the first matching auto-scaling group with Stack and App tags" in {
@@ -82,7 +102,7 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
 
     val desiredGroup = AutoScalingGroup("Stack" -> "contentapi", "App" -> "logcabin", "Stage" -> "PROD")
 
-    when (asgClientMock.describeAutoScalingGroups(any[DescribeAutoScalingGroupsRequest])) thenReturn
+    when(asgClientMock.describeAutoScalingGroups(any[DescribeAutoScalingGroupsRequest])) thenReturn
       new DescribeAutoScalingGroupsResult().withAutoScalingGroups(List(
         desiredGroup,
         AutoScalingGroup("Role" -> "other", "Stage" -> "PROD"),
@@ -92,17 +112,23 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         AutoScalingGroup("Stack" -> "monkey", "App" -> "logcabin", "Stage" -> "PROD")
       ))
 
-    val p = DeploymentPackage("example", Seq(App("logcabin"), App("elasticsearch")), Map.empty, deploymentType = null,
-      S3Path("artifact-bucket", "project/123/example"), true)
-    ASG.groupForAppAndStage(p, Stage("PROD"), NamedStack("contentapi"), asgClientMock, reporter) should be (desiredGroup)
+    val p = DeploymentPackage("example",
+                              Seq(App("logcabin"), App("elasticsearch")),
+                              Map.empty,
+                              deploymentType = null,
+                              S3Path("artifact-bucket", "project/123/example"),
+                              true)
+    ASG.groupForAppAndStage(p, Stage("PROD"), NamedStack("contentapi"), asgClientMock, reporter) should be(
+      desiredGroup)
   }
 
   it should "fail if more than one ASG matches the Stack and App tags" in {
     val asgClientMock = mock[AmazonAutoScalingClient]
 
-    val desiredGroup = AutoScalingGroup("Stack" -> "contentapi", "App" -> "logcabin", "Stage" -> "PROD", "Role" -> "monkey")
+    val desiredGroup =
+      AutoScalingGroup("Stack" -> "contentapi", "App" -> "logcabin", "Stage" -> "PROD", "Role" -> "monkey")
 
-    when (asgClientMock.describeAutoScalingGroups(any[DescribeAutoScalingGroupsRequest])) thenReturn
+    when(asgClientMock.describeAutoScalingGroups(any[DescribeAutoScalingGroupsRequest])) thenReturn
       new DescribeAutoScalingGroupsResult().withAutoScalingGroups(List(
         desiredGroup,
         AutoScalingGroup("Role" -> "other", "Stage" -> "PROD"),
@@ -113,11 +139,16 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         AutoScalingGroup("Stack" -> "monkey", "App" -> "logcabin", "Stage" -> "PROD")
       ))
 
-    val p = DeploymentPackage("example", Seq(App("logcabin"), App("elasticsearch")), Map.empty, deploymentType = null,
-      S3Path("artifact-bucket", "project/123/example"), true)
+    val p = DeploymentPackage("example",
+                              Seq(App("logcabin"), App("elasticsearch")),
+                              Map.empty,
+                              deploymentType = null,
+                              S3Path("artifact-bucket", "project/123/example"),
+                              true)
 
-    a [FailException] should be thrownBy {
-      ASG.groupForAppAndStage(p, Stage("PROD"), NamedStack("contentapi"), asgClientMock, reporter) should be (desiredGroup)
+    a[FailException] should be thrownBy {
+      ASG.groupForAppAndStage(p, Stage("PROD"), NamedStack("contentapi"), asgClientMock, reporter) should be(
+        desiredGroup)
     }
   }
 
@@ -128,16 +159,18 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
 
     val group = AutoScalingGroup("elb", "Role" -> "example", "Stage" -> "PROD").withDesiredCapacity(1)
 
-    when (classicELBClient.describeInstanceHealth(
-      new DescribeInstanceHealthRequest().withLoadBalancerName("elb")
-    )).thenReturn(new DescribeInstanceHealthResult().withInstanceStates(new InstanceState().withState("")))
+    when(
+      classicELBClient.describeInstanceHealth(
+        new DescribeInstanceHealthRequest().withLoadBalancerName("elb")
+      )).thenReturn(new DescribeInstanceHealthResult().withInstanceStates(new InstanceState().withState("")))
 
     ASG.isStabilized(group, asgClientMock, ELB.Client(classicELBClient, appELBClient)) shouldBe
       Left("Only 0 of 1 ELB instances InService")
 
-    when (classicELBClient.describeInstanceHealth(
-      new DescribeInstanceHealthRequest().withLoadBalancerName("elb")
-    )).thenReturn(new DescribeInstanceHealthResult().withInstanceStates(new InstanceState().withState("InService")))
+    when(
+      classicELBClient.describeInstanceHealth(
+        new DescribeInstanceHealthRequest().withLoadBalancerName("elb")
+      )).thenReturn(new DescribeInstanceHealthResult().withInstanceStates(new InstanceState().withState("InService")))
 
     ASG.isStabilized(group, asgClientMock, ELB.Client(classicELBClient, appELBClient)) shouldBe Right(())
   }
@@ -151,18 +184,23 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
       .withTargetGroupARNs("elbTargetARN")
       .withDesiredCapacity(1)
 
-    when (appELBClient.describeTargetHealth(
-      new DescribeTargetHealthRequest().withTargetGroupArn("elbTargetARN")
-    )).thenReturn(new DescribeTargetHealthResult().withTargetHealthDescriptions(
-      new TargetHealthDescription().withTargetHealth(new TargetHealth().withState(TargetHealthStateEnum.Unhealthy))))
+    when(
+      appELBClient.describeTargetHealth(
+        new DescribeTargetHealthRequest().withTargetGroupArn("elbTargetARN")
+      )).thenReturn(new DescribeTargetHealthResult()
+      .withTargetHealthDescriptions(
+        new TargetHealthDescription().withTargetHealth(new TargetHealth().withState(TargetHealthStateEnum.Unhealthy))))
 
     ASG.isStabilized(group, asgClientMock, ELB.Client(classicELBClient, appELBClient)) shouldBe
       Left("Only 0 of 1 Application ELB instances healthy")
 
-    when (appELBClient.describeTargetHealth(
-      new DescribeTargetHealthRequest().withTargetGroupArn("elbTargetARN")
-    )).thenReturn(new DescribeTargetHealthResult().withTargetHealthDescriptions(
-      new TargetHealthDescription().withTargetHealth(new TargetHealth().withState(TargetHealthStateEnum.Healthy))))
+    when(
+      appELBClient.describeTargetHealth(
+        new DescribeTargetHealthRequest().withTargetGroupArn("elbTargetARN")
+      )).thenReturn(
+      new DescribeTargetHealthResult()
+        .withTargetHealthDescriptions(
+          new TargetHealthDescription().withTargetHealth(new TargetHealth().withState(TargetHealthStateEnum.Healthy))))
 
     ASG.isStabilized(group, asgClientMock, ELB.Client(classicELBClient, appELBClient)) shouldBe Right(())
   }
@@ -173,17 +211,20 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
     val classicELBClient = mock[ClassicELBClient]
 
     val group = AutoScalingGroup("Role" -> "example", "Stage" -> "PROD")
-      .withDesiredCapacity(1).withInstances(new ASGInstance().withHealthStatus("Foobar"))
+      .withDesiredCapacity(1)
+      .withInstances(new ASGInstance().withHealthStatus("Foobar"))
 
-    when (classicELBClient.describeInstanceHealth(
-      new DescribeInstanceHealthRequest().withLoadBalancerName("elb")
-    )).thenReturn(new DescribeInstanceHealthResult().withInstanceStates(new InstanceState().withState("")))
+    when(
+      classicELBClient.describeInstanceHealth(
+        new DescribeInstanceHealthRequest().withLoadBalancerName("elb")
+      )).thenReturn(new DescribeInstanceHealthResult().withInstanceStates(new InstanceState().withState("")))
 
     ASG.isStabilized(group, asgClientMock, ELB.Client(classicELBClient, appELBClient)) shouldBe
       Left("Only 0 of 1 instances InService")
 
     val updatedGroup = AutoScalingGroup("Role" -> "example", "Stage" -> "PROD")
-      .withDesiredCapacity(1).withInstances(new ASGInstance().withLifecycleState(LifecycleState.InService))
+      .withDesiredCapacity(1)
+      .withInstances(new ASGInstance().withLifecycleState(LifecycleState.InService))
 
     ASG.isStabilized(updatedGroup, asgClientMock, ELB.Client(classicELBClient, appELBClient)) shouldBe Right(())
   }
@@ -196,13 +237,16 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
 
     val desiredGroup = AutoScalingGroup("Stack" -> "contentapi", "App" -> "logcabin", "Stage" -> "PROD")
 
-    when (asgClientMock.describeAutoScalingGroups(firstRequest)) thenReturn
-      new DescribeAutoScalingGroupsResult().withAutoScalingGroups(List(
-        AutoScalingGroup("Role" -> "other", "Stage" -> "PROD"),
-        AutoScalingGroup("Role" -> "example", "Stage" -> "TEST")
-      )).withNextToken("someToken" +
-        "")
-    when (asgClientMock.describeAutoScalingGroups(secondRequest)) thenReturn
+    when(asgClientMock.describeAutoScalingGroups(firstRequest)) thenReturn
+      new DescribeAutoScalingGroupsResult()
+        .withAutoScalingGroups(
+          List(
+            AutoScalingGroup("Role" -> "other", "Stage" -> "PROD"),
+            AutoScalingGroup("Role" -> "example", "Stage" -> "TEST")
+          ))
+        .withNextToken("someToken" +
+          "")
+    when(asgClientMock.describeAutoScalingGroups(secondRequest)) thenReturn
       new DescribeAutoScalingGroupsResult().withAutoScalingGroups(List(
         AutoScalingGroup("Stack" -> "contentapi", "App" -> "logcabin", "Stage" -> "TEST"),
         AutoScalingGroup("Stack" -> "contentapi", "App" -> "elasticsearch", "Stage" -> "PROD"),
@@ -210,17 +254,26 @@ class ASGTest extends FlatSpec with Matchers with MockitoSugar {
         desiredGroup
       ))
 
-    val p = DeploymentPackage("example", Seq(App("logcabin"), App("elasticsearch")), Map.empty, deploymentType = null,
-      S3Path("artifact-bucket", "project/123/example"), true)
-    ASG.groupForAppAndStage(p, Stage("PROD"), NamedStack("contentapi"), asgClientMock, reporter) should be (desiredGroup)
+    val p = DeploymentPackage("example",
+                              Seq(App("logcabin"), App("elasticsearch")),
+                              Map.empty,
+                              deploymentType = null,
+                              S3Path("artifact-bucket", "project/123/example"),
+                              true)
+    ASG.groupForAppAndStage(p, Stage("PROD"), NamedStack("contentapi"), asgClientMock, reporter) should be(
+      desiredGroup)
   }
 
   object AutoScalingGroup {
-    def apply(tags: (String, String)*) = new AutoScalingGroup().withTags(tags map {
-      case (key, value) => new TagDescription().withKey(key).withValue(value)
-    })
-    def apply(elbName: String, tags: (String, String)*) = new AutoScalingGroup().withTags(tags map {
-      case (key, value) => new TagDescription().withKey(key).withValue(value)
-    }).withLoadBalancerNames(elbName)
+    def apply(tags: (String, String)*) =
+      new AutoScalingGroup().withTags(tags map {
+        case (key, value) => new TagDescription().withKey(key).withValue(value)
+      })
+    def apply(elbName: String, tags: (String, String)*) =
+      new AutoScalingGroup()
+        .withTags(tags map {
+          case (key, value) => new TagDescription().withKey(key).withValue(value)
+        })
+        .withLoadBalancerNames(elbName)
   }
 }

--- a/magenta-lib/src/test/scala/magenta/tasks/CommandLineTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/CommandLineTest.scala
@@ -9,35 +9,36 @@ import org.scalatest.{FlatSpec, Matchers}
 
 import scala.collection.mutable.ListBuffer
 
-
 class CommandLineTest extends FlatSpec with Matchers {
 
   "CommandLine" should "return sensible description for simple commands" in {
-    CommandLine(List("ls", "-l")).quoted should be ("ls -l")
+    CommandLine(List("ls", "-l")).quoted should be("ls -l")
   }
 
   it should "return quoted description for commands with string params with spaces" in {
     CommandLine(List("echo", "this needs to be quoted")).quoted should
-      be ("echo \"this needs to be quoted\"")
+      be("echo \"this needs to be quoted\"")
   }
 
   it should "execute command and pipe progress results to reporter" in {
     val recordedMessages = new ListBuffer[List[Message]]()
-    DeployReporter.messages.filter(_.stack.deployParameters == Some(parameters)).subscribe(recordedMessages += _.stack.messages)
+    DeployReporter.messages
+      .filter(_.stack.deployParameters == Some(parameters))
+      .subscribe(recordedMessages += _.stack.messages)
 
     val reporter = DeployReporter.startDeployContext(DeployReporter.rootReporterFor(UUID.randomUUID(), parameters))
     val c = CommandLine(List("echo", "hello"))
     c.run(reporter)
     DeployReporter.finishContext(reporter)
 
-    recordedMessages.toList should be (
+    recordedMessages.toList should be(
       List(StartContext(Deploy(parameters))) ::
-      List(StartContext(Info("$ echo hello")),Deploy(parameters)) ::
-      List(CommandOutput("hello"),Info("$ echo hello"),Deploy(parameters)) ::
-      List(Verbose("return value 0"),Info("$ echo hello"),Deploy(parameters)) ::
-      List(FinishContext(Info("$ echo hello")), Info("$ echo hello"), Deploy(parameters)) ::
-      List(FinishContext(Deploy(parameters)), Deploy(parameters)) ::
-      Nil
+        List(StartContext(Info("$ echo hello")), Deploy(parameters)) ::
+        List(CommandOutput("hello"), Info("$ echo hello"), Deploy(parameters)) ::
+        List(Verbose("return value 0"), Info("$ echo hello"), Deploy(parameters)) ::
+        List(FinishContext(Info("$ echo hello")), Info("$ echo hello"), Deploy(parameters)) ::
+        List(FinishContext(Deploy(parameters)), Deploy(parameters)) ::
+        Nil
     )
   }
 
@@ -55,6 +56,6 @@ class CommandLineTest extends FlatSpec with Matchers {
     }
   }
 
-  val parameters = DeployParameters(Deployer("tester"), Build("Project","1"), CODE, RecipeName(baseRecipe.name))
+  val parameters = DeployParameters(Deployer("tester"), Build("Project", "1"), CODE, RecipeName(baseRecipe.name))
 
 }

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -21,7 +21,6 @@ import magenta.Region
 
 import scala.collection.JavaConverters._
 
-
 class TasksTest extends FlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing = KeyRing()
   implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
@@ -30,63 +29,68 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
     val putRec = PutReq(
       MagentaS3Object("artifact-bucket", "foo/bar/foo-bar.jar", 31),
       S3Path("artifact-bucket", "foo/bar/the-jar.jar"),
-      None, None,
+      None,
+      None,
       publicReadAcl = false
     )
 
     val stream = new ByteArrayInputStream("bob".getBytes("UTF-8"))
     val awsRequest = putRec.toAwsRequest(stream)
 
-    awsRequest.getBucketName should be ("artifact-bucket")
-    awsRequest.getCannedAcl should be (null)
-    awsRequest.getKey should be ("foo/bar/the-jar.jar")
-    awsRequest.getInputStream should be (stream)
-    Option(awsRequest.getMetadata.getCacheControl) should be (None)
-    awsRequest.getMetadata.getContentType should be ("application/octet-stream")
+    awsRequest.getBucketName should be("artifact-bucket")
+    awsRequest.getCannedAcl should be(null)
+    awsRequest.getKey should be("foo/bar/the-jar.jar")
+    awsRequest.getInputStream should be(stream)
+    Option(awsRequest.getMetadata.getCacheControl) should be(None)
+    awsRequest.getMetadata.getContentType should be("application/octet-stream")
 
     val reqWithoutAcl = putRec.copy(publicReadAcl = true)
 
     val awsRequestWithoutAcl = reqWithoutAcl.toAwsRequest(stream)
 
-    awsRequestWithoutAcl.getCannedAcl should be (CannedAccessControlList.PublicRead)
+    awsRequestWithoutAcl.getCannedAcl should be(CannedAccessControlList.PublicRead)
   }
 
   it should "create an upload request with cache control and content type" in {
     val putRec = PutReq(
       MagentaS3Object("artifact-bucket", "foo/bar/foo-bar.jar", 31),
       S3Path("artifact-bucket", "foo/bar/the-jar.jar"),
-      Some("no-cache"), Some("application/json"),
+      Some("no-cache"),
+      Some("application/json"),
       publicReadAcl = false
     )
 
     val stream = new ByteArrayInputStream("bob".getBytes("UTF-8"))
     val awsRequest = putRec.toAwsRequest(stream)
 
-    awsRequest.getBucketName should be ("artifact-bucket")
-    awsRequest.getCannedAcl should be (null)
-    awsRequest.getKey should be ("foo/bar/the-jar.jar")
-    awsRequest.getInputStream should be (stream)
-    Option(awsRequest.getMetadata.getCacheControl) should be (Some("no-cache"))
-    Option(awsRequest.getMetadata.getContentType) should be (Some("application/json"))
+    awsRequest.getBucketName should be("artifact-bucket")
+    awsRequest.getCannedAcl should be(null)
+    awsRequest.getKey should be("foo/bar/the-jar.jar")
+    awsRequest.getInputStream should be(stream)
+    Option(awsRequest.getMetadata.getCacheControl) should be(Some("no-cache"))
+    Option(awsRequest.getMetadata.getContentType) should be(Some("application/json"))
   }
 
   it should "use a default mime type from S3" in {
     val putRecOne = PutReq(
       MagentaS3Object("artifact-bucket", "foo/bar/foo-bar.css", 31),
       S3Path("artifact-bucket", "foo/bar/the-jar.css"),
-      Some("no-cache"), None,
+      Some("no-cache"),
+      None,
       publicReadAcl = false
     )
     val putRecTwo = PutReq(
       MagentaS3Object("artifact-bucket", "foo/bar/foo-bar.xpi", 31),
       S3Path("artifact-bucket", "foo/bar/the-jar.xpi"),
-      Some("no-cache"), None,
+      Some("no-cache"),
+      None,
       publicReadAcl = false
     )
     val putRecThree = PutReq(
       MagentaS3Object("artifact-bucket", "foo/bar/foo-bar.js", 31),
       S3Path("artifact-bucket", "foo/bar/the-jar.js"),
-      Some("no-cache"), None,
+      Some("no-cache"),
+      None,
       publicReadAcl = false
     )
 
@@ -95,16 +99,17 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
     val awsRequestTwo = putRecTwo.toAwsRequest(stream)
     val awsRequestThree = putRecThree.toAwsRequest(stream)
 
-    awsRequestOne.getMetadata.getContentType should be ("text/css")
-    awsRequestTwo.getMetadata.getContentType should be ("application/octet-stream")
-    awsRequestThree.getMetadata.getContentType should be ("application/x-javascript")
+    awsRequestOne.getMetadata.getContentType should be("text/css")
+    awsRequestTwo.getMetadata.getContentType should be("application/octet-stream")
+    awsRequestThree.getMetadata.getContentType should be("application/x-javascript")
   }
 
   "S3Upload" should "upload a single file to S3" in {
     val artifactClient = mock[AmazonS3Client]
     val objectResult = mockListObjects(List(MagentaS3Object("artifact-bucket", "foo/bar/the-jar.jar", 31)))
     when(artifactClient.listObjectsV2(any[ListObjectsV2Request])).thenReturn(objectResult)
-    when(artifactClient.getObject("artifact-bucket", "foo/bar/the-jar.jar")).thenReturn(mockObject("Some content for this S3 object"))
+    when(artifactClient.getObject("artifact-bucket", "foo/bar/the-jar.jar"))
+      .thenReturn(mockObject("Some content for this S3 object"))
 
     val fileToUpload = new S3Path("artifact-bucket", "foo/bar/the-jar.jar")
     val s3Client = mock[AmazonS3Client]
@@ -117,25 +122,28 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
       por
     }
     when(s3Client.putObject(any[PutObjectRequest])).thenReturn(putObjectResult)
-    val task = new S3Upload(Region("eu-west-1"), "destination-bucket", Seq(fileToUpload -> "keyPrefix/the-jar.jar"))(fakeKeyRing, artifactClient, clientFactory(s3Client))
+    val task = new S3Upload(Region("eu-west-1"), "destination-bucket", Seq(fileToUpload -> "keyPrefix/the-jar.jar"))(
+      fakeKeyRing,
+      artifactClient,
+      clientFactory(s3Client))
 
     val mappings = task.objectMappings
-    mappings.size should be (1)
+    mappings.size should be(1)
     val (source, target) = mappings.head
-    source.bucket should be ("artifact-bucket")
-    source.key should be ("foo/bar/the-jar.jar")
-    source.size should be (31)
+    source.bucket should be("artifact-bucket")
+    source.key should be("foo/bar/the-jar.jar")
+    source.size should be(31)
 
-    target.bucket should be ("destination-bucket")
-    target.key should be ("keyPrefix/the-jar.jar")
+    target.bucket should be("destination-bucket")
+    target.key should be("keyPrefix/the-jar.jar")
 
     task.execute(reporter)
 
     val request = ArgumentCaptor.forClass(classOf[PutObjectRequest])
     verify(s3Client).putObject(request.capture())
     verifyNoMoreInteractions(s3Client)
-    request.getValue.getKey should be ("keyPrefix/the-jar.jar")
-    request.getValue.getBucketName should be ("destination-bucket")
+    request.getValue.getKey should be("keyPrefix/the-jar.jar")
+    request.getValue.getBucketName should be("destination-bucket")
   }
 
   it should "upload a directory to S3" in {
@@ -158,14 +166,17 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
       por
     }
     when(s3Client.putObject(any[PutObjectRequest])).thenReturn(putObjectResult)
-    val task = new S3Upload(Region("eu-west-1"), "bucket", Seq(packageRoot -> "myStack/CODE/myApp"))(fakeKeyRing, artifactClient, clientFactory(s3Client))
+    val task =
+      new S3Upload(Region("eu-west-1"), "bucket", Seq(packageRoot -> "myStack/CODE/myApp"))(fakeKeyRing,
+                                                                                            artifactClient,
+                                                                                            clientFactory(s3Client))
     task.execute(reporter)
 
     val files = task.objectMappings
-    files.size should be (3)
-    files should contain ((fileOne, S3Path("bucket", "myStack/CODE/myApp/one.txt")))
-    files should contain ((fileTwo, S3Path("bucket", "myStack/CODE/myApp/two.txt")))
-    files should contain ((fileThree, S3Path("bucket", "myStack/CODE/myApp/sub/three.txt")))
+    files.size should be(3)
+    files should contain((fileOne, S3Path("bucket", "myStack/CODE/myApp/one.txt")))
+    files should contain((fileTwo, S3Path("bucket", "myStack/CODE/myApp/two.txt")))
+    files should contain((fileThree, S3Path("bucket", "myStack/CODE/myApp/sub/three.txt")))
 
     verify(s3Client, times(3)).putObject(any(classOf[PutObjectRequest]))
 
@@ -193,15 +204,17 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
       por
     }
     when(s3Client.putObject(any[PutObjectRequest])).thenReturn(putObjectResult)
-    val task = new S3Upload(Region("eu-west-1"), "bucket", Seq(packageRoot -> ""))(fakeKeyRing, artifactClient, clientFactory(s3Client))
+    val task = new S3Upload(Region("eu-west-1"), "bucket", Seq(packageRoot -> ""))(fakeKeyRing,
+                                                                                   artifactClient,
+                                                                                   clientFactory(s3Client))
     task.execute(reporter)
 
     val files = task.objectMappings
-    files.size should be (3)
+    files.size should be(3)
     // these should have no initial '/' in the target key
-    files should contain ((fileOne, S3Path("bucket", "one.txt")))
-    files should contain ((fileTwo, S3Path("bucket", "two.txt")))
-    files should contain ((fileThree, S3Path("bucket", "sub/three.txt")))
+    files should contain((fileOne, S3Path("bucket", "one.txt")))
+    files should contain((fileTwo, S3Path("bucket", "two.txt")))
+    files should contain((fileThree, S3Path("bucket", "sub/three.txt")))
 
     verify(s3Client, times(3)).putObject(any(classOf[PutObjectRequest]))
 
@@ -218,7 +231,10 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
 
     val patternValues = List(PatternValue("^keyPrefix/sub/", "public; max-age=3600"), PatternValue(".*", "no-cache"))
     val packageRoot = new S3Path("artifact-bucket", "test/123/package/")
-    val task = new S3Upload(Region("eu-west-1"), "bucket", Seq(packageRoot -> "keyPrefix"), cacheControlPatterns = patternValues)(fakeKeyRing, artifactClient)
+    val task = new S3Upload(Region("eu-west-1"),
+                            "bucket",
+                            Seq(packageRoot -> "keyPrefix"),
+                            cacheControlPatterns = patternValues)(fakeKeyRing, artifactClient)
 
     task.requests.find(_.source == fileOne).get.cacheControl should be(Some("no-cache"))
     task.requests.find(_.source == fileTwo).get.cacheControl should be(Some("no-cache"))
@@ -234,7 +250,9 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
 
     val mimeTypes = Map("xpi" -> "application/x-xpinstall")
     val packageRoot = new S3Path("artifact-bucket", "test/123/package/")
-    val task = new S3Upload(Region("eu-west-1"), "bucket", Seq(packageRoot -> ""), extensionToMimeType = mimeTypes)(fakeKeyRing, artifactClient)
+    val task = new S3Upload(Region("eu-west-1"), "bucket", Seq(packageRoot -> ""), extensionToMimeType = mimeTypes)(
+      fakeKeyRing,
+      artifactClient)
 
     task.requests.find(_.source == fileOne).get.contentType should be(None)
     task.requests.find(_.source == fileTwo).get.contentType should be(Some("application/x-xpinstall"))
@@ -260,14 +278,16 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
     mockedObject.setObjectContent(new ByteArrayInputStream(content.getBytes("UTF-8")))
     mockedObject
   }
-  
-  def clientFactory(client: AmazonS3): (KeyRing, Region, ClientConfiguration) => AmazonS3 = { (_, _, _) => client }
 
-  val parameters = DeployParameters(Deployer("tester"), Build("Project","1"), Stage("CODE"), RecipeName("baseRecipe.name"))
+  def clientFactory(client: AmazonS3): (KeyRing, Region, ClientConfiguration) => AmazonS3 = { (_, _, _) =>
+    client
+  }
+
+  val parameters =
+    DeployParameters(Deployer("tester"), Build("Project", "1"), Stage("CODE"), RecipeName("baseRecipe.name"))
 }
 
-
-class TestServer(port:Int = 9997) {
+class TestServer(port: Int = 9997) {
 
   def withResponse(response: String) {
     val server = new ServerSocket(port)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,11 +45,10 @@ object Dependencies {
     "com.typesafe.play" %% "play-json" % Versions.play
   ).map((m: ModuleID) =>
     // don't even ask why I need to do this
-    m.excludeAll(ExclusionRule(organization = "com.google.code.findbugs", name = "jsr305"))
-  )
+    m.excludeAll(ExclusionRule(organization = "com.google.code.findbugs", name = "jsr305")))
 
   val riffRaffDeps = commonDeps ++ Seq(
-    "com.gu" %% "management-play" % Versions.guardianManagementPlay exclude("javassist", "javassist"), // http://code.google.com/p/reflections/issues/detail?id=140
+    "com.gu" %% "management-play" % Versions.guardianManagementPlay exclude ("javassist", "javassist"), // http://code.google.com/p/reflections/issues/detail?id=140
     "com.gu" %% "management-logback" % Versions.guardianManagement,
     "com.gu" %% "configuration" % "4.0",
     "com.gu" %% "play-googleauth" % "0.5.1",
@@ -71,7 +70,6 @@ object Dependencies {
     "org.gnieh" %% "diffson" % "2.0.2" % Test
   ).map((m: ModuleID) =>
     // don't even ask why I need to do this
-    m.excludeAll(ExclusionRule(organization = "com.google.code.findbugs", name = "jsr305"))
-  )
+    m.excludeAll(ExclusionRule(organization = "com.google.code.findbugs", name = "jsr305")))
 
 }

--- a/project/Helpers.scala
+++ b/project/Helpers.scala
@@ -1,4 +1,3 @@
-
 object Helpers {
 
   // TODO is this actually needed?

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -21,19 +21,28 @@ import scala.concurrent.duration._
 
 import router.Routes
 
-class AppComponents(context: Context) extends BuiltInComponentsFromContext(context)
-  with AhcWSComponents
-  with I18nComponents
-  with CSRFComponents
-  with GzipFilterComponents {
+class AppComponents(context: Context)
+    extends BuiltInComponentsFromContext(context)
+    with AhcWSComponents
+    with I18nComponents
+    with CSRFComponents
+    with GzipFilterComponents {
 
   implicit val implicitMessagesApi = messagesApi
   implicit val implicitWsClient = wsClient
 
   val availableDeploymentTypes = Seq(
-    ElasticSearch, S3, AutoScaling, Fastly, CloudFormation, Lambda, AmiCloudFormationParameter, SelfDeploy
+    ElasticSearch,
+    S3,
+    AutoScaling,
+    Fastly,
+    CloudFormation,
+    Lambda,
+    AmiCloudFormationParameter,
+    SelfDeploy
   )
-  val prismLookup = new PrismLookup(wsClient, conf.Configuration.lookup.prismUrl, conf.Configuration.lookup.timeoutSeconds.seconds)
+  val prismLookup =
+    new PrismLookup(wsClient, conf.Configuration.lookup.prismUrl, conf.Configuration.lookup.timeoutSeconds.seconds)
   val deploymentEngine = new DeploymentEngine(prismLookup, availableDeploymentTypes)
   val deployments = new Deployments(deploymentEngine)
   val continuousDeployment = new ContinuousDeployment(deployments)
@@ -56,13 +65,14 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
   val testingController = new Testing(prismLookup)
   val assets = new Assets(httpErrorHandler)
 
-  override lazy val httpErrorHandler = new DefaultHttpErrorHandler(environment, configuration, sourceMapper, Some(router)) {
-    override def onServerError(request: RequestHeader, t: Throwable): Future[Result] = {
-      Logger.error("Error whilst trying to serve request", t)
-      val reportException = if (t.getCause != null) t.getCause else t
-      Future.successful(InternalServerError(views.html.errorPage(reportException)))
+  override lazy val httpErrorHandler =
+    new DefaultHttpErrorHandler(environment, configuration, sourceMapper, Some(router)) {
+      override def onServerError(request: RequestHeader, t: Throwable): Future[Result] = {
+        Logger.error("Error whilst trying to serve request", t)
+        val reportException = if (t.getCause != null) t.getCause else t
+        Future.successful(InternalServerError(views.html.errorPage(reportException)))
+      }
     }
-  }
 
   override def router: Router = new Routes(
     httpErrorHandler,

--- a/riff-raff/app/AppLoader.scala
+++ b/riff-raff/app/AppLoader.scala
@@ -34,21 +34,25 @@ class AppLoader extends ApplicationLoader {
       ShutdownWhenInactive
     )
 
-    Logger.info(s"Calling init() on Lifecycle singletons: ${lifecycleSingletons.map(_.getClass.getName).mkString(", ")}")
+    Logger.info(
+      s"Calling init() on Lifecycle singletons: ${lifecycleSingletons.map(_.getClass.getName).mkString(", ")}")
     lifecycleSingletons.foreach(_.init())
 
-    context.lifecycle.addStopHook(() => Future {
-      lifecycleSingletons.reverse.foreach { singleton =>
-        try {
-          singleton.shutdown()
-        } catch {
-          case NonFatal(e) => Logger.error("Caught unhandled exception whilst calling shutdown() on Lifecycle singleton", e)
+    context.lifecycle.addStopHook(() =>
+      Future {
+        lifecycleSingletons.reverse.foreach { singleton =>
+          try {
+            singleton.shutdown()
+          } catch {
+            case NonFatal(e) =>
+              Logger.error("Caught unhandled exception whilst calling shutdown() on Lifecycle singleton", e)
+          }
         }
-      }
-    }(ExecutionContext.global))
+      }(ExecutionContext.global))
 
     // the management server takes care of shutting itself down with a lifecycle hook
-    new InternalManagementServerImpl(context.lifecycle).startServer(conf.Management.applicationName, conf.Management.pages)
+    new InternalManagementServerImpl(context.lifecycle)
+      .startServer(conf.Management.applicationName, conf.Management.pages)
 
     components.application
   }

--- a/riff-raff/app/ci/Builds.scala
+++ b/riff-raff/app/ci/Builds.scala
@@ -14,21 +14,21 @@ object Builds extends Lifecycle with Logging {
   def all: List[CIBuild] = buildsAgent.get().toList
   def build(project: String, number: String) = all.find(b => b.jobName == project && b.number == number)
   def buildFromRevision(project: String, revision: String) = all.find {
-    case build:S3Build => build.jobName == project && build.revision == revision
+    case build: S3Build => build.jobName == project && build.revision == revision
     case _ => false
   }
 
   val buildsAgent = Agent[Set[CIBuild]](BoundedSet(100000))
   val jobsAgent = Agent[Set[Job]](Set())
-  def successfulBuilds(jobName: String): List[CIBuild] = all.filter(_.jobName == jobName).sortBy(- _.id)
+  def successfulBuilds(jobName: String): List[CIBuild] = all.filter(_.jobName == jobName).sortBy(-_.id)
   def getLastSuccessful(jobName: String): Option[String] =
-    successfulBuilds(jobName).headOption.map{ latestBuild =>
+    successfulBuilds(jobName).headOption.map { latestBuild =>
       latestBuild.number
     }
 
   def init() {
     subscriptions = Seq(
-      CIBuild.builds.subscribe ({ b =>
+      CIBuild.builds.subscribe({ b =>
         buildsAgent.send(_ + b)
       }, e => log.error("Build poller failed", e)),
       CIBuild.jobs.subscribe { b =>

--- a/riff-raff/app/ci/CIBuild.scala
+++ b/riff-raff/app/ci/CIBuild.scala
@@ -36,7 +36,8 @@ object CIBuild extends Logging {
 
   lazy val newBuilds: Observable[CIBuild] = {
     val observable = (for {
-      location <- Every(pollingPeriod)(Observable.from(S3Build.buildJsons)).distinct if !initialFiles.contains(location)
+      location <- Every(pollingPeriod)(Observable.from(S3Build.buildJsons)).distinct
+      if !initialFiles.contains(location)
       build <- Observable.from(retrieveBuild(location))
     } yield build).publish
     observable.connect // make it a "hot" observable, i.e. it runs even if nobody is subscribed to it
@@ -58,7 +59,8 @@ object CIBuild extends Logging {
 
   private def retrieveBuild(location: S3Object): Option[CIBuild] = {
     import cats.syntax.either._
-    S3Build.buildAt(location)
+    S3Build
+      .buildAt(location)
       .leftMap(e => log.error(s"Problem getting build definition from $location: $e"))
       .toOption
   }

--- a/riff-raff/app/ci/ContinuousDeployment.scala
+++ b/riff-raff/app/ci/ContinuousDeployment.scala
@@ -28,12 +28,12 @@ class ContinuousDeployment(deployments: Deployments) extends Lifecycle with Logg
   def init() {
     val builds = buildCandidates(CIBuild.newBuilds)
 
-    def cdConfigs = retryUpTo(5)(getContinuousDeploymentList).getOrElse{
+    def cdConfigs = retryUpTo(5)(getContinuousDeploymentList).getOrElse {
       log.error("Failed to retrieve CD configs")
       Nil
     }
     sub = Some(builds.subscribe { b =>
-      getMatchesForSuccessfulBuilds(b, cdConfigs) foreach  { x =>
+      getMatchesForSuccessfulBuilds(b, cdConfigs) foreach { x =>
         runDeploy(getDeployParams(x))
       }
     })
@@ -65,29 +65,31 @@ class ContinuousDeployment(deployments: Deployments) extends Lifecycle with Logg
 
 object ContinuousDeployment extends Logging {
 
-  def getMatchesForSuccessfulBuilds(build: CIBuild, configs: Iterable[ContinuousDeploymentConfig]): Iterable[(ContinuousDeploymentConfig, CIBuild)] = {
+  def getMatchesForSuccessfulBuilds(
+      build: CIBuild,
+      configs: Iterable[ContinuousDeploymentConfig]): Iterable[(ContinuousDeploymentConfig, CIBuild)] = {
     configs.flatMap { config =>
       log.debug(s"Matching $build against $config")
       config.findMatchOnSuccessfulBuild(build).map(build => config -> build)
     }
   }
 
-  def getDeployParams(configBuildTuple:(ContinuousDeploymentConfig, CIBuild)): DeployParameters = {
-    val (config,build) = configBuildTuple
+  def getDeployParams(configBuildTuple: (ContinuousDeploymentConfig, CIBuild)): DeployParameters = {
+    val (config, build) = configBuildTuple
     DeployParameters(
       Deployer("Continuous Deployment"),
-      MagentaBuild(build.jobName,build.number),
+      MagentaBuild(build.jobName, build.number),
       Stage(config.stage),
       RecipeName(config.recipe)
     )
   }
 
   def retryUpTo[T](maxAttempts: Int)(thunk: () => T): Try[T] = {
-    val thunkStream = Stream.continually(Try(thunk()))
+    val thunkStream = Stream
+      .continually(Try(thunk()))
       .take(maxAttempts)
 
     thunkStream.find(_.isSuccess).getOrElse(thunkStream.head)
   }
 
 }
-

--- a/riff-raff/app/ci/ContinuousDeploymentConfig.scala
+++ b/riff-raff/app/ci/ContinuousDeploymentConfig.scala
@@ -13,18 +13,18 @@ object Trigger extends Enumeration {
 }
 
 case class ContinuousDeploymentConfig(
-                                       id: UUID,
-                                       projectName: String,
-                                       stage: String,
-                                       recipe: String,
-                                       branchMatcher:Option[String],
-                                       trigger: Trigger.Mode,
-                                       user: String,
-                                       lastEdited: DateTime = new DateTime()
-                                       ) {
+    id: UUID,
+    projectName: String,
+    stage: String,
+    recipe: String,
+    branchMatcher: Option[String],
+    trigger: Trigger.Mode,
+    user: String,
+    lastEdited: DateTime = new DateTime()
+) {
   lazy val branchRE = branchMatcher.map(re => "^%s$".format(re).r).getOrElse(".*".r)
   lazy val buildFilter =
-    (build:CIBuild) => build.jobName == projectName && branchRE.findFirstMatchIn(build.branchName).isDefined
+    (build: CIBuild) => build.jobName == projectName && branchRE.findFirstMatchIn(build.branchName).isDefined
 
   def findMatchOnSuccessfulBuild(build: CIBuild): Option[CIBuild] = {
     if (trigger == Trigger.SuccessfulBuild && buildFilter(build))
@@ -60,16 +60,17 @@ object ContinuousDeploymentConfig extends MongoSerialisable[ContinuousDeployment
         case _ => Trigger.Disabled
       }
 
-      Some(ContinuousDeploymentConfig(
-        id = dbo.as[UUID]("_id"),
-        projectName = dbo.as[String]("projectName"),
-        stage = dbo.as[String]("stage"),
-        recipe = dbo.as[String]("recipe"),
-        trigger = triggerMode,
-        user = dbo.as[String]("user"),
-        lastEdited = dbo.as[DateTime]("lastEdited"),
-        branchMatcher = dbo.getAs[String]("branchMatcher")
-      ))
+      Some(
+        ContinuousDeploymentConfig(
+          id = dbo.as[UUID]("_id"),
+          projectName = dbo.as[String]("projectName"),
+          stage = dbo.as[String]("stage"),
+          recipe = dbo.as[String]("recipe"),
+          trigger = triggerMode,
+          user = dbo.as[String]("user"),
+          lastEdited = dbo.as[DateTime]("lastEdited"),
+          branchMatcher = dbo.getAs[String]("branchMatcher")
+        ))
 
     }
   }

--- a/riff-raff/app/ci/Every.scala
+++ b/riff-raff/app/ci/Every.scala
@@ -8,9 +8,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 object Every extends Logging {
 
-  def apply[T](frequency: Duration)
-              (buildRetriever: => Observable[T])
-              (implicit ec: ExecutionContext): Observable[T] = {
+  def apply[T](frequency: Duration)(buildRetriever: => Observable[T])(implicit ec: ExecutionContext): Observable[T] = {
     (for {
       _ <- Observable.interval(1.second, frequency)
       _ = log.debug("Ping!")

--- a/riff-raff/app/ci/GreatestSoFar.scala
+++ b/riff-raff/app/ci/GreatestSoFar.scala
@@ -4,7 +4,6 @@ import rx.lang.scala.Observable
 import scala.util.Random
 import scala.concurrent.duration._
 
-
 object GreatestSoFar {
   def apply[T: Ordering](obs: Observable[T]): Observable[T] = {
     val ord = implicitly[Ordering[T]]

--- a/riff-raff/app/ci/S3Build.scala
+++ b/riff-raff/app/ci/S3Build.scala
@@ -12,14 +12,14 @@ import scala.util.control.NonFatal
 import cats.syntax.either._
 
 case class S3Build(
-  id: Long,
-  jobName: String,
-  jobId: String,
-  branchName: String,
-  number: String,
-  startTime: DateTime,
-  revision: String,
-  vcsURL: String
+    id: Long,
+    jobName: String,
+    jobId: String,
+    branchName: String,
+    number: String,
+    startTime: DateTime,
+    revision: String,
+    vcsURL: String
 ) extends CIBuild
 
 case class S3Project(id: String, name: String) extends Job
@@ -29,16 +29,19 @@ object S3Build extends Logging {
   lazy val bucketName = Configuration.build.aws.bucketName.get
   implicit lazy val client = Configuration.build.aws.client
 
-  def buildJsons: Seq[S3Object] = Try {
-    S3Location.listAll(bucketName).filter(_.key.endsWith("build.json"))
-  } recover {
-    case NonFatal(e) =>
-      log.error(s"Error finding buildJsons", e)
-      Nil
-  } get
+  def buildJsons: Seq[S3Object] =
+    Try {
+      S3Location.listAll(bucketName).filter(_.key.endsWith("build.json"))
+    } recover {
+      case NonFatal(e) =>
+        log.error(s"Error finding buildJsons", e)
+        Nil
+    } get
 
   def buildAt(location: S3Object): Either[S3BuildError, S3Build] =
-    location.fetchContentAsString().leftMap[S3BuildError](S3BuildRetrievalError(_))
+    location
+      .fetchContentAsString()
+      .leftMap[S3BuildError](S3BuildRetrievalError(_))
       .flatMap(s => parse(s).leftMap[S3BuildError](S3BuildParseError(_)))
 
   def parse(json: String): Either[Seq[(JsPath, Seq[ValidationError])], S3Build] = {
@@ -46,12 +49,14 @@ object S3Build extends Logging {
     import utils.Json.DefaultJodaDateReads
     import cats.syntax.either._
     implicit val reads: Reads[S3Build] = (
-      (JsPath \ "buildNumber").read[String].flatMap(s => Reads(_ =>
-        Either.catchOnly[NumberFormatException](s.toLong) match {
-          case Left(e) => JsError(s"'$s' is not a number")
-          case Right(l) => JsSuccess(l)
-        }
-      )) and
+      (JsPath \ "buildNumber")
+        .read[String]
+        .flatMap(s =>
+          Reads(_ =>
+            Either.catchOnly[NumberFormatException](s.toLong) match {
+              case Left(e) => JsError(s"'$s' is not a number")
+              case Right(l) => JsSuccess(l)
+          })) and
         (JsPath \ "projectName").read[String] and
         (JsPath \ "projectName").read[String] and
         (JsPath \ "branch").read[String] and
@@ -59,7 +64,7 @@ object S3Build extends Logging {
         (JsPath \ "startTime").read[DateTime] and
         (JsPath \ "revision").read[String] and
         (JsPath \ "vcsURL").read[String]
-      )(S3Build.apply _)
+    )(S3Build.apply _)
 
     Json.parse(json).validate[S3Build].asEither
   }

--- a/riff-raff/app/ci/TagClassification.scala
+++ b/riff-raff/app/ci/TagClassification.scala
@@ -15,11 +15,12 @@ case class TagClassification(text: String) {
   lazy val status = keywordStatusMap.get(text.toLowerCase)
 
   lazy val link = text match {
-    case HttpMatcher(l) => try {
-      Some(new URI(l))
-    } catch {
-      case e:URISyntaxException => None
-    }
+    case HttpMatcher(l) =>
+      try {
+        Some(new URI(l))
+      } catch {
+        case e: URISyntaxException => None
+      }
     case _ => None
   }
 }

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -52,14 +52,15 @@ class Configuration(val application: String, val webappConfDirectory: String = "
           new Filter("resource-type").withValues("instance"),
           new Filter("resource-id").withValues(instanceId)
         )
-        val ec2Client = AmazonEC2ClientBuilder.standard()
+        val ec2Client = AmazonEC2ClientBuilder
+          .standard()
           .withCredentials(credentialsProviderChain(None, None))
           .withRegion(Regions.getCurrentRegion.getName)
           .build()
         try {
           val describeTagsResult = ec2Client.describeTags(request)
           describeTagsResult.getTags.asScala
-            .collectFirst{ case t if t.getKey == "Stage" => t.getValue }
+            .collectFirst { case t if t.getKey == "Stage" => t.getValue }
             .getOrException("Couldn't find a Stage tag on the Riff Raff instance")
         } finally {
           ec2Client.shutdown()
@@ -76,9 +77,13 @@ class Configuration(val application: String, val webappConfDirectory: String = "
       lazy val useDatabase: Boolean = configuration.getStringProperty("auth.whitelist.useDatabase", "false") == "true"
       lazy val addresses: List[String] = configuration.getStringPropertiesSplitByComma("auth.whitelist.addresses")
     }
-    lazy val clientId: String = configuration.getStringProperty("auth.clientId").getOrException("No client ID configured")
-    lazy val clientSecret: String = configuration.getStringProperty("auth.clientSecret").getOrException("No client secret configured")
-    lazy val redirectUrl: String = configuration.getStringProperty("auth.redirectUrl").getOrElse(s"${urls.publicPrefix}${routes.Login.oauth2Callback().url}")
+    lazy val clientId: String =
+      configuration.getStringProperty("auth.clientId").getOrException("No client ID configured")
+    lazy val clientSecret: String =
+      configuration.getStringProperty("auth.clientSecret").getOrException("No client secret configured")
+    lazy val redirectUrl: String = configuration
+      .getStringProperty("auth.redirectUrl")
+      .getOrElse(s"${urls.publicPrefix}${routes.Login.oauth2Callback().url}")
     lazy val domain: Option[String] = configuration.getStringProperty("auth.domain")
     lazy val googleAuthConfig = GoogleAuthConfig(auth.clientId, auth.clientSecret, auth.redirectUrl, auth.domain)
     lazy val superusers: List[String] = configuration.getStringPropertiesSplitByComma("auth.superusers")
@@ -90,7 +95,8 @@ class Configuration(val application: String, val webappConfDirectory: String = "
 
   object continuousDeployment {
     lazy val enabled = configuration.getStringProperty("continuousDeployment.enabled", "false") == "true"
-    val dynamoClient = AmazonDynamoDBAsyncClientBuilder.standard()
+    val dynamoClient = AmazonDynamoDBAsyncClientBuilder
+      .standard()
       .withCredentials(credentialsProviderChain(None, None))
       .withRegion(Regions.getCurrentRegion.getName)
       .withClientConfiguration(new ClientConfiguration())
@@ -98,7 +104,7 @@ class Configuration(val application: String, val webappConfDirectory: String = "
   }
 
   object credentials {
-    def lookupSecret(service: String, id:String): Option[String] = {
+    def lookupSecret(service: String, id: String): Option[String] = {
       configuration.getStringProperty("credentials.%s.%s" format (service, id))
     }
   }
@@ -107,7 +113,9 @@ class Configuration(val application: String, val webappConfDirectory: String = "
     private val formatter = ISODateTimeFormat.dateTime()
     lazy val startDate = configuration.getStringProperty("freeze.startDate").map(formatter.parseDateTime)
     lazy val endDate = configuration.getStringProperty("freeze.endDate").map(formatter.parseDateTime)
-    lazy val message = configuration.getStringProperty("freeze.message", "There is currently a change freeze. I'm not going to stop you, but you should think carefully about what you are about to do.")
+    lazy val message = configuration.getStringProperty(
+      "freeze.message",
+      "There is currently a change freeze. I'm not going to stop you, but you should think carefully about what you are about to do.")
     lazy val stages = configuration.getStringPropertiesSplitByComma("freeze.stages")
   }
 
@@ -129,22 +137,25 @@ class Configuration(val application: String, val webappConfDirectory: String = "
   object mongo {
     lazy val isConfigured = uri.isDefined
     lazy val uri = configuration.getStringProperty("mongo.uri")
-    lazy val collectionPrefix = configuration.getStringProperty("mongo.collectionPrefix","")
+    lazy val collectionPrefix = configuration.getStringProperty("mongo.collectionPrefix", "")
   }
 
   object stages {
-    lazy val order = configuration.getStringPropertiesSplitByComma("stages.order").filterNot(""==)
+    lazy val order = configuration.getStringPropertiesSplitByComma("stages.order").filterNot("" ==)
     lazy val ordering = UnnaturalOrdering(order, aliensAtEnd = false)
   }
 
   object artifact {
     object aws {
-      implicit lazy val bucketName = configuration.getStringProperty("artifact.aws.bucketName").getOrException("Artifact bucket name not configured")
+      implicit lazy val bucketName = configuration
+        .getStringProperty("artifact.aws.bucketName")
+        .getOrException("Artifact bucket name not configured")
       lazy val accessKey = configuration.getStringProperty("artifact.aws.accessKey")
       lazy val secretKey = configuration.getStringProperty("artifact.aws.secretKey")
       lazy val credentialsProvider = credentialsProviderChain(accessKey, secretKey)
       lazy val regionName = configuration.getStringProperty("artifact.aws.region", "eu-west-1")
-      implicit lazy val client: AmazonS3 = AmazonS3ClientBuilder.standard()
+      implicit lazy val client: AmazonS3 = AmazonS3ClientBuilder
+        .standard()
         .withCredentials(credentialsProvider)
         .withRegion(regionName)
         .build()
@@ -159,7 +170,8 @@ class Configuration(val application: String, val webappConfDirectory: String = "
       lazy val secretKey = configuration.getStringProperty("build.aws.secretKey")
       lazy val credentialsProvider = credentialsProviderChain(accessKey, secretKey)
       lazy val regionName = configuration.getStringProperty("build.aws.region", "eu-west-1")
-      implicit lazy val client: AmazonS3 = AmazonS3ClientBuilder.standard()
+      implicit lazy val client: AmazonS3 = AmazonS3ClientBuilder
+        .standard()
         .withCredentials(credentialsProvider)
         .withRegion(regionName)
         .build()
@@ -173,7 +185,8 @@ class Configuration(val application: String, val webappConfDirectory: String = "
       lazy val secretKey = configuration.getStringProperty("tag.aws.secretKey")
       lazy val credentialsProvider = credentialsProviderChain(accessKey, secretKey)
       lazy val regionName = configuration.getStringProperty("tag.aws.region", "eu-west-1")
-      implicit lazy val client: AmazonS3 = AmazonS3ClientBuilder.standard()
+      implicit lazy val client: AmazonS3 = AmazonS3ClientBuilder
+        .standard()
         .withCredentials(credentialsProvider)
         .withRegion(regionName)
         .build()
@@ -193,10 +206,11 @@ class Configuration(val application: String, val webappConfDirectory: String = "
   def credentialsProviderChain(accessKey: Option[String], secretKey: Option[String]): AWSCredentialsProviderChain =
     new AWSCredentialsProviderChain(
       new AWSCredentialsProvider {
-        override def getCredentials: AWSCredentials = (for {
-          key <- accessKey
-          secret <- secretKey
-        } yield new BasicAWSCredentials(key, secret)).orNull
+        override def getCredentials: AWSCredentials =
+          (for {
+            key <- accessKey
+            secret <- secretKey
+          } yield new BasicAWSCredentials(key, secret)).orNull
 
         override def refresh(): Unit = {}
       },
@@ -212,7 +226,7 @@ class Configuration(val application: String, val webappConfDirectory: String = "
     lazy val publicPrefix: String = configuration.getStringProperty("urls.publicPrefix", "http://localhost:9000")
   }
 
-  val version:String = BuildInfo.buildNumber
+  val version: String = BuildInfo.buildNumber
 
   override def toString: String = configuration.toString
 }
@@ -247,11 +261,23 @@ object PlayRequestMetrics extends com.gu.management.play.RequestMetrics.Standard
 object DeployMetrics extends Lifecycle {
   val runningDeploys = mutable.Buffer[UUID]()
 
-  object DeployStart extends CountMetric("riffraff", "start_deploy", "Start deploy", "Number of deploys that are kicked off")
-  object DeployComplete extends CountMetric("riffraff", "complete_deploy", "Complete deploy", "Number of deploys that completed", Some(DeployStart))
-  object DeployFail extends CountMetric("riffraff", "fail_deploy", "Fail deploy", "Number of deploys that failed", Some(DeployStart))
+  object DeployStart
+      extends CountMetric("riffraff", "start_deploy", "Start deploy", "Number of deploys that are kicked off")
+  object DeployComplete
+      extends CountMetric("riffraff",
+                          "complete_deploy",
+                          "Complete deploy",
+                          "Number of deploys that completed",
+                          Some(DeployStart))
+  object DeployFail
+      extends CountMetric("riffraff", "fail_deploy", "Fail deploy", "Number of deploys that failed", Some(DeployStart))
 
-  object DeployRunning extends GaugeMetric("riffraff", "running_deploys", "Running deploys", "Number of currently running deploys", () => runningDeploys.length)
+  object DeployRunning
+      extends GaugeMetric("riffraff",
+                          "running_deploys",
+                          "Running deploys",
+                          "Number of currently running deploys",
+                          () => runningDeploys.length)
 
   val all = Seq(DeployStart, DeployComplete, DeployFail, DeployRunning)
 
@@ -270,56 +296,78 @@ object DeployMetrics extends Lifecycle {
     }
   })
 
-  def init() { }
+  def init() {}
   def shutdown() { messageSub.unsubscribe() }
 }
 
 object TaskMetrics {
   object TaskTimer extends TimingMetric("riffraff", "task_run", "Tasks running", "Timing of deployment tasks")
-  object TaskStartLatency extends TimingMetric("riffraff", "task_start_latency", "Task start latency", "Timing of deployment task start latency", Some(TaskTimer))
-  object TasksRunning extends GaugeMetric("riffraff", "running_tasks", "Running tasks", "Number of currently running tasks", () => DeployMetricsActor.runningTaskCount)
+  object TaskStartLatency
+      extends TimingMetric("riffraff",
+                           "task_start_latency",
+                           "Task start latency",
+                           "Timing of deployment task start latency",
+                           Some(TaskTimer))
+  object TasksRunning
+      extends GaugeMetric("riffraff",
+                          "running_tasks",
+                          "Running tasks",
+                          "Number of currently running tasks",
+                          () => DeployMetricsActor.runningTaskCount)
   val all = Seq(TaskTimer, TaskStartLatency, TasksRunning)
 }
 
 object DatastoreMetrics {
-  object DatastoreRequest extends TimingMetric(
-    "performance",
-    "database_requests",
-    "Database requests",
-    "outgoing requests to the database"
-  )
-  val collectionStats = ScheduledAgent(5 seconds, 5 minutes, Map.empty[String, CollectionStats]) { map =>  Persistence.store.collectionStats }
+  object DatastoreRequest
+      extends TimingMetric(
+        "performance",
+        "database_requests",
+        "Database requests",
+        "outgoing requests to the database"
+      )
+  val collectionStats = ScheduledAgent(5 seconds, 5 minutes, Map.empty[String, CollectionStats]) { map =>
+    Persistence.store.collectionStats
+  }
   def dataSize: Long = collectionStats().values.map(_.dataSize).foldLeft(0L)(_ + _)
   def storageSize: Long = collectionStats().values.map(_.storageSize).foldLeft(0L)(_ + _)
-  def deployCollectionCount: Long = collectionStats().get("%sdeployV2" format Configuration.mongo.collectionPrefix).map(_.documentCount).getOrElse(0L)
-  object MongoDataSize extends GaugeMetric("mongo", "data_size", "MongoDB data size", "The size of the data held in mongo collections", () => dataSize)
-  object MongoStorageSize extends GaugeMetric("mongo", "storage_size", "MongoDB storage size", "The size of the storage used by the MongoDB collections", () => storageSize)
-  object MongoDeployCollectionCount extends GaugeMetric("mongo", "deploys_collection_count", "Deploys collection count", "The number of documents in the deploys collection", () => deployCollectionCount)
+  def deployCollectionCount: Long =
+    collectionStats().get("%sdeployV2" format Configuration.mongo.collectionPrefix).map(_.documentCount).getOrElse(0L)
+  object MongoDataSize
+      extends GaugeMetric("mongo",
+                          "data_size",
+                          "MongoDB data size",
+                          "The size of the data held in mongo collections",
+                          () => dataSize)
+  object MongoStorageSize
+      extends GaugeMetric("mongo",
+                          "storage_size",
+                          "MongoDB storage size",
+                          "The size of the storage used by the MongoDB collections",
+                          () => storageSize)
+  object MongoDeployCollectionCount
+      extends GaugeMetric("mongo",
+                          "deploys_collection_count",
+                          "Deploys collection count",
+                          "The number of documents in the deploys collection",
+                          () => deployCollectionCount)
   val all = Seq(DatastoreRequest, MongoDataSize, MongoStorageSize, MongoDeployCollectionCount)
 }
 
-object LoginCounter extends CountMetric("webapp",
-  "login_attempts",
-  "Login attempts",
-  "Number of attempted logins")
+object LoginCounter extends CountMetric("webapp", "login_attempts", "Login attempts", "Number of attempted logins")
 
-object FailedLoginCounter extends CountMetric("webapp",
-  "failed_logins",
-  "Failed logins",
-  "Number of failed logins")
+object FailedLoginCounter extends CountMetric("webapp", "failed_logins", "Failed logins", "Number of failed logins")
 
 object Metrics {
   val all: Seq[Metric] =
     magenta.metrics.MagentaMetrics.all ++
-    Seq(LoginCounter, FailedLoginCounter) ++
-    //PlayRequestMetrics.asMetrics ++
-    DeployMetrics.all ++
-    DatastoreMetrics.all ++
-    TaskMetrics.all
+      Seq(LoginCounter, FailedLoginCounter) ++
+      //PlayRequestMetrics.asMetrics ++
+      DeployMetrics.all ++
+      DatastoreMetrics.all ++
+      TaskMetrics.all
 }
 
 object Switches {
   //  val switch = new DefaultSwitch("name", "Description Text")
   val all: Seq[Switchable] = ShutdownWhenInactive.switch :: Healthcheck.switch :: Deployments.enableSwitches
 }
-

--- a/riff-raff/app/controllers/Application.scala
+++ b/riff-raff/app/controllers/Application.scala
@@ -6,7 +6,19 @@ import docs.{DeployTypeDocs, MarkDownParser}
 import play.api.mvc._
 import play.api.{Environment, Logger}
 import magenta.deployment_type.{DeploymentType, Param}
-import magenta.{App, Build, DeployParameters, DeployTarget, Deployer, DeploymentPackage, NamedStack, RecipeName, Region, Stage, withResource}
+import magenta.{
+  App,
+  Build,
+  DeployParameters,
+  DeployTarget,
+  Deployer,
+  DeploymentPackage,
+  NamedStack,
+  RecipeName,
+  Region,
+  Stage,
+  withResource
+}
 import magenta.artifact.S3Path
 import magenta.input.All
 import magenta.input.resolver.Resolver
@@ -20,23 +32,30 @@ trait Logging {
 }
 
 trait MenuItem {
-  def title:String
-  def target:Call
-  def isActive(implicit request:Request[AnyContent]):Boolean
-  def isVisible(hasIdentity:Boolean):Boolean
-  def isVisible(implicit request:Request[AnyContent]):Boolean = isVisible(UserIdentity.fromRequest(request).isDefined)
+  def title: String
+  def target: Call
+  def isActive(implicit request: Request[AnyContent]): Boolean
+  def isVisible(hasIdentity: Boolean): Boolean
+  def isVisible(implicit request: Request[AnyContent]): Boolean =
+    isVisible(UserIdentity.fromRequest(request).isDefined)
 }
 
-case class SingleMenuItem(title: String, target: Call, identityRequired: Boolean = true, activeInSubPaths: Boolean = false, enabled: Boolean = true) extends MenuItem{
+case class SingleMenuItem(title: String,
+                          target: Call,
+                          identityRequired: Boolean = true,
+                          activeInSubPaths: Boolean = false,
+                          enabled: Boolean = true)
+    extends MenuItem {
   def isActive(implicit request: Request[AnyContent]): Boolean = {
     activeInSubPaths && request.path.startsWith(target.url) || request.path == target.url
   }
-  def isVisible(hasIdentity:Boolean = false) = enabled && (hasIdentity || !identityRequired)
+  def isVisible(hasIdentity: Boolean = false) = enabled && (hasIdentity || !identityRequired)
 }
 
-case class DropDownMenuItem(title:String, items: Seq[SingleMenuItem], target: Call = Call("GET", "#")) extends MenuItem {
+case class DropDownMenuItem(title: String, items: Seq[SingleMenuItem], target: Call = Call("GET", "#"))
+    extends MenuItem {
   def isActive(implicit request: Request[AnyContent]) = items.exists(_.isActive(request))
-  def isVisible(hasIdentity:Boolean = false) = items.exists(_.isVisible(hasIdentity))
+  def isVisible(hasIdentity: Boolean = false) = items.exists(_.isVisible(hasIdentity))
 }
 
 object Menu {
@@ -45,18 +64,26 @@ object Menu {
     SingleMenuItem("History", routes.DeployController.history()),
     SingleMenuItem("Deploy", routes.DeployController.deploy()),
     DropDownMenuItem("Deployment Info", deployInfoMenu),
-    DropDownMenuItem("Configuration", Seq(
-      SingleMenuItem("Continuous Deployment", routes.ContinuousDeployController.list()),
-      SingleMenuItem("Hooks", routes.Hooks.list()),
-      SingleMenuItem("Authorisation", routes.Login.authList(), enabled = conf.Configuration.auth.whitelist.useDatabase),
-      SingleMenuItem("API keys", routes.Api.listKeys()),
-      SingleMenuItem("Restrictions", routes.Restrictions.list())
-    )),
-    DropDownMenuItem("Documentation", Seq(
-      SingleMenuItem("Deployment Types", routes.Application.documentation("magenta-lib/types")),
-      SingleMenuItem("Validate configuration", routes.Application.validationForm),
-      SingleMenuItem("Everything else", routes.Application.documentation(""))
-    ))
+    DropDownMenuItem(
+      "Configuration",
+      Seq(
+        SingleMenuItem("Continuous Deployment", routes.ContinuousDeployController.list()),
+        SingleMenuItem("Hooks", routes.Hooks.list()),
+        SingleMenuItem("Authorisation",
+                       routes.Login.authList(),
+                       enabled = conf.Configuration.auth.whitelist.useDatabase),
+        SingleMenuItem("API keys", routes.Api.listKeys()),
+        SingleMenuItem("Restrictions", routes.Restrictions.list())
+      )
+    ),
+    DropDownMenuItem(
+      "Documentation",
+      Seq(
+        SingleMenuItem("Deployment Types", routes.Application.documentation("magenta-lib/types")),
+        SingleMenuItem("Validate configuration", routes.Application.validationForm),
+        SingleMenuItem("Everything else", routes.Application.documentation(""))
+      )
+    )
   )
 
   lazy val deployInfoMenu = Seq(
@@ -69,7 +96,10 @@ object Menu {
 }
 
 class Application(prismLookup: PrismLookup, deploymentTypes: Seq[DeploymentType])(implicit environment: Environment,
-  val wsClient: WSClient) extends Controller with Logging with LoginActions {
+                                                                                  val wsClient: WSClient)
+    extends Controller
+    with Logging
+    with LoginActions {
 
   import Application._
 
@@ -89,10 +119,12 @@ class Application(prismLookup: PrismLookup, deploymentTypes: Seq[DeploymentType]
   }
 
   def deployInfoHosts(appFilter: String) = AuthAction { implicit request =>
-    val hosts = prismLookup.hosts.all.filter { host =>
-      host.apps.exists(_.toString.matches(s"(?i).*${appFilter}.*")) &&
-      request.getQueryString("stack").forall(s => host.stack.exists(_ == s))
-    }.groupBy(_.stage)
+    val hosts = prismLookup.hosts.all
+      .filter { host =>
+        host.apps.exists(_.toString.matches(s"(?i).*${appFilter}.*")) &&
+        request.getQueryString("stack").forall(s => host.stack.exists(_ == s))
+      }
+      .groupBy(_.stage)
     Ok(views.html.deploy.deployInfoHosts(request, hosts, prismLookup))
   }
 
@@ -103,22 +135,22 @@ class Application(prismLookup: PrismLookup, deploymentTypes: Seq[DeploymentType]
   val Prev = """.*prev:(\S+).*""".r
   val Next = """.*next:(\S+).*""".r
 
-  def makeAbsolute(resource:String, relative:String): String = {
+  def makeAbsolute(resource: String, relative: String): String = {
     if (relative.isEmpty)
       resource
     else if (relative.startsWith("/"))
       relative
     else {
-      val base = if (resource.endsWith("/")) resource else resource.split("/").init.mkString("","/","/")
+      val base = if (resource.endsWith("/")) resource else resource.split("/").init.mkString("", "/", "/")
       if (relative.startsWith("../")) {
-        makeAbsolute(resource.split("/").init.init.mkString("","/","/"),relative.stripPrefix("../"))
+        makeAbsolute(resource.split("/").init.init.mkString("", "/", "/"), relative.stripPrefix("../"))
       } else {
         base + relative
       }
     }
   }
 
-  def getNextPrevFromHeader(resource: String, lines: List[String]):(Option[Link], Option[Link]) = {
+  def getNextPrevFromHeader(resource: String, lines: List[String]): (Option[Link], Option[Link]) = {
     val header = lines.head
     val prev = header match {
       case Prev(prevUrl) => Link(makeAbsolute(resource, prevUrl))
@@ -129,12 +161,12 @@ class Application(prismLookup: PrismLookup, deploymentTypes: Seq[DeploymentType]
       case _ => None
     }
     log.info(s"Header is $header $prev $next")
-    (next,prev)
+    (next, prev)
   }
 
   def documentation(resource: String) = {
     if (resource.endsWith(".png")) {
-      Assets.at("/docs",resource)
+      Assets.at("/docs", resource)
     } else {
       AuthAction { request =>
         if (resource.endsWith("/index")) {
@@ -142,29 +174,33 @@ class Application(prismLookup: PrismLookup, deploymentTypes: Seq[DeploymentType]
         } else {
           val markDownLines = getMarkdownLines(resource)
           if (markDownLines.isEmpty) {
-              NotFound(views.html.notFound(request,s"No documentation found for $resource"))
+            NotFound(views.html.notFound(request, s"No documentation found for $resource"))
           } else {
             val markDown = markDownLines.mkString("\n")
 
             val title = getMarkdownTitle(markDownLines).getOrElse(resource)
-            val (next,prev) = getNextPrevFromHeader(resource,markDownLines)
+            val (next, prev) = getNextPrevFromHeader(resource, markDownLines)
 
             val breadcrumbs = {
               val hierarchy = resource.split('/').filterNot(_.isEmpty).dropRight(1)
-              hierarchy.foldLeft(List(Link("Documentation",routes.Application.documentation(""),""))){ (acc, crumb) =>
-                acc ++ Link(List(acc.last.url.stripSuffix("/"),crumb).filterNot(_.isEmpty).mkString("","/","/"))
+              hierarchy.foldLeft(List(Link("Documentation", routes.Application.documentation(""), ""))) {
+                (acc, crumb) =>
+                  acc ++ Link(List(acc.last.url.stripSuffix("/"), crumb).filterNot(_.isEmpty).mkString("", "/", "/"))
               } ++ Some(Link(title, routes.Application.documentation(resource), resource))
             }
 
             resource match {
               case "magenta-lib/types" =>
-                val sections = DeployTypeDocs.generateDocs(deploymentTypes).map { case (dt, docs) =>
-                  val typeDocumentation = views.html.documentation.deploymentTypeSnippet(docs)
-                  (dt.name, typeDocumentation)
+                val sections = DeployTypeDocs.generateDocs(deploymentTypes).map {
+                  case (dt, docs) =>
+                    val typeDocumentation = views.html.documentation.deploymentTypeSnippet(docs)
+                    (dt.name, typeDocumentation)
                 }
                 Ok(views.html.documentation.markdownBlocks(request, "Deployment Types", breadcrumbs, sections))
               case _ =>
-                Ok(views.html.documentation.markdown(request, s"Documentation: $title", markDown, breadcrumbs, prev, next))
+                Ok(
+                  views.html.documentation
+                    .markdown(request, s"Documentation: $title", markDown, breadcrumbs, prev, next))
             }
           }
         }
@@ -181,9 +217,9 @@ class Application(prismLookup: PrismLookup, deploymentTypes: Seq[DeploymentType]
     val data = request.body
     log.warn(data.toString)
     val maybeConfiguration = data.asFormUrlEncoded.flatMap(_.get("configuration")).getOrElse(Nil).headOption
-    maybeConfiguration.fold{
+    maybeConfiguration.fold {
       BadRequest("No configuration provided to validate")
-    }{ config =>
+    } { config =>
       Resolver.resolveDeploymentGraph(config, deploymentTypes, All) match {
         case Valid(deployments) =>
           Ok(views.html.validation.validationPassed(request, deployments))
@@ -195,7 +231,7 @@ class Application(prismLookup: PrismLookup, deploymentTypes: Seq[DeploymentType]
 
   def javascriptRoutes = Action { implicit request =>
     import play.api.routing._
-    Ok{
+    Ok {
       JavaScriptReverseRouter("jsRoutes")(
         routes.javascript.DeployController.stop,
         routes.javascript.DeployController.deployHistory,
@@ -212,9 +248,9 @@ class Application(prismLookup: PrismLookup, deploymentTypes: Seq[DeploymentType]
 
 object Application extends Logging {
 
-  case class Link(title:String, call:Call, url:String)
+  case class Link(title: String, call: Call, url: String)
   object Link {
-    def apply(url:String)(implicit environment: Environment):Option[Link] = {
+    def apply(url: String)(implicit environment: Environment): Option[Link] = {
       getMarkdownTitle(getMarkdownLines(url)).map { prevTitle =>
         Link(prevTitle, routes.Application.documentation(url), url)
       }
@@ -222,25 +258,28 @@ object Application extends Logging {
 
   }
 
-  def getMarkdownTitle(lines: List[String]):Option[String] = {
+  def getMarkdownTitle(lines: List[String]): Option[String] = {
     lines.find(line => !line.trim.isEmpty && !line.trim.startsWith("<!--"))
   }
 
   def getMarkdownLines(resource: String)(implicit environment: Environment): List[String] = {
     val res = if (resource.isEmpty || resource.last == '/') s"${resource}index" else resource
-    val realResource = if(res.endsWith(".md")) res else res + ".md"
+    val realResource = if (res.endsWith(".md")) res else res + ".md"
     log.info(s"Getting page for $realResource")
     try {
-      withResource(environment.resourceAsStream(s"public/docs/$realResource").orElse(environment.resourceAsStream(s"$realResource")).get) { url =>
+      withResource(
+        environment
+          .resourceAsStream(s"public/docs/$realResource")
+          .orElse(environment.resourceAsStream(s"$realResource"))
+          .get) { url =>
         log.info(s"Resolved URL $url")
         Source.fromInputStream(url).getLines().toList
       }
     } catch {
-      case e:Throwable =>
+      case e: Throwable =>
         log.warn(s"$resource is not a valid page of documentation")
         Nil
     }
   }
-
 
 }

--- a/riff-raff/app/controllers/ContinuousDeployController.scala
+++ b/riff-raff/app/controllers/ContinuousDeployController.scala
@@ -14,7 +14,12 @@ import ci.{ContinuousDeploymentConfig, Trigger}
 import persistence.ContinuousDeploymentConfigRepository
 import resources.PrismLookup
 
-class ContinuousDeployController(prismLookup: PrismLookup)(implicit val messagesApi: MessagesApi, val wsClient: WSClient) extends Controller with Logging with LoginActions with I18nSupport {
+class ContinuousDeployController(prismLookup: PrismLookup)(implicit val messagesApi: MessagesApi,
+                                                           val wsClient: WSClient)
+    extends Controller
+    with Logging
+    with LoginActions
+    with I18nSupport {
   import ContinuousDeployController._
 
   val continuousDeploymentForm = Form[ConfigForm](
@@ -29,41 +34,59 @@ class ContinuousDeployController(prismLookup: PrismLookup)(implicit val messages
   )
 
   def list = AuthAction { implicit request =>
-    val configs = ContinuousDeploymentConfigRepository.getContinuousDeploymentList().sortBy(q => (q.projectName, q.stage))
+    val configs =
+      ContinuousDeploymentConfigRepository.getContinuousDeploymentList().sortBy(q => (q.projectName, q.stage))
     Ok(views.html.continuousDeployment.list(request, configs))
   }
 
   def form = AuthAction { implicit request =>
-    Ok(views.html.continuousDeployment.form(continuousDeploymentForm.fill(ConfigForm(UUID.randomUUID(),"","","default",None,Trigger.SuccessfulBuild.id)), prismLookup))
+    Ok(
+      views.html.continuousDeployment.form(
+        continuousDeploymentForm.fill(
+          ConfigForm(UUID.randomUUID(), "", "", "default", None, Trigger.SuccessfulBuild.id)),
+        prismLookup))
   }
 
   def save = AuthAction { implicit request =>
-    continuousDeploymentForm.bindFromRequest().fold(
-      formWithErrors => Ok(views.html.continuousDeployment.form(formWithErrors, prismLookup)),
-      form => {
-        val config = ContinuousDeploymentConfig(
-          form.id, form.projectName, form.stage, form.recipe, form.branchMatcher, Trigger(form.trigger), request.user.fullName, new DateTime()
-        )
-        ContinuousDeploymentConfigRepository.setContinuousDeployment(config)
-        Redirect(routes.ContinuousDeployController.list())
-      }
-    )
+    continuousDeploymentForm
+      .bindFromRequest()
+      .fold(
+        formWithErrors => Ok(views.html.continuousDeployment.form(formWithErrors, prismLookup)),
+        form => {
+          val config = ContinuousDeploymentConfig(
+            form.id,
+            form.projectName,
+            form.stage,
+            form.recipe,
+            form.branchMatcher,
+            Trigger(form.trigger),
+            request.user.fullName,
+            new DateTime()
+          )
+          ContinuousDeploymentConfigRepository.setContinuousDeployment(config)
+          Redirect(routes.ContinuousDeployController.list())
+        }
+      )
   }
 
   def edit(id: String) = AuthAction { implicit request =>
-    ContinuousDeploymentConfigRepository.getContinuousDeployment(UUID.fromString(id)).map{ config =>
-      Ok(views.html.continuousDeployment.form(continuousDeploymentForm.fill(ConfigForm(config)), prismLookup))
-    }.getOrElse(Redirect(routes.ContinuousDeployController.list()))
+    ContinuousDeploymentConfigRepository
+      .getContinuousDeployment(UUID.fromString(id))
+      .map { config =>
+        Ok(views.html.continuousDeployment.form(continuousDeploymentForm.fill(ConfigForm(config)), prismLookup))
+      }
+      .getOrElse(Redirect(routes.ContinuousDeployController.list()))
   }
 
   def delete(id: String) = AuthAction { implicit request =>
-    Form("action" -> nonEmptyText).bindFromRequest().fold(
-      errors => {},
-      {
-        case "delete" =>
-          ContinuousDeploymentConfigRepository.deleteContinuousDeployment(UUID.fromString(id))
-      }
-    )
+    Form("action" -> nonEmptyText)
+      .bindFromRequest()
+      .fold(
+        errors => {}, {
+          case "delete" =>
+            ContinuousDeploymentConfigRepository.deleteContinuousDeployment(UUID.fromString(id))
+        }
+      )
     Redirect(routes.ContinuousDeployController.list())
   }
 
@@ -71,11 +94,15 @@ class ContinuousDeployController(prismLookup: PrismLookup)(implicit val messages
 
 object ContinuousDeployController {
 
-  case class ConfigForm(id: UUID, projectName: String, stage: String, recipe: String, branchMatcher:Option[String], trigger: Int)
+  case class ConfigForm(id: UUID,
+                        projectName: String,
+                        stage: String,
+                        recipe: String,
+                        branchMatcher: Option[String],
+                        trigger: Int)
   object ConfigForm {
     def apply(cd: ContinuousDeploymentConfig): ConfigForm =
       ConfigForm(cd.id, cd.projectName, cd.stage, cd.recipe, cd.branchMatcher, cd.trigger.id)
   }
 
 }
-

--- a/riff-raff/app/controllers/DeployController.scala
+++ b/riff-raff/app/controllers/DeployController.scala
@@ -28,55 +28,67 @@ import restrictions.RestrictionChecker
 
 import scala.util.{Failure, Success}
 
-class DeployController(deployments: Deployments, prismLookup: PrismLookup, deploymentTypes: Seq[DeploymentType])
-                      (implicit val messagesApi: MessagesApi, val wsClient: WSClient) extends Controller with Logging with LoginActions with I18nSupport {
+class DeployController(deployments: Deployments, prismLookup: PrismLookup, deploymentTypes: Seq[DeploymentType])(
+    implicit val messagesApi: MessagesApi,
+    val wsClient: WSClient)
+    extends Controller
+    with Logging
+    with LoginActions
+    with I18nSupport {
 
   def deploy = AuthAction { implicit request =>
     Ok(views.html.deploy.form(DeployParameterForm.form, prismLookup))
   }
 
   def processForm = AuthAction { implicit request =>
-    DeployParameterForm.form.bindFromRequest().fold(
-      errors => {
-        logger.info(s"Errors: ${errors.errors}")
-        BadRequest(views.html.deploy.form(errors, prismLookup))
-      },
-      form => {
-        log.info(s"Host list: ${form.hosts}")
-        val defaultRecipe = prismLookup.data
-          .datum("default-recipe", App(form.project), Stage(form.stage), UnnamedStack)
-          .map(data => RecipeName(data.value)).getOrElse(DefaultRecipe())
-        val parameters = new DeployParameters(Deployer(request.user.fullName),
-          Build(form.project, form.build.toString),
-          Stage(form.stage),
-          recipe = form.recipe.map(RecipeName).getOrElse(defaultRecipe),
-          stacks = form.stacks.map(NamedStack(_)),
-          hostList = form.hosts,
-          selector = form.makeSelector
-        )
+    DeployParameterForm.form
+      .bindFromRequest()
+      .fold(
+        errors => {
+          logger.info(s"Errors: ${errors.errors}")
+          BadRequest(views.html.deploy.form(errors, prismLookup))
+        },
+        form => {
+          log.info(s"Host list: ${form.hosts}")
+          val defaultRecipe = prismLookup.data
+            .datum("default-recipe", App(form.project), Stage(form.stage), UnnamedStack)
+            .map(data => RecipeName(data.value))
+            .getOrElse(DefaultRecipe())
+          val parameters = new DeployParameters(
+            Deployer(request.user.fullName),
+            Build(form.project, form.build.toString),
+            Stage(form.stage),
+            recipe = form.recipe.map(RecipeName).getOrElse(defaultRecipe),
+            stacks = form.stacks.map(NamedStack(_)),
+            hostList = form.hosts,
+            selector = form.makeSelector
+          )
 
-        form.action match {
-          case "preview" =>
-            val maybeKeys = parameters.selector match {
-              case All => None
-              case DeploymentKeysSelector(keys) => Some(DeploymentKey.asString(keys))
-            }
-            Redirect(routes.PreviewController.preview(
-              parameters.build.projectName, parameters.build.id, parameters.stage.name, maybeKeys)
-            ).flashing(
-              "previewRecipe" -> parameters.recipe.name,
-              "previewHosts" -> parameters.hostList.mkString(","),
-              "previewStacks" -> parameters.stacks.flatMap(_.nameOption).mkString(",")
-            )
-          case "deploy" =>
-            val uuid = deployments.deploy(parameters, requestSource = UserRequestSource(request.user)).valueOr{ error =>
-              throw new IllegalStateException(error.message)
-            }
-            Redirect(routes.DeployController.viewUUID(uuid.toString))
-          case _ => throw new RuntimeException("Unknown action")
+          form.action match {
+            case "preview" =>
+              val maybeKeys = parameters.selector match {
+                case All => None
+                case DeploymentKeysSelector(keys) => Some(DeploymentKey.asString(keys))
+              }
+              Redirect(
+                routes.PreviewController.preview(parameters.build.projectName,
+                                                 parameters.build.id,
+                                                 parameters.stage.name,
+                                                 maybeKeys)).flashing(
+                "previewRecipe" -> parameters.recipe.name,
+                "previewHosts" -> parameters.hostList.mkString(","),
+                "previewStacks" -> parameters.stacks.flatMap(_.nameOption).mkString(",")
+              )
+            case "deploy" =>
+              val uuid = deployments.deploy(parameters, requestSource = UserRequestSource(request.user)).valueOr {
+                error =>
+                  throw new IllegalStateException(error.message)
+              }
+              Redirect(routes.DeployController.viewUUID(uuid.toString))
+            case _ => throw new RuntimeException("Unknown action")
+          }
         }
-      }
-    )
+      )
   }
 
   def stop(uuid: String) = AuthAction { implicit request =>
@@ -96,20 +108,36 @@ class DeployController(deployments: Deployments, prismLookup: PrismLookup, deplo
     Ok(views.html.deploy.logContent(record))
   }
 
-  def preview(projectName: String, buildId: String, stage: String, recipe: String, hosts: String, stacks: String) = AuthAction { implicit request =>
-    val hostList = hosts.split(",").toList.filterNot(_.isEmpty)
-    val stackList = stacks.split(",").toList.filterNot(_.isEmpty).map(NamedStack(_))
-    val parameters = DeployParameters(Deployer(request.user.fullName), Build(projectName, buildId), Stage(stage), RecipeName(recipe), stackList, hostList)
-    val previewId = LegacyPreviewController.startPreview(parameters, prismLookup, deploymentTypes)
-    Ok(views.html.preview.json.preview(request, parameters, previewId.toString))
-  }
+  def preview(projectName: String, buildId: String, stage: String, recipe: String, hosts: String, stacks: String) =
+    AuthAction { implicit request =>
+      val hostList = hosts.split(",").toList.filterNot(_.isEmpty)
+      val stackList = stacks.split(",").toList.filterNot(_.isEmpty).map(NamedStack(_))
+      val parameters = DeployParameters(Deployer(request.user.fullName),
+                                        Build(projectName, buildId),
+                                        Stage(stage),
+                                        RecipeName(recipe),
+                                        stackList,
+                                        hostList)
+      val previewId = LegacyPreviewController.startPreview(parameters, prismLookup, deploymentTypes)
+      Ok(views.html.preview.json.preview(request, parameters, previewId.toString))
+    }
 
-  def previewContent(previewId: String, projectName: String, buildId: String, stage: String, recipe: String, hosts: String) =
+  def previewContent(previewId: String,
+                     projectName: String,
+                     buildId: String,
+                     stage: String,
+                     recipe: String,
+                     hosts: String) =
     AuthAction { implicit request =>
       val previewUUID = UUID.fromString(previewId)
       val hostList = hosts.split(",").toList.filterNot(_.isEmpty)
       val parameters = DeployParameters(
-        Deployer(request.user.fullName), Build(projectName, buildId), Stage(stage), RecipeName(recipe), Seq(), hostList
+        Deployer(request.user.fullName),
+        Build(projectName, buildId),
+        Stage(stage),
+        RecipeName(recipe),
+        Seq(),
+        hostList
       )
       val result = LegacyPreviewController.getPreview(previewUUID, parameters)
       result match {
@@ -122,7 +150,8 @@ class DeployController(deployments: Deployments, prismLookup: PrismLookup, deplo
                 case exception: Exception =>
                   Ok(views.html.errorContent(exception, "Couldn't resolve preview information."))
               }
-            case Some(Failure(exception)) => Ok(views.html.errorContent(exception, "Couldn't retrieve preview information."))
+            case Some(Failure(exception)) =>
+              Ok(views.html.errorContent(exception, "Couldn't retrieve preview information."))
             case None =>
               val duration = new org.joda.time.Duration(startTime, new DateTime())
               Ok(views.html.preview.json.loading(request, duration.getStandardSeconds))
@@ -139,7 +168,11 @@ class DeployController(deployments: Deployments, prismLookup: PrismLookup, deplo
 
   def historyContent() = AuthAction { implicit request =>
     val records = try {
-      Deployments.getDeploys(deployment.DeployFilter.fromRequest(request), deployment.PaginationView.fromRequest(request), fetchLogs = false).reverse
+      Deployments
+        .getDeploys(deployment.DeployFilter.fromRequest(request),
+                    deployment.PaginationView.fromRequest(request),
+                    fetchLogs = false)
+        .reverse
     } catch {
       case e: Exception =>
         log.error("Exception whilst fetching records", e)
@@ -150,23 +183,29 @@ class DeployController(deployments: Deployments, prismLookup: PrismLookup, deplo
     } catch {
       case e: Exception => None
     }
-    Ok(views.html.deploy.historyContent(request, records, deployment.DeployFilterPagination.fromRequest.withItemCount(count)))
+    Ok(
+      views.html.deploy
+        .historyContent(request, records, deployment.DeployFilterPagination.fromRequest.withItemCount(count)))
   }
 
   def autoCompleteProject(term: String) = AuthAction {
-    val possibleProjects = Builds.jobs.map(_.name).filter(_.toLowerCase.contains(term.toLowerCase)).toList.sorted.take(10)
+    val possibleProjects =
+      Builds.jobs.map(_.name).filter(_.toLowerCase.contains(term.toLowerCase)).toList.sorted.take(10)
     Ok(Json.toJson(possibleProjects))
   }
 
   val shortFormat = DateTimeFormat.forPattern("HH:mm d/M/yy").withZone(DateTimeZone.forID("Europe/London"))
 
   def autoCompleteBuild(project: String, term: String) = AuthAction {
-    val possibleProjects = Builds.successfulBuilds(project).filter(
-      p => p.number.contains(term) || p.branchName.contains(term)
-    ).map { build =>
-      val label = "%s [%s] (%s)" format(build.number, build.branchName, shortFormat.print(build.startTime))
-      Map("label" -> label, "value" -> build.number)
-    }
+    val possibleProjects = Builds
+      .successfulBuilds(project)
+      .filter(
+        p => p.number.contains(term) || p.branchName.contains(term)
+      )
+      .map { build =>
+        val label = "%s [%s] (%s)" format (build.number, build.branchName, shortFormat.print(build.startTime))
+        Map("label" -> label, "value" -> build.number)
+      }
     Ok(Json.toJson(possibleProjects))
   }
 
@@ -175,7 +214,10 @@ class DeployController(deployments: Deployments, prismLookup: PrismLookup, deplo
       Ok("")
     } else {
       val restrictions = maybeStage.toSeq.flatMap { stage =>
-        RestrictionChecker.configsThatPreventDeployment(RestrictionConfigDynamoRepository, project, stage, UserRequestSource(request.user))
+        RestrictionChecker.configsThatPreventDeployment(RestrictionConfigDynamoRepository,
+                                                        project,
+                                                        stage,
+                                                        UserRequestSource(request.user))
       }
       val filter = DeployFilter(projectName = Some(s"^$project$$"), stage = maybeStage)
       val records = Deployments.getDeploys(Some(filter), PaginationView(pageSize = Some(5)), fetchLogs = false).reverse
@@ -190,8 +232,9 @@ class DeployController(deployments: Deployments, prismLookup: PrismLookup, deplo
       tags <- S3Tag.of(b)
     } yield (b, tags)
 
-    buildTagTuple map { case (b, tags) =>
-      Ok(views.html.deploy.buildInfo(b, tags.map(TagClassification.apply)))
+    buildTagTuple map {
+      case (b, tags) =>
+        Ok(views.html.deploy.buildInfo(b, tags.map(TagClassification.apply)))
     } getOrElse Ok("")
   }
 
@@ -199,7 +242,7 @@ class DeployController(deployments: Deployments, prismLookup: PrismLookup, deplo
     val header = Seq("Build Type Name", "Build Number", "Build Branch", "Build Type ID", "Build ID")
     val data =
       for (build <- Builds.all.sortBy(_.jobName))
-      yield Seq(build.jobName, build.number, build.branchName, build.jobId, build.id)
+        yield Seq(build.jobName, build.number, build.branchName, build.jobId, build.id)
 
     Ok((header :: data.toList).map(_.mkString(",")).mkString("\n")).as("text/csv")
   }
@@ -228,32 +271,44 @@ class DeployController(deployments: Deployments, prismLookup: PrismLookup, deplo
       case All => Nil
     }
 
-    val params = DeployParameterForm(record.buildName, record.buildId, record.stage.name,
-      Some(record.recipe.name), "deploy", Nil, record.stacks.toList.flatMap(_.nameOption), keys, None)
+    val params = DeployParameterForm(record.buildName,
+                                     record.buildId,
+                                     record.stage.name,
+                                     Some(record.recipe.name),
+                                     "deploy",
+                                     Nil,
+                                     record.stacks.toList.flatMap(_.nameOption),
+                                     keys,
+                                     None)
 
     val fields = DeployParameterForm.form.fill(params).data
 
-    def queryString = fields.map {
-      case (k, v) => k + "=" + URLEncoder.encode(v, "UTF-8")
-    }.mkString("&")
+    def queryString =
+      fields
+        .map {
+          case (k, v) => k + "=" + URLEncoder.encode(v, "UTF-8")
+        }
+        .mkString("&")
 
     val url = s"${routes.DeployController.deployAgain().url}?$queryString"
     Redirect(url)
   }
 
   def markAsFailed = AuthAction { implicit request =>
-    UuidForm.form.bindFromRequest().fold(
-      errors => Redirect(routes.DeployController.history),
-      form => {
-        form.action match {
-          case "markAsFailed" =>
-            val record = Deployments.get(UUID.fromString(form.uuid))
-            if (record.isStalled)
-              Deployments.markAsFailed(record)
-            Redirect(routes.DeployController.viewUUID(form.uuid))
+    UuidForm.form
+      .bindFromRequest()
+      .fold(
+        errors => Redirect(routes.DeployController.history),
+        form => {
+          form.action match {
+            case "markAsFailed" =>
+              val record = Deployments.get(UUID.fromString(form.uuid))
+              if (record.isStalled)
+                Deployments.markAsFailed(record)
+              Redirect(routes.DeployController.viewUUID(form.uuid))
+          }
         }
-      }
-    )
+      )
   }
 
   def dashboard(projects: String, search: Boolean) = AuthAction { implicit request =>
@@ -267,9 +322,11 @@ class DeployController(deployments: Deployments, prismLookup: PrismLookup, deplo
         Deployments.findProjects().filter(_.contains(term))
       })
     } else projectTerms
-    val deploys = projectNames.map { project =>
-      project -> Deployments.getLastCompletedDeploys(project)
-    }.filterNot(_._2.isEmpty)
+    val deploys = projectNames
+      .map { project =>
+        project -> Deployments.getLastCompletedDeploys(project)
+      }
+      .filterNot(_._2.isEmpty)
     Ok(views.html.deploy.dashboardContent(deploys))
   }
 
@@ -284,12 +341,17 @@ class DeployController(deployments: Deployments, prismLookup: PrismLookup, deplo
     val deployObject = pathAndContent(S3YamlArtifact(build, Configuration.artifact.aws.bucketName))
       .orElse(pathAndContent(S3JsonArtifact(build, Configuration.artifact.aws.bucketName)))
 
-    deployObject.map {
-      case (path, contents) => Ok(contents).as(path.extension.map {
-        case "json" => "application/json"
-        case "yaml" => "text/vnd-yaml"
-      }.getOrElse("text/plain"))
-    }.getOrElse(NotFound(s"Deploy file not found for $projectName $id"))
+    deployObject
+      .map {
+        case (path, contents) =>
+          Ok(contents).as(path.extension
+            .map {
+              case "json" => "application/json"
+              case "yaml" => "text/vnd-yaml"
+            }
+            .getOrElse("text/plain"))
+      }
+      .getOrElse(NotFound(s"Deploy file not found for $projectName $id"))
   }
 
   def deployFiles(projectName: String, id: String) = AuthAction { implicit request =>
@@ -303,17 +365,21 @@ class DeployController(deployments: Deployments, prismLookup: PrismLookup, deplo
     val deployObject = pathAndContent(S3YamlArtifact(build, Configuration.artifact.aws.bucketName))
       .orElse(pathAndContent(S3JsonArtifact(build, Configuration.artifact.aws.bucketName)))
 
-    deployObject.map { case (artifact, path, configFile) =>
-      val objects = artifact.listAll()(Configuration.artifact.aws.client)
-      val relativeObjects = objects.map{ obj => obj.relativeTo(artifact) -> obj}
-      Ok(views.html.artifact.listFiles(request, projectName, id, relativeObjects))
+    deployObject.map {
+      case (artifact, path, configFile) =>
+        val objects = artifact.listAll()(Configuration.artifact.aws.client)
+        val relativeObjects = objects.map { obj =>
+          obj.relativeTo(artifact) -> obj
+        }
+        Ok(views.html.artifact.listFiles(request, projectName, id, relativeObjects))
     } getOrElse {
       NotFound("Project not found")
     }
   }
 
   def getArtifactFile(key: String) = AuthAction { implicit request =>
-    val s3doc = Configuration.artifact.aws.client.getObject(new GetObjectRequest(Configuration.artifact.aws.bucketName, key))
+    val s3doc =
+      Configuration.artifact.aws.client.getObject(new GetObjectRequest(Configuration.artifact.aws.bucketName, key))
     val stream = s3doc.getObjectContent
     val source: Source[ByteString, _] = StreamConverters.fromInputStream(() => stream)
     Ok.sendEntity(HttpEntity.Streamed(source, None, Some(""))).as(s3doc.getObjectMetadata.getContentType)

--- a/riff-raff/app/controllers/Restrictions.scala
+++ b/riff-raff/app/controllers/Restrictions.scala
@@ -15,8 +15,10 @@ import restrictions.{RestrictionChecker, RestrictionConfig, RestrictionForm}
 
 import scala.util.Try
 
-class Restrictions()(implicit val messagesApi: MessagesApi, val wsClient: WSClient) extends Controller with LoginActions
-  with I18nSupport {
+class Restrictions()(implicit val messagesApi: MessagesApi, val wsClient: WSClient)
+    extends Controller
+    with LoginActions
+    with I18nSupport {
 
   lazy val restrictionsForm = Form[RestrictionForm](
     mapping(
@@ -27,16 +29,28 @@ class Restrictions()(implicit val messagesApi: MessagesApi, val wsClient: WSClie
       "whitelist" -> optional(text),
       "continuousDeployment" -> boolean,
       "note" -> nonEmptyText
-    )((id, projectName, stage, editingLocked, whitelist, cdPermitted, note) =>
-      RestrictionForm(id, projectName, stage, editingLocked,
-        whitelist.map(_.split('\n').map(_.trim).toSeq.filter(_.nonEmpty)).getOrElse(Seq.empty), cdPermitted, note)
-    )(f =>
-      Some((f.id, f.projectName, f.stage, f.editingLocked, Some(f.whitelist.mkString("\n")),
-        f.continuousDeployment,  f.note))
-    ).verifying(
-      "Stage is invalid - should be a valid regular expression or contain no special values",
-      form => Try(form.stage.r).isSuccess
-    )
+    )(
+      (id, projectName, stage, editingLocked, whitelist, cdPermitted, note) =>
+        RestrictionForm(id,
+                        projectName,
+                        stage,
+                        editingLocked,
+                        whitelist.map(_.split('\n').map(_.trim).toSeq.filter(_.nonEmpty)).getOrElse(Seq.empty),
+                        cdPermitted,
+                        note))(
+      f =>
+        Some(
+          (f.id,
+           f.projectName,
+           f.stage,
+           f.editingLocked,
+           Some(f.whitelist.mkString("\n")),
+           f.continuousDeployment,
+           f.note)))
+      .verifying(
+        "Stage is invalid - should be a valid regular expression or contain no special values",
+        form => Try(form.stage.r).isSuccess
+      )
   )
 
   def list = AuthAction { implicit request =>
@@ -51,38 +65,62 @@ class Restrictions()(implicit val messagesApi: MessagesApi, val wsClient: WSClie
   }
 
   def save = AuthAction { implicit request =>
-    restrictionsForm.bindFromRequest().fold(
-      formWithErrors => Ok(views.html.restrictions.form(formWithErrors, saveDisabled = false)),
-      f => {
-        RestrictionChecker.isEditable(RestrictionConfigDynamoRepository.getRestriction(f.id), request.user, auth.superusers) match {
-          case Right(_) =>
-            val newConfig = RestrictionConfig(f.id, f.projectName, f.stage, new DateTime(), request.user.fullName,
-              request.user.email, f.editingLocked, f.whitelist, f.continuousDeployment, f.note)
-            RestrictionConfigDynamoRepository.setRestriction(newConfig)
-            Redirect(routes.Restrictions.list())
-          case Left(Error(reason)) =>
-            Forbidden(s"Not possible to update this restriction: $reason")
+    restrictionsForm
+      .bindFromRequest()
+      .fold(
+        formWithErrors => Ok(views.html.restrictions.form(formWithErrors, saveDisabled = false)),
+        f => {
+          RestrictionChecker.isEditable(RestrictionConfigDynamoRepository.getRestriction(f.id),
+                                        request.user,
+                                        auth.superusers) match {
+            case Right(_) =>
+              val newConfig = RestrictionConfig(f.id,
+                                                f.projectName,
+                                                f.stage,
+                                                new DateTime(),
+                                                request.user.fullName,
+                                                request.user.email,
+                                                f.editingLocked,
+                                                f.whitelist,
+                                                f.continuousDeployment,
+                                                f.note)
+              RestrictionConfigDynamoRepository.setRestriction(newConfig)
+              Redirect(routes.Restrictions.list())
+            case Left(Error(reason)) =>
+              Forbidden(s"Not possible to update this restriction: $reason")
+          }
         }
-      }
-    )
+      )
   }
 
   def edit(id: String) = AuthAction { implicit request =>
-    RestrictionConfigDynamoRepository.getRestriction(UUID.fromString(id)).map{ rc =>
-      val form = restrictionsForm.fill(
-        RestrictionForm(rc.id, rc.projectName, rc.stage, rc.editingLocked, rc.whitelist, rc.continuousDeployment, rc.note)
-      )
-      val cannotSave = RestrictionChecker.isEditable(Some(rc), request.user, auth.superusers).isLeft
+    RestrictionConfigDynamoRepository
+      .getRestriction(UUID.fromString(id))
+      .map { rc =>
+        val form = restrictionsForm.fill(
+          RestrictionForm(rc.id,
+                          rc.projectName,
+                          rc.stage,
+                          rc.editingLocked,
+                          rc.whitelist,
+                          rc.continuousDeployment,
+                          rc.note)
+        )
+        val cannotSave = RestrictionChecker.isEditable(Some(rc), request.user, auth.superusers).isLeft
 
-      Ok(views.html.restrictions.form(
-        restrictionForm = form,
-        saveDisabled = cannotSave
-      ))
-    }.getOrElse(Redirect(routes.Restrictions.list()))
+        Ok(
+          views.html.restrictions.form(
+            restrictionForm = form,
+            saveDisabled = cannotSave
+          ))
+      }
+      .getOrElse(Redirect(routes.Restrictions.list()))
   }
 
   def delete(id: String) = AuthAction { request =>
-    RestrictionChecker.isEditable(RestrictionConfigDynamoRepository.getRestriction(UUID.fromString(id)), request.user, auth.superusers) match {
+    RestrictionChecker.isEditable(RestrictionConfigDynamoRepository.getRestriction(UUID.fromString(id)),
+                                  request.user,
+                                  auth.superusers) match {
       case Right(_) =>
         RestrictionConfigDynamoRepository.deleteRestriction(UUID.fromString(id))
         Redirect(routes.Restrictions.list())

--- a/riff-raff/app/controllers/Testing.scala
+++ b/riff-raff/app/controllers/Testing.scala
@@ -19,12 +19,17 @@ import resources.PrismLookup
 
 case class SimpleDeployDetail(uuid: UUID, time: Option[DateTime])
 
-class Testing(prismLookup: PrismLookup)(implicit val messagesApi: MessagesApi, val wsClient: WSClient) extends Controller with Logging with LoginActions with I18nSupport {
+class Testing(prismLookup: PrismLookup)(implicit val messagesApi: MessagesApi, val wsClient: WSClient)
+    extends Controller
+    with Logging
+    with LoginActions
+    with I18nSupport {
   import Testing._
 
   def reportTestPartial(take: Int, verbose: Boolean) = Action { implicit request =>
     val logUUID = UUID.randomUUID()
-    val parameters = DeployParameters(Deployer("Simon Hildrew"), Build("tools::deploy", "131"), Stage("DEV"), DefaultRecipe())
+    val parameters =
+      DeployParameters(Deployer("Simon Hildrew"), Build("tools::deploy", "131"), Stage("DEV"), DefaultRecipe())
 
     val testTask1 = new Task {
       override def execute(reporter: DeployReporter, stopFlag: => Boolean) {}
@@ -58,31 +63,67 @@ class Testing(prismLookup: PrismLookup)(implicit val messagesApi: MessagesApi, v
 
     val input = ArrayBuffer(
       wrapper(None, message.deployUUID, StartContext(message.deploy)),
-      wrapper(Some(message.deployUUID), UUID.randomUUID(), Info("Downloading artifact"),message.deploy),
-      wrapper(Some(message.deployUUID), UUID.randomUUID(), Verbose("Downloading from http://teamcity.guprod.gnm:80/guestAuth/repository/download/tools%3A%3Adeploy/131/artifacts.zip to /var/folders/ZO/ZOSa3fR3FsCiU3jxetWKQU+++TQ/-Tmp-/sbt_5489e15..."),message.deploy),
-      wrapper(Some(message.deployUUID), UUID.randomUUID(), Verbose("http: teamcity.gudev.gnl GET /guestAuth/repository/download/tools%3A%3Adeploy/131/artifacts.zip HTTP/1.1"), message.deploy),
-      wrapper(Some(message.deployUUID), UUID.randomUUID(), Verbose("""downloaded:
+      wrapper(Some(message.deployUUID), UUID.randomUUID(), Info("Downloading artifact"), message.deploy),
+      wrapper(
+        Some(message.deployUUID),
+        UUID.randomUUID(),
+        Verbose(
+          "Downloading from http://teamcity.guprod.gnm:80/guestAuth/repository/download/tools%3A%3Adeploy/131/artifacts.zip to /var/folders/ZO/ZOSa3fR3FsCiU3jxetWKQU+++TQ/-Tmp-/sbt_5489e15..."),
+        message.deploy
+      ),
+      wrapper(
+        Some(message.deployUUID),
+        UUID.randomUUID(),
+        Verbose(
+          "http: teamcity.gudev.gnl GET /guestAuth/repository/download/tools%3A%3Adeploy/131/artifacts.zip HTTP/1.1"),
+        message.deploy
+      ),
+      wrapper(
+        Some(message.deployUUID),
+        UUID.randomUUID(),
+        Verbose("""downloaded:
       /var/folders/ZO/ZOSa3fR3FsCiU3jxetWKQU+++TQ/-Tmp-/sbt_5489e15/deploy.json
-    /var/folders/ZO/ZOSa3fR3FsCiU3jxetWKQU+++TQ/-Tmp-/sbt_5489e15/packages/riff-raff/riff-raff.jar"""), message.deploy),
+    /var/folders/ZO/ZOSa3fR3FsCiU3jxetWKQU+++TQ/-Tmp-/sbt_5489e15/packages/riff-raff/riff-raff.jar"""),
+        message.deploy
+      ),
       wrapper(Some(message.deployUUID), UUID.randomUUID(), Info("Reading deploy.json"), message.deploy),
-      wrapper(Some(message.deployUUID), UUID.randomUUID(), Warning("DEPRECATED: Something in your deploy.json is deprecated!"), message.deploy),
+      wrapper(Some(message.deployUUID),
+              UUID.randomUUID(),
+              Warning("DEPRECATED: Something in your deploy.json is deprecated!"),
+              message.deploy),
       wrapper(Some(message.deployUUID), message.task1UUID, StartContext(message.task1), message.deploy),
       wrapper(Some(message.task1UUID), UUID.randomUUID(), FinishContext(message.task1), message.task1, message.deploy),
       wrapper(Some(message.deployUUID), message.task2UUID, StartContext(message.task2), message.deploy),
       wrapper(Some(message.task2UUID), message.infoUUID, StartContext(message.info), message.task2, message.deploy),
-
-      wrapper(Some(message.infoUUID), UUID.randomUUID(), CommandOutput("Some command output from command line action"), message.info, message.task2, message.deploy),
-      wrapper(Some(message.infoUUID), UUID.randomUUID(), CommandError("Some command error from command line action"), message.info, message.task2, message.deploy),
-      wrapper(Some(message.infoUUID), UUID.randomUUID(), CommandOutput("Some more command output from command line action"), message.info, message.task2, message.deploy)
+      wrapper(Some(message.infoUUID),
+              UUID.randomUUID(),
+              CommandOutput("Some command output from command line action"),
+              message.info,
+              message.task2,
+              message.deploy),
+      wrapper(Some(message.infoUUID),
+              UUID.randomUUID(),
+              CommandError("Some command error from command line action"),
+              message.info,
+              message.task2,
+              message.deploy),
+      wrapper(Some(message.infoUUID),
+              UUID.randomUUID(),
+              CommandOutput("Some more command output from command line action"),
+              message.info,
+              message.task2,
+              message.deploy)
     )
 
+    val report = DeployRecord(new DateTime(), logUUID, parameters, messages = input.toList.take(take))
 
-    val report = DeployRecord(new DateTime(), logUUID, parameters, messages=input.toList.take(take))
-
-    Ok(views.html.test.reportTest(request,report,verbose))
+    Ok(views.html.test.reportTest(request, report, verbose))
   }
 
-  def hosts = AuthAction { Ok(s"Deploy Info hosts:\n${prismLookup.hosts.all.map(h => s"${h.name} - ${h.tags.getOrElse("group", "n/a")}").mkString("\n")}") }
+  def hosts = AuthAction {
+    Ok(
+      s"Deploy Info hosts:\n${prismLookup.hosts.all.map(h => s"${h.name} - ${h.tags.getOrElse("group", "n/a")}").mkString("\n")}")
+  }
 
   def form =
     AuthAction { implicit request =>
@@ -91,25 +132,28 @@ class Testing(prismLookup: PrismLookup)(implicit val messagesApi: MessagesApi, v
 
   def formPost =
     AuthAction { implicit request =>
-      testForm.bindFromRequest().fold(
-        errors => BadRequest(views.html.test.form(errors)),
-        form => {
-          log.info("Form post: %s" format form.toString)
-          Redirect(routes.Testing.form)
-        }
-      )
+      testForm
+        .bindFromRequest()
+        .fold(
+          errors => BadRequest(views.html.test.form(errors)),
+          form => {
+            log.info("Form post: %s" format form.toString)
+            Redirect(routes.Testing.form)
+          }
+        )
     }
 
   def testcharset = AuthAction { implicit request =>
     Ok("Raw string: %s\nParsed strings: \n%s" format (request.rawQueryString, request.queryString))
   }
 
-  def uuidList(limit:Int) = AuthAction { implicit request =>
-    val allDeploys = Persistence.store.getDeployUUIDs().toSeq.sortBy(_.time.map(_.getMillis).getOrElse(Long.MaxValue)).reverse
+  def uuidList(limit: Int) = AuthAction { implicit request =>
+    val allDeploys =
+      Persistence.store.getDeployUUIDs().toSeq.sortBy(_.time.map(_.getMillis).getOrElse(Long.MaxValue)).reverse
     Ok(views.html.test.uuidList(request, allDeploys.take(limit)))
   }
 
-  def S3LatencyList(limit:Int, csv: Boolean) = AuthAction { implicit request =>
+  def S3LatencyList(limit: Int, csv: Boolean) = AuthAction { implicit request =>
     val filter = DeployFilter.fromRequest
     val pagination = PaginationView.fromRequest
     val allDeploys = DocumentStoreConverter.getDeployList(filter, pagination, fetchLog = true)
@@ -125,48 +169,54 @@ class Testing(prismLookup: PrismLookup)(implicit val messagesApi: MessagesApi, v
       val endOfS3UploadTasks = s3UploadTasks.dropWhile(_._2.name.contains("S3Upload"))
       val s3Start = s3UploadTasks.headOption.map(_._1.stack.time)
       val s3End = endOfS3UploadTasks.headOption.map(_._1.stack.time)
-      deploy -> s3Start.zip(s3End).map{ case (start, end) => new Duration(start,end) }.headOption
+      deploy -> s3Start.zip(s3End).map { case (start, end) => new Duration(start, end) }.headOption
     }
     if (csv) {
       val formatter = DateTimeFormat.forPattern("dd/MM/yyyy HH:mm:ss")
       val csvLines = s"Time,Project,S3 Duration" +:
-        times.map{case(deploy, duration) =>
+        times.map {
+        case (deploy, duration) =>
           s"${formatter.print(deploy.time)},${deploy.parameters.build.projectName},${duration.map(_.getStandardSeconds).getOrElse("")}"
-        }
-      Ok(csvLines.mkString("\n")).as("text/csv").withHeaders("Content-Disposition" -> "attachment; filename=s3Latencies.csv")
-    }
-    else
+      }
+      Ok(csvLines.mkString("\n"))
+        .as("text/csv")
+        .withHeaders("Content-Disposition" -> "attachment; filename=s3Latencies.csv")
+    } else
       Ok(views.html.test.s3Latencies(request, times))
   }
 
   def debugLogViewer(uuid: String) = AuthAction { implicit request =>
     val deploy = DocumentStoreConverter.getDeploy(UUID.fromString(uuid))
-    deploy.map(deploy => Ok(views.html.test.debugLogViewer(request, deploy))).getOrElse(NotFound("Can't find document with that UUID"))
+    deploy
+      .map(deploy => Ok(views.html.test.debugLogViewer(request, deploy)))
+      .getOrElse(NotFound("Can't find document with that UUID"))
   }
 
   def actionUUID = AuthAction { implicit request =>
-    uuidForm.bindFromRequest().fold(
-      errors => Redirect(routes.Testing.uuidList()),
-      form => {
-        form.action match {
-          case "summarise" => {
-            log.info("Summarising deploy with UUID %s" format form.uuid)
-            Persistence.store.summariseDeploy(UUID.fromString(form.uuid))
-            Redirect(routes.Testing.uuidList())
-          }
-          case "deleteV2" => {
-            log.info("Deleting deploy in V2 with UUID %s" format form.uuid)
-            Persistence.store.deleteDeployLog(UUID.fromString(form.uuid))
-            Redirect(routes.Testing.uuidList())
-          }
-          case "addStringUUID" => {
-            log.info("Adding string UUID for %s" format form.uuid)
-            Persistence.store.addStringUUID(UUID.fromString(form.uuid))
-            Redirect(routes.Testing.uuidList())
+    uuidForm
+      .bindFromRequest()
+      .fold(
+        errors => Redirect(routes.Testing.uuidList()),
+        form => {
+          form.action match {
+            case "summarise" => {
+              log.info("Summarising deploy with UUID %s" format form.uuid)
+              Persistence.store.summariseDeploy(UUID.fromString(form.uuid))
+              Redirect(routes.Testing.uuidList())
+            }
+            case "deleteV2" => {
+              log.info("Deleting deploy in V2 with UUID %s" format form.uuid)
+              Persistence.store.deleteDeployLog(UUID.fromString(form.uuid))
+              Redirect(routes.Testing.uuidList())
+            }
+            case "addStringUUID" => {
+              log.info("Adding string UUID for %s" format form.uuid)
+              Persistence.store.addStringUUID(UUID.fromString(form.uuid))
+              Redirect(routes.Testing.uuidList())
+            }
           }
         }
-      }
-    )
+      )
   }
 
   def transferAllUUIDs = AuthAction { implicit request =>
@@ -179,25 +229,23 @@ class Testing(prismLookup: PrismLookup)(implicit val messagesApi: MessagesApi, v
 
 object Testing {
 
-  case class UuidForm(uuid:String, action:String)
+  case class UuidForm(uuid: String, action: String)
 
   lazy val uuidForm = Form[UuidForm](
     mapping(
-      "uuid" -> text(36,36),
+      "uuid" -> text(36, 36),
       "action" -> nonEmptyText
-    )(UuidForm.apply)
-    (UuidForm.unapply)
+    )(UuidForm.apply)(UuidForm.unapply)
   )
 
-  case class TestForm(project:String, action:String, hosts: List[String])
+  case class TestForm(project: String, action: String, hosts: List[String])
 
   lazy val testForm = Form[TestForm](
     mapping(
       "project" -> text,
       "action" -> nonEmptyText,
       "hosts" -> list(text)
-    )(TestForm.apply)
-    (TestForm.unapply)
+    )(TestForm.apply)(TestForm.unapply)
   )
 
 }

--- a/riff-raff/app/controllers/api.scala
+++ b/riff-raff/app/controllers/api.scala
@@ -24,21 +24,21 @@ import utils.Json.DefaultJodaDateWrites
 import utils.{ChangeFreeze, Graph}
 
 case class ApiKey(
-  application:String,
-  key:String,
-  issuedBy:String,
-  created:DateTime,
-  lastUsed:Option[DateTime] = None,
-  callCounters:Map[String, Long] = Map.empty
-){
-  lazy val totalCalls = callCounters.values.fold(0L){_+_}
+    application: String,
+    key: String,
+    issuedBy: String,
+    created: DateTime,
+    lastUsed: Option[DateTime] = None,
+    callCounters: Map[String, Long] = Map.empty
+) {
+  lazy val totalCalls = callCounters.values.fold(0L) { _ + _ }
 }
 
 object ApiKey extends MongoSerialisable[ApiKey] {
-  implicit val keyFormat:MongoFormat[ApiKey] = new KeyMongoFormat
+  implicit val keyFormat: MongoFormat[ApiKey] = new KeyMongoFormat
   private class KeyMongoFormat extends MongoFormat[ApiKey] with Logging {
     def toDBO(a: ApiKey) = {
-      val fields:List[(String,Any)] =
+      val fields: List[(String, Any)] =
         List(
           "application" -> a.application,
           "_id" -> a.key,
@@ -51,24 +51,29 @@ object ApiKey extends MongoSerialisable[ApiKey] {
       fields.toMap
     }
 
-    def fromDBO(dbo: MongoDBObject) = Some(ApiKey(
-      application = dbo.as[String]("application"),
-      key = dbo.as[String]("_id"),
-      issuedBy = dbo.as[String]("issuedBy"),
-      created = dbo.as[DateTime]("created"),
-      lastUsed = dbo.getAs[DateTime]("lastUsed"),
-      callCounters = dbo.as[DBObject]("callCounters").map { entry =>
-        val key = entry._1
-        val counter = try {
-          entry._2.asInstanceOf[Long]
-        } catch {
-          case cce:ClassCastException =>
-            log.warn("Automatically marshalling an Int to a Long (you should only see this during unit tests)")
-            entry._2.asInstanceOf[Int].toLong
-        }
-        key -> counter
-      }.toMap
-    ))
+    def fromDBO(dbo: MongoDBObject) =
+      Some(
+        ApiKey(
+          application = dbo.as[String]("application"),
+          key = dbo.as[String]("_id"),
+          issuedBy = dbo.as[String]("issuedBy"),
+          created = dbo.as[DateTime]("created"),
+          lastUsed = dbo.getAs[DateTime]("lastUsed"),
+          callCounters = dbo
+            .as[DBObject]("callCounters")
+            .map { entry =>
+              val key = entry._1
+              val counter = try {
+                entry._2.asInstanceOf[Long]
+              } catch {
+                case cce: ClassCastException =>
+                  log.warn("Automatically marshalling an Int to a Long (you should only see this during unit tests)")
+                  entry._2.asInstanceOf[Int].toLong
+              }
+              key -> counter
+            }
+            .toMap
+        ))
   }
 }
 
@@ -78,7 +83,7 @@ object ApiKeyGenerator {
   def newKey(length: Int = 32): String = {
     val rawData = new Array[Byte](length)
     secureRandom.nextBytes(rawData)
-    rawData.map{ byteData =>
+    rawData.map { byteData =>
       val char = byteData & 63
       char match {
         case lower if lower < 26 => ('a' + lower).toChar
@@ -94,8 +99,12 @@ object ApiKeyGenerator {
 
 }
 
-
-class Api(deployments: Deployments, deploymentTypes: Seq[DeploymentType])(implicit val messagesApi: MessagesApi, val wsClient: WSClient) extends Controller with Logging with LoginActions with I18nSupport {
+class Api(deployments: Deployments, deploymentTypes: Seq[DeploymentType])(implicit val messagesApi: MessagesApi,
+                                                                          val wsClient: WSClient)
+    extends Controller
+    with Logging
+    with LoginActions
+    with I18nSupport {
 
   object ApiJsonEndpoint {
     val INTERNAL_KEY = ApiKey("internal", "n/a", "n/a", new DateTime())
@@ -107,19 +116,21 @@ class Api(deployments: Deployments, deploymentTypes: Seq[DeploymentType])(implic
       val response = try {
         f(authenticatedRequest)
       } catch {
-        case t:Throwable =>
-          toJson(Map(
-            "response" -> toJson(Map(
-              "status" -> toJson("error"),
-              "message" -> toJson(t.getMessage),
-              "stacktrace" -> toJson(t.getStackTrace.map(_.toString))
+        case t: Throwable =>
+          toJson(
+            Map(
+              "response" -> toJson(
+                Map(
+                  "status" -> toJson("error"),
+                  "message" -> toJson(t.getMessage),
+                  "stacktrace" -> toJson(t.getStackTrace.map(_.toString))
+                ))
             ))
-          ))
       }
 
       val responseObject = response match {
-        case jso:JsObject => jso
-        case jsv:JsValue => JsObject(Seq(("value", jsv)))
+        case jso: JsObject => jso
+        case jsv: JsValue => JsObject(Seq(("value", jsv)))
       }
 
       jsonpCallback map { callback =>
@@ -134,19 +145,22 @@ class Api(deployments: Deployments, deploymentTypes: Seq[DeploymentType])(implic
     }
 
     def apply[A](counter: String, p: BodyParser[A])(f: ApiRequest[A] => JsValue): Action[A] =
-      ApiAuthAction(counter, p) { apiRequest => this.apply(apiRequest)(f) }
+      ApiAuthAction(counter, p) { apiRequest =>
+        this.apply(apiRequest)(f)
+      }
 
     def apply(counter: String)(f: ApiRequest[AnyContent] => JsValue): Action[AnyContent] =
       this.apply(counter, parse.anyContent)(f)
 
     def withAuthAccess(f: ApiRequest[AnyContent] => JsValue): Action[AnyContent] = AuthAction { request =>
-      val apiRequest:ApiRequest[AnyContent] = new ApiRequest[AnyContent](INTERNAL_KEY, request)
+      val apiRequest: ApiRequest[AnyContent] = new ApiRequest[AnyContent](INTERNAL_KEY, request)
       this.apply(apiRequest)(f)
     }
   }
 
   val applicationForm = Form(
-    "application" -> nonEmptyText.verifying("Application name already exists", Persistence.store.getApiKeyByApplication(_).isEmpty)
+    "application" -> nonEmptyText.verifying("Application name already exists",
+                                            Persistence.store.getApiKeyByApplication(_).isEmpty)
   )
 
   val apiKeyForm = Form(
@@ -158,15 +172,17 @@ class Api(deployments: Deployments, deploymentTypes: Seq[DeploymentType])(implic
   }
 
   def createKey = AuthAction { implicit request =>
-    applicationForm.bindFromRequest().fold(
-      errors => BadRequest(views.html.api.form(errors)),
-      applicationName => {
-        val randomKey = ApiKeyGenerator.newKey()
-        val key = ApiKey(applicationName, randomKey, request.user.fullName, new DateTime())
-        Persistence.store.createApiKey(key)
-        Redirect(routes.Api.listKeys)
-      }
-    )
+    applicationForm
+      .bindFromRequest()
+      .fold(
+        errors => BadRequest(views.html.api.form(errors)),
+        applicationName => {
+          val randomKey = ApiKeyGenerator.newKey()
+          val key = ApiKey(applicationName, randomKey, request.user.fullName, new DateTime())
+          Persistence.store.createApiKey(key)
+          Redirect(routes.Api.listKeys)
+        }
+      )
   }
 
   def listKeys = AuthAction { implicit request =>
@@ -174,24 +190,32 @@ class Api(deployments: Deployments, deploymentTypes: Seq[DeploymentType])(implic
   }
 
   def delete = AuthAction { implicit request =>
-    apiKeyForm.bindFromRequest().fold(
-      errors => Redirect(routes.Api.listKeys()),
-      apiKey => {
-        Persistence.store.deleteApiKey(apiKey)
-        Redirect(routes.Api.listKeys())
-      }
-    )
+    apiKeyForm
+      .bindFromRequest()
+      .fold(
+        errors => Redirect(routes.Api.listKeys()),
+        apiKey => {
+          Persistence.store.deleteApiKey(apiKey)
+          Redirect(routes.Api.listKeys())
+        }
+      )
   }
 
   def historyGraph = ApiJsonEndpoint.withAuthAccess { implicit request =>
-    val filter = deployment.DeployFilter.fromRequest(request).map(_.withMaxDaysAgo(Some(90))).orElse(Some(DeployFilter(maxDaysAgo = Some(30))))
+    val filter = deployment.DeployFilter
+      .fromRequest(request)
+      .map(_.withMaxDaysAgo(Some(90)))
+      .orElse(Some(DeployFilter(maxDaysAgo = Some(30))))
     val count = Deployments.countDeploys(filter)
     val pagination = deployment.DeployFilterPagination.fromRequest.withItemCount(Some(count)).withPageSize(None)
     val deployList = Deployments.getDeploys(filter, pagination.pagination, fetchLogs = false)
 
-    def description(state: RunState.Value) = state + " deploys" + filter.map { f =>
-      f.projectName.map(" of " + _).getOrElse("") + f.stage.map(" in " + _).getOrElse("")
-    }.getOrElse("")
+    def description(state: RunState.Value) =
+      state + " deploys" + filter
+        .map { f =>
+          f.projectName.map(" of " + _).getOrElse("") + f.stage.map(" in " + _).getOrElse("")
+        }
+        .getOrElse("")
 
     implicit val dateOrdering = new Ordering[LocalDate] {
       override def compare(x: LocalDate, y: LocalDate): Int = x.compareTo(y)
@@ -210,32 +234,37 @@ class Api(deployments: Deployments, deploymentTypes: Seq[DeploymentType])(implic
       case default => 5
     }
 
-    val deploys = deploysByState.map { case (state, deploysInThatState) =>
-      val seriesDataByDay = deploysInThatState.groupBy(_.time.toLocalDate).mapValues(_.size).toList.sortBy {
-        case (day, _) => day
-      }
-      val seriesJson = Graph.zeroFillDays(seriesDataByDay, firstDate, lastDate).map {
-        case (day, deploysOnThatDay) =>
-          toJson(Map(
-            "x" -> toJson(day.toDateTimeAtStartOfDay.getMillis / 1000),
-            "y" -> toJson(deploysOnThatDay)
-          ))
-      }
-      Map(
-        "data" -> toJson(seriesJson),
-        "points" -> toJson(seriesJson.length),
-        "deploystate" -> toJson(state.toString),
-        "name" -> toJson(description(state))
-      )
+    val deploys = deploysByState.map {
+      case (state, deploysInThatState) =>
+        val seriesDataByDay = deploysInThatState.groupBy(_.time.toLocalDate).mapValues(_.size).toList.sortBy {
+          case (day, _) => day
+        }
+        val seriesJson = Graph.zeroFillDays(seriesDataByDay, firstDate, lastDate).map {
+          case (day, deploysOnThatDay) =>
+            toJson(
+              Map(
+                "x" -> toJson(day.toDateTimeAtStartOfDay.getMillis / 1000),
+                "y" -> toJson(deploysOnThatDay)
+              ))
+        }
+        Map(
+          "data" -> toJson(seriesJson),
+          "points" -> toJson(seriesJson.length),
+          "deploystate" -> toJson(state.toString),
+          "name" -> toJson(description(state))
+        )
     }
 
-    toJson(Map("response" -> toJson(Map(
-      "series" -> toJson(deploys),
-      "status" -> toJson("ok")
-    ))))
+    toJson(
+      Map(
+        "response" -> toJson(
+          Map(
+            "series" -> toJson(deploys),
+            "status" -> toJson("ok")
+          ))))
   }
 
-  def record2apiResponse(deploy:Record)(implicit request: ApiRequest[AnyContent]) =
+  def record2apiResponse(deploy: Record)(implicit request: ApiRequest[AnyContent]) =
     Json.obj(
       "time" -> deploy.time,
       "uuid" -> deploy.uuid.toString,
@@ -249,85 +278,89 @@ class Api(deployments: Deployments, deploymentTypes: Seq[DeploymentType])(implic
       "tags" -> toJson(deploy.allMetaData)
     )
 
-
   def history = ApiJsonEndpoint("history") { implicit request =>
     val filter = deployment.DeployFilter.fromRequest(request)
     val count = Deployments.countDeploys(filter)
     val pagination = deployment.DeployFilterPagination.fromRequest.withItemCount(Some(count))
     val deployList = Deployments.getDeploys(filter, pagination.pagination, fetchLogs = false).reverse
 
-    val deploys = deployList.map{ record2apiResponse }
+    val deploys = deployList.map { record2apiResponse }
     val response = Map(
-      "response" -> toJson(Map(
-        "status" -> toJson("ok"),
-        "total" -> toJson(pagination.itemCount),
-        "pageSize" -> toJson(pagination.pageSize),
-        "currentPage" -> toJson(pagination.page),
-        "pages" -> toJson(pagination.pageCount.get),
-        "filter" -> toJson(filter.map(_.queryStringParams.toMap.mapValues(toJson(_))).getOrElse(Map.empty)),
-        "results" -> toJson(deploys)
-      ))
+      "response" -> toJson(
+        Map(
+          "status" -> toJson("ok"),
+          "total" -> toJson(pagination.itemCount),
+          "pageSize" -> toJson(pagination.pageSize),
+          "currentPage" -> toJson(pagination.page),
+          "pages" -> toJson(pagination.pageCount.get),
+          "filter" -> toJson(filter.map(_.queryStringParams.toMap.mapValues(toJson(_))).getOrElse(Map.empty)),
+          "results" -> toJson(deploys)
+        ))
     )
     toJson(response)
   }
 
   val deployRequestReader =
     (__ \ "project").read[String] and
-    (__ \ "build").read[String] and
-    (__ \ "stage").read[String] and
-    (__ \ "recipe").readNullable[String] and
-    (__ \ "hosts").readNullable[List[String]] tupled
+      (__ \ "build").read[String] and
+      (__ \ "stage").read[String] and
+      (__ \ "recipe").readNullable[String] and
+      (__ \ "hosts").readNullable[List[String]] tupled
 
   def deploy = ApiJsonEndpoint("deploy", parse.json) { implicit request =>
-    deployRequestReader.reads(request.body).fold(
-      valid = { deployRequest =>
-        val (project, build, stage, recipeOption, hostsOption) = deployRequest
-        val recipe = recipeOption.map(RecipeName).getOrElse(DefaultRecipe())
-        val hosts = hostsOption.getOrElse(Nil)
-        val params = DeployParameters(
-          Deployer(request.fullName),
-          Build(project, build),
-          Stage(stage),
-          recipe,
-          Nil,
-          hosts
-        )
-        assert(!ChangeFreeze.frozen(stage), s"Deployment to $stage is frozen (API disabled, use the web interface if you need to deploy): ${ChangeFreeze.message}")
-
-        deployments.deploy(params, requestSource = ApiRequestSource(request.apiKey)) match {
-          case Right(deployId) =>
-            Json.obj(
-              "response" -> Json.obj(
-                "status" -> "ok",
-                "request" -> Json.obj(
-                  "project" -> project,
-                  "build" -> build,
-                  "stage" -> stage,
-                  "recipe" -> recipe.name,
-                  "hosts" -> toJson(hosts)
-                ),
-                "uuid" -> deployId.toString,
-                "logURL" -> routes.DeployController.viewUUID(deployId.toString).absoluteURL()
-              )
-            )
-          case Left(error) =>
-            Json.obj(
-              "response" -> Json.obj(
-                "status" -> "error",
-                "errors" -> Json.arr(error.message)
-              )
-            )
-        }
-      },
-      invalid = { error =>
-        Json.obj(
-          "response" -> Json.obj(
-            "status" -> "error",
-            "errors" -> JsError.toJson(error)
+    deployRequestReader
+      .reads(request.body)
+      .fold(
+        valid = { deployRequest =>
+          val (project, build, stage, recipeOption, hostsOption) = deployRequest
+          val recipe = recipeOption.map(RecipeName).getOrElse(DefaultRecipe())
+          val hosts = hostsOption.getOrElse(Nil)
+          val params = DeployParameters(
+            Deployer(request.fullName),
+            Build(project, build),
+            Stage(stage),
+            recipe,
+            Nil,
+            hosts
           )
-        )
-      }
-    )
+          assert(
+            !ChangeFreeze.frozen(stage),
+            s"Deployment to $stage is frozen (API disabled, use the web interface if you need to deploy): ${ChangeFreeze.message}")
+
+          deployments.deploy(params, requestSource = ApiRequestSource(request.apiKey)) match {
+            case Right(deployId) =>
+              Json.obj(
+                "response" -> Json.obj(
+                  "status" -> "ok",
+                  "request" -> Json.obj(
+                    "project" -> project,
+                    "build" -> build,
+                    "stage" -> stage,
+                    "recipe" -> recipe.name,
+                    "hosts" -> toJson(hosts)
+                  ),
+                  "uuid" -> deployId.toString,
+                  "logURL" -> routes.DeployController.viewUUID(deployId.toString).absoluteURL()
+                )
+              )
+            case Left(error) =>
+              Json.obj(
+                "response" -> Json.obj(
+                  "status" -> "error",
+                  "errors" -> Json.arr(error.message)
+                )
+              )
+          }
+        },
+        invalid = { error =>
+          Json.obj(
+            "response" -> Json.obj(
+              "status" -> "error",
+              "errors" -> JsError.toJson(error)
+            )
+          )
+        }
+      )
   }
 
   def view(uuid: String) = ApiJsonEndpoint("viewDeploy") { implicit request =>
@@ -359,14 +392,14 @@ class Api(deployments: Deployments, deploymentTypes: Seq[DeploymentType])(implic
   }
 
   def validate = ApiJsonEndpoint("validate") { implicit request =>
-    request.body.asText.fold{
+    request.body.asText.fold {
       Json.obj(
         "response" -> Json.obj(
           "status" -> "error",
           "errors" -> Json.arr("No configuration provided in request body")
         )
       )
-    }{ body =>
+    } { body =>
       val validatedGraph = YamlResolver.resolveDeploymentGraph(body, deploymentTypes, All)
       validatedGraph match {
         case Valid(graph) =>

--- a/riff-raff/app/controllers/authentication.scala
+++ b/riff-raff/app/controllers/authentication.scala
@@ -25,23 +25,27 @@ class ApiRequest[A](val apiKey: ApiKey, request: Request[A]) extends WrappedRequ
 
 case class AuthorisationRecord(email: String, approvedBy: String, approvedDate: DateTime)
 object AuthorisationRecord extends MongoSerialisable[AuthorisationRecord] {
-  implicit val authFormat:MongoFormat[AuthorisationRecord] = new AuthMongoFormat
+  implicit val authFormat: MongoFormat[AuthorisationRecord] = new AuthMongoFormat
   private class AuthMongoFormat extends MongoFormat[AuthorisationRecord] {
-    def toDBO(a: AuthorisationRecord) = MongoDBObject("_id" -> a.email, "approvedBy" -> a.approvedBy, "approvedDate" -> a.approvedDate)
-    def fromDBO(dbo: MongoDBObject) = Some(AuthorisationRecord(dbo.as[String]("_id"), dbo.as[String]("approvedBy"), dbo.as[DateTime]("approvedDate")))
+    def toDBO(a: AuthorisationRecord) =
+      MongoDBObject("_id" -> a.email, "approvedBy" -> a.approvedBy, "approvedDate" -> a.approvedDate)
+    def fromDBO(dbo: MongoDBObject) =
+      Some(AuthorisationRecord(dbo.as[String]("_id"), dbo.as[String]("approvedBy"), dbo.as[DateTime]("approvedDate")))
   }
 }
 
 trait AuthorisationValidator {
   def emailDomainWhitelist: List[String]
   def emailWhitelistEnabled: Boolean
-  def emailWhitelistContains(email:String): Boolean
+  def emailWhitelistContains(email: String): Boolean
   def isAuthorised(id: UserIdentity) = authorisationError(id).isEmpty
   def authorisationError(id: UserIdentity): Option[String] = {
     if (!emailDomainWhitelist.isEmpty && !emailDomainWhitelist.contains(id.emailDomain)) {
-      Some(s"The e-mail address domain you used to login to Riff-Raff (${id.email}) is not in the configured whitelist.  Please try again with another account or contact the Riff-Raff administrator.")
+      Some(
+        s"The e-mail address domain you used to login to Riff-Raff (${id.email}) is not in the configured whitelist.  Please try again with another account or contact the Riff-Raff administrator.")
     } else if (emailWhitelistEnabled && !emailWhitelistContains(id.email)) {
-      Some(s"The e-mail address you used to login to Riff-Raff (${id.email}) is not authorised.  Please try again with another account, ask a colleague to add your address or contact the Riff-Raff administrator.")
+      Some(
+        s"The e-mail address you used to login to Riff-Raff (${id.email}) is not authorised.  Please try again with another account, ask a colleague to add your address or contact the Riff-Raff administrator.")
     } else {
       None
     }
@@ -50,7 +54,7 @@ trait AuthorisationValidator {
 
 object ApiAuthAction {
 
-  def apply[A](counter: Option[String], p: BodyParser[A])(f: ApiRequest[A] => Result): Action[A]  = {
+  def apply[A](counter: Option[String], p: BodyParser[A])(f: ApiRequest[A] => Result): Action[A] = {
     Action(p) { implicit request =>
       request.queryString.get("key").flatMap(_.headOption) match {
         case Some(urlParam) =>
@@ -64,7 +68,7 @@ object ApiAuthAction {
     }
   }
 
-  def apply[A](counter: String, p: BodyParser[A])(f: ApiRequest[A] => Result): Action[A]  =
+  def apply[A](counter: String, p: BodyParser[A])(f: ApiRequest[A] => Result): Action[A] =
     this.apply(Some(counter), p)(f)
   def apply[A](p: BodyParser[A])(f: ApiRequest[A] => Result): Action[A] =
     this.apply(None, p)(f)
@@ -84,7 +88,11 @@ trait LoginActions extends Actions {
   def authConfig: GoogleAuthConfig = auth.googleAuthConfig
 }
 
-class Login(implicit val messagesApi: MessagesApi, val wsClient: WSClient) extends Controller with Logging with LoginActions with I18nSupport {
+class Login(implicit val messagesApi: MessagesApi, val wsClient: WSClient)
+    extends Controller
+    with Logging
+    with LoginActions
+    with I18nSupport {
 
   val validator = new AuthorisationValidator {
     def emailDomainWhitelist = auth.domains
@@ -92,7 +100,7 @@ class Login(implicit val messagesApi: MessagesApi, val wsClient: WSClient) exten
     def emailWhitelistContains(email: String) = {
       val lowerCaseEmail = email.toLowerCase
       auth.whitelist.addresses.contains(lowerCaseEmail) ||
-        (auth.whitelist.useDatabase && Persistence.store.getAuthorisation(lowerCaseEmail).isDefined)
+      (auth.whitelist.useDatabase && Persistence.store.getAuthorisation(lowerCaseEmail).isDefined)
     }
   }
 
@@ -121,7 +129,9 @@ class Login(implicit val messagesApi: MessagesApi, val wsClient: WSClient) exten
             case None => Redirect(routes.Application.index())
           }
           redirect.withSession {
-            request.session + (UserIdentity.KEY -> Json.toJson(identity).toString) - authConfig.antiForgeryKey - GoogleAuthFilters.LOGIN_ORIGIN_KEY
+            request.session + (UserIdentity.KEY -> Json
+              .toJson(identity)
+              .toString) - authConfig.antiForgeryKey - GoogleAuthFilters.LOGIN_ORIGIN_KEY
           }
         } recover {
           case t =>
@@ -139,11 +149,11 @@ class Login(implicit val messagesApi: MessagesApi, val wsClient: WSClient) exten
   }
 
   def profile = AuthAction { request =>
-    val records = Deployments.getDeploys(Some(DeployFilter(deployer=Some(request.user.fullName)))).reverse
+    val records = Deployments.getDeploys(Some(DeployFilter(deployer = Some(request.user.fullName)))).reverse
     Ok(views.html.auth.profile(request, records))
   }
 
-  val authorisationForm = Form( "email" -> nonEmptyText )
+  val authorisationForm = Form("email" -> nonEmptyText)
 
   def authList = AuthAction { request =>
     Ok(views.html.auth.list(request, Persistence.store.getAuthorisationList.sortBy(_.email)))
@@ -154,21 +164,25 @@ class Login(implicit val messagesApi: MessagesApi, val wsClient: WSClient) exten
   }
 
   def authSave = AuthAction { implicit request =>
-    authorisationForm.bindFromRequest().fold(
-      errors => BadRequest(views.html.auth.form(errors)),
-      email => {
-        val auth = AuthorisationRecord(email.toLowerCase, request.user.fullName, new DateTime())
-        Persistence.store.setAuthorisation(auth)
-        Redirect(routes.Login.authList())
-      }
-    )
+    authorisationForm
+      .bindFromRequest()
+      .fold(
+        errors => BadRequest(views.html.auth.form(errors)),
+        email => {
+          val auth = AuthorisationRecord(email.toLowerCase, request.user.fullName, new DateTime())
+          Persistence.store.setAuthorisation(auth)
+          Redirect(routes.Login.authList())
+        }
+      )
   }
 
   def authDelete = AuthAction { implicit request =>
-    authorisationForm.bindFromRequest().fold( _ => {}, email => {
-      log.info(s"${request.user.fullName} deleted authorisation for $email")
-      Persistence.store.deleteAuthorisation(email)
-    } )
+    authorisationForm
+      .bindFromRequest()
+      .fold(_ => {}, email => {
+        log.info(s"${request.user.fullName} deleted authorisation for $email")
+        Persistence.store.deleteAuthorisation(email)
+      })
     Redirect(routes.Login.authList())
   }
 

--- a/riff-raff/app/controllers/forms/DeployParameterForm.scala
+++ b/riff-raff/app/controllers/forms/DeployParameterForm.scala
@@ -5,8 +5,15 @@ import play.api.data.Form
 import play.api.data.Forms._
 import utils.Forms._
 
-case class DeployParameterForm(project:String, build:String, stage:String, recipe: Option[String], action: String,
-  hosts: List[String], stacks: List[String], selectedKeys: List[DeploymentKey], totalKeyCount: Option[Int]) {
+case class DeployParameterForm(project: String,
+                               build: String,
+                               stage: String,
+                               recipe: Option[String],
+                               action: String,
+                               hosts: List[String],
+                               stacks: List[String],
+                               selectedKeys: List[DeploymentKey],
+                               totalKeyCount: Option[Int]) {
 
   def makeSelector: DeploymentSelector = {
     val keysList =

--- a/riff-raff/app/controllers/forms/UuidForm.scala
+++ b/riff-raff/app/controllers/forms/UuidForm.scala
@@ -3,14 +3,13 @@ package controllers.forms
 import play.api.data.Form
 import play.api.data.Forms._
 
-case class UuidForm(uuid:String, action:String)
+case class UuidForm(uuid: String, action: String)
 
 object UuidForm {
   lazy val form = Form[UuidForm](
     mapping(
       "uuid" -> text(36, 36),
       "action" -> nonEmptyText
-    )(UuidForm.apply)
-    (UuidForm.unapply)
+    )(UuidForm.apply)(UuidForm.unapply)
   )
 }

--- a/riff-raff/app/controllers/hooks.scala
+++ b/riff-raff/app/controllers/hooks.scala
@@ -15,10 +15,19 @@ import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.libs.ws.WSClient
 import resources.PrismLookup
 
-case class HookForm(id:UUID, projectName: String, stage: String, url: String, enabled: Boolean,
-                    method: HttpMethod, postBody: Option[String])
+case class HookForm(id: UUID,
+                    projectName: String,
+                    stage: String,
+                    url: String,
+                    enabled: Boolean,
+                    method: HttpMethod,
+                    postBody: Option[String])
 
-class Hooks(prismLookup: PrismLookup)(implicit val messagesApi: MessagesApi, val wsClient: WSClient) extends Controller with Logging with LoginActions with I18nSupport {
+class Hooks(prismLookup: PrismLookup)(implicit val messagesApi: MessagesApi, val wsClient: WSClient)
+    extends Controller
+    with Logging
+    with LoginActions
+    with I18nSupport {
   implicit val httpMethodFormatter = new Formatter[HttpMethod] {
     override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], HttpMethod] = {
       data.get(key).map { value =>
@@ -38,8 +47,9 @@ class Hooks(prismLookup: PrismLookup)(implicit val messagesApi: MessagesApi, val
       "enabled" -> boolean,
       "method" -> default(of[HttpMethod], GET),
       "postBody" -> optional(text)
-    )( HookForm.apply)(HookForm.unapply ).verifying(
-      "URL is invalid", form => try { new URL(form.url); true } catch { case e:MalformedURLException => false }
+    )(HookForm.apply)(HookForm.unapply).verifying(
+      "URL is invalid",
+      form => try { new URL(form.url); true } catch { case e: MalformedURLException => false }
     )
   )
 
@@ -49,35 +59,54 @@ class Hooks(prismLookup: PrismLookup)(implicit val messagesApi: MessagesApi, val
   }
 
   def form = AuthAction { implicit request =>
-    Ok(views.html.hooks.form(hookForm.fill(HookForm(UUID.randomUUID(),"","","",enabled=true, GET, None)), prismLookup))
+    Ok(
+      views.html.hooks.form(hookForm.fill(HookForm(UUID.randomUUID(), "", "", "", enabled = true, GET, None)),
+                            prismLookup))
   }
 
   def save = AuthAction { implicit request =>
-    hookForm.bindFromRequest().fold(
-      formWithErrors => Ok(views.html.hooks.form(formWithErrors, prismLookup)),
-      f => {
-        val config = HookConfig(f.id,f.projectName,f.stage,f.url,f.enabled,new DateTime(),request.user.fullName, f.method, f.postBody)
-        HookConfigRepository.setPostDeployHook(config)
-        Redirect(routes.Hooks.list())
-      }
-    )
+    hookForm
+      .bindFromRequest()
+      .fold(
+        formWithErrors => Ok(views.html.hooks.form(formWithErrors, prismLookup)),
+        f => {
+          val config = HookConfig(f.id,
+                                  f.projectName,
+                                  f.stage,
+                                  f.url,
+                                  f.enabled,
+                                  new DateTime(),
+                                  request.user.fullName,
+                                  f.method,
+                                  f.postBody)
+          HookConfigRepository.setPostDeployHook(config)
+          Redirect(routes.Hooks.list())
+        }
+      )
   }
 
   def edit(id: String) = AuthAction { implicit request =>
     val uuid = UUID.fromString(id)
-    HookConfigRepository.getPostDeployHook(uuid).map{ hc =>
-      Ok(views.html.hooks.form(hookForm.fill(HookForm(hc.id,hc.projectName,hc.stage,hc.url,hc.enabled, hc.method, hc.postBody)), prismLookup))
-    }.getOrElse(Redirect(routes.Hooks.list()))
+    HookConfigRepository
+      .getPostDeployHook(uuid)
+      .map { hc =>
+        Ok(
+          views.html.hooks.form(
+            hookForm.fill(HookForm(hc.id, hc.projectName, hc.stage, hc.url, hc.enabled, hc.method, hc.postBody)),
+            prismLookup))
+      }
+      .getOrElse(Redirect(routes.Hooks.list()))
   }
 
   def delete(id: String) = AuthAction { implicit request =>
-    Form("action" -> nonEmptyText).bindFromRequest().fold(
-      errors => {},
-      {
-        case "delete" =>
-          HookConfigRepository.deletePostDeployHook(UUID.fromString(id))
-      }
-    )
+    Form("action" -> nonEmptyText)
+      .bindFromRequest()
+      .fold(
+        errors => {}, {
+          case "delete" =>
+            HookConfigRepository.deletePostDeployHook(UUID.fromString(id))
+        }
+      )
     Redirect(routes.Hooks.list())
   }
 }

--- a/riff-raff/app/deployment/DeploymentEngine.scala
+++ b/riff-raff/app/deployment/DeploymentEngine.scala
@@ -15,22 +15,30 @@ import scala.collection.JavaConverters._
 class DeploymentEngine(prismLookup: PrismLookup, deploymentTypes: Seq[DeploymentType]) extends Logging {
   import DeploymentEngine._
 
-  private lazy val deploymentRunnerFactory = (context: ActorRefFactory, runnerName: String) => context.actorOf(
-    props = Props(new TasksRunner(stopFlagAgent)).withDispatcher("akka.deploy-dispatcher"),
-    name = s"deploymentRunner-$runnerName"
+  private lazy val deploymentRunnerFactory = (context: ActorRefFactory, runnerName: String) =>
+    context.actorOf(
+      props = Props(new TasksRunner(stopFlagAgent)).withDispatcher("akka.deploy-dispatcher"),
+      name = s"deploymentRunner-$runnerName"
   )
 
   private lazy val deployRunnerFactory = (context: ActorRefFactory, record: Record, deployCoordinator: ActorRef) =>
     context.actorOf(
       props = Props(
-        new DeployGroupRunner(record, deployCoordinator, deploymentRunnerFactory, stopFlagAgent, prismLookup, deploymentTypes)
+        new DeployGroupRunner(record,
+                              deployCoordinator,
+                              deploymentRunnerFactory,
+                              stopFlagAgent,
+                              prismLookup,
+                              deploymentTypes)
       ).withDispatcher("akka.deploy-dispatcher"),
       name = s"deployGroupRunner-${record.uuid.toString}"
-    )
+  )
 
-  private lazy val deployCoordinator = system.actorOf(Props(
-    new DeployCoordinator(deployRunnerFactory, concurrentDeploys, stopFlagAgent)
-  ), name = "deployCoordinator")
+  private lazy val deployCoordinator = system.actorOf(
+    Props(
+      new DeployCoordinator(deployRunnerFactory, concurrentDeploys, stopFlagAgent)
+    ),
+    name = "deployCoordinator")
 
   def interruptibleDeploy(record: Record) {
     log.debug("Sending start deploy message to co-ordinator")

--- a/riff-raff/app/deployment/Deployments.scala
+++ b/riff-raff/app/deployment/Deployments.scala
@@ -24,26 +24,39 @@ class Deployments(deploymentEngine: DeploymentEngine) extends Logging {
 
   def deploy(requestedParams: DeployParameters, requestSource: RequestSource): Either[Error, UUID] = {
     log.info(s"Started deploying $requestedParams")
-    val restrictionsPreventingDeploy = RestrictionChecker.configsThatPreventDeployment(RestrictionConfigDynamoRepository,
-      requestedParams.build.projectName, requestedParams.stage.name, requestSource)
+    val restrictionsPreventingDeploy = RestrictionChecker.configsThatPreventDeployment(
+      RestrictionConfigDynamoRepository,
+      requestedParams.build.projectName,
+      requestedParams.stage.name,
+      requestSource)
     if (restrictionsPreventingDeploy.nonEmpty) {
-      Left(Error(s"Unable to queue deploy as restrictions are currently in place: ${restrictionsPreventingDeploy.map(r => s"${r.fullName}: ${r.note}").mkString("; ")}"))
+      Left(Error(s"Unable to queue deploy as restrictions are currently in place: ${restrictionsPreventingDeploy
+        .map(r => s"${r.fullName}: ${r.note}")
+        .mkString("; ")}"))
     } else if (enableQueueingSwitch.isSwitchedOff) {
-      Left(Error(s"Unable to queue a new deploy; deploys are currently disabled by the ${enableQueueingSwitch.name} switch"))
+      Left(
+        Error(
+          s"Unable to queue a new deploy; deploys are currently disabled by the ${enableQueueingSwitch.name} switch"))
     } else {
-      val params = if (requestedParams.build.id != "lastSuccessful")
-        requestedParams
-      else {
-        Builds.getLastSuccessful(requestedParams.build.projectName).map { latestId =>
-          requestedParams.copy(build = requestedParams.build.copy(id=latestId))
-        }.getOrElse(requestedParams)
-      }
+      val params =
+        if (requestedParams.build.id != "lastSuccessful")
+          requestedParams
+        else {
+          Builds
+            .getLastSuccessful(requestedParams.build.projectName)
+            .map { latestId =>
+              requestedParams.copy(build = requestedParams.build.copy(id = latestId))
+            }
+            .getOrElse(requestedParams)
+        }
       deploysEnabled.whileOnYield {
         val record = Deployments.create(params)
         deploymentEngine.interruptibleDeploy(record)
         Right(record.uuid)
       } getOrElse {
-        Left(Error(s"Unable to queue a new deploy; deploys are currently disabled by the ${enableDeploysSwitch.name} switch"))
+        Left(
+          Error(
+            s"Unable to queue a new deploy; deploys are currently disabled by the ${enableDeploysSwitch.name} switch"))
       }
     }
   }
@@ -61,7 +74,7 @@ object Deployments extends Logging with Lifecycle {
   private lazy val deployCompleteSubject = Subject[UUID]()
 
   private val messagesSubscription: Subscription =
-    DeployReporter.messages.subscribe{ wrapper =>
+    DeployReporter.messages.subscribe { wrapper =>
       try {
         update(wrapper)
       } catch {
@@ -72,15 +85,14 @@ object Deployments extends Logging with Lifecycle {
   def init() {}
   def shutdown() { messagesSubscription.unsubscribe() }
 
-
   val deploysEnabled = new Switch(startAsOn = true)
 
   /**
     * Attempt to disable deploys from running.
- *
+    *
     * @return true if successful and false if this failed because a deploy was currently running
     */
-  def atomicDisableDeploys:Boolean = {
+  def atomicDisableDeploys: Boolean = {
     try {
       deploysEnabled.switchOff {
         if (getControllerDeploys.exists(!_.isDone))
@@ -88,7 +100,7 @@ object Deployments extends Logging with Lifecycle {
       }
       true
     } catch {
-      case e:IllegalStateException => false
+      case e: IllegalStateException => false
     }
   }
 
@@ -96,9 +108,13 @@ object Deployments extends Logging with Lifecycle {
 
   lazy val enableSwitches = List(enableDeploysSwitch, enableQueueingSwitch)
 
-  lazy val enableDeploysSwitch = new DefaultSwitch("enable-deploys", "Enable riff-raff to queue and run deploys.  This switch can only be turned off if no deploys are running.", deploysEnabled.isOn) {
+  lazy val enableDeploysSwitch = new DefaultSwitch(
+    "enable-deploys",
+    "Enable riff-raff to queue and run deploys.  This switch can only be turned off if no deploys are running.",
+    deploysEnabled.isOn) {
     override def switchOff() {
-      if (!atomicDisableDeploys) throw new IllegalStateException("Cannot turn switch off as builds are currently running")
+      if (!atomicDisableDeploys)
+        throw new IllegalStateException("Cannot turn switch off as builds are currently running")
       super.switchOff()
     }
     override def switchOn(): Unit = {
@@ -107,11 +123,15 @@ object Deployments extends Logging with Lifecycle {
     }
   }
 
-  lazy val enableQueueingSwitch = new DefaultSwitch("enable-deploy-queuing", "Enable riff-raff to queue deploys.  Turning this off will prevent anyone queueing a new deploy, although running deploys will continue.", true)
+  lazy val enableQueueingSwitch = new DefaultSwitch(
+    "enable-deploy-queuing",
+    "Enable riff-raff to queue deploys.  Turning this off will prevent anyone queueing a new deploy, although running deploys will continue.",
+    true
+  )
 
   implicit val system = ActorSystem("deploy")
 
-  val library = Agent(Map.empty[UUID,Agent[DeployRecord]])
+  val library = Agent(Map.empty[UUID, Agent[DeployRecord]])
 
   def create(params: DeployParameters): Record = {
     log.info(s"Creating deploy record for $params")
@@ -148,17 +168,24 @@ object Deployments extends Logging with Lifecycle {
   }
 
   def firePostCleanup(uuid: UUID) {
-    library.future().onComplete{ _ =>
+    library.future().onComplete { _ =>
       deployCompleteSubject.onNext(uuid)
     }
   }
-  def getControllerDeploys: Iterable[Record] = { library().values.map{ _() } }
-  def getDatastoreDeploys(filter:Option[DeployFilter] = None, pagination: PaginationView, fetchLogs: Boolean): Iterable[Record] =
+  def getControllerDeploys: Iterable[Record] = { library().values.map { _() } }
+  def getDatastoreDeploys(filter: Option[DeployFilter] = None,
+                          pagination: PaginationView,
+                          fetchLogs: Boolean): Iterable[Record] =
     DocumentStoreConverter.getDeployList(filter, pagination, fetchLogs)
 
-  def getDeploys(filter:Option[DeployFilter] = None, pagination: PaginationView = PaginationView(), fetchLogs: Boolean = false): List[Record] = {
-    require(!fetchLogs || pagination.pageSize.isDefined, "Too much effort required to fetch complete record with no pagination")
-    getDatastoreDeploys(filter, pagination, fetchLogs=fetchLogs).toList.sortWith{ _.time.getMillis < _.time.getMillis }
+  def getDeploys(filter: Option[DeployFilter] = None,
+                 pagination: PaginationView = PaginationView(),
+                 fetchLogs: Boolean = false): List[Record] = {
+    require(!fetchLogs || pagination.pageSize.isDefined,
+            "Too much effort required to fetch complete record with no pagination")
+    getDatastoreDeploys(filter, pagination, fetchLogs = fetchLogs).toList.sortWith {
+      _.time.getMillis < _.time.getMillis
+    }
   }
 
   def getLastCompletedDeploys(project: String): Map[String, Record] = {
@@ -169,7 +196,7 @@ object Deployments extends Logging with Lifecycle {
     DocumentStoreConverter.findProjects()
   }
 
-  def countDeploys(filter:Option[DeployFilter]) = DocumentStoreConverter.countDeploys(filter)
+  def countDeploys(filter: Option[DeployFilter]) = DocumentStoreConverter.countDeploys(filter)
 
   def markAsFailed(record: Record) {
     DocumentStoreConverter.updateDeployStatus(record.uuid, RunState.Failed)
@@ -183,6 +210,6 @@ object Deployments extends Logging with Lifecycle {
   }
 
   def await(uuid: UUID): Record = {
-    Await.result(library.future().flatMap(_(uuid).future()),5 seconds)
+    Await.result(library.future().flatMap(_(uuid).future()), 5 seconds)
   }
 }

--- a/riff-raff/app/deployment/actors/DeployCoordinator.scala
+++ b/riff-raff/app/deployment/actors/DeployCoordinator.scala
@@ -12,9 +12,11 @@ import scala.collection.mutable.ListBuffer
 import scala.util.control.NonFatal
 
 class DeployCoordinator(
-  val deployGroupRunnerFactory: (ActorRefFactory, Record, ActorRef) => ActorRef,
-  maxDeploys: Int, stopFlagAgent: Agent[Map[UUID, String]]
-) extends Actor with Logging {
+    val deployGroupRunnerFactory: (ActorRefFactory, Record, ActorRef) => ActorRef,
+    maxDeploys: Int,
+    stopFlagAgent: Agent[Map[UUID, String]]
+) extends Actor
+    with Logging {
 
   override def supervisorStrategy() = OneForOneStrategy() {
     case throwable =>
@@ -27,10 +29,11 @@ class DeployCoordinator(
 
   private def schedulable(recordToSchedule: Record): Boolean = {
     deployRunners.size < maxDeploys &&
-      !deployRunners.values.exists{ case (record, actor) =>
+    !deployRunners.values.exists {
+      case (record, actor) =>
         record.parameters.build.projectName == recordToSchedule.parameters.build.projectName &&
           record.parameters.stage == recordToSchedule.parameters.stage
-      }
+    }
   }
 
   private def cleanup(uuid: UUID) {
@@ -63,7 +66,7 @@ class DeployCoordinator(
       cleanup(uuid)
 
     case Terminated(actor) =>
-      val maybeUUID = deployRunners.find{case (_, (_, ref)) => ref == actor}.map(_._1)
+      val maybeUUID = deployRunners.find { case (_, (_, ref)) => ref == actor }.map(_._1)
       maybeUUID.foreach { uuid =>
         log.warn(s"Received premature terminate from ${actor.path} (had not been cleaned up)")
         cleanup(uuid)

--- a/riff-raff/app/deployment/filter.scala
+++ b/riff-raff/app/deployment/filter.scala
@@ -5,19 +5,22 @@ import play.api.mvc.{Call, RequestHeader}
 import magenta.RunState
 
 trait QueryStringBuilder {
-  def queryStringParams: List[(String,String)]
-  def queryString = queryStringParams.map {
-    case (k, v) => k + "=" + URLEncoder.encode(v, "UTF-8")
-  }.mkString("&")
+  def queryStringParams: List[(String, String)]
+  def queryString =
+    queryStringParams
+      .map {
+        case (k, v) => k + "=" + URLEncoder.encode(v, "UTF-8")
+      }
+      .mkString("&")
   def q = queryString
 }
 
-case class DeployFilter(
-  projectName: Option[String] = None,
-  stage: Option[String] = None,
-  deployer: Option[String] = None,
-  status: Option[RunState.Value] = None,
-  maxDaysAgo: Option[Int] = None ) extends QueryStringBuilder {
+case class DeployFilter(projectName: Option[String] = None,
+                        stage: Option[String] = None,
+                        deployer: Option[String] = None,
+                        status: Option[RunState.Value] = None,
+                        maxDaysAgo: Option[Int] = None)
+    extends QueryStringBuilder {
 
   lazy val queryStringParams: List[(String, String)] = {
     Nil ++
@@ -28,11 +31,11 @@ case class DeployFilter(
       maxDaysAgo.map("maxDaysAgo" -> _.toString)
   }
 
-  def withProjectName(projectName: Option[String]) = this.copy(projectName=projectName)
-  def withStage(stage: Option[String]) = this.copy(stage=stage)
-  def withDeployer(deployer: Option[String]) = this.copy(deployer=deployer)
-  def withStatus(status: Option[RunState.Value]) = this.copy(status=status)
-  def withMaxDaysAgo(maxDaysAgo: Option[Int]) = this.copy(maxDaysAgo=maxDaysAgo)
+  def withProjectName(projectName: Option[String]) = this.copy(projectName = projectName)
+  def withStage(stage: Option[String]) = this.copy(stage = stage)
+  def withDeployer(deployer: Option[String]) = this.copy(deployer = deployer)
+  def withStatus(status: Option[RunState.Value]) = this.copy(status = status)
+  def withMaxDaysAgo(maxDaysAgo: Option[Int]) = this.copy(maxDaysAgo = maxDaysAgo)
 
   lazy val default = this == DeployFilter()
 
@@ -42,13 +45,13 @@ case class DeployFilter(
 }
 
 object DeployFilter {
-  def fromRequest(implicit r: RequestHeader):Option[DeployFilter] = {
+  def fromRequest(implicit r: RequestHeader): Option[DeployFilter] = {
     def param(s: String): Option[String] =
       r.queryString.get(s).flatMap(_.headOption).filter(!_.isEmpty)
 
     val statusType = try {
       param("status").map(RunState.withName)
-    } catch { case t:Throwable => throw new IllegalArgumentException("Unknown value for status parameter")}
+    } catch { case t: Throwable => throw new IllegalArgumentException("Unknown value for status parameter") }
 
     val filter = DeployFilter(
       projectName = param("projectName"),
@@ -62,10 +65,8 @@ object DeployFilter {
   }
 }
 
-case class HostFilter(
-  stage: Option[String] = None,
-  app: Option[String] = None,
-  hostList: List[String] = Nil ) extends QueryStringBuilder {
+case class HostFilter(stage: Option[String] = None, app: Option[String] = None, hostList: List[String] = Nil)
+    extends QueryStringBuilder {
   lazy val queryStringParams: List[(String, String)] = {
     Nil ++
       stage.map("stage" -> _.toString) ++
@@ -75,7 +76,7 @@ case class HostFilter(
 }
 
 object HostFilter {
-  def fromRequest(implicit r:RequestHeader):HostFilter = {
+  def fromRequest(implicit r: RequestHeader): HostFilter = {
     def param(s: String): Option[String] =
       r.queryString.get(s).flatMap(_.headOption).filter(!_.isEmpty)
 
@@ -103,11 +104,11 @@ trait Pagination extends QueryStringBuilder {
     }
   }
 
-  val DISABLED = Call("GET","#")
+  val DISABLED = Call("GET", "#")
 
   def pageList: List[Int] = (lowerBound to upperBound).toList
-  def lowerBound: Int = math.max(1, pageCount.map(pageCount => math.min(page-2,pageCount-4)).getOrElse(page-4))
-  def upperBound: Int = pageCount.map(pageCount => math.min(pageCount, math.max(page+2,5))).getOrElse(page)
+  def lowerBound: Int = math.max(1, pageCount.map(pageCount => math.min(page - 2, pageCount - 4)).getOrElse(page - 4))
+  def upperBound: Int = pageCount.map(pageCount => math.min(pageCount, math.max(page + 2, 5))).getOrElse(page)
 
   def pageCount: Option[Int] = itemCount.map(itemCount => math.ceil(itemCount.toDouble / pageSize).toInt)
 
@@ -125,8 +126,8 @@ trait Pagination extends QueryStringBuilder {
 }
 
 case class PaginationView(
-  pageSize: Option[Int] = PaginationView.DEFAULT_PAGESIZE,
-  page: Int = PaginationView.DEFAULT_PAGE
+    pageSize: Option[Int] = PaginationView.DEFAULT_PAGESIZE,
+    page: Int = PaginationView.DEFAULT_PAGE
 ) extends QueryStringBuilder {
   def isDefault = pageSize == PaginationView.DEFAULT_PAGESIZE && page == PaginationView.DEFAULT_PAGE
 
@@ -135,17 +136,17 @@ case class PaginationView(
       pageSize.map("pageSize" -> _.toString) ++
       Some("page" -> page.toString)
 
-  lazy val skip = pageSize.map(_*(page-1))
+  lazy val skip = pageSize.map(_ * (page - 1))
 
-  def withPageSize(pageSize: Option[Int]) = this.copy(pageSize=pageSize)
-  def withPage(page: Int): PaginationView = this.copy(page=page)
+  def withPageSize(pageSize: Option[Int]) = this.copy(pageSize = pageSize)
+  def withPage(page: Int): PaginationView = this.copy(page = page)
 }
 
 object PaginationView {
   val DEFAULT_PAGESIZE = Some(20)
   val DEFAULT_PAGE = 1
 
-  def fromRequest(implicit r: RequestHeader):PaginationView = {
+  def fromRequest(implicit r: RequestHeader): PaginationView = {
     def param(s: String): Option[String] =
       r.queryString.get(s).flatMap(_.headOption).filter(!_.isEmpty)
 
@@ -156,18 +157,21 @@ object PaginationView {
   }
 }
 
-case class DeployFilterPagination(filter: DeployFilter, pagination: PaginationView, itemCount:Option[Int] = None) extends QueryStringBuilder with Pagination {
+case class DeployFilterPagination(filter: DeployFilter, pagination: PaginationView, itemCount: Option[Int] = None)
+    extends QueryStringBuilder
+    with Pagination {
   lazy val queryStringParams = filter.queryStringParams ++ pagination.queryStringParams
 
-  def replaceFilter(f: DeployFilter => DeployFilter) = this.copy(filter=f(filter), pagination=pagination.withPage(1))
-  def replacePagination(f: PaginationView => PaginationView) = this.copy(pagination=f(pagination))
+  def replaceFilter(f: DeployFilter => DeployFilter) =
+    this.copy(filter = f(filter), pagination = pagination.withPage(1))
+  def replacePagination(f: PaginationView => PaginationView) = this.copy(pagination = f(pagination))
 
-  def withProjectName(projectName: Option[String]) = this.copy(filter=filter.withProjectName(projectName))
-  def withStage(stage: Option[String]) = this.copy(filter=filter.withStage(stage))
-  def withDeployer(deployer: Option[String]) = this.copy(filter=filter.withDeployer(deployer))
-  def withStatus(status: Option[RunState.Value]) = this.copy(filter=filter.withStatus(status))
-  def withPage(page: Int): DeployFilterPagination = this.copy(pagination=pagination.withPage(page))
-  def withPageSize(size: Option[Int]) = this.copy(pagination=pagination.withPageSize(size))
+  def withProjectName(projectName: Option[String]) = this.copy(filter = filter.withProjectName(projectName))
+  def withStage(stage: Option[String]) = this.copy(filter = filter.withStage(stage))
+  def withDeployer(deployer: Option[String]) = this.copy(filter = filter.withDeployer(deployer))
+  def withStatus(status: Option[RunState.Value]) = this.copy(filter = filter.withStatus(status))
+  def withPage(page: Int): DeployFilterPagination = this.copy(pagination = pagination.withPage(page))
+  def withPageSize(size: Option[Int]) = this.copy(pagination = pagination.withPageSize(size))
 
   def withItemCount(count: Option[Int]) = this.copy(itemCount = count)
 
@@ -177,7 +181,7 @@ case class DeployFilterPagination(filter: DeployFilter, pagination: PaginationVi
 }
 
 object DeployFilterPagination {
-  def fromRequest(implicit r: RequestHeader):DeployFilterPagination = {
+  def fromRequest(implicit r: RequestHeader): DeployFilterPagination = {
     DeployFilterPagination(DeployFilter.fromRequest.getOrElse(DeployFilter()), PaginationView.fromRequest)
   }
 }

--- a/riff-raff/app/deployment/model.scala
+++ b/riff-raff/app/deployment/model.scala
@@ -21,8 +21,7 @@ object Record {
   val RIFFRAFF_HOSTNAME = "riffraff-hostname"
   val RIFFRAFF_DOMAIN = "riffraff-domain"
 
-  private val formatter = new PeriodFormatterBuilder()
-    .appendDays
+  private val formatter = new PeriodFormatterBuilder().appendDays
     .appendSuffix("d")
     .appendSeparator(" ")
     .appendHours
@@ -35,7 +34,7 @@ object Record {
     .appendSuffix("s")
     .toFormatter
 
-  def prettyPrintDuration(duration: Duration): String = 
+  def prettyPrintDuration(duration: Duration): String =
     formatter.print(duration.toPeriod)
 }
 
@@ -98,7 +97,7 @@ trait Record {
       recordTotalTasks
     else {
       val taskListMessages: Seq[TaskList] = report.allMessages.flatMap {
-        case SimpleMessageState(list@TaskList(tasks), _, _) => Some(list)
+        case SimpleMessageState(list @ TaskList(tasks), _, _) => Some(list)
         case _ => None
       }
       assert(taskListMessages.size <= 1, "More than one TaskList in report")
@@ -117,21 +116,23 @@ trait Record {
   }
 
   lazy val completedPercentage: Int =
-    totalTasks.map{total =>
-      (completedTasks * 100) / total
-    }.getOrElse(0)
+    totalTasks
+      .map { total =>
+        (completedTasks * 100) / total
+      }
+      .getOrElse(0)
 }
 
 object DeployRecord {
-  def apply(uuid: UUID,
-            parameters: DeployParameters ): DeployRecord = {
+  def apply(uuid: UUID, parameters: DeployParameters): DeployRecord = {
     val build = Builds.all.find(b => b.jobName == parameters.build.projectName && b.id.toString == parameters.build.id)
-    val metaData = build.map { case b: S3Build =>
-      Map(
-        "branch" -> b.branchName,
-        VCSInfo.REVISION -> b.revision,
-        VCSInfo.CIURL -> b.vcsURL
-      )
+    val metaData = build.map {
+      case b: S3Build =>
+        Map(
+          "branch" -> b.branchName,
+          VCSInfo.REVISION -> b.revision,
+          VCSInfo.CIURL -> b.vcsURL
+        )
     }
 
     DeployRecord(new DateTime(), uuid, parameters, metaData.getOrElse(Map.empty[String, String]))
@@ -139,14 +140,15 @@ object DeployRecord {
 }
 
 case class DeployRecord(time: DateTime,
-                           uuid: UUID,
-                           parameters: DeployParameters,
-                           metaData: Map[String, String] = Map.empty,
-                           messages: List[MessageWrapper] = Nil,
-                           recordState: Option[RunState.Value] = None,
-                           recordTotalTasks: Option[Int] = None,
-                           recordCompletedTasks: Option[Int] = None,
-                           recordLastActivityTime: Option[DateTime] = None) extends Record {
+                        uuid: UUID,
+                        parameters: DeployParameters,
+                        metaData: Map[String, String] = Map.empty,
+                        messages: List[MessageWrapper] = Nil,
+                        recordState: Option[RunState.Value] = None,
+                        recordTotalTasks: Option[Int] = None,
+                        recordCompletedTasks: Option[Int] = None,
+                        recordLastActivityTime: Option[DateTime] = None)
+    extends Record {
   lazy val report = DeployReport(messages)
 
   def +(message: MessageWrapper): DeployRecord = {

--- a/riff-raff/app/deployment/preview/Preview.scala
+++ b/riff-raff/app/deployment/preview/Preview.scala
@@ -16,8 +16,11 @@ import magenta.input._
 import magenta.{DeployParameters, DeploymentResources}
 
 object Preview extends Loggable {
-  def apply(artifact: S3YamlArtifact, yamlConfig: String, parameters: DeployParameters,
-    resources: DeploymentResources, deploymentTypes: Seq[DeploymentType]): Preview = {
+  def apply(artifact: S3YamlArtifact,
+            yamlConfig: String,
+            parameters: DeployParameters,
+            resources: DeploymentResources,
+            deploymentTypes: Seq[DeploymentType]): Preview = {
 
     val validatedGraph = for {
       deploymentGraph <- Resolver.resolveDeploymentGraph(yamlConfig, deploymentTypes, parameters.selector)
@@ -32,12 +35,13 @@ object Preview extends Loggable {
     Preview(validatedGraph, parameters)
   }
 
-  private[preview] def sequenceGraph[A, E](graph: Graph[Validated[E, A]])(implicit E: Semigroup[E]): Validated[E, Graph[A]] = {
-    val anyErrors = graph.toList.collect{case Invalid(errors) => errors}
+  private[preview] def sequenceGraph[A, E](graph: Graph[Validated[E, A]])(
+      implicit E: Semigroup[E]): Validated[E, Graph[A]] = {
+    val anyErrors = graph.toList.collect { case Invalid(errors) => errors }
     if (anyErrors.nonEmpty) {
       Invalid(anyErrors.reduce(_ |+| _))
     } else {
-      Valid(graph.map{
+      Valid(graph.map {
         case Valid(node) => node
         case Invalid(_) => `wtf?`
       })
@@ -45,4 +49,5 @@ object Preview extends Loggable {
   }
 }
 
-case class Preview(graph: Validated[ConfigErrors, Graph[(DeploymentKey, DeploymentTasks)]], parameters: DeployParameters)
+case class Preview(graph: Validated[ConfigErrors, Graph[(DeploymentKey, DeploymentTasks)]],
+                   parameters: DeployParameters)

--- a/riff-raff/app/deployment/preview/PreviewCoordinator.scala
+++ b/riff-raff/app/deployment/preview/PreviewCoordinator.scala
@@ -20,7 +20,7 @@ class PreviewCoordinator(prismLookup: PrismLookup, deploymentTypes: Seq[Deployme
   private val previews: ConcurrentMap[UUID, PreviewResult] = new ConcurrentHashMap[UUID, PreviewResult]().asScala
 
   def cleanupPreviews() {
-    previews.retain{(uuid, result) =>
+    previews.retain { (uuid, result) =>
       !result.future.isCompleted || result.duration.toStandardMinutes.getMinutes < 60
     }
   }

--- a/riff-raff/app/docs/DeployTypeDocs.scala
+++ b/riff-raff/app/docs/DeployTypeDocs.scala
@@ -1,7 +1,18 @@
 package docs
 
 import magenta.artifact.S3Path
-import magenta.{App, Build, DeployParameters, DeployTarget, Deployer, DeploymentPackage, NamedStack, RecipeName, Region, Stage}
+import magenta.{
+  App,
+  Build,
+  DeployParameters,
+  DeployTarget,
+  Deployer,
+  DeploymentPackage,
+  NamedStack,
+  RecipeName,
+  Region,
+  Stage
+}
 import magenta.deployment_type.{DeploymentType, Param}
 
 case class ActionDoc(name: String, documentation: String, isDefault: Boolean)
@@ -10,7 +21,15 @@ case class DeployTypeDocs(documentation: String, actions: Seq[ActionDoc], params
 
 object DeployTypeDocs {
   def defaultFromParam(fakePackage: DeploymentPackage, param: Param[_]): Option[String] = {
-    val fakeTarget = DeployTarget(DeployParameters(Deployer("<deployerName>"), Build("<projectName>", "<buildNo>"), Stage("<stage>"), RecipeName("<recipe>"), stacks = Seq(NamedStack("<stack>"))), NamedStack("<stack>"), Region("<region>"))
+    val fakeTarget = DeployTarget(
+      DeployParameters(Deployer("<deployerName>"),
+                       Build("<projectName>", "<buildNo>"),
+                       Stage("<stage>"),
+                       RecipeName("<recipe>"),
+                       stacks = Seq(NamedStack("<stack>"))),
+      NamedStack("<stack>"),
+      Region("<region>")
+    )
     (param.defaultValue, param.defaultValueFromContext.map(_(fakePackage, fakeTarget))) match {
       case (Some(default), _) => Some(default.toString)
       case (None, Some(Right(pkgFunction))) => Some(pkgFunction.toString)
@@ -21,25 +40,42 @@ object DeployTypeDocs {
 
   def generateDocs(deploymentTypes: Seq[DeploymentType]): Seq[(DeploymentType, DeployTypeDocs)] = {
     deploymentTypes.sortBy(_.name).map { dt =>
-      val actionDocs = dt.actionsMap.values.map { action =>
-        ActionDoc(action.name, action.documentation, dt.defaultActionNames.contains(action.name))
-      }.toList.sortBy{
-        doc =>
+      val actionDocs = dt.actionsMap.values
+        .map { action =>
+          ActionDoc(action.name, action.documentation, dt.defaultActionNames.contains(action.name))
+        }
+        .toList
+        .sortBy { doc =>
           val defaultOrdering = dt.defaultActionNames.indexOf(doc.name)
           val defaultOrderingWithNonDefaultLast = if (defaultOrdering == -1) Int.MaxValue else defaultOrdering
           (defaultOrderingWithNonDefaultLast, doc.name)
-      }
+        }
 
-      val legacyPackage = DeploymentPackage("<packageName>",Seq(App("<app>")),Map.empty,dt.name,
-        S3Path("<bucket>", "<prefix>"), legacyConfig = true, deploymentTypes)
-      val newPackage = DeploymentPackage("<packageName>",Seq(App("<app>")),Map.empty,dt.name,
-        S3Path("<bucket>", "<prefix>"), legacyConfig = false, deploymentTypes)
+      val legacyPackage =
+        DeploymentPackage("<packageName>",
+                          Seq(App("<app>")),
+                          Map.empty,
+                          dt.name,
+                          S3Path("<bucket>", "<prefix>"),
+                          legacyConfig = true,
+                          deploymentTypes)
+      val newPackage =
+        DeploymentPackage("<packageName>",
+                          Seq(App("<app>")),
+                          Map.empty,
+                          dt.name,
+                          S3Path("<bucket>", "<prefix>"),
+                          legacyConfig = false,
+                          deploymentTypes)
 
-      val paramDocs = dt.params.sortBy(_.name).map { param =>
-        val defaultLegacy = defaultFromParam(legacyPackage, param)
-        val defaultNew = defaultFromParam(newPackage, param)
-        ParamDoc(param.name, param.documentation, defaultLegacy, defaultNew)
-      }.sortBy(doc => (doc.default.isDefined, doc.name))
+      val paramDocs = dt.params
+        .sortBy(_.name)
+        .map { param =>
+          val defaultLegacy = defaultFromParam(legacyPackage, param)
+          val defaultNew = defaultFromParam(newPackage, param)
+          ParamDoc(param.name, param.documentation, defaultLegacy, defaultNew)
+        }
+        .sortBy(doc => (doc.default.isDefined, doc.name))
 
       dt -> DeployTypeDocs(dt.documentation, actionDocs, paramDocs)
     }

--- a/riff-raff/app/lifecycle/Lifecycle.scala
+++ b/riff-raff/app/lifecycle/Lifecycle.scala
@@ -1,10 +1,10 @@
 package lifecycle
 
 /**
- * Any objects with this trait mixed in will automatically get
- * instantiated and lifecycled.  init() called by the Global
- * onStart() and shutdown called by onStop().
- */
+  * Any objects with this trait mixed in will automatically get
+  * instantiated and lifecycled.  init() called by the Global
+  * onStart() and shutdown called by onStop().
+  */
 trait Lifecycle {
   def init()
   def shutdown()

--- a/riff-raff/app/lifecycle/ShutdownWhenInactive.scala
+++ b/riff-raff/app/lifecycle/ShutdownWhenInactive.scala
@@ -11,7 +11,11 @@ object ShutdownWhenInactive extends Lifecycle with Logging {
   val EXITCODE = 217
 
   // switch to enable this mode
-  lazy val switch = new DefaultSwitch("shutdown-when-inactive", s"Shutdown riff-raff when there are no running deploys. Turning this on will cause RiffRaff to exit with exitcode $EXITCODE as soon as the last queued deploy finishes.", false) {
+  lazy val switch = new DefaultSwitch(
+    "shutdown-when-inactive",
+    s"Shutdown riff-raff when there are no running deploys. Turning this on will cause RiffRaff to exit with exitcode $EXITCODE as soon as the last queued deploy finishes.",
+    false
+  ) {
     override def switchOn() = {
       super.switchOn()
       // try and shutdown immediately
@@ -29,7 +33,8 @@ object ShutdownWhenInactive extends Lifecycle with Logging {
         System.exit(EXITCODE)
       } else {
         val activeBuilds: Iterable[Record] = Deployments.getControllerDeploys.filterNot(_.isDone)
-        log.info(s"RiffRaff not yet inactive (Still running: ${activeBuilds.map(_.uuid).mkString(", ")}), deferring shutdown request")
+        log.info(
+          s"RiffRaff not yet inactive (Still running: ${activeBuilds.map(_.uuid).mkString(", ")}), deferring shutdown request")
       }
     }
   }
@@ -37,6 +42,6 @@ object ShutdownWhenInactive extends Lifecycle with Logging {
   val sub = Deployments.completed.subscribe(_ => if (switch.isSwitchedOn) attemptShutdown())
 
   // add hooks to listen and exit when desired
-  def init() { }
+  def init() {}
   def shutdown() { sub.unsubscribe() }
 }

--- a/riff-raff/app/notification/HookTemplate.scala
+++ b/riff-raff/app/notification/HookTemplate.scala
@@ -7,9 +7,9 @@ import org.parboiled2.CharPredicate._
 import persistence.{DeployRecordDocument}
 
 class HookTemplate(val input: ParserInput, record: DeployRecordDocument, urlEncode: Boolean = false) extends Parser {
-  def Template = rule{ NonToken ~ (zeroOrMore(SubstitutionToken ~ NonToken ~> (_ + _)) ~> (_.mkString)) ~> (_ + _) }
+  def Template = rule { NonToken ~ (zeroOrMore(SubstitutionToken ~ NonToken ~> (_ + _)) ~> (_.mkString)) ~> (_ + _) }
 
-  def NonToken = rule { capture(zeroOrMore(!SubstitutionToken ~ ANY))  }
+  def NonToken = rule { capture(zeroOrMore(!SubstitutionToken ~ ANY)) }
 
   def SubstitutionToken = rule { "%deploy." ~ Param ~ '%' }
 
@@ -17,9 +17,10 @@ class HookTemplate(val input: ParserInput, record: DeployRecordDocument, urlEnco
 
   def SimpleParam = rule { HookTemplate.paramSubstitutions.mapValues(f => encode(f(record))) }
 
-  def Tag = rule { "tag." ~ capture( oneOrMore(Alpha | '-' | '_')) ~> (tagName =>
-    encode(record.parameters.tags.getOrElse(tagName, ""))
-  )}
+  def Tag = rule {
+    "tag." ~ capture(oneOrMore(Alpha | '-' | '_')) ~> (tagName =>
+      encode(record.parameters.tags.getOrElse(tagName, "")))
+  }
 
   def encode(p: String) = if (urlEncode) URLEncoder.encode(p, "utf-8") else p
 }
@@ -31,7 +32,7 @@ object HookTemplate {
     ("project", _.parameters.projectName),
     ("stage", _.parameters.stage),
     ("recipe", _.parameters.recipe),
-    ("hostList",  _.parameters.hostList.mkString(",")),
+    ("hostList", _.parameters.hostList.mkString(",")),
     ("deployer", _.parameters.deployer),
     ("uuid", _.uuid.toString)
   )

--- a/riff-raff/app/notification/hooks.scala
+++ b/riff-raff/app/notification/hooks.scala
@@ -17,7 +17,7 @@ import play.api.libs.ws._
 import scala.util.Try
 import scala.util.control.NonFatal
 
-case class Auth(user:String, password:String, scheme:WSAuthScheme=WSAuthScheme.BASIC)
+case class Auth(user: String, password: String, scheme: WSAuthScheme = WSAuthScheme.BASIC)
 
 case class HookConfig(id: UUID,
                       projectName: String,
@@ -27,11 +27,13 @@ case class HookConfig(id: UUID,
                       lastEdited: DateTime,
                       user: String,
                       method: HttpMethod = GET,
-                      postBody: Option[String] = None) extends Logging {
+                      postBody: Option[String] = None)
+    extends Logging {
 
   def request(record: DeployRecordDocument)(implicit wsClient: WSClient) = {
     val templatedUrl = new HookTemplate(url, record, urlEncode = true).Template.run().get
-    authFor(templatedUrl).map(ui => wsClient.url(templatedUrl).withAuth(ui.user, ui.password, ui.scheme))
+    authFor(templatedUrl)
+      .map(ui => wsClient.url(templatedUrl).withAuth(ui.user, ui.password, ui.scheme))
       .getOrElse(wsClient.url(templatedUrl))
   }
 
@@ -50,38 +52,41 @@ case class HookConfig(id: UUID,
         case GET =>
           urlRequest.get()
         case POST =>
-          postBody.map { t =>
-            val body = new HookTemplate(t, record, urlEncode = false).Template.run().get
-            val json = Try {
-              Json.parse(body)
-            }.toOption
-            json.map(urlRequest.post(_)).getOrElse(urlRequest.post(body))
-          }.getOrElse (
-            urlRequest.post(Map[String, Seq[String]](
-              "build" -> Seq(record.parameters.buildId),
-              "project" -> Seq(record.parameters.projectName),
-              "stage" -> Seq(record.parameters.stage),
-              "recipe" -> Seq(record.parameters.recipe),
-              "hosts" -> record.parameters.hostList,
-              "stacks" -> record.parameters.stacks,
-              "deployer" -> Seq(record.parameters.deployer),
-              "uuid" -> Seq(record.uuid.toString),
-              "tags" -> record.parameters.tags.toSeq.map{ case ((k, v)) => s"$k:$v" }
-            ))
-          )
+          postBody
+            .map { t =>
+              val body = new HookTemplate(t, record, urlEncode = false).Template.run().get
+              val json = Try {
+                Json.parse(body)
+              }.toOption
+              json.map(urlRequest.post(_)).getOrElse(urlRequest.post(body))
+            }
+            .getOrElse(
+              urlRequest.post(Map[String, Seq[String]](
+                "build" -> Seq(record.parameters.buildId),
+                "project" -> Seq(record.parameters.projectName),
+                "stage" -> Seq(record.parameters.stage),
+                "recipe" -> Seq(record.parameters.recipe),
+                "hosts" -> record.parameters.hostList,
+                "stacks" -> record.parameters.stacks,
+                "deployer" -> Seq(record.parameters.deployer),
+                "uuid" -> Seq(record.uuid.toString),
+                "tags" -> record.parameters.tags.toSeq.map { case ((k, v)) => s"$k:$v" }
+              ))
+            )
       }).map { response =>
-        log.info(s"HTTP status code ${response.status} from ${urlRequest.url}")
-        log.debug(s"HTTP response body from ${urlRequest.url}: ${response.status}")
-      }.recover {
-        case NonFatal(e) => log.error(s"Problem calling ${urlRequest.url}", e)
-      }
+          log.info(s"HTTP status code ${response.status} from ${urlRequest.url}")
+          log.debug(s"HTTP response body from ${urlRequest.url}: ${response.status}")
+        }
+        .recover {
+          case NonFatal(e) => log.error(s"Problem calling ${urlRequest.url}", e)
+        }
     } else {
       log.info("Hook disabled")
     }
   }
 }
 object HookConfig {
-  def apply(projectName: String, stage: String, url: String, enabled: Boolean, updatedBy:String): HookConfig =
+  def apply(projectName: String, stage: String, url: String, enabled: Boolean, updatedBy: String): HookConfig =
     HookConfig(UUID.randomUUID(), projectName, stage, url, enabled, new DateTime(), updatedBy)
 }
 
@@ -90,7 +95,7 @@ class HooksClient(wsClient: WSClient) extends Lifecycle with Logging {
   val actor = try {
     Some(system.actorOf(Props(classOf[HooksClientActor], wsClient), "hook-client"))
   } catch {
-    case t:Throwable =>
+    case t: Throwable =>
       log.error("Failed to start HookClient", t)
       None
   }
@@ -107,7 +112,7 @@ class HooksClient(wsClient: WSClient) extends Lifecycle with Logging {
     }
   })
 
-  def init() { }
+  def init() {}
   def shutdown() {
     messageSub.unsubscribe()
     actor.foreach(system.stop)
@@ -128,7 +133,7 @@ class HooksClientActor(implicit wsClient: WSClient) extends Actor with Logging {
         try {
           config.act(Persistence.store.readDeploy(uuid).get)
         } catch {
-          case t:Throwable =>
+          case t: Throwable =>
             log.warn(s"Exception caught whilst processing post deploy hooks for $config", t)
         }
       }

--- a/riff-raff/app/persistence/HookConfigRepository.scala
+++ b/riff-raff/app/persistence/HookConfigRepository.scala
@@ -18,9 +18,10 @@ object HookConfigRepository extends DynamoRepository {
 
   def getPostDeployHook(id: UUID): Option[HookConfig] = exec(table.get('id -> id)).flatMap(_.toOption)
   def getPostDeployHook(projectName: String, stage: String): Seq[HookConfig] =
-    exec(table.index("hook-config-project").query('projectName -> projectName)).flatMap(_.toOption)
-        .filter(_.stage == stage)
-  def getPostDeployHookList:Iterable[HookConfig] = exec(table.scan()).flatMap(_.toOption)
+    exec(table.index("hook-config-project").query('projectName -> projectName))
+      .flatMap(_.toOption)
+      .filter(_.stage == stage)
+  def getPostDeployHookList: Iterable[HookConfig] = exec(table.scan()).flatMap(_.toOption)
   def setPostDeployHook(config: HookConfig): Unit = exec(table.put(config))
   def deletePostDeployHook(id: UUID): Unit = exec(table.delete('id -> id))
 }

--- a/riff-raff/app/persistence/datastore.scala
+++ b/riff-raff/app/persistence/datastore.scala
@@ -19,29 +19,29 @@ trait DataStore extends DocumentStore {
       message.foreach(m => log.debug("Completed: %s" format m))
       value
     } catch {
-      case t:Throwable =>
+      case t: Throwable =>
         val errorMessage = "Squashing uncaught exception%s" format message.map("whilst %s" format _).getOrElse("")
         log.error(errorMessage, t)
         default
     }
   }
 
-  def collectionStats:Map[String, CollectionStats] = Map.empty
+  def collectionStats: Map[String, CollectionStats] = Map.empty
 
   def getAuthorisation(email: String): Option[AuthorisationRecord] = None
-  def getAuthorisationList:List[AuthorisationRecord] = Nil
+  def getAuthorisationList: List[AuthorisationRecord] = Nil
   def setAuthorisation(auth: AuthorisationRecord) {}
   def deleteAuthorisation(email: String) {}
 
   def createApiKey(newKey: ApiKey) {}
-  def getApiKeyList:Iterable[ApiKey] = Nil
+  def getApiKeyList: Iterable[ApiKey] = Nil
   def getApiKey(key: String): Option[ApiKey] = None
   def getAndUpdateApiKey(key: String, counter: Option[String] = None): Option[ApiKey] = None
   def getApiKeyByApplication(application: String): Option[ApiKey] = None
   def deleteApiKey(key: String) {}
 
-  def writeKey(key:String, value:String) {}
-  def readKey(key:String): Option[String] = None
+  def writeKey(key: String, value: String) {}
+  def readKey(key: String): Option[String] = None
   def deleteKey(key: String) {}
 }
 
@@ -56,5 +56,3 @@ object Persistence extends Logging {
   }
 
 }
-
-

--- a/riff-raff/app/persistence/housekeeping.scala
+++ b/riff-raff/app/persistence/housekeeping.scala
@@ -21,9 +21,9 @@ object SummariseDeploysHousekeeping extends Lifecycle with Logging {
     deploys.size
   }
 
-  var summariseSchedule:Option[ScheduledAgent[Int]] = None
+  var summariseSchedule: Option[ScheduledAgent[Int]] = None
 
-  val update = DailyScheduledAgentUpdate[Int](housekeepingTime){ _ + summariseDeploys() }
+  val update = DailyScheduledAgentUpdate[Int](housekeepingTime) { _ + summariseDeploys() }
 
   def init() {
     summariseSchedule = Some(ScheduledAgent(0, update))

--- a/riff-raff/app/persistence/mapping.scala
+++ b/riff-raff/app/persistence/mapping.scala
@@ -10,12 +10,17 @@ import controllers.SimpleDeployDetail
 import automagic.transform
 import magenta.input.{DeploymentKey, DeploymentKeysSelector, All}
 
-case class RecordConverter(uuid:UUID, startTime:DateTime, params: ParametersDocument, status:RunState.Value, messages:List[MessageWrapper] = Nil) extends Logging {
+case class RecordConverter(uuid: UUID,
+                           startTime: DateTime,
+                           params: ParametersDocument,
+                           status: RunState.Value,
+                           messages: List[MessageWrapper] = Nil)
+    extends Logging {
   def +(newWrapper: MessageWrapper): RecordConverter = copy(messages = messages ::: List(newWrapper))
   def +(newStatus: RunState.Value): RecordConverter = copy(status = newStatus)
 
   def apply(message: MessageWrapper): Option[LogDocument] = {
-    val stackId=message.messageId
+    val stackId = message.messageId
     logDocuments.find(_.id == stackId)
   }
 
@@ -86,16 +91,21 @@ case class DocumentConverter(deploy: DeployRecordDocument, logs: Seq[LogDocument
     if (logs.isEmpty) Nil else convertToMessageWrappers(LogDocumentTree(logs))
   }
 
-  def convertToMessageWrappers(tree: LogDocumentTree): List[MessageWrapper] = convertToMessageWrappers(tree, tree.roots.head)
+  def convertToMessageWrappers(tree: LogDocumentTree): List[MessageWrapper] =
+    convertToMessageWrappers(tree, tree.roots.head)
 
-  def convertToMessageWrappers(tree: LogDocumentTree, log: LogDocument, messagesTail: List[Message] = Nil): List[MessageWrapper] = {
+  def convertToMessageWrappers(tree: LogDocumentTree,
+                               log: LogDocument,
+                               messagesTail: List[Message] = Nil): List[MessageWrapper] = {
     val children = tree.childrenOf(log).toList
     log.document match {
       case leaf if children.isEmpty =>
-        List(messageWrapper(log, MessageStack(leaf.asMessage(parameters, messagesTail.headOption) :: messagesTail, log.time)))
+        List(
+          messageWrapper(log,
+                         MessageStack(leaf.asMessage(parameters, messagesTail.headOption) :: messagesTail, log.time)))
       case node => {
-        val message:Message = node.asMessage(parameters)
-        messageWrapper(log,MessageStack(StartContext(message) :: messagesTail, log.time)) ::
+        val message: Message = node.asMessage(parameters)
+        messageWrapper(log, MessageStack(StartContext(message) :: messagesTail, log.time)) ::
           children.flatMap(child => convertToMessageWrappers(tree, child, message :: messagesTail))
       }
     }
@@ -110,14 +120,14 @@ trait DocumentStore {
   def writeDeploy(deploy: DeployRecordDocument) {}
   def writeLog(log: LogDocument) {}
   def updateStatus(uuid: UUID, status: RunState.Value) {}
-  def updateDeploySummary(uuid: UUID, totalTasks:Option[Int], completedTasks:Int, lastActivityTime:DateTime) {}
+  def updateDeploySummary(uuid: UUID, totalTasks: Option[Int], completedTasks: Int, lastActivityTime: DateTime) {}
   def readDeploy(uuid: UUID): Option[DeployRecordDocument] = None
   def readLogs(uuid: UUID): Iterable[LogDocument] = Nil
   def getDeployUUIDs(limit: Int = 0): Iterable[SimpleDeployDetail] = Nil
   def getDeploys(filter: Option[DeployFilter], pagination: PaginationView): Iterable[DeployRecordDocument] = Nil
   def countDeploys(filter: Option[DeployFilter]): Int = 0
   def deleteDeployLog(uuid: UUID) {}
-  def getLastCompletedDeploys(projectName: String):Map[String,UUID] = Map.empty
+  def getLastCompletedDeploys(projectName: String): Map[String, UUID] = Map.empty
   def addStringUUID(uuid: UUID) {}
   def getDeployUUIDsWithoutStringUUIDs: Iterable[SimpleDeployDetail] = Nil
   def summariseDeploy(uuid: UUID) {}
@@ -144,7 +154,7 @@ object DocumentStoreConverter extends Logging {
     updateDeploySummary(record.uuid, record.totalTasks, record.completedTasks, record.lastActivityTime)
   }
 
-  def updateDeploySummary(uuid: UUID, totalTasks:Option[Int], completedTasks:Int, lastActivityTime:DateTime) {
+  def updateDeploySummary(uuid: UUID, totalTasks: Option[Int], completedTasks: Int, lastActivityTime: DateTime) {
     documentStore.updateDeploySummary(uuid, totalTasks, completedTasks, lastActivityTime)
   }
 
@@ -160,10 +170,10 @@ object DocumentStoreConverter extends Logging {
     documentStore.addMetaData(uuid, metaData)
   }
 
-  def getDeployDocument(uuid:UUID) = documentStore.readDeploy(uuid)
-  def getDeployLogs(uuid:UUID) = documentStore.readLogs(uuid)
+  def getDeployDocument(uuid: UUID) = documentStore.readDeploy(uuid)
+  def getDeployLogs(uuid: UUID) = documentStore.readLogs(uuid)
 
-  def getDeploy(uuid:UUID, fetchLog: Boolean = true): Option[DeployRecord] = {
+  def getDeploy(uuid: UUID, fetchLog: Boolean = true): Option[DeployRecord] = {
     try {
       val deployDocument = getDeployDocument(uuid)
       val logDocuments = if (fetchLog) getDeployLogs(uuid) else Nil
@@ -171,19 +181,21 @@ object DocumentStoreConverter extends Logging {
         DocumentConverter(deploy, logDocuments.toSeq).deployRecord
       }
     } catch {
-      case e:Exception =>
+      case e: Exception =>
         log.error(s"Couldn't get DeployRecord for $uuid", e)
         None
     }
   }
 
-  def getDeployList(filter: Option[DeployFilter], pagination: PaginationView, fetchLog: Boolean = true): Seq[DeployRecord] = {
-    documentStore.getDeploys(filter, pagination).toSeq.flatMap{ deployDocument =>
+  def getDeployList(filter: Option[DeployFilter],
+                    pagination: PaginationView,
+                    fetchLog: Boolean = true): Seq[DeployRecord] = {
+    documentStore.getDeploys(filter, pagination).toSeq.flatMap { deployDocument =>
       try {
         val logs = if (fetchLog) getDeployLogs(deployDocument.uuid) else Nil
         Some(DocumentConverter(deployDocument, logs.toSeq).deployRecord)
       } catch {
-        case e:Exception =>
+        case e: Exception =>
           log.error(s"Couldn't get DeployRecord for ${deployDocument.uuid}", e)
           None
       }
@@ -192,7 +204,7 @@ object DocumentStoreConverter extends Logging {
 
   def countDeploys(filter: Option[DeployFilter]): Int = documentStore.countDeploys(filter)
 
-  def getLastCompletedDeploys(project: String, fetchLog:Boolean = false): Map[String, DeployRecord] =
+  def getLastCompletedDeploys(project: String, fetchLog: Boolean = false): Map[String, DeployRecord] =
     documentStore.getLastCompletedDeploys(project).mapValues(uuid => getDeploy(uuid, fetchLog = fetchLog).get)
 
   def findProjects(): List[String] = documentStore.findProjects()

--- a/riff-raff/app/persistence/mongodb.scala
+++ b/riff-raff/app/persistence/mongodb.scala
@@ -42,18 +42,19 @@ object MongoDatastore extends Logging {
 
   RegisterJodaTimeConversionHelpers()
 
-  def buildDatastore() = try {
-    if (Configuration.mongo.isConfigured) {
-      val uri = MongoClientURI(Configuration.mongo.uri.get)
-      val mongoClient = MongoClient(uri)
-      val db = MongoDB(mongoClient, uri.database.get)
-      Some(new MongoDatastore(db))
-    } else None
-  } catch {
-    case e:Throwable =>
-      log.error("Couldn't initialise MongoDB connection", e)
-      None
-  }
+  def buildDatastore() =
+    try {
+      if (Configuration.mongo.isConfigured) {
+        val uri = MongoClientURI(Configuration.mongo.uri.get)
+        val mongoClient = MongoClient(uri)
+        val db = MongoDB(mongoClient, uri.database.get)
+        Some(new MongoDatastore(db))
+      } else None
+    } catch {
+      case e: Throwable =>
+        log.error("Couldn't initialise MongoDB connection", e)
+        None
+    }
 }
 
 class MongoDatastore(database: MongoDB) extends DataStore with DocumentStore with Logging {
@@ -69,13 +70,14 @@ class MongoDatastore(database: MongoDB) extends DataStore with DocumentStore wit
   private def collectionStats(collection: MongoCollection): CollectionStats = {
     val stats = collection.stats
     new CollectionStats {
-      def dataSize = logAndSquashExceptions(None,0L){ stats.getLong("size", 0L) }
-      def storageSize = logAndSquashExceptions(None,0L){ stats.getLong("storageSize", 0L) }
-      def documentCount = logAndSquashExceptions(None,0L){ collection.getCount() }
+      def dataSize = logAndSquashExceptions(None, 0L) { stats.getLong("size", 0L) }
+      def storageSize = logAndSquashExceptions(None, 0L) { stats.getLong("storageSize", 0L) }
+      def documentCount = logAndSquashExceptions(None, 0L) { collection.getCount() }
     }
   }
 
-  override def collectionStats: Map[String, CollectionStats] = collections.map(coll => (coll.name, collectionStats(coll))).toMap
+  override def collectionStats: Map[String, CollectionStats] =
+    collections.map(coll => (coll.name, collectionStats(coll))).toMap
 
   // ensure indexes
   deployCollection.createIndex("startTime")
@@ -83,21 +85,23 @@ class MongoDatastore(database: MongoDB) extends DataStore with DocumentStore wit
   apiKeyCollection.createIndex(MongoDBObject("application" -> 1), "uniqueApplicationIndex", true)
 
   override def setAuthorisation(auth: AuthorisationRecord) {
-    logAndSquashExceptions(Some("Creating auth object %s" format auth),()) {
+    logAndSquashExceptions(Some("Creating auth object %s" format auth), ()) {
       val criteriaId = MongoDBObject("_id" -> auth.email)
       authCollection.findAndModify(
         query = criteriaId,
         update = auth.toDBO,
-        upsert = true, fields = MongoDBObject(),
+        upsert = true,
+        fields = MongoDBObject(),
         sort = MongoDBObject(),
         remove = false,
-        returnNew=false
+        returnNew = false
       )
     }
   }
 
   override def getAuthorisation(email: String): Option[AuthorisationRecord] =
-    logAndSquashExceptions[Option[AuthorisationRecord]](Some("Requesting authorisation object for %s" format email),None) {
+    logAndSquashExceptions[Option[AuthorisationRecord]](Some("Requesting authorisation object for %s" format email),
+                                                        None) {
       authCollection.findOneByID(email).flatMap(AuthorisationRecord.fromDBO(_))
     }
 
@@ -107,13 +111,13 @@ class MongoDatastore(database: MongoDB) extends DataStore with DocumentStore wit
     }
 
   override def deleteAuthorisation(email: String) {
-    logAndSquashExceptions(Some("Deleting authorisation object for %s" format email),()) {
+    logAndSquashExceptions(Some("Deleting authorisation object for %s" format email), ()) {
       authCollection.findAndRemove(MongoDBObject("_id" -> email))
     }
   }
 
   override def createApiKey(newKey: ApiKey) {
-    logAndSquashExceptions(Some("Saving new API key %s" format newKey.key),()) {
+    logAndSquashExceptions(Some("Saving new API key %s" format newKey.key), ()) {
       val dbo = newKey.toDBO
       apiKeyCollection.insert(dbo)
     }
@@ -121,11 +125,11 @@ class MongoDatastore(database: MongoDB) extends DataStore with DocumentStore wit
 
   override def getApiKeyList = logAndSquashExceptions[Iterable[ApiKey]](Some("Requesting list of API keys"), Nil) {
     val keys = apiKeyCollection.find().sort(MongoDBObject("application" -> 1))
-    keys.toIterable.flatMap( ApiKey.fromDBO(_) )
+    keys.toIterable.flatMap(ApiKey.fromDBO(_))
   }
 
   override def getApiKey(key: String) =
-    logAndSquashExceptions[Option[ApiKey]](Some("Getting API key details for %s" format key),None) {
+    logAndSquashExceptions[Option[ApiKey]](Some("Getting API key details for %s" format key), None) {
       apiKeyCollection.findOneByID(key).flatMap(ApiKey.fromDBO(_))
     }
 
@@ -133,32 +137,34 @@ class MongoDatastore(database: MongoDB) extends DataStore with DocumentStore wit
     val setLastUsed = $set("lastUsed" -> (new DateTime()))
     val incCounter = counter.map(name => $inc(("callCounters.%s" format name) -> 1L)).getOrElse(MongoDBObject())
     val update = setLastUsed ++ incCounter
-    logAndSquashExceptions[Option[ApiKey]](Some("Getting and updating API key details for %s" format key),None) {
-      apiKeyCollection.findAndModify(
-        query = MongoDBObject("_id" -> key),
-        fields = MongoDBObject(),
-        sort = MongoDBObject(),
-        remove = false,
-        update = update,
-        returnNew = true,
-        upsert = false
-      ).flatMap(ApiKey.fromDBO(_))
+    logAndSquashExceptions[Option[ApiKey]](Some("Getting and updating API key details for %s" format key), None) {
+      apiKeyCollection
+        .findAndModify(
+          query = MongoDBObject("_id" -> key),
+          fields = MongoDBObject(),
+          sort = MongoDBObject(),
+          remove = false,
+          update = update,
+          returnNew = true,
+          upsert = false
+        )
+        .flatMap(ApiKey.fromDBO(_))
     }
   }
 
   override def getApiKeyByApplication(application: String) =
-    logAndSquashExceptions[Option[ApiKey]](Some("Getting API key details for application %s" format application),None) {
+    logAndSquashExceptions[Option[ApiKey]](Some("Getting API key details for application %s" format application), None) {
       apiKeyCollection.findOne(MongoDBObject("application" -> application)).flatMap(ApiKey.fromDBO(_))
     }
 
   override def deleteApiKey(key: String) {
-    logAndSquashExceptions(Some("Deleting API key for %s" format key),()) {
+    logAndSquashExceptions(Some("Deleting API key for %s" format key), ()) {
       apiKeyCollection.findAndRemove(MongoDBObject("_id" -> key))
     }
   }
 
   override def writeDeploy(deploy: DeployRecordDocument) {
-    logAndSquashExceptions(Some("Saving deploy record document for %s" format deploy.uuid),()) {
+    logAndSquashExceptions(Some("Saving deploy record document for %s" format deploy.uuid), ()) {
       val gratedDeploy = deploy.toDBO
       deployCollection.insert(gratedDeploy, WriteConcern.Safe)
     }
@@ -166,38 +172,49 @@ class MongoDatastore(database: MongoDB) extends DataStore with DocumentStore wit
 
   override def updateStatus(uuid: UUID, status: RunState.Value) {
     logAndSquashExceptions(Some("Updating status of %s to %s" format (uuid, status)), ()) {
-      deployCollection.update(MongoDBObject("_id" -> uuid), $set("status" -> status.toString), concern=WriteConcern.Safe)
+      deployCollection.update(MongoDBObject("_id" -> uuid),
+                              $set("status" -> status.toString),
+                              concern = WriteConcern.Safe)
     }
   }
 
-  override def updateDeploySummary(uuid: UUID, totalTasks:Option[Int], completedTasks:Int, lastActivityTime:DateTime) {
-    logAndSquashExceptions(Some(s"Updating summary of $uuid to total:$totalTasks, completed:$completedTasks, lastActivivty:$lastActivityTime"), ()) {
+  override def updateDeploySummary(uuid: UUID,
+                                   totalTasks: Option[Int],
+                                   completedTasks: Int,
+                                   lastActivityTime: DateTime) {
+    logAndSquashExceptions(
+      Some(
+        s"Updating summary of $uuid to total:$totalTasks, completed:$completedTasks, lastActivivty:$lastActivityTime"),
+      ()) {
       val fields =
         List("completedTasks" -> completedTasks, "lastActivityTime" -> lastActivityTime) ++
-        totalTasks.map("totalTasks" ->)
-      deployCollection.update(MongoDBObject("_id" -> uuid), $set(fields: _*), concern=WriteConcern.Safe)
+          totalTasks.map("totalTasks" ->)
+      deployCollection.update(MongoDBObject("_id" -> uuid), $set(fields: _*), concern = WriteConcern.Safe)
     }
   }
 
   override def readDeploy(uuid: UUID): Option[DeployRecordDocument] =
-    logAndSquashExceptions[Option[DeployRecordDocument]](Some("Retrieving deploy record document for %s" format uuid), None) {
+    logAndSquashExceptions[Option[DeployRecordDocument]](Some("Retrieving deploy record document for %s" format uuid),
+                                                         None) {
       deployCollection.findOneByID(uuid).flatMap(DeployRecordDocument.fromDBO(_))
     }
 
   override def writeLog(log: LogDocument) {
-    logAndSquashExceptions(Some("Writing new log document with id %s for deploy %s" format (log.id, log.deploy)),()) {
+    logAndSquashExceptions(Some("Writing new log document with id %s for deploy %s" format (log.id, log.deploy)), ()) {
       deployLogCollection.insert(log.toDBO, WriteConcern.Safe)
     }
   }
 
   override def readLogs(uuid: UUID): Iterable[LogDocument] =
-    logAndSquashExceptions[Iterable[LogDocument]](Some("Retriving logs for deploy %s" format uuid),Nil) {
+    logAndSquashExceptions[Iterable[LogDocument]](Some("Retriving logs for deploy %s" format uuid), Nil) {
       val criteria = MongoDBObject("deploy" -> uuid)
       deployLogCollection.find(criteria).toIterable.flatMap(LogDocument.fromDBO(_))
     }
 
-  override def getDeployUUIDs(limit: Int = 0) = logAndSquashExceptions[Iterable[SimpleDeployDetail]](None,Nil){
-    val cursor = deployCollection.find(MongoDBObject(), MongoDBObject("_id" -> 1, "startTime" -> 1)).sort(MongoDBObject("startTime" -> -1))
+  override def getDeployUUIDs(limit: Int = 0) = logAndSquashExceptions[Iterable[SimpleDeployDetail]](None, Nil) {
+    val cursor = deployCollection
+      .find(MongoDBObject(), MongoDBObject("_id" -> 1, "startTime" -> 1))
+      .sort(MongoDBObject("startTime" -> -1))
     val limitedCursor = if (limit == 0) cursor else cursor.limit(limit)
     limitedCursor.toIterable.map { dbo =>
       val uuid = dbo.getAs[UUID]("_id").get
@@ -206,71 +223,80 @@ class MongoDatastore(database: MongoDB) extends DataStore with DocumentStore wit
     }
   }
 
-  override def getDeploys(filter: Option[DeployFilter], pagination: PaginationView) = logAndSquashExceptions[Iterable[DeployRecordDocument]](None,Nil){
-    val criteria = filter.map(_.criteria).getOrElse(MongoDBObject())
-    val cursor = deployCollection.find(criteria).sort(MongoDBObject("startTime" -> -1)).pagination(pagination)
-    cursor.toIterable.flatMap { DeployRecordDocument.fromDBO(_) }
-  }
+  override def getDeploys(filter: Option[DeployFilter], pagination: PaginationView) =
+    logAndSquashExceptions[Iterable[DeployRecordDocument]](None, Nil) {
+      val criteria = filter.map(_.criteria).getOrElse(MongoDBObject())
+      val cursor = deployCollection.find(criteria).sort(MongoDBObject("startTime" -> -1)).pagination(pagination)
+      cursor.toIterable.flatMap { DeployRecordDocument.fromDBO(_) }
+    }
 
-  override def countDeploys(filter: Option[DeployFilter]) = logAndSquashExceptions[Int](Some("Counting documents matching filter"),0) {
-    val criteria = filter.map(_.criteria).getOrElse(MongoDBObject())
-    deployCollection.count(criteria).toInt
-  }
+  override def countDeploys(filter: Option[DeployFilter]) =
+    logAndSquashExceptions[Int](Some("Counting documents matching filter"), 0) {
+      val criteria = filter.map(_.criteria).getOrElse(MongoDBObject())
+      deployCollection.count(criteria).toInt
+    }
 
   override def deleteDeployLog(uuid: UUID) {
-    logAndSquashExceptions(None,()) {
+    logAndSquashExceptions(None, ()) {
       deployCollection.findAndRemove(MongoDBObject("_id" -> uuid))
       deployLogCollection.remove(MongoDBObject("deploy" -> uuid))
     }
   }
 
-  override def getCompleteDeploysOlderThan(dateTime: DateTime) = logAndSquashExceptions[Iterable[SimpleDeployDetail]](None,Nil){
-    deployCollection.find(
-      MongoDBObject(
-        "startTime" -> MongoDBObject("$lt" -> dateTime),
-        "summarised" -> MongoDBObject("$ne" -> true)
-      )
-    ).toIterable.map { dbo =>
-      val uuid = dbo.getAs[UUID]("_id").get
-      val dateTime = dbo.getAs[DateTime]("startTime")
-      SimpleDeployDetail(uuid, dateTime)
+  override def getCompleteDeploysOlderThan(dateTime: DateTime) =
+    logAndSquashExceptions[Iterable[SimpleDeployDetail]](None, Nil) {
+      deployCollection
+        .find(
+          MongoDBObject(
+            "startTime" -> MongoDBObject("$lt" -> dateTime),
+            "summarised" -> MongoDBObject("$ne" -> true)
+          )
+        )
+        .toIterable
+        .map { dbo =>
+          val uuid = dbo.getAs[UUID]("_id").get
+          val dateTime = dbo.getAs[DateTime]("startTime")
+          SimpleDeployDetail(uuid, dateTime)
+        }
     }
-  }
 
   override def addMetaData(uuid: UUID, metaData: Map[String, String]) {
-    logAndSquashExceptions(Some("Adding metadata %s to %s" format (metaData, uuid)),()) {
-      val update = metaData.map { case (tag, value) =>
-        $set(("parameters.tags.%s" format tag) -> value)
-      }.fold(MongoDBObject())(_ ++ _)
+    logAndSquashExceptions(Some("Adding metadata %s to %s" format (metaData, uuid)), ()) {
+      val update = metaData
+        .map {
+          case (tag, value) =>
+            $set(("parameters.tags.%s" format tag) -> value)
+        }
+        .fold(MongoDBObject())(_ ++ _)
       if (update.size > 0)
-        deployCollection.update( MongoDBObject("_id" -> uuid), update )
+        deployCollection.update(MongoDBObject("_id" -> uuid), update)
     }
   }
 
   override def summariseDeploy(uuid: UUID) {
-    logAndSquashExceptions(Some("Summarising deploy %s" format uuid),()) {
-      deployCollection.update( MongoDBObject("_id" -> uuid), $set("summarised" -> true))
+    logAndSquashExceptions(Some("Summarising deploy %s" format uuid), ()) {
+      deployCollection.update(MongoDBObject("_id" -> uuid), $set("summarised" -> true))
       deployLogCollection.remove(MongoDBObject("deploy" -> uuid))
     }
   }
 
-  override def getLastCompletedDeploys(projectName: String):Map[String,UUID] = {
+  override def getLastCompletedDeploys(projectName: String): Map[String, UUID] = {
     val threshold = new DateTime().minus(new Period().withDays(90))
     val pipeBuilder = MongoDBList.newBuilder
-    pipeBuilder += MongoDBObject("$match" ->
-      MongoDBObject(
-        "parameters.projectName" -> projectName,
-        "status" -> "Completed",
-        "startTime" -> MongoDBObject("$gte" -> threshold)
-      )
-    )
+    pipeBuilder += MongoDBObject(
+      "$match" ->
+        MongoDBObject(
+          "parameters.projectName" -> projectName,
+          "status" -> "Completed",
+          "startTime" -> MongoDBObject("$gte" -> threshold)
+        ))
     pipeBuilder += MongoDBObject("$sort" -> MongoDBObject("startTime" -> 1))
-    pipeBuilder += MongoDBObject("$group" ->
-      MongoDBObject(
-        "_id" -> MongoDBObject("projectName" -> "$parameters.projectName", "stage" -> "$parameters.stage"),
-        "uuid" -> MongoDBObject("$last" -> "$stringUUID")
-      )
-    )
+    pipeBuilder += MongoDBObject(
+      "$group" ->
+        MongoDBObject(
+          "_id" -> MongoDBObject("projectName" -> "$parameters.projectName", "stage" -> "$parameters.stage"),
+          "uuid" -> MongoDBObject("$last" -> "$stringUUID")
+        ))
     val pipeline = pipeBuilder.result()
     log.debug(s"Aggregate query: ${pipeline.toString()}")
     val result = database.command(MongoDBObject("aggregate" -> deployCollection.name, "pipeline" -> pipeline))
@@ -279,10 +305,11 @@ class MongoDatastore(database: MongoDB) extends DataStore with DocumentStore wit
       case 1.0 =>
         log.debug(s"Result of aggregate query: ${result.toString}")
         result.get("result") match {
-          case results: BasicDBList => results.map {
-            case dbo: BasicDBObject =>
-              dbo.as[BasicDBObject]("_id").as[String]("stage") -> UUID.fromString(dbo.as[String]("uuid"))
-          }.toMap
+          case results: BasicDBList =>
+            results.map {
+              case dbo: BasicDBObject =>
+                dbo.as[BasicDBObject]("_id").as[String]("stage") -> UUID.fromString(dbo.as[String]("uuid"))
+            }.toMap
           case _ =>
             throw new IllegalArgumentException("Mongo query did not return valid result")
         }
@@ -317,13 +344,13 @@ class MongoDatastore(database: MongoDB) extends DataStore with DocumentStore wit
     }
   }
 
-  override def findProjects(): List[String] = logAndSquashExceptions[List[String]](None,Nil) {
+  override def findProjects(): List[String] = logAndSquashExceptions[List[String]](None, Nil) {
     deployCollection.distinct("parameters.projectName").map(_.asInstanceOf[String]).toList
   }
 
   override def addStringUUID(uuid: UUID) {
     val setStringUUID = $set("stringUUID" -> uuid.toString)
-    logAndSquashExceptions(Some("Updating stringUUID for %s" format uuid),()) {
+    logAndSquashExceptions(Some("Updating stringUUID for %s" format uuid), ()) {
       deployCollection.findAndModify(
         query = MongoDBObject("_id" -> uuid),
         fields = MongoDBObject(),
@@ -336,8 +363,11 @@ class MongoDatastore(database: MongoDB) extends DataStore with DocumentStore wit
     }
   }
 
-  override def getDeployUUIDsWithoutStringUUIDs = logAndSquashExceptions[Iterable[SimpleDeployDetail]](None,Nil){
-    val cursor = deployCollection.find(MongoDBObject("stringUUID" -> MongoDBObject("$exists" -> false)), MongoDBObject("_id" -> 1, "startTime" -> 1)).sort(MongoDBObject("startTime" -> -1))
+  override def getDeployUUIDsWithoutStringUUIDs = logAndSquashExceptions[Iterable[SimpleDeployDetail]](None, Nil) {
+    val cursor = deployCollection
+      .find(MongoDBObject("stringUUID" -> MongoDBObject("$exists" -> false)),
+            MongoDBObject("_id" -> 1, "startTime" -> 1))
+      .sort(MongoDBObject("startTime" -> -1))
     cursor.toIterable.map { dbo =>
       val uuid = dbo.getAs[UUID]("_id").get
       val dateTime = dbo.getAs[DateTime]("startTime")

--- a/riff-raff/app/persistence/representation.scala
+++ b/riff-raff/app/persistence/representation.scala
@@ -7,8 +7,8 @@ import com.mongodb.{BasicDBList, DBObject}
 import com.mongodb.casbah.commons.Implicits._
 import com.mongodb.casbah.commons.{MongoDBList, MongoDBObject}
 
-case class DeployRecordDocument(uuid:UUID,
-                                stringUUID:Option[String],
+case class DeployRecordDocument(uuid: UUID,
+                                stringUUID: Option[String],
                                 startTime: DateTime,
                                 parameters: ParametersDocument,
                                 status: RunState.Value,
@@ -18,57 +18,58 @@ case class DeployRecordDocument(uuid:UUID,
                                 lastActivityTime: Option[DateTime] = None)
 
 object DeployRecordDocument extends MongoSerialisable[DeployRecordDocument] {
-  def apply(uuid:String, startTime: DateTime, parameters: ParametersDocument, status: String): DeployRecordDocument = {
+  def apply(uuid: String, startTime: DateTime, parameters: ParametersDocument, status: String): DeployRecordDocument = {
     DeployRecordDocument(UUID.fromString(uuid), Some(uuid), startTime, parameters, RunState.withName(status))
   }
-  implicit val deployFormat:MongoFormat[DeployRecordDocument] = new DeployMongoFormat
+  implicit val deployFormat: MongoFormat[DeployRecordDocument] = new DeployMongoFormat
   private class DeployMongoFormat extends MongoFormat[DeployRecordDocument] {
     def toDBO(a: DeployRecordDocument) = {
-      val fields:List[(String,Any)] =
+      val fields: List[(String, Any)] =
         List(
           "_id" -> a.uuid,
           "startTime" -> a.startTime,
           "parameters" -> a.parameters.toDBO,
           "status" -> a.status.toString
         ) ++ a.stringUUID.map("stringUUID" ->) ++ a.summarised.map("summarised" -> _) ++
-             a.totalTasks.map("totalTasks" ->) ++ a.completedTasks.map("completedTasks" ->) ++
-             a.lastActivityTime.map("lastActivityTime" ->)
+          a.totalTasks.map("totalTasks" ->) ++ a.completedTasks.map("completedTasks" ->) ++
+          a.lastActivityTime.map("lastActivityTime" ->)
       fields.toMap
     }
     def fromDBO(dbo: MongoDBObject) =
-      ParametersDocument.fromDBO(dbo.as[DBObject]("parameters")).map(pd =>
-        DeployRecordDocument(
-        uuid = dbo.as[UUID]("_id"),
-        stringUUID = dbo.getAs[String]("stringUUID"),
-        startTime = dbo.as[DateTime]("startTime"),
-        parameters = pd,
-        status = RunState.withName(dbo.as[String]("status")),
-        summarised = dbo.getAs[Boolean]("summarised"),
-        totalTasks = dbo.getAs[Int]("totalTasks"),
-        completedTasks = dbo.getAs[Int]("completedTasks"),
-        lastActivityTime = dbo.getAs[DateTime]("lastActivityTime")
-      )
-    )
+      ParametersDocument
+        .fromDBO(dbo.as[DBObject]("parameters"))
+        .map(pd =>
+          DeployRecordDocument(
+            uuid = dbo.as[UUID]("_id"),
+            stringUUID = dbo.getAs[String]("stringUUID"),
+            startTime = dbo.as[DateTime]("startTime"),
+            parameters = pd,
+            status = RunState.withName(dbo.as[String]("status")),
+            summarised = dbo.getAs[Boolean]("summarised"),
+            totalTasks = dbo.getAs[Int]("totalTasks"),
+            completedTasks = dbo.getAs[Int]("completedTasks"),
+            lastActivityTime = dbo.getAs[DateTime]("lastActivityTime")
+        ))
   }
 }
 
 case class ParametersDocument(
-  deployer: String,
-  projectName: String,
-  buildId: String,
-  stage: String,
-  recipe: String,
-  stacks: List[String],
-  hostList: List[String],
-  tags: Map[String,String],
-  selector: DeploymentSelectorDocument
+    deployer: String,
+    projectName: String,
+    buildId: String,
+    stage: String,
+    recipe: String,
+    stacks: List[String],
+    hostList: List[String],
+    tags: Map[String, String],
+    selector: DeploymentSelectorDocument
 )
 
 object ParametersDocument extends MongoSerialisable[ParametersDocument] {
-  implicit val parametersFormat:MongoFormat[ParametersDocument] = new ParameterMongoFormat
+  implicit val parametersFormat: MongoFormat[ParametersDocument] = new ParameterMongoFormat
   private class ParameterMongoFormat extends MongoFormat[ParametersDocument] {
     def toDBO(a: ParametersDocument) = {
-      val fields:List[(String,Any)] =
+      val fields: List[(String, Any)] =
         List(
           "deployer" -> a.deployer,
           "projectName" -> a.projectName,
@@ -82,44 +83,50 @@ object ParametersDocument extends MongoSerialisable[ParametersDocument] {
         )
       fields.toMap
     }
-    def fromDBO(dbo: MongoDBObject) = Some(ParametersDocument(
-      deployer = dbo.as[String]("deployer"),
-      projectName = dbo.as[String]("projectName"),
-      buildId = dbo.as[String]("buildId"),
-      stage = dbo.as[String]("stage"),
-      recipe = dbo.as[String]("recipe"),
-      stacks = dbo.getAsOrElse[MongoDBList]("stacks", MongoDBList()).map(_.asInstanceOf[String]).toList,
-      hostList = dbo.as[MongoDBList]("hostList").map(_.asInstanceOf[String]).toList,
-      tags = dbo.as[DBObject]("tags").map(entry => (entry._1, entry._2.asInstanceOf[String])).toMap,
-      selector = dbo.getAs[DBObject]("selector").map(DeploymentSelectorDocument.from).getOrElse(AllDocument)
-    ))
+    def fromDBO(dbo: MongoDBObject) =
+      Some(
+        ParametersDocument(
+          deployer = dbo.as[String]("deployer"),
+          projectName = dbo.as[String]("projectName"),
+          buildId = dbo.as[String]("buildId"),
+          stage = dbo.as[String]("stage"),
+          recipe = dbo.as[String]("recipe"),
+          stacks = dbo.getAsOrElse[MongoDBList]("stacks", MongoDBList()).map(_.asInstanceOf[String]).toList,
+          hostList = dbo.as[MongoDBList]("hostList").map(_.asInstanceOf[String]).toList,
+          tags = dbo.as[DBObject]("tags").map(entry => (entry._1, entry._2.asInstanceOf[String])).toMap,
+          selector = dbo.getAs[DBObject]("selector").map(DeploymentSelectorDocument.from).getOrElse(AllDocument)
+        ))
   }
 }
 
 case class LogDocument(
-  deploy: UUID,
-  id: UUID,
-  parent: Option[UUID],
-  document: MessageDocument,
-  time: DateTime
+    deploy: UUID,
+    id: UUID,
+    parent: Option[UUID],
+    document: MessageDocument,
+    time: DateTime
 )
 
 object LogDocument extends MongoSerialisable[LogDocument] {
   def apply(wrapper: MessageWrapper): LogDocument = {
-    LogDocument(wrapper.context.deployId, wrapper.messageId, wrapper.context.parentId, wrapper.stack.top, wrapper.stack.time)
+    LogDocument(wrapper.context.deployId,
+                wrapper.messageId,
+                wrapper.context.parentId,
+                wrapper.stack.top,
+                wrapper.stack.time)
   }
   def apply(deploy: UUID, id: UUID, parent: Option[UUID], document: Message, time: DateTime): LogDocument = {
     val messageDocument = document match {
-        case StartContext(message) => message
-        case other => other
-      }
+      case StartContext(message) => message
+      case other => other
+    }
     LogDocument(deploy, id, parent, messageDocument.asMessageDocument, time)
   }
 
-  implicit val logFormat:MongoFormat[LogDocument] = new LogMongoFormat
+  implicit val logFormat: MongoFormat[LogDocument] = new LogMongoFormat
   private class LogMongoFormat extends MongoFormat[LogDocument] {
     def toDBO(a: LogDocument) = {
-      val fields:List[(String,Any)] =
+      val fields: List[(String, Any)] =
         List(
           "deploy" -> a.deploy,
           "id" -> a.id,
@@ -129,18 +136,20 @@ object LogDocument extends MongoSerialisable[LogDocument] {
       fields.toMap
     }
 
-    def fromDBO(dbo: MongoDBObject) = Some(LogDocument(
-      deploy = dbo.as[UUID]("deploy"),
-      id = dbo.as[UUID]("id"),
-      parent = dbo.getAs[UUID]("parent"),
-      document = MessageDocument.from(dbo.as[DBObject]("document")),
-      time = dbo.as[DateTime]("time")
-    ))
+    def fromDBO(dbo: MongoDBObject) =
+      Some(
+        LogDocument(
+          deploy = dbo.as[UUID]("deploy"),
+          id = dbo.as[UUID]("id"),
+          parent = dbo.getAs[UUID]("parent"),
+          document = MessageDocument.from(dbo.as[DBObject]("document")),
+          time = dbo.as[DateTime]("time")
+        ))
   }
 }
 
 case class LogDocumentTree(documents: Seq[LogDocument]) {
-  lazy val idMap = documents.map(log => log.id-> log).toMap
+  lazy val idMap = documents.map(log => log.id -> log).toMap
   lazy val parentMap = documents.filter(_.parent.isDefined).groupBy(_.parent.get).withDefaultValue(Nil)
 
   lazy val roots = documents.filter(_.parent.isEmpty)
@@ -156,7 +165,7 @@ case class LogDocumentTree(documents: Seq[LogDocument]) {
 object DetailConversions {
   val host = new MongoFormat[Host] {
     def toDBO(a: Host) = {
-      val fields:List[(String,Any)] =
+      val fields: List[(String, Any)] =
         List(
           "name" -> a.name,
           "apps" -> a.apps.map(a => MongoDBObject("name" -> a.name)).toList,
@@ -165,23 +174,28 @@ object DetailConversions {
       fields.toMap
     }
 
-    def fromDBO(dbo: MongoDBObject) = Some(Host(
-      name = dbo.as[String]("name"),
-      apps = dbo.as[List[DBObject]]("apps").map{dbo =>
-        (dbo.getAs[String]("name"),dbo.getAs[String]("stack"),dbo.getAs[String]("app")) match {
-          case (Some(name), None, None) => App(name)
-          case (None, Some(stack), Some(app)) => App(app)
-          case other => throw new IllegalArgumentException(s"Don't know how to construct App from tuple $other")
-        }
-      }.toSet,
-      stage = dbo.as[String]("stage"),
-      connectAs = dbo.getAs[String]("connectAs")
-    ))
+    def fromDBO(dbo: MongoDBObject) =
+      Some(
+        Host(
+          name = dbo.as[String]("name"),
+          apps = dbo
+            .as[List[DBObject]]("apps")
+            .map { dbo =>
+              (dbo.getAs[String]("name"), dbo.getAs[String]("stack"), dbo.getAs[String]("app")) match {
+                case (Some(name), None, None) => App(name)
+                case (None, Some(stack), Some(app)) => App(app)
+                case other => throw new IllegalArgumentException(s"Don't know how to construct App from tuple $other")
+              }
+            }
+            .toSet,
+          stage = dbo.as[String]("stage"),
+          connectAs = dbo.getAs[String]("connectAs")
+        ))
   }
 
   val taskDetail = new MongoFormat[TaskDetail] {
     def toDBO(a: TaskDetail) = {
-      val fields:List[(String,Any)] =
+      val fields: List[(String, Any)] =
         List(
           "name" -> a.name,
           "description" -> a.description,
@@ -191,17 +205,20 @@ object DetailConversions {
       fields.toMap
     }
 
-    def fromDBO(dbo: MongoDBObject) = Some(TaskDetail(
-      name = dbo.as[String]("name"),
-      description = dbo.as[String]("description"),
-      verbose = dbo.as[String]("verbose"),
-      taskHosts = dbo.as[MongoDBList]("taskHosts").flatMap(item => host.fromDBO(item.asInstanceOf[DBObject])).toList
-    ))
+    def fromDBO(dbo: MongoDBObject) =
+      Some(
+        TaskDetail(
+          name = dbo.as[String]("name"),
+          description = dbo.as[String]("description"),
+          verbose = dbo.as[String]("verbose"),
+          taskHosts =
+            dbo.as[MongoDBList]("taskHosts").flatMap(item => host.fromDBO(item.asInstanceOf[DBObject])).toList
+        ))
   }
 
   val throwableDetail = new MongoFormat[ThrowableDetail] {
     def toDBO(a: ThrowableDetail) = {
-      val fields:List[(String,Any)] =
+      val fields: List[(String, Any)] =
         List(
           "name" -> a.name,
           "message" -> a.message,
@@ -210,23 +227,25 @@ object DetailConversions {
       fields.toMap
     }
 
-    def fromDBO(dbo: MongoDBObject): Option[ThrowableDetail] = Some(ThrowableDetail(
-      name = dbo.as[String]("name"),
-      message = dbo.as[String]("message"),
-      stackTrace = dbo.as[String]("stackTrace"),
-      cause = dbo.getAs[DBObject]("cause").flatMap(dbo => fromDBO(dbo))
-    ))
+    def fromDBO(dbo: MongoDBObject): Option[ThrowableDetail] =
+      Some(
+        ThrowableDetail(
+          name = dbo.as[String]("name"),
+          message = dbo.as[String]("message"),
+          stackTrace = dbo.as[String]("stackTrace"),
+          cause = dbo.getAs[DBObject]("cause").flatMap(dbo => fromDBO(dbo))
+        ))
   }
 }
 
 sealed trait MessageDocument {
   def asMessage(params: DeployParameters, originalMessage: Option[Message] = None): Message
-  def asDBObject:DBObject = {
-    val fields:List[(String,Any)] =
+  def asDBObject: DBObject = {
+    val fields: List[(String, Any)] =
       List("_typeHint" -> getClass.getName) ++ dboFields
     fields.toMap
   }
-  def dboFields:List[(String,Any)] = Nil
+  def dboFields: List[(String, Any)] = Nil
 }
 
 case class DeployDocument() extends MessageDocument {
@@ -281,19 +300,21 @@ object MessageDocument {
       case CommandOutput(text) => CommandOutputDocument(text)
       case CommandError(text) => CommandErrorDocument(text)
       case Verbose(text) => VerboseDocument(text)
-      case Fail(text, detail) => FailDocument(text,detail)
+      case Fail(text, detail) => FailDocument(text, detail)
       case FinishContext(message) => FinishContextDocument()
       case FailContext(message) => FailContextDocument()
       case Warning(text) => WarningDocument(text)
-      case StartContext(_) => throw new IllegalArgumentException("StartContext can not be turned into a MessageDocument")
+      case StartContext(_) =>
+        throw new IllegalArgumentException("StartContext can not be turned into a MessageDocument")
     }
   }
-  def from(dbo:DBObject): MessageDocument = {
+  def from(dbo: DBObject): MessageDocument = {
     import DetailConversions._
     dbo.as[String]("_typeHint") match {
       case "persistence.DeployDocument" => DeployDocument()
       case "persistence.TaskListDocument" =>
-        TaskListDocument(dbo.as[MongoDBList]("taskList").flatMap(dbo => taskDetail.fromDBO(dbo.asInstanceOf[DBObject])).toList)
+        TaskListDocument(
+          dbo.as[MongoDBList]("taskList").flatMap(dbo => taskDetail.fromDBO(dbo.asInstanceOf[DBObject])).toList)
       case "persistence.TaskRunDocument" => TaskRunDocument(taskDetail.fromDBO(dbo.as[DBObject]("task")).get)
       case "persistence.InfoDocument" => InfoDocument(dbo.as[String]("text"))
       case "persistence.CommandOutputDocument" => CommandOutputDocument(dbo.as[String]("text"))
@@ -327,23 +348,24 @@ object DeploymentKeyDocument extends MongoSerialisable[DeploymentKeyDocument] {
     }
 
     def fromDBO(dbo: MongoDBObject) = {
-      Some(DeploymentKeyDocument(
-        name = dbo.as[String]("name"),
-        action = dbo.as[String]("action"),
-        stack = dbo.as[String]("stack"),
-        region = dbo.as[String]("region")
-      ))
+      Some(
+        DeploymentKeyDocument(
+          name = dbo.as[String]("name"),
+          action = dbo.as[String]("action"),
+          stack = dbo.as[String]("stack"),
+          region = dbo.as[String]("region")
+        ))
     }
   }
 }
 
 sealed trait DeploymentSelectorDocument {
-  def asDBObject:DBObject = {
-    val fields:List[(String,Any)] =
+  def asDBObject: DBObject = {
+    val fields: List[(String, Any)] =
       List("_typeHint" -> getClass.getName) ++ dboFields
     fields.toMap
   }
-  def dboFields:List[(String,Any)]
+  def dboFields: List[(String, Any)]
 }
 case object AllDocument extends DeploymentSelectorDocument {
   def dboFields = Nil
@@ -353,12 +375,13 @@ case class DeploymentKeysSelectorDocument(ids: List[DeploymentKeyDocument]) exte
 }
 
 object DeploymentSelectorDocument {
-  def from(dbo:DBObject): DeploymentSelectorDocument = {
+  def from(dbo: DBObject): DeploymentSelectorDocument = {
     dbo.as[String]("_typeHint") match {
       case "persistence.AllDocument$" => AllDocument
-      case "persistence.DeploymentKeysSelectorDocument" => DeploymentKeysSelectorDocument(
-        dbo.as[List[DBObject]]("keys").flatMap(dbo => DeploymentKeyDocument.fromDBO(dbo))
-      )
+      case "persistence.DeploymentKeysSelectorDocument" =>
+        DeploymentKeysSelectorDocument(
+          dbo.as[List[DBObject]]("keys").flatMap(dbo => DeploymentKeyDocument.fromDBO(dbo))
+        )
     }
   }
 }

--- a/riff-raff/app/restrictions/RestrictionChecker.scala
+++ b/riff-raff/app/restrictions/RestrictionChecker.scala
@@ -4,6 +4,7 @@ import com.gu.googleauth.UserIdentity
 import deployment.{ContinuousDeploymentRequestSource, Error, RequestSource, UserRequestSource}
 
 object RestrictionChecker {
+
   /** Method that checks whether the supplied config is editable by the supplied source and reports and error reason if
     * not.
     * @param currentConfig The config to check - note that when a config is being checked this must be the original
@@ -11,18 +12,24 @@ object RestrictionChecker {
     * @param identity The identity of the user trying to make the edit
     * @return Either true or a string containing the reason it is not editable
     */
-  def isEditable(currentConfig: Option[RestrictionConfig], identity: UserIdentity, superusers: List[String]): Either[Error, Boolean] = {
+  def isEditable(currentConfig: Option[RestrictionConfig],
+                 identity: UserIdentity,
+                 superusers: List[String]): Either[Error, Boolean] = {
     currentConfig match {
       case None => Right(true)
-      case Some(config) if !config.editingLocked || config.email == identity.email || superusers.contains(identity.email) => Right(true)
+      case Some(config)
+          if !config.editingLocked || config.email == identity.email || superusers.contains(identity.email) =>
+        Right(true)
       case Some(config) =>
         val superuserInfo = if (superusers.nonEmpty) s" - can also be modified by ${superusers.mkString(", ")}" else ""
         Left(Error(s"Locked by ${config.email}$superuserInfo"))
     }
   }
 
-  def configsThatPreventDeployment(restrictions: RestrictionsConfigRepository, projectName: String, stage: String,
-    source: RequestSource): Seq[RestrictionConfig] = {
+  def configsThatPreventDeployment(restrictions: RestrictionsConfigRepository,
+                                   projectName: String,
+                                   stage: String,
+                                   source: RequestSource): Seq[RestrictionConfig] = {
     for {
       restriction <- restrictions.getRestrictions(projectName)
       if stageMatches(restriction.stage, stage)

--- a/riff-raff/app/restrictions/RestrictionConfig.scala
+++ b/riff-raff/app/restrictions/RestrictionConfig.scala
@@ -19,14 +19,14 @@ import org.joda.time.DateTime
   * @param note Note explaining why thie restriction is in place
   */
 case class RestrictionConfig(
-  id: UUID,
-  projectName: String,
-  stage: String,
-  lastEdited: DateTime,
-  fullName: String,
-  email: String,
-  editingLocked: Boolean,
-  whitelist: Seq[String],
-  continuousDeployment: Boolean,
-  note: String
+    id: UUID,
+    projectName: String,
+    stage: String,
+    lastEdited: DateTime,
+    fullName: String,
+    email: String,
+    editingLocked: Boolean,
+    whitelist: Seq[String],
+    continuousDeployment: Boolean,
+    note: String
 )

--- a/riff-raff/app/restrictions/RestrictionForm.scala
+++ b/riff-raff/app/restrictions/RestrictionForm.scala
@@ -3,11 +3,11 @@ package restrictions
 import java.util.UUID
 
 case class RestrictionForm(
-  id: UUID,
-  projectName: String,
-  stage: String,
-  editingLocked: Boolean,
-  whitelist: Seq[String],
-  continuousDeployment: Boolean,
-  note: String
+    id: UUID,
+    projectName: String,
+    stage: String,
+    editingLocked: Boolean,
+    whitelist: Seq[String],
+    continuousDeployment: Boolean,
+    note: String
 )

--- a/riff-raff/app/utils/ChangeFreeze.scala
+++ b/riff-raff/app/utils/ChangeFreeze.scala
@@ -9,19 +9,19 @@ object ChangeFreeze {
   lazy val message = freeze.message
   lazy val freezeInterval =
     (freeze.startDate, freeze.endDate) match {
-      case (Some(startDate:DateTime), Some(endDate:DateTime)) =>
+      case (Some(startDate: DateTime), Some(endDate: DateTime)) =>
         Some(new Interval(startDate, endDate))
       case _ => None
     }
 
   lazy val formatter = DateTimeFormat.longDateTime()
-  lazy val from:String = freeze.startDate.map(formatter.print).getOrElse("")
-  lazy val to:String = freeze.endDate.map(formatter.print).getOrElse("")
+  lazy val from: String = freeze.startDate.map(formatter.print).getOrElse("")
+  lazy val to: String = freeze.endDate.map(formatter.print).getOrElse("")
 
-  def choose[A](defrosted: A)(frozen: A):A =
+  def choose[A](defrosted: A)(frozen: A): A =
     if (freezeInterval.exists(_.contains(new DateTime()))) frozen else defrosted
 
-  def chooseWithStage[A](forStage: String)(defrosted: A)(frozen: A):A =
+  def chooseWithStage[A](forStage: String)(defrosted: A)(frozen: A): A =
     choose(defrosted) {
       if (stages.contains(forStage)) {
         frozen
@@ -30,6 +30,6 @@ object ChangeFreeze {
       }
     }
 
-  def frozen(stage:String) = chooseWithStage(stage)(false)(true)
+  def frozen(stage: String) = chooseWithStage(stage)(false)(true)
   def frozen = choose(false)(true)
 }

--- a/riff-raff/app/utils/DateFormats.scala
+++ b/riff-raff/app/utils/DateFormats.scala
@@ -5,8 +5,8 @@ import org.joda.time.format.DateTimeFormat
 import java.util.Locale
 
 /**
- * Date formats to print datetimes in English style and London time.
- */
+  * Date formats to print datetimes in English style and London time.
+  */
 object DateFormats {
 
   val Medium = DateTimeFormat.mediumDateTime

--- a/riff-raff/app/utils/Forms.scala
+++ b/riff-raff/app/utils/Forms.scala
@@ -10,7 +10,7 @@ import play.api.data.format.Formatter
 object Forms extends Loggable {
   val deploymentKey = of[DeploymentKey](new Formatter[DeploymentKey] {
     def bind(key: String, data: Map[String, String]) = {
-      stringFormat.bind(key, data).right.flatMap{ s =>
+      stringFormat.bind(key, data).right.flatMap { s =>
         DeploymentKey.fromString(s).toRight(Seq(FormError("form.deployment-key", "Couldn't parse as deployment key")))
       }
     }
@@ -19,7 +19,7 @@ object Forms extends Loggable {
 
   val deploymentKeyList = of[List[DeploymentKey]](new Formatter[List[DeploymentKey]] {
     def bind(key: String, data: Map[String, String]) = {
-      stringFormat.bind(key, data).right.flatMap{ s =>
+      stringFormat.bind(key, data).right.flatMap { s =>
         Right(DeploymentKey.fromStringToList(s))
       }
     }

--- a/riff-raff/app/utils/Graph.scala
+++ b/riff-raff/app/utils/Graph.scala
@@ -4,7 +4,7 @@ import org.joda.time.LocalDate
 
 object Graph {
   implicit def series2prefixDate(series: List[(LocalDate, Int)]) = new {
-    def prefixDate(prefixDate: Option[LocalDate]):List[(LocalDate, Int)] = series match {
+    def prefixDate(prefixDate: Option[LocalDate]): List[(LocalDate, Int)] = series match {
       case Nil => Nil
       case (date, count) :: tail if prefixDate.isDefined && date != prefixDate.get =>
         (prefixDate.get, 0) :: (date, count) :: tail

--- a/riff-raff/app/utils/HstsFilter.scala
+++ b/riff-raff/app/utils/HstsFilter.scala
@@ -5,6 +5,7 @@ import play.api.libs.concurrent.Execution.Implicits._
 
 class HstsFilter extends EssentialFilter {
   def apply(next: EssentialAction) = new EssentialAction {
-    def apply(request: RequestHeader) = next(request).map(_.withHeaders("Strict-Transport-Security" -> "max-age=31536000"))
+    def apply(request: RequestHeader) =
+      next(request).map(_.withHeaders("Strict-Transport-Security" -> "max-age=31536000"))
   }
 }

--- a/riff-raff/app/utils/UnnaturalOrdering.scala
+++ b/riff-raff/app/utils/UnnaturalOrdering.scala
@@ -1,13 +1,14 @@
 package utils
 
 /**
- * Class to help ordering things in a mandated order, rather than the natural ordering of a given type
- * @param order The seq of objects in the order they should be returned in
- * @param aliensAtEnd If true, the compare function will sort unknown items to the end, false will sort them to the start
- * @tparam A
- */
-class UnnaturalOrdering[A](val order: List[A], val aliensAtEnd: Boolean = true, val oldOrdering: Ordering[A]) extends Ordering[A] {
-  val alienValue = if (aliensAtEnd) order.size+1 else -1
+  * Class to help ordering things in a mandated order, rather than the natural ordering of a given type
+  * @param order The seq of objects in the order they should be returned in
+  * @param aliensAtEnd If true, the compare function will sort unknown items to the end, false will sort them to the start
+  * @tparam A
+  */
+class UnnaturalOrdering[A](val order: List[A], val aliensAtEnd: Boolean = true, val oldOrdering: Ordering[A])
+    extends Ordering[A] {
+  val alienValue = if (aliensAtEnd) order.size + 1 else -1
   val orderMap = order.zipWithIndex.map(e => e._1 -> e._2).toMap.withDefault(_ => alienValue)
   def compare(left: A, right: A): Int = {
     val leftIndex = orderMap(left)

--- a/riff-raff/app/utils/VCSInfo.scala
+++ b/riff-raff/app/utils/VCSInfo.scala
@@ -15,7 +15,7 @@ trait VCSInfo {
   def headUrl: URI
 
   import VCSInfo._
-  def map: Map[String,String] = Map(
+  def map: Map[String, String] = Map(
     REVISION -> revision,
     CIURL -> ciVcsUrl,
     NAME -> name,
@@ -50,7 +50,7 @@ object VCSInfo extends Logging {
   val GitHubWeb = """https://github\.com/(.*)""".r
 
   def apply(ciVcsUrl: String, revision: String): Option[VCSInfo] = {
-    log.debug("url:%s revision:%s" format(ciVcsUrl, revision))
+    log.debug("url:%s revision:%s" format (ciVcsUrl, revision))
     ciVcsUrl match {
       case GitHubProtocol(repo) => Some(GitHub(ciVcsUrl, revision, repo))
       case GitHubUser(repo) => Some(GitHub(ciVcsUrl, revision, repo))
@@ -60,7 +60,7 @@ object VCSInfo extends Logging {
   }
 
   def apply(metaData: Map[String, String]): Option[VCSInfo] = {
-    metaData.get(REVISION).flatMap{ revision =>
+    metaData.get(REVISION).flatMap { revision =>
       metaData.get(CIURL).flatMap { url =>
         VCSInfo(url, revision)
       }

--- a/riff-raff/app/views/html/helper/magenta/MessageHelper.scala
+++ b/riff-raff/app/views/html/helper/magenta/MessageHelper.scala
@@ -4,7 +4,7 @@ import magenta._
 import play.twirl.api.Html
 
 object MessageHelper {
-  def state(reportNode:DeployReport): String = {
+  def state(reportNode: DeployReport): String = {
     reportNode.cascadeState match {
       case RunState.Running => "state-running"
       case RunState.NotRunning => "state-not-running"
@@ -13,8 +13,8 @@ object MessageHelper {
       case RunState.Failed => "state-failed"
     }
   }
-  def messageType(reportNode:DeployReport): String = {
-    reportNode.message.getClass.getName.toLowerCase.replace("magenta.","")
+  def messageType(reportNode: DeployReport): String = {
+    reportNode.message.getClass.getName.toLowerCase.replace("magenta.", "")
   }
-  def trim(html:Html): Html = { Html(html.body.trim) }
+  def trim(html: Html): Html = { Html(html.body.trim) }
 }

--- a/riff-raff/app/views/html/helper/magenta/PreviewHelper.scala
+++ b/riff-raff/app/views/html/helper/magenta/PreviewHelper.scala
@@ -4,7 +4,8 @@ import magenta.graph.{DeploymentTasks, Graph}
 import magenta.input.DeploymentKey
 
 object PreviewHelper {
-  def dependencies(graph: Graph[(DeploymentKey, DeploymentTasks)], node: (DeploymentKey, DeploymentTasks)): List[(DeploymentKey, DeploymentTasks)] = {
+  def dependencies(graph: Graph[(DeploymentKey, DeploymentTasks)],
+                   node: (DeploymentKey, DeploymentTasks)): List[(DeploymentKey, DeploymentTasks)] = {
     graph.predecessors(graph.get(node)).toList.values
   }
 }

--- a/riff-raff/test/AuthenticationTest.scala
+++ b/riff-raff/test/AuthenticationTest.scala
@@ -24,7 +24,7 @@ class AuthenticationTest extends FlatSpec with Matchers {
       def emailWhitelistEnabled = false
       def emailWhitelistContains(email: String) = false
     }
-    val id = UserIdentity("","test@test.com", "Test", "Testing", 3600, None)
+    val id = UserIdentity("", "test@test.com", "Test", "Testing", 3600, None)
     validator.isAuthorised(id) should be(true)
   }
 
@@ -34,7 +34,7 @@ class AuthenticationTest extends FlatSpec with Matchers {
       def emailWhitelistEnabled = false
       def emailWhitelistContains(email: String) = false
     }
-    val id = UserIdentity("","test@guardian.co.uk", "Test", "Testing", 3600, None)
+    val id = UserIdentity("", "test@guardian.co.uk", "Test", "Testing", 3600, None)
     validator.isAuthorised(id) should be(true)
   }
 
@@ -44,9 +44,10 @@ class AuthenticationTest extends FlatSpec with Matchers {
       def emailWhitelistEnabled = false
       def emailWhitelistContains(email: String) = false
     }
-    val id = UserIdentity("","test@test.com", "Test", "Testing", 3600, None)
+    val id = UserIdentity("", "test@test.com", "Test", "Testing", 3600, None)
     validator.isAuthorised(id) should be(false)
-    validator.authorisationError(id).get should be("The e-mail address domain you used to login to Riff-Raff (test@test.com) is not in the configured whitelist.  Please try again with another account or contact the Riff-Raff administrator.")
+    validator.authorisationError(id).get should be(
+      "The e-mail address domain you used to login to Riff-Raff (test@test.com) is not in the configured whitelist.  Please try again with another account or contact the Riff-Raff administrator.")
   }
 
   it should "allow a whitelisted e-mail address" in {
@@ -55,7 +56,7 @@ class AuthenticationTest extends FlatSpec with Matchers {
       def emailWhitelistEnabled = true
       def emailWhitelistContains(email: String) = email == "test@guardian.co.uk"
     }
-    val id = UserIdentity("","test@guardian.co.uk", "Test", "Testing", 3600, None)
+    val id = UserIdentity("", "test@guardian.co.uk", "Test", "Testing", 3600, None)
     validator.isAuthorised(id) should be(true)
   }
 
@@ -65,9 +66,10 @@ class AuthenticationTest extends FlatSpec with Matchers {
       def emailWhitelistEnabled = true
       def emailWhitelistContains(email: String) = email == "test@test.com"
     }
-    val id = UserIdentity("","test@test.com", "Test", "Testing", 3600, None)
+    val id = UserIdentity("", "test@test.com", "Test", "Testing", 3600, None)
     validator.isAuthorised(id) should be(false)
-    validator.authorisationError(id).get should be("The e-mail address domain you used to login to Riff-Raff (test@test.com) is not in the configured whitelist.  Please try again with another account or contact the Riff-Raff administrator.")
+    validator.authorisationError(id).get should be(
+      "The e-mail address domain you used to login to Riff-Raff (test@test.com) is not in the configured whitelist.  Please try again with another account or contact the Riff-Raff administrator.")
   }
 
   it should "disallow a non-whitelisted e-mail address in a whitelisted domain" in {
@@ -76,9 +78,10 @@ class AuthenticationTest extends FlatSpec with Matchers {
       def emailWhitelistEnabled = true
       def emailWhitelistContains(email: String) = false
     }
-    val id = UserIdentity("","test@guardian.co.uk", "Test", "Testing", 3600, None)
+    val id = UserIdentity("", "test@guardian.co.uk", "Test", "Testing", 3600, None)
     validator.isAuthorised(id) should be(false)
-    validator.authorisationError(id).get should be("The e-mail address you used to login to Riff-Raff (test@guardian.co.uk) is not authorised.  Please try again with another account, ask a colleague to add your address or contact the Riff-Raff administrator.")
+    validator.authorisationError(id).get should be(
+      "The e-mail address you used to login to Riff-Raff (test@guardian.co.uk) is not authorised.  Please try again with another account, ask a colleague to add your address or contact the Riff-Raff administrator.")
   }
 
 }

--- a/riff-raff/test/MappingTest.scala
+++ b/riff-raff/test/MappingTest.scala
@@ -15,7 +15,15 @@ class MappingTest extends FlatSpec with Matchers with Utilities with Persistence
         testUUID,
         Some(testUUID.toString),
         testTime,
-        ParametersDocument("Tester", "test-project", "1", "CODE", "test-recipe", Nil, Nil, Map("branch"->"master"), AllDocument),
+        ParametersDocument("Tester",
+                           "test-project",
+                           "1",
+                           "CODE",
+                           "test-recipe",
+                           Nil,
+                           Nil,
+                           Map("branch" -> "master"),
+                           AllDocument),
         RunState.Completed
       )
     )
@@ -39,28 +47,31 @@ class MappingTest extends FlatSpec with Matchers with Utilities with Persistence
 
   it should "transfer the deploy UUID into the log documents" in {
     val logDocuments = RecordConverter(testRecord).logDocuments
-    logDocuments.foreach{ doc =>
+    logDocuments.foreach { doc =>
       doc.deploy should be(testRecord.uuid)
     }
   }
 
   it should "translate a deploy keys selector" in {
-    val deployKeysSelector = DeploymentKeysSelector(List(
-      DeploymentKey("testName", "actionOne", "stackOne", "testRegion"),
-      DeploymentKey("testName", "actionTwo", "stackTwo", "testRegion")
-    ))
-    val convertedSelector = RecordConverter(testRecord.copy(parameters = parameters.copy(selector = deployKeysSelector))).deployDocument.parameters.selector
-    convertedSelector shouldBe DeploymentKeysSelectorDocument(List(
-      DeploymentKeyDocument("testName", "actionOne", "stackOne", "testRegion"),
-      DeploymentKeyDocument("testName", "actionTwo", "stackTwo", "testRegion")
-    ))
+    val deployKeysSelector = DeploymentKeysSelector(
+      List(
+        DeploymentKey("testName", "actionOne", "stackOne", "testRegion"),
+        DeploymentKey("testName", "actionTwo", "stackTwo", "testRegion")
+      ))
+    val convertedSelector = RecordConverter(
+      testRecord.copy(parameters = parameters.copy(selector = deployKeysSelector))).deployDocument.parameters.selector
+    convertedSelector shouldBe DeploymentKeysSelectorDocument(
+      List(
+        DeploymentKeyDocument("testName", "actionOne", "stackOne", "testRegion"),
+        DeploymentKeyDocument("testName", "actionTwo", "stackTwo", "testRegion")
+      ))
   }
 
   "LogDocumentTree" should "identify the root" in {
     val tree = LogDocumentTree(logDocuments)
     tree.roots.size should be(1)
     tree.roots.head match {
-      case LogDocument(_, _, None, DeployDocument(),_) =>
+      case LogDocument(_, _, None, DeployDocument(), _) =>
       case _ => fail("Didn't get the expected document when trying to locate the root")
     }
   }

--- a/riff-raff/test/RepresentationTest.scala
+++ b/riff-raff/test/RepresentationTest.scala
@@ -14,7 +14,6 @@ import org.joda.time.DateTime
 import org.scalatest.{FlatSpec, Matchers}
 import persistence._
 
-
 class RepresentationTest extends FlatSpec with Matchers with Utilities with PersistenceTestInstances {
 
   RegisterJodaTimeConversionHelpers()
@@ -32,7 +31,7 @@ class RepresentationTest extends FlatSpec with Matchers with Utilities with Pers
   }
 
   it should "not convert StartContext log messages" in {
-    intercept[IllegalArgumentException]{
+    intercept[IllegalArgumentException] {
       startDeploy.asMessageDocument
     }
   }
@@ -40,7 +39,7 @@ class RepresentationTest extends FlatSpec with Matchers with Utilities with Pers
   "LogDocument" should "serialise all message types to BSON" in {
     val messages = Seq(deploy, infoMsg, cmdOut, verbose, finishDep, finishInfo, failInfo, failDep)
     val documents = messages.map(LogDocument(testUUID, UUID.randomUUID(), Some(UUID.randomUUID()), _, testTime))
-    documents.foreach{ document =>
+    documents.foreach { document =>
       val dbObject = document.toDBO
       dbObject should not be null
       val encoder = new BasicBSONEncoder()
@@ -50,7 +49,7 @@ class RepresentationTest extends FlatSpec with Matchers with Utilities with Pers
   }
 
   it should "not change without careful thought and testing of migration" in {
-    val time = new DateTime(2012,11,8,17,20,0)
+    val time = new DateTime(2012, 11, 8, 17, 20, 0)
     val id = UUID.fromString("4ef18506-3b38-4235-9933-d7da831247a6")
     val parentId = UUID.fromString("4236c133-be50-4169-8e0c-096eded5bfeb")
     val messageJsonMap = Map(
@@ -64,27 +63,28 @@ class RepresentationTest extends FlatSpec with Matchers with Utilities with Pers
       failDep -> """{ "deploy" : { "$uuid" : "90013e69-8afc-4ba2-80a8-d7b063183d13"} , "id" : { "$uuid" : "4ef18506-3b38-4235-9933-d7da831247a6"} , "parent" : { "$uuid" : "4236c133-be50-4169-8e0c-096eded5bfeb"} , "document" : { "_typeHint" : "persistence.FailContextDocument"} , "time" : { "$date" : "2012-11-08T17:20:00.000Z"}}""",
       warning -> """{ "deploy" : { "$uuid" : "90013e69-8afc-4ba2-80a8-d7b063183d13"} , "id" : { "$uuid" : "4ef18506-3b38-4235-9933-d7da831247a6"} , "parent" : { "$uuid" : "4236c133-be50-4169-8e0c-096eded5bfeb"} , "document" : { "_typeHint" : "persistence.WarningDocument" , "text" : "deprecation"} , "time" : { "$date" : "2012-11-08T17:20:00.000Z"}}"""
     )
-    messageJsonMap.foreach { case (message, json) =>
-      val logDocument = LogDocument(testUUID, id, Some(parentId), message, time)
+    messageJsonMap.foreach {
+      case (message, json) =>
+        val logDocument = LogDocument(testUUID, id, Some(parentId), message, time)
 
-      val gratedDocument = logDocument.toDBO
-      val jsonLogDocument = JSON.serialize(gratedDocument)
+        val gratedDocument = logDocument.toDBO
+        val jsonLogDocument = JSON.serialize(gratedDocument)
 
-      val diff = compareJson(json, jsonLogDocument)
+        val diff = compareJson(json, jsonLogDocument)
 
-      if (json.isEmpty) {
-        jsonLogDocument should be(json)
-      } else {
-        diff.toString should be("[ ]")
-        // TODO - check ordering as well?
-        //jsonLogDocument should be(json)
-      }
+        if (json.isEmpty) {
+          jsonLogDocument should be(json)
+        } else {
+          diff.toString should be("[ ]")
+          // TODO - check ordering as well?
+          //jsonLogDocument should be(json)
+        }
 
-      val ungratedDBObject = JSON.parse(json).asInstanceOf[DBObject]
-      ungratedDBObject.toString should be(json)
+        val ungratedDBObject = JSON.parse(json).asInstanceOf[DBObject]
+        ungratedDBObject.toString should be(json)
 
-      val ungratedDeployDocument = LogDocument.fromDBO(new MongoDBObject(ungratedDBObject))
-      ungratedDeployDocument should be(Some(logDocument))
+        val ungratedDeployDocument = LogDocument.fromDBO(new MongoDBObject(ungratedDBObject))
+        ungratedDeployDocument should be(Some(logDocument))
     }
   }
 
@@ -94,7 +94,15 @@ class RepresentationTest extends FlatSpec with Matchers with Utilities with Pers
         testUUID,
         Some(testUUID.toString),
         testTime,
-        ParametersDocument("Tester", "test-project", "1", "CODE", "test-recipe", Nil, Nil, Map("branch"->"master"), AllDocument),
+        ParametersDocument("Tester",
+                           "test-project",
+                           "1",
+                           "CODE",
+                           "test-recipe",
+                           Nil,
+                           Nil,
+                           Map("branch" -> "master"),
+                           AllDocument),
         RunState.Completed
       )
     )
@@ -109,7 +117,8 @@ class RepresentationTest extends FlatSpec with Matchers with Utilities with Pers
   }
 
   it should "never change without careful thought and testing of migration" in {
-    val dataModelDump = """{ "_id" : { "$uuid" : "39320f5b-7837-4f47-85f7-bc2d780e19f6"} , "stringUUID" : "39320f5b-7837-4f47-85f7-bc2d780e19f6" , "startTime" : { "$date" : "2012-11-08T17:20:00.000Z"} , "parameters" : { "deployer" : "Tester" , "projectName" : "test::project" , "buildId" : "1" , "stage" : "TEST" , "recipe" : "test-recipe" , "hostList" : [ "testhost1" , "testhost2"] , "stacks" : [ ] , "tags" : { "branch" : "test"} , "selector" : { "_typeHint" : "persistence.AllDocument$"}} , "status" : "Completed"}"""
+    val dataModelDump =
+      """{ "_id" : { "$uuid" : "39320f5b-7837-4f47-85f7-bc2d780e19f6"} , "stringUUID" : "39320f5b-7837-4f47-85f7-bc2d780e19f6" , "startTime" : { "$date" : "2012-11-08T17:20:00.000Z"} , "parameters" : { "deployer" : "Tester" , "projectName" : "test::project" , "buildId" : "1" , "stage" : "TEST" , "recipe" : "test-recipe" , "hostList" : [ "testhost1" , "testhost2"] , "stacks" : [ ] , "tags" : { "branch" : "test"} , "selector" : { "_typeHint" : "persistence.AllDocument$"}} , "status" : "Completed"}"""
 
     val deployDocument = RecordConverter(comprehensiveDeployRecord).deployDocument
     val gratedDeployDocument = deployDocument.toDBO
@@ -128,9 +137,14 @@ class RepresentationTest extends FlatSpec with Matchers with Utilities with Pers
   }
 
   "ApiKey" should "serialise to and from BSON" in {
-    val time = new DateTime(2012,11,8,17,20,0)
-    val lastTime = new DateTime(2013,1,8,17,20,0)
-    val apiKey = ApiKey("test-application", "hfeklwb34uiopfnu34io2tr_-fffDS", "Test User", time, Some(lastTime), Map("counter1" -> 34L, "counter2" -> 2345L))
+    val time = new DateTime(2012, 11, 8, 17, 20, 0)
+    val lastTime = new DateTime(2013, 1, 8, 17, 20, 0)
+    val apiKey = ApiKey("test-application",
+                        "hfeklwb34uiopfnu34io2tr_-fffDS",
+                        "Test User",
+                        time,
+                        Some(lastTime),
+                        Map("counter1" -> 34L, "counter2" -> 2345L))
 
     val dbObject = apiKey.toDBO
     val encoder = new BasicBSONEncoder()
@@ -144,12 +158,18 @@ class RepresentationTest extends FlatSpec with Matchers with Utilities with Pers
   }
 
   it should "never change without careful thought and testing of migration" in {
-    val time = new DateTime(2012,11,8,17,20,0)
-    val lastTime = new DateTime(2013,1,8,17,20,0)
+    val time = new DateTime(2012, 11, 8, 17, 20, 0)
+    val lastTime = new DateTime(2013, 1, 8, 17, 20, 0)
 
-    val apiKeyDump = """{ "application" : "test-application" , "_id" : "hfeklwb34uiopfnu34io2tr_-fffDS" , "issuedBy" : "Test User" , "created" : { "$date" : "2012-11-08T17:20:00.000Z"} , "lastUsed" : { "$date" : "2013-01-08T17:20:00.000Z"} , "callCounters" : { "counter1" : 34 , "counter2" : 2345}}"""
+    val apiKeyDump =
+      """{ "application" : "test-application" , "_id" : "hfeklwb34uiopfnu34io2tr_-fffDS" , "issuedBy" : "Test User" , "created" : { "$date" : "2012-11-08T17:20:00.000Z"} , "lastUsed" : { "$date" : "2013-01-08T17:20:00.000Z"} , "callCounters" : { "counter1" : 34 , "counter2" : 2345}}"""
 
-    val apiKey = ApiKey("test-application", "hfeklwb34uiopfnu34io2tr_-fffDS", "Test User", time, Some(lastTime), Map("counter1" -> 34L, "counter2" -> 2345L))
+    val apiKey = ApiKey("test-application",
+                        "hfeklwb34uiopfnu34io2tr_-fffDS",
+                        "Test User",
+                        time,
+                        Some(lastTime),
+                        Map("counter1" -> 34L, "counter2" -> 2345L))
     val gratedApiKey = apiKey.toDBO
 
     val jsonApiKey = JSON.serialize(gratedApiKey)
@@ -167,11 +187,20 @@ class RepresentationTest extends FlatSpec with Matchers with Utilities with Pers
 
   "ContinuousDeploymentConfig" should "never change without careful thought and testing of migration" in {
     val uuid = UUID.fromString("ae46a1c9-7762-4f05-9f32-6d6cd8c496c7")
-    val lastTime = new DateTime(2013,1,8,17,20,0)
-    val configDump = """{ "_id" : { "$uuid" : "ae46a1c9-7762-4f05-9f32-6d6cd8c496c7"} , "projectName" : "test::project" , "stage" : "TEST" , "recipe" : "default" , "branchMatcher" : "^master$" , "enabled" : true , "user" : "Test user" , "lastEdited" : { "$date" : "2013-01-08T17:20:00.000Z"}}"""
-    val configV2Dump = """{ "_id" : { "$uuid" : "ae46a1c9-7762-4f05-9f32-6d6cd8c496c7"} , "projectName" : "test::project" , "stage" : "TEST" , "recipe" : "default" , "branchMatcher" : "^master$" , "triggerMode" : 1 , "user" : "Test user" , "lastEdited" : { "$date" : "2013-01-08T17:20:00.000Z"}}"""
+    val lastTime = new DateTime(2013, 1, 8, 17, 20, 0)
+    val configDump =
+      """{ "_id" : { "$uuid" : "ae46a1c9-7762-4f05-9f32-6d6cd8c496c7"} , "projectName" : "test::project" , "stage" : "TEST" , "recipe" : "default" , "branchMatcher" : "^master$" , "enabled" : true , "user" : "Test user" , "lastEdited" : { "$date" : "2013-01-08T17:20:00.000Z"}}"""
+    val configV2Dump =
+      """{ "_id" : { "$uuid" : "ae46a1c9-7762-4f05-9f32-6d6cd8c496c7"} , "projectName" : "test::project" , "stage" : "TEST" , "recipe" : "default" , "branchMatcher" : "^master$" , "triggerMode" : 1 , "user" : "Test user" , "lastEdited" : { "$date" : "2013-01-08T17:20:00.000Z"}}"""
 
-    val config = ContinuousDeploymentConfig(uuid, "test::project", "TEST", "default", Some("^master$"), Trigger.SuccessfulBuild, "Test user", lastTime)
+    val config = ContinuousDeploymentConfig(uuid,
+                                            "test::project",
+                                            "TEST",
+                                            "default",
+                                            Some("^master$"),
+                                            Trigger.SuccessfulBuild,
+                                            "Test user",
+                                            lastTime)
     val gratedConfig = config.toDBO
 
     val jsonConfig = JSON.serialize(gratedConfig)
@@ -210,8 +239,10 @@ class RepresentationTest extends FlatSpec with Matchers with Utilities with Pers
 
   it should "not change DeployIdsFilterDocument without careful thought and testing of migration" in {
     // deploy IDs filter
-    val deployKeysDump = """{ "_typeHint" : "persistence.DeploymentKeysSelectorDocument" , "keys" : [ { "name" : "testName" , "action" : "testAction" , "stack" : "testStack" , "region" : "testRegion"}]}"""
-    val keysSelectorDocument = DeploymentKeysSelectorDocument(List(DeploymentKeyDocument("testName", "testAction", "testStack", "testRegion")))
+    val deployKeysDump =
+      """{ "_typeHint" : "persistence.DeploymentKeysSelectorDocument" , "keys" : [ { "name" : "testName" , "action" : "testAction" , "stack" : "testStack" , "region" : "testRegion"}]}"""
+    val keysSelectorDocument =
+      DeploymentKeysSelectorDocument(List(DeploymentKeyDocument("testName", "testAction", "testStack", "testRegion")))
     val keysSelectorDbo = keysSelectorDocument.asDBObject
     val keySelectorJson = JSON.serialize(keysSelectorDbo)
     val keysSelectorDiff = compareJson(deployKeysDump, keySelectorJson)

--- a/riff-raff/test/Utilities.scala
+++ b/riff-raff/test/Utilities.scala
@@ -17,29 +17,35 @@ trait Utilities {
 trait PersistenceTestInstances {
   val testTime = new DateTime()
   lazy val testUUID = UUID.fromString("90013e69-8afc-4ba2-80a8-d7b063183d13")
-  lazy val parameters = DeployParameters(Deployer("Tester"), Build("test-project", "1"), Stage("CODE"), RecipeName("test-recipe"), selector = All)
-  lazy val testParamsWithHosts = parameters.copy(hostList=List("host1", "host2"))
-  lazy val testRecord = DeployRecord(testTime, testUUID, parameters, Map("branch"->"master"), messageWrappers)
+  lazy val parameters = DeployParameters(Deployer("Tester"),
+                                         Build("test-project", "1"),
+                                         Stage("CODE"),
+                                         RecipeName("test-recipe"),
+                                         selector = All)
+  lazy val testParamsWithHosts = parameters.copy(hostList = List("host1", "host2"))
+  lazy val testRecord = DeployRecord(testTime, testUUID, parameters, Map("branch" -> "master"), messageWrappers)
   lazy val testDocument = RecordConverter(testRecord).deployDocument
 
   lazy val comprehensiveDeployRecord = {
-    val time = new DateTime(2012,11,8,17,20,0)
+    val time = new DateTime(2012, 11, 8, 17, 20, 0)
     val uuid = UUID.fromString("39320f5b-7837-4f47-85f7-bc2d780e19f6")
-    val parameters = DeployParameters(
-      Deployer("Tester"), Build("test::project", "1"), Stage("TEST"), RecipeName("test-recipe"), Nil,
-      List("testhost1", "testhost2"))
-    DeployRecord(time, uuid, parameters, Map("branch"->"test"), messageWrappers)
+    val parameters =
+      DeployParameters(Deployer("Tester"),
+                       Build("test::project", "1"),
+                       Stage("TEST"),
+                       RecipeName("test-recipe"),
+                       Nil,
+                       List("testhost1", "testhost2"))
+    DeployRecord(time, uuid, parameters, Map("branch" -> "test"), messageWrappers)
   }
 
-  def stack( messages: Message * ): MessageStack = {
+  def stack(messages: Message*): MessageStack = {
     stack(testTime, messages: _*)
   }
 
-  def stack( time: DateTime, messages: Message * ): MessageStack = {
+  def stack(time: DateTime, messages: Message*): MessageStack = {
     MessageStack(messages.toList, time)
   }
-
-
 
   val deploy = Deploy(parameters)
   val startDeploy = StartContext(deploy)
@@ -64,11 +70,11 @@ trait PersistenceTestInstances {
   val deployMessageId = UUID.randomUUID()
   val infoMessageId = UUID.randomUUID()
 
-  def wrapper( id: UUID, parentId: Option[UUID], stack: MessageStack ): MessageWrapper = {
+  def wrapper(id: UUID, parentId: Option[UUID], stack: MessageStack): MessageWrapper = {
     MessageWrapper(MessageContext(testUUID, parameters, parentId), id, stack)
   }
 
-  def wrapper( parentId: Option[UUID], stack: MessageStack ): MessageWrapper = {
+  def wrapper(parentId: Option[UUID], stack: MessageStack): MessageWrapper = {
     MessageWrapper(MessageContext(testUUID, parameters, parentId), UUID.randomUUID(), stack)
   }
 
@@ -84,7 +90,11 @@ trait PersistenceTestInstances {
       finishDeployWrapper ::
       Nil
 
-  val logDocuments: List[LogDocument] = messageWrappers.map{wrapper =>
-    LogDocument(wrapper.context.deployId, wrapper.messageId, wrapper.context.parentId, wrapper.stack.top, wrapper.stack.time)
+  val logDocuments: List[LogDocument] = messageWrappers.map { wrapper =>
+    LogDocument(wrapper.context.deployId,
+                wrapper.messageId,
+                wrapper.context.parentId,
+                wrapper.stack.top,
+                wrapper.stack.time)
   }
 }

--- a/riff-raff/test/ci/BoundedSetTest.scala
+++ b/riff-raff/test/ci/BoundedSetTest.scala
@@ -2,29 +2,29 @@ package ci
 
 import org.scalatest.{FunSuite, Matchers}
 
-class BoundedSetTest  extends FunSuite with Matchers {
+class BoundedSetTest extends FunSuite with Matchers {
   test("bounded set obeys contains") {
     val set = BoundedSet[Int](5) + 1 + 2
-    Seq(1,2) map (i => set.contains(i) should be (true))
-    set.contains(3) should be (false)
+    Seq(1, 2) map (i => set.contains(i) should be(true))
+    set.contains(3) should be(false)
   }
 
   test("bounded set should dump first element if overflows") {
     val set = BoundedSet[Int](5) + 1 + 2 + 3 + 4 + 5 + 6
 
-    Seq(2,3,4,5,6) map (i => set.contains(i) should be (true))
-    set.contains(1) should be (false)
+    Seq(2, 3, 4, 5, 6) map (i => set.contains(i) should be(true))
+    set.contains(1) should be(false)
   }
 
   test("bounded set's capacity isn't affected by duplicates") {
     val set = BoundedSet[Int](5) + 1 + 2 + 2 + 2 + 2 + 3
 
-    Seq(1,2,3) map (i => set.contains(i) should be (true))
+    Seq(1, 2, 3) map (i => set.contains(i) should be(true))
   }
 
-  test("bounded set should keep the most recent regardless of dupes")  {
+  test("bounded set should keep the most recent regardless of dupes") {
     val set = BoundedSet[Int](2) + 1 + 2 + 2 + 2 + 1 + 3
 
-    Seq(1,3) map (i => set.contains(i) should be (true))
+    Seq(1, 3) map (i => set.contains(i) should be(true))
   }
 }

--- a/riff-raff/test/ci/ContinuousDeploymentTest.scala
+++ b/riff-raff/test/ci/ContinuousDeploymentTest.scala
@@ -13,37 +13,96 @@ import scala.util.{Failure, Success}
 class ContinuousDeploymentTest extends FlatSpec with Matchers {
 
   "Continuous Deployment" should "create deploy parameters for a set of builds" in {
-    val params = ContinuousDeployment.getMatchesForSuccessfulBuilds(tdB71, contDeployConfigs).map(ContinuousDeployment.getDeployParams(_)).toSet
+    val params = ContinuousDeployment
+      .getMatchesForSuccessfulBuilds(tdB71, contDeployConfigs)
+      .map(ContinuousDeployment.getDeployParams(_))
+      .toSet
     params.size should be(1)
-    params should be(Set(
-      DeployParameters(Deployer("Continuous Deployment"), Build("tools::deploy", "71"), Stage("PROD"), RecipeName("default"))
-    ))
+    params should be(
+      Set(
+        DeployParameters(Deployer("Continuous Deployment"),
+                         Build("tools::deploy", "71"),
+                         Stage("PROD"),
+                         RecipeName("default"))
+      ))
   }
 
   it should "return nothing if no matches" in {
-    val params = ContinuousDeployment.getMatchesForSuccessfulBuilds(otherBranch, contDeployBranchConfigs).map(ContinuousDeployment.getDeployParams(_)).toSet
+    val params = ContinuousDeployment
+      .getMatchesForSuccessfulBuilds(otherBranch, contDeployBranchConfigs)
+      .map(ContinuousDeployment.getDeployParams(_))
+      .toSet
     params should be(Set())
   }
 
   it should "take account of branch" in {
-    val params = ContinuousDeployment.getMatchesForSuccessfulBuilds(td2B392, contDeployBranchConfigs).map(ContinuousDeployment.getDeployParams(_)).toSet
-    params should be(Set(DeployParameters(Deployer("Continuous Deployment"), Build("tools::deploy2", "392"), Stage("QA"), RecipeName("default"))))
+    val params = ContinuousDeployment
+      .getMatchesForSuccessfulBuilds(td2B392, contDeployBranchConfigs)
+      .map(ContinuousDeployment.getDeployParams(_))
+      .toSet
+    params should be(
+      Set(
+        DeployParameters(Deployer("Continuous Deployment"),
+                         Build("tools::deploy2", "392"),
+                         Stage("QA"),
+                         RecipeName("default"))))
   }
 
   /* Test types */
 
-  val tdProdEnabled = ContinuousDeploymentConfig(UUID.randomUUID(), "tools::deploy", "PROD", "default", None, Trigger.SuccessfulBuild, "Test user")
-  val tdCodeDisabled = ContinuousDeploymentConfig(UUID.randomUUID(), "tools::deploy", "CODE", "default", None, Trigger.Disabled, "Test user")
-  val td2ProdDisabled = ContinuousDeploymentConfig(UUID.randomUUID(), "tools::deploy2", "PROD", "default", None, Trigger.Disabled, "Test user")
-  val td2QaEnabled = ContinuousDeploymentConfig(UUID.randomUUID(), "tools::deploy2", "QA", "default", None, Trigger.SuccessfulBuild, "Test user")
-  val td2QaBranchEnabled = ContinuousDeploymentConfig(UUID.randomUUID(), "tools::deploy2", "QA", "default", Some("branch"), Trigger.SuccessfulBuild, "Test user")
-  val td2ProdBranchEnabled = ContinuousDeploymentConfig(UUID.randomUUID(), "tools::deploy2", "PROD", "default", Some("master"), Trigger.SuccessfulBuild, "Test user")
+  val tdProdEnabled = ContinuousDeploymentConfig(UUID.randomUUID(),
+                                                 "tools::deploy",
+                                                 "PROD",
+                                                 "default",
+                                                 None,
+                                                 Trigger.SuccessfulBuild,
+                                                 "Test user")
+  val tdCodeDisabled = ContinuousDeploymentConfig(UUID.randomUUID(),
+                                                  "tools::deploy",
+                                                  "CODE",
+                                                  "default",
+                                                  None,
+                                                  Trigger.Disabled,
+                                                  "Test user")
+  val td2ProdDisabled = ContinuousDeploymentConfig(UUID.randomUUID(),
+                                                   "tools::deploy2",
+                                                   "PROD",
+                                                   "default",
+                                                   None,
+                                                   Trigger.Disabled,
+                                                   "Test user")
+  val td2QaEnabled = ContinuousDeploymentConfig(UUID.randomUUID(),
+                                                "tools::deploy2",
+                                                "QA",
+                                                "default",
+                                                None,
+                                                Trigger.SuccessfulBuild,
+                                                "Test user")
+  val td2QaBranchEnabled =
+    ContinuousDeploymentConfig(UUID.randomUUID(),
+                               "tools::deploy2",
+                               "QA",
+                               "default",
+                               Some("branch"),
+                               Trigger.SuccessfulBuild,
+                               "Test user")
+  val td2ProdBranchEnabled =
+    ContinuousDeploymentConfig(UUID.randomUUID(),
+                               "tools::deploy2",
+                               "PROD",
+                               "default",
+                               Some("master"),
+                               Trigger.SuccessfulBuild,
+                               "Test user")
   val contDeployConfigs = Seq(tdProdEnabled, tdCodeDisabled, td2ProdDisabled, td2QaEnabled)
-  val contDeployBranchConfigs = Seq(tdProdEnabled, tdCodeDisabled, td2ProdDisabled, td2QaBranchEnabled, td2ProdBranchEnabled)
+  val contDeployBranchConfigs =
+    Seq(tdProdEnabled, tdCodeDisabled, td2ProdDisabled, td2QaBranchEnabled, td2ProdBranchEnabled)
 
-  val tdB71 = S3Build(45397, "tools::deploy", "45397", "branch", "71", new DateTime(2013,1,25,14,42,47), "", "")
-  val td2B392 = S3Build(45400, "tools::deploy2", "45400", "branch", "392", new DateTime(2013,1,25,15,34,47), "", "")
-  val otherBranch = S3Build(45401, "tools::deploy2", "45401", "other", "393", new DateTime(2013,1,25,15,34,47), "", "")
+  val tdB71 = S3Build(45397, "tools::deploy", "45397", "branch", "71", new DateTime(2013, 1, 25, 14, 42, 47), "", "")
+  val td2B392 =
+    S3Build(45400, "tools::deploy2", "45400", "branch", "392", new DateTime(2013, 1, 25, 15, 34, 47), "", "")
+  val otherBranch =
+    S3Build(45401, "tools::deploy2", "45401", "other", "393", new DateTime(2013, 1, 25, 15, 34, 47), "", "")
 
   it should "retry until finds success" in {
     var i = 0
@@ -51,15 +110,14 @@ class ContinuousDeploymentTest extends FlatSpec with Matchers {
       if (i < 3) {
         i = i + 1
         throw new RuntimeException(s"erk $i")
-      }
-      else i
+      } else i
     }
 
     val success = ContinuousDeployment.retryUpTo(4)(failingFun)
-    success should be (Success(3))
+    success should be(Success(3))
 
     i = 0
     val failure = ContinuousDeployment.retryUpTo(2)(failingFun)
-    failure.isFailure should be (true)
+    failure.isFailure should be(true)
   }
 }

--- a/riff-raff/test/ci/GreatestSoFarTest.scala
+++ b/riff-raff/test/ci/GreatestSoFarTest.scala
@@ -6,7 +6,6 @@ import rx.lang.scala.Observable
 class GreatestSoFarTest extends FunSuite with Matchers {
 
   test("should return the greatest element seen so far") {
-    GreatestSoFar(Observable.just(1, 2, 3, 3, 5, 4)).toBlocking.toList should be (
-      List(1, 2, 3, 3, 5, 5))
+    GreatestSoFar(Observable.just(1, 2, 3, 3, 5, 4)).toBlocking.toList should be(List(1, 2, 3, 3, 5, 5))
   }
 }

--- a/riff-raff/test/ci/S3BuildTest.scala
+++ b/riff-raff/test/ci/S3BuildTest.scala
@@ -19,8 +19,17 @@ class S3BuildTest extends FunSuite with Matchers with EitherValues {
       """.stripMargin
 
     S3Build.parse(json).right.value shouldBe (
-      S3Build(42, "foo", "foo", "master", "42", new DateTime(2017,3,14, 17, 57, 8),
-        "f29427661d227eaf3e6b89c75e76b99484d551c4", "git@github.com:guardian/riff-raff.git"))
+      S3Build(
+        42,
+        "foo",
+        "foo",
+        "master",
+        "42",
+        new DateTime(2017, 3, 14, 17, 57, 8),
+        "f29427661d227eaf3e6b89c75e76b99484d551c4",
+        "git@github.com:guardian/riff-raff.git"
+      )
+    )
   }
 
   test("parsing should not barf if buildNumber is not a number") {

--- a/riff-raff/test/deployment/Fixtures.scala
+++ b/riff-raff/test/deployment/Fixtures.scala
@@ -4,7 +4,19 @@ import java.util.UUID
 
 import com.amazonaws.services.s3.AmazonS3Client
 import magenta.graph.{DeploymentGraph, DeploymentTasks, Graph}
-import magenta.{Build, DeployContext, DeployParameters, DeployReporter, Deployer, Host, KeyRing, NamedStack, Project, Region, Stage}
+import magenta.{
+  Build,
+  DeployContext,
+  DeployParameters,
+  DeployReporter,
+  Deployer,
+  Host,
+  KeyRing,
+  NamedStack,
+  Project,
+  Region,
+  Stage
+}
 import magenta.tasks._
 import org.scalatest.mock.MockitoSugar
 
@@ -28,19 +40,18 @@ object Fixtures extends MockitoSugar {
   }
 
   def createRecord(
-    projectName: String = "test",
-    stage: String = "TEST",
-    buildId: String = "1",
-    deployer: String = "Tester",
-    stacks: Seq[String] = Seq("test"),
-    uuid:UUID = UUID.randomUUID()
-  ) = DeployRecord(uuid,
-    DeployParameters(Deployer(deployer),
-      Build(projectName, buildId),
-      Stage(stage),
-      stacks = stacks.map(NamedStack.apply)
-    )
-  )
+      projectName: String = "test",
+      stage: String = "TEST",
+      buildId: String = "1",
+      deployer: String = "Tester",
+      stacks: Seq[String] = Seq("test"),
+      uuid: UUID = UUID.randomUUID()
+  ) =
+    DeployRecord(uuid,
+                 DeployParameters(Deployer(deployer),
+                                  Build(projectName, buildId),
+                                  Stage(stage),
+                                  stacks = stacks.map(NamedStack.apply)))
 
   def createContext(tasks: List[Task], uuid: UUID, parameters: DeployParameters): DeployContext =
     createContext(DeploymentGraph(tasks, parameters.stacks.head.name), uuid, parameters)

--- a/riff-raff/test/deployment/actors/DeployCoordinatorTest.scala
+++ b/riff-raff/test/deployment/actors/DeployCoordinatorTest.scala
@@ -15,13 +15,19 @@ import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object DeployCoordinatorTest {
-  lazy val testConfig = ConfigFactory.parseMap(
-    Map("akka.test.single-expect-default" -> "500").asJava
-  ).withFallback(ConfigFactory.load())
+  lazy val testConfig = ConfigFactory
+    .parseMap(
+      Map("akka.test.single-expect-default" -> "500").asJava
+    )
+    .withFallback(ConfigFactory.load())
 }
 
-class DeployCoordinatorTest extends TestKit(ActorSystem("DeployCoordinatorTest", DeployCoordinatorTest.testConfig))
-  with FlatSpecLike with Matchers with BeforeAndAfterAll with MockitoSugar {
+class DeployCoordinatorTest
+    extends TestKit(ActorSystem("DeployCoordinatorTest", DeployCoordinatorTest.testConfig))
+    with FlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with MockitoSugar {
 
   import Fixtures._
 
@@ -34,7 +40,7 @@ class DeployCoordinatorTest extends TestKit(ActorSystem("DeployCoordinatorTest",
     val record = createRecord()
     dc.actor ! DeployCoordinator.StartDeploy(record)
 
-    dc.deployProbe.expectMsgPF(){
+    dc.deployProbe.expectMsgPF() {
       case DeployGroupRunner.Start =>
     }
 
@@ -45,8 +51,8 @@ class DeployCoordinatorTest extends TestKit(ActorSystem("DeployCoordinatorTest",
 
   it should "queue a StartDeploy message if the deploy is already running" in {
     val dc = createDeployCoordinatorWithUnderlying()
-    val record = createRecord(projectName="test", stage="TEST")
-    val recordTwo = createRecord(projectName="test", stage="TEST")
+    val record = createRecord(projectName = "test", stage = "TEST")
+    val recordTwo = createRecord(projectName = "test", stage = "TEST")
 
     dc.actor ! DeployCoordinator.StartDeploy(record)
     dc.deployProbe.expectMsg(DeployGroupRunner.Start)
@@ -59,9 +65,9 @@ class DeployCoordinatorTest extends TestKit(ActorSystem("DeployCoordinatorTest",
 
   it should "queue a StartDeploy message if there are already too many running" in {
     val dc = createDeployCoordinatorWithUnderlying(2)
-    val record = createRecord(projectName="test", stage="TEST")
-    val recordTwo = createRecord(projectName="test2", stage="TEST")
-    val recordThree = createRecord(projectName="test3", stage="TEST")
+    val record = createRecord(projectName = "test", stage = "TEST")
+    val recordTwo = createRecord(projectName = "test2", stage = "TEST")
+    val recordThree = createRecord(projectName = "test3", stage = "TEST")
 
     dc.actor ! DeployCoordinator.StartDeploy(record)
     dc.deployProbe.expectMsg(DeployGroupRunner.Start)
@@ -79,8 +85,8 @@ class DeployCoordinatorTest extends TestKit(ActorSystem("DeployCoordinatorTest",
 
   it should "dequeue StartDeploy messages when deploys complete" in {
     val dc = createDeployCoordinatorWithUnderlying()
-    val record = createRecord(projectName="test", stage="TEST")
-    val recordTwo = createRecord(projectName="test", stage="TEST")
+    val record = createRecord(projectName = "test", stage = "TEST")
+    val recordTwo = createRecord(projectName = "test", stage = "TEST")
 
     dc.actor ! DeployCoordinator.StartDeploy(record)
     dc.actor ! DeployCoordinator.StartDeploy(recordTwo)
@@ -106,7 +112,10 @@ class DeployCoordinatorTest extends TestKit(ActorSystem("DeployCoordinatorTest",
     DC(deployGroupProbe, ref)
   }
 
-  case class DCwithUnderlying(deployProbe: TestProbe, actor: ActorRef, ul: DeployCoordinator, deployRunnerRecords: mutable.Set[Record])
+  case class DCwithUnderlying(deployProbe: TestProbe,
+                              actor: ActorRef,
+                              ul: DeployCoordinator,
+                              deployRunnerRecords: mutable.Set[Record])
 
   def createDeployCoordinatorWithUnderlying(maxDeploys: Int = 5) = {
     val deployProbe = TestProbe()

--- a/riff-raff/test/deployment/actors/DeployGroupRunnerTest.scala
+++ b/riff-raff/test/deployment/actors/DeployGroupRunnerTest.scala
@@ -13,7 +13,10 @@ import org.scalatest.{FlatSpecLike, ShouldMatchers}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")) with FlatSpecLike with ShouldMatchers {
+class DeployGroupRunnerTest
+    extends TestKit(ActorSystem("DeployGroupRunnerTest"))
+    with FlatSpecLike
+    with ShouldMatchers {
   import Fixtures._
   "DeployGroupRunnerTest" should "initalise the state from a set of tasks" in {
     val dr = createDeployRunnerWithUnderlying()
@@ -86,7 +89,8 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
     prepare(dr, threeSimpleTasks)
     dr.ref ! DeployGroupRunner.StartDeployment
     val runDeployment = dr.deploymentRunnerProbe.expectMsgClass(classOf[TasksRunner.RunDeployment])
-    dr.deploymentRunnerProbe.reply(DeployGroupRunner.DeploymentFailed(runDeployment.deployment, new RuntimeException("test exception")))
+    dr.deploymentRunnerProbe.reply(
+      DeployGroupRunner.DeploymentFailed(runDeployment.deployment, new RuntimeException("test exception")))
     dr.ul.isExecuting should be(false)
     dr.ul.executing should be(Set.empty)
     dr.ul.failed should be(Set(ValueNode(runDeployment.deployment)))
@@ -103,7 +107,12 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
     def ref: ActorRef
   }
 
-  case class DRImpl(record: Record, deployCoordinatorProbe: TestProbe, deploymentRunnerProbe: TestProbe, ref: ActorRef, stopFlagAgent: Agent[Map[UUID, String]]) extends DR
+  case class DRImpl(record: Record,
+                    deployCoordinatorProbe: TestProbe,
+                    deploymentRunnerProbe: TestProbe,
+                    ref: ActorRef,
+                    stopFlagAgent: Agent[Map[UUID, String]])
+      extends DR
 
   def createDeployRunner(): DRImpl = {
     val deployCoordinatorProbe = TestProbe()
@@ -112,15 +121,25 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
     val stopFlagAgent = Agent(Map.empty[UUID, String])
     val record = createRecord()
     val ref = system.actorOf(
-      Props(new DeployGroupRunner(record, deployCoordinatorProbe.ref, deploymentRunnerFactory, stopFlagAgent,
-        prismLookup = null, deploymentTypes)),
-      name=s"DeployGroupRunner-${record.uuid.toString}"
+      Props(
+        new DeployGroupRunner(record,
+                              deployCoordinatorProbe.ref,
+                              deploymentRunnerFactory,
+                              stopFlagAgent,
+                              prismLookup = null,
+                              deploymentTypes)),
+      name = s"DeployGroupRunner-${record.uuid.toString}"
     )
     DRImpl(record, deployCoordinatorProbe, deploymentRunnerProbe, ref, stopFlagAgent)
   }
 
-  case class DRwithUnderlying(record: Record, deployCoordinatorProbe: TestProbe, deploymentRunnerProbe: TestProbe, ref: ActorRef, stopFlagAgent: Agent[Map[UUID, String]], ul: DeployGroupRunner) extends DR {
-  }
+  case class DRwithUnderlying(record: Record,
+                              deployCoordinatorProbe: TestProbe,
+                              deploymentRunnerProbe: TestProbe,
+                              ref: ActorRef,
+                              stopFlagAgent: Agent[Map[UUID, String]],
+                              ul: DeployGroupRunner)
+      extends DR {}
 
   def createDeployRunnerWithUnderlying(): DRwithUnderlying = {
     val deployCoordinatorProbe = TestProbe()
@@ -129,9 +148,13 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
     val stopFlagAgent = Agent(Map.empty[UUID, String])
     val record = createRecord()
     val ref = TestActorRef(
-      new DeployGroupRunner(record, deployCoordinatorProbe.ref, deploymentRunnerFactory, stopFlagAgent,
-        prismLookup = null, deploymentTypes),
-      name=s"DeployGroupRunner-${record.uuid.toString}"
+      new DeployGroupRunner(record,
+                            deployCoordinatorProbe.ref,
+                            deploymentRunnerFactory,
+                            stopFlagAgent,
+                            prismLookup = null,
+                            deploymentTypes),
+      name = s"DeployGroupRunner-${record.uuid.toString}"
     )
     DRwithUnderlying(record, deployCoordinatorProbe, deploymentRunnerProbe, ref, stopFlagAgent, ref.underlyingActor)
   }

--- a/riff-raff/test/deployment/preview/PreviewTest.scala
+++ b/riff-raff/test/deployment/preview/PreviewTest.scala
@@ -34,7 +34,6 @@ class PreviewTest extends FlatSpec with Matchers with ValidatedValues with Mocki
     inverted.invalid shouldBe NEL.of("error-one", "error-two")
   }
 
-
   implicit val artifactClient = mock[AmazonS3Client]
 
   "apply" should "create a preview" in {
@@ -54,10 +53,13 @@ class PreviewTest extends FlatSpec with Matchers with ValidatedValues with Mocki
 
     val deploymentTuple = (
       DeploymentKey("testDeployment", "testAction", "testStack", "testRegion"),
-      DeploymentTasks(List(
-        StubTask("testAction per app task number one", Region("testRegion"), None, None),
-        StubTask("testAction per app task number two", Region("testRegion"), None, None)
-      ), "testDeployment [testAction] => testRegion/testStack")
+      DeploymentTasks(
+        List(
+          StubTask("testAction per app task number one", Region("testRegion"), None, None),
+          StubTask("testAction per app task number two", Region("testRegion"), None, None)
+        ),
+        "testDeployment [testAction] => testRegion/testStack"
+      )
     )
 
     preview.graph.valid shouldBe Graph(

--- a/riff-raff/test/docs/DeployTypeDocsTest.scala
+++ b/riff-raff/test/docs/DeployTypeDocsTest.scala
@@ -7,7 +7,8 @@ class DeployTypeDocsTest extends FlatSpec with Matchers {
   "generateDocs" should "generate documentation for our fake deployment type" in {
     val testDeploymentType = new DeploymentType {
       val action = Action("myAction", "some docs for my action")((_, _, _) => Nil)
-      val action2 = Action("myNonDefaultAction", "some docs for my action that doesn't run by default")((_, _, _) => Nil)
+      val action2 =
+        Action("myNonDefaultAction", "some docs for my action that doesn't run by default")((_, _, _) => Nil)
       override def defaultActions = List(action)
 
       override def name = "testDeploymentType"
@@ -15,12 +16,12 @@ class DeployTypeDocsTest extends FlatSpec with Matchers {
 
       val param1 = Param[String]("param1", "first parameter which has no default")
       val simianType = Param[String]("simianType", "simianType param which has a default").default("monkey")
-      val foodType = Param[String]("foodType", "another param with a contextual default").
-        defaultFromContext((pkg, target) => Right(s"banana${target.stack.nameOption.getOrElse("")}"))
-      val foodCount = Param[Int]("foodCount", "param with different default for legacy and new").
-        defaultFromContext((pkg, target) =>
-          Right(if (pkg.legacyConfig) 1 else 100)
-        )
+      val foodType =
+        Param[String]("foodType", "another param with a contextual default").defaultFromContext((pkg, target) =>
+          Right(s"banana${target.stack.nameOption.getOrElse("")}"))
+      val foodCount =
+        Param[Int]("foodCount", "param with different default for legacy and new").defaultFromContext((pkg, target) =>
+          Right(if (pkg.legacyConfig) 1 else 100))
     }
     val result = DeployTypeDocs.generateDocs(Seq(testDeploymentType))
     result.size shouldBe 1
@@ -30,20 +31,31 @@ class DeployTypeDocsTest extends FlatSpec with Matchers {
     docs shouldBe testDeploymentType.documentation
 
     actionDocs.size shouldBe 2
-    actionDocs should contain (ActionDoc("myAction", "some docs for my action", true))
-    actionDocs should contain (ActionDoc("myNonDefaultAction", "some docs for my action that doesn't run by default", false))
+    actionDocs should contain(ActionDoc("myAction", "some docs for my action", true))
+    actionDocs should contain(
+      ActionDoc("myNonDefaultAction", "some docs for my action that doesn't run by default", false))
 
     paramDocs.size shouldBe 4
-    paramDocs should contain (ParamDoc("param1", "first parameter which has no default", None, None))
-    paramDocs should contain (ParamDoc("simianType", "simianType param which has a default", Some("monkey"), Some("monkey")))
-    paramDocs should contain (ParamDoc("foodType", "another param with a contextual default", Some("banana<stack>"), Some("banana<stack>")))
-    paramDocs should contain (ParamDoc("foodCount", "param with different default for legacy and new", Some("1"), Some("100")))
+    paramDocs should contain(ParamDoc("param1", "first parameter which has no default", None, None))
+    paramDocs should contain(
+      ParamDoc("simianType", "simianType param which has a default", Some("monkey"), Some("monkey")))
+    paramDocs should contain(
+      ParamDoc("foodType", "another param with a contextual default", Some("banana<stack>"), Some("banana<stack>")))
+    paramDocs should contain(
+      ParamDoc("foodCount", "param with different default for legacy and new", Some("1"), Some("100")))
   }
 
   it should "successfully generate documentation for the standard set of deployment types" in {
     // we can't easily check correctness, but we can check exceptions are not thrown
     val availableDeploymentTypes = Seq(
-      ElasticSearch, S3, AutoScaling, Fastly, CloudFormation, Lambda, AmiCloudFormationParameter, SelfDeploy
+      ElasticSearch,
+      S3,
+      AutoScaling,
+      Fastly,
+      CloudFormation,
+      Lambda,
+      AmiCloudFormationParameter,
+      SelfDeploy
     )
     val result = DeployTypeDocs.generateDocs(availableDeploymentTypes)
     result.size shouldBe availableDeploymentTypes.size

--- a/riff-raff/test/lookup/PrismLookupTest.scala
+++ b/riff-raff/test/lookup/PrismLookupTest.scala
@@ -16,17 +16,19 @@ import scala.concurrent.duration._
 
 class PrismLookupTest extends FlatSpec with Matchers {
 
-  def withPrismClient[T](images: List[Image])(block: WSClient => T):(T, Option[Request[AnyContent]]) = {
+  def withPrismClient[T](images: List[Image])(block: WSClient => T): (T, Option[Request[AnyContent]]) = {
     var mockRequest: Option[Request[AnyContent]] = None
     val result = Server.withRouter() {
-      case GET(p"/images") => Action { request =>
-        mockRequest = Some(request)
-        Ok(Json.obj(
-          "data" -> Json.obj(
-            "images" -> Json.toJson(images)
-          )
-        ))
-      }
+      case GET(p"/images") =>
+        Action { request =>
+          mockRequest = Some(request)
+          Ok(
+            Json.obj(
+              "data" -> Json.obj(
+                "images" -> Json.toJson(images)
+              )
+            ))
+        }
     } { implicit port =>
       WsTestClient.withClient { client =>
         block(client)
@@ -37,10 +39,10 @@ class PrismLookupTest extends FlatSpec with Matchers {
 
   "PrismLookup" should "return latest image" in {
     val images = List(
-      Image("test-ami", new DateTime(2017,3,2,13,32,0)),
-      Image("test-later-ami", new DateTime(2017,4,2,13,32,0)),
-      Image("test-later-still-ami", new DateTime(2017,5,2,13,32,0)),
-      Image("test-early-ami", new DateTime(2017,1,2,13,32,0))
+      Image("test-ami", new DateTime(2017, 3, 2, 13, 32, 0)),
+      Image("test-later-ami", new DateTime(2017, 4, 2, 13, 32, 0)),
+      Image("test-later-still-ami", new DateTime(2017, 5, 2, 13, 32, 0)),
+      Image("test-early-ami", new DateTime(2017, 1, 2, 13, 32, 0))
     )
     withPrismClient(images) { client =>
       val lookup = new PrismLookup(client, "", 10 seconds)
@@ -63,10 +65,11 @@ class PrismLookupTest extends FlatSpec with Matchers {
       val lookup = new PrismLookup(client, "", 10 seconds)
       lookup.getLatestAmi("bob")(Map("tagName" -> "tagValue?", "tagName*" -> "tagValue2"))
     }
-    request.map(_.queryString) shouldBe Some(Map(
-      "region" -> ArrayBuffer("bob"),
-      "tags.tagName" -> ArrayBuffer("tagValue?"),
-      "tags.tagName*" -> ArrayBuffer("tagValue2")
-    ))
+    request.map(_.queryString) shouldBe Some(
+      Map(
+        "region" -> ArrayBuffer("bob"),
+        "tags.tagName" -> ArrayBuffer("tagValue?"),
+        "tags.tagName*" -> ArrayBuffer("tagValue2")
+      ))
   }
 }

--- a/riff-raff/test/notification/HookTemplateTest.scala
+++ b/riff-raff/test/notification/HookTemplateTest.scala
@@ -13,50 +13,51 @@ class HookTemplateTest extends FunSuite with Matchers {
   test("HookTemplate should leave unparameterised template as is") {
     val template = new HookTemplate("foo", record)
     val res: Try[String] = template.Template.run()
-    res should be (Success("foo"))
+    res should be(Success("foo"))
   }
 
   test("HookTemplate should replace project in template") {
     val template = new HookTemplate("{'name': '%deploy.project%'}", record)
     val res: Try[String] = template.Template.run()
-    res should be (Success("{'name': 'A Project'}"))
+    res should be(Success("{'name': 'A Project'}"))
   }
 
   test("HookTemplate should replace projectName in template") {
     val template = new HookTemplate("{'name': '%deploy.projectName%'}", record)
     val res: Try[String] = template.Template.run()
-    res should be (Success("{'name': 'A Project'}"))
+    res should be(Success("{'name': 'A Project'}"))
   }
 
   test("HookTemplate should leave as is an input with a single %") {
     val template = new HookTemplate("{'name': '%deploy.project'}", record)
     val res: Try[String] = template.Template.run()
-    res should be (Success("{'name': '%deploy.project'}"))
+    res should be(Success("{'name': '%deploy.project'}"))
   }
 
   test("HookTemplate should replace tags if they exist") {
     val template = new HookTemplate("{'blah': '%deploy.tag.foo%'}", record)
     val res: Try[String] = template.Template.run()
-    res should be (Success("{'blah': 'bar'}"))
+    res should be(Success("{'blah': 'bar'}"))
   }
 
   test("HookTemplate should replace unknown tag with an empty string") {
     val template = new HookTemplate("{'blah': '%deploy.tag.foo%'}", record)
     val res: Try[String] = template.Template.run()
-    res should be (Success("{'blah': 'bar'}"))
+    res should be(Success("{'blah': 'bar'}"))
   }
 
   test("Should url escape params if so configured") {
     val template = new HookTemplate("http://localhost:80/test?project=%deploy.project%",
-      record.copy(parameters = paramsDoc.copy(projectName = "test::project")), urlEncode = true)
+                                    record.copy(parameters = paramsDoc.copy(projectName = "test::project")),
+                                    urlEncode = true)
     val res: Try[String] = template.Template.run()
-    res should be (Success("http://localhost:80/test?project=test%3A%3Aproject"))
+    res should be(Success("http://localhost:80/test?project=test%3A%3Aproject"))
   }
 
   test("Should replace build") {
     val template = new HookTemplate("{'build': '%deploy.build%'}", record)
     val res: Try[String] = template.Template.run()
-    res should be (Success("{'build': 'a123'}"))
+    res should be(Success("{'build': 'a123'}"))
   }
 
   val paramsDoc = ParametersDocument(

--- a/riff-raff/test/notification/HooksTest.scala
+++ b/riff-raff/test/notification/HooksTest.scala
@@ -40,19 +40,24 @@ class HooksTest extends FlatSpec with Matchers with BeforeAndAfterAll {
   }
 
   it should "escape substitute parameters" in {
-    val action = HookConfig("testProject", "TEST", "http://localhost:80/test?project=%deploy.project%", true, "Mr. Tester")
+    val action =
+      HookConfig("testProject", "TEST", "http://localhost:80/test?project=%deploy.project%", true, "Mr. Tester")
     val req = action.request(testDeployParams)
     req.url should be("http://localhost:80/test?project=test%3A%3Aproject")
   }
 
   it should "substitute tag parameters" in {
-    val action = HookConfig("testProject", "TEST", "http://localhost:80/test?build=%deploy.build%&sha=%deploy.tag.vcsRevision%", true, "Mr. Tester")
+    val action = HookConfig("testProject",
+                            "TEST",
+                            "http://localhost:80/test?build=%deploy.build%&sha=%deploy.tag.vcsRevision%",
+                            true,
+                            "Mr. Tester")
     val req = action.request(testDeployParams)
     req.url should be("http://localhost:80/test?build=23&sha=9110598b83a908d7882ac4e3cd4b643d7d8bc54e")
   }
 
   val testUUID = UUID.fromString("758fa00e-e9da-41e0-b31f-1af417e333a1")
-  val startTime = new DateTime(2013,9,23,13,23,33)
+  val startTime = new DateTime(2013, 9, 23, 13, 23, 33)
   val testDeployParams = DeployRecordDocument(
     testUUID,
     Some(testUUID.toString),

--- a/riff-raff/test/restrictions/RestrictionCheckerTest.scala
+++ b/riff-raff/test/restrictions/RestrictionCheckerTest.scala
@@ -13,7 +13,7 @@ class RestrictionCheckerTest extends FlatSpec with Matchers {
   val config = makeConfig("", "")
   val configs: Seq[RestrictionConfig] = Seq(
     makeConfig("testProject1", "PROD"),
-    makeConfig("testProject1", "CODE", cd=true, whitelist = Seq("test.user@example.com")),
+    makeConfig("testProject1", "CODE", cd = true, whitelist = Seq("test.user@example.com")),
     makeConfig("testProject2", ".*")
   )
 
@@ -24,55 +24,78 @@ class RestrictionCheckerTest extends FlatSpec with Matchers {
 
   "editable" should "run the editable path when there is no existing config" in {
     RestrictionChecker.isEditable(
-      None, makeUser("test.user@example.com"), Nil
+      None,
+      makeUser("test.user@example.com"),
+      Nil
     ) shouldBe Right(true)
   }
 
   it should "run the editable path when the config is not locked even if the user is different" in {
-    val someConfig = Some(makeConfig("testProject", "PROD", creator = "test.creator@example.com", editingLocked = false))
+    val someConfig =
+      Some(makeConfig("testProject", "PROD", creator = "test.creator@example.com", editingLocked = false))
     RestrictionChecker.isEditable(
-      someConfig, makeUser("test.user@example.com"), Nil
+      someConfig,
+      makeUser("test.user@example.com"),
+      Nil
     ) shouldBe Right(true)
   }
 
   it should "run the not editable path when the config is locked when the user is different" in {
-    val someConfig = Some(makeConfig("testProject", "PROD", creator = "test.creator@example.com", editingLocked = true))
+    val someConfig =
+      Some(makeConfig("testProject", "PROD", creator = "test.creator@example.com", editingLocked = true))
     RestrictionChecker.isEditable(
-      someConfig, makeUser("test.user@example.com"), Nil
+      someConfig,
+      makeUser("test.user@example.com"),
+      Nil
     ) shouldBe Left(Error("Locked by test.creator@example.com"))
   }
 
   it should "run the editable path when the config is locked and the user is the creator" in {
-    val someConfig = Some(makeConfig("testProject", "PROD", creator = "test.creator@example.com", editingLocked = true))
+    val someConfig =
+      Some(makeConfig("testProject", "PROD", creator = "test.creator@example.com", editingLocked = true))
     RestrictionChecker.isEditable(
-      someConfig, makeUser("test.creator@example.com"), Nil
+      someConfig,
+      makeUser("test.creator@example.com"),
+      Nil
     ) shouldBe Right(true)
   }
 
   it should "allow modifications by super users" in {
-    val someConfig = Some(makeConfig("testProject", "PROD", creator = "test.creator@example.com", editingLocked = true))
+    val someConfig =
+      Some(makeConfig("testProject", "PROD", creator = "test.creator@example.com", editingLocked = true))
     RestrictionChecker.isEditable(
-      someConfig, makeUser("superuser@example.com"), List("superuser@example.com")
+      someConfig,
+      makeUser("superuser@example.com"),
+      List("superuser@example.com")
     ) shouldBe Right(true)
   }
 
   it should "report superusers when locked" in {
-    val someConfig = Some(makeConfig("testProject", "PROD", creator = "test.creator@example.com", editingLocked = true))
+    val someConfig =
+      Some(makeConfig("testProject", "PROD", creator = "test.creator@example.com", editingLocked = true))
     RestrictionChecker.isEditable(
-      someConfig, makeUser("test.user@example.com"), List("superuser@example.com")
+      someConfig,
+      makeUser("test.user@example.com"),
+      List("superuser@example.com")
     ) shouldBe Left(Error("Locked by test.creator@example.com - can also be modified by superuser@example.com"))
   }
 
   "configsThatPreventDeploy" should "return no configs when deploying to a project with no restrictions" in {
     val restrictions = RestrictionChecker.configsThatPreventDeployment(
-      testRestrictions, "testProject0", "PROD", UserRequestSource(makeUser("test.user@example.com"))
+      testRestrictions,
+      "testProject0",
+      "PROD",
+      UserRequestSource(makeUser("test.user@example.com"))
     )
     restrictions.size shouldBe 0
   }
 
   it should "return the matching config for a prevented stage" in {
     val restrictions = RestrictionChecker.configsThatPreventDeployment(
-        testRestrictions, "testProject1", "PROD", UserRequestSource(makeUser("test.user@example.com"))
+      testRestrictions,
+      "testProject1",
+      "PROD",
+      UserRequestSource(makeUser("test.user@example.com"))
     )
     restrictions.size shouldBe 1
     restrictions should contain(configs(0))
@@ -80,14 +103,20 @@ class RestrictionCheckerTest extends FlatSpec with Matchers {
 
   it should "return no configs for a stage that isn't prevented" in {
     val restrictions = RestrictionChecker.configsThatPreventDeployment(
-      testRestrictions, "testProject1", "TEST", UserRequestSource(makeUser("test.user@example.com"))
+      testRestrictions,
+      "testProject1",
+      "TEST",
+      UserRequestSource(makeUser("test.user@example.com"))
     )
     restrictions.size shouldBe 0
   }
 
   it should "return the matching config for a prevented stage with a non-whitelisted user" in {
     val restrictions = RestrictionChecker.configsThatPreventDeployment(
-      testRestrictions, "testProject1", "CODE", UserRequestSource(makeUser("bad.user@example.com"))
+      testRestrictions,
+      "testProject1",
+      "CODE",
+      UserRequestSource(makeUser("bad.user@example.com"))
     )
     restrictions.size shouldBe 1
     restrictions should contain(configs(1))
@@ -95,21 +124,30 @@ class RestrictionCheckerTest extends FlatSpec with Matchers {
 
   it should "return no configs for a prevented stage with a whitelisted user" in {
     val restrictions = RestrictionChecker.configsThatPreventDeployment(
-      testRestrictions, "testProject1", "CODE", UserRequestSource(makeUser("test.user@example.com"))
+      testRestrictions,
+      "testProject1",
+      "CODE",
+      UserRequestSource(makeUser("test.user@example.com"))
     )
     restrictions.size shouldBe 0
   }
 
   it should "return no configs for a permitted continuous deployment" in {
     val restrictions = RestrictionChecker.configsThatPreventDeployment(
-      testRestrictions, "testProject1", "CODE", ContinuousDeploymentRequestSource
+      testRestrictions,
+      "testProject1",
+      "CODE",
+      ContinuousDeploymentRequestSource
     )
     restrictions.size shouldBe 0
   }
 
   it should "return a config when the stage is a regex" in {
     val restrictions = RestrictionChecker.configsThatPreventDeployment(
-      testRestrictions, "testProject2", "ANY", ContinuousDeploymentRequestSource
+      testRestrictions,
+      "testProject2",
+      "ANY",
+      ContinuousDeploymentRequestSource
     )
     restrictions.size shouldBe 1
     restrictions should contain(configs(2))
@@ -117,19 +155,22 @@ class RestrictionCheckerTest extends FlatSpec with Matchers {
 
   "sourceMatches" should "match when a CD and CD is permitted" in {
     RestrictionChecker.sourceMatches(
-      config.copy(continuousDeployment=true), ContinuousDeploymentRequestSource
+      config.copy(continuousDeployment = true),
+      ContinuousDeploymentRequestSource
     ) shouldBe true
   }
 
   it should "not match when a CD and CD is not permitted" in {
     RestrictionChecker.sourceMatches(
-      config.copy(continuousDeployment=false), ContinuousDeploymentRequestSource
+      config.copy(continuousDeployment = false),
+      ContinuousDeploymentRequestSource
     ) shouldBe false
   }
 
   it should "not match when an API source" in {
     RestrictionChecker.sourceMatches(
-      config, ApiRequestSource(ApiKey("", "", "", new DateTime()))
+      config,
+      ApiRequestSource(ApiKey("", "", "", new DateTime()))
     ) shouldBe false
   }
 
@@ -170,9 +211,22 @@ class RestrictionCheckerTest extends FlatSpec with Matchers {
     RestrictionChecker.stageMatches("PROD.*", "ZEBRA-PROD") shouldBe false
   }
 
-  def makeConfig(projectName: String, stage: String, whitelist: Seq[String] = Seq.empty, cd: Boolean = false,
-    creator:String = "", editingLocked: Boolean = false) =
-  RestrictionConfig(UUID.randomUUID, projectName, stage, new DateTime(), creator, creator, editingLocked, whitelist, cd, "")
+  def makeConfig(projectName: String,
+                 stage: String,
+                 whitelist: Seq[String] = Seq.empty,
+                 cd: Boolean = false,
+                 creator: String = "",
+                 editingLocked: Boolean = false) =
+    RestrictionConfig(UUID.randomUUID,
+                      projectName,
+                      stage,
+                      new DateTime(),
+                      creator,
+                      creator,
+                      editingLocked,
+                      whitelist,
+                      cd,
+                      "")
   def makeUser(email: String) = UserIdentity("1234", email, "Test", "User", 123344567845L, None)
 
 }

--- a/riff-raff/test/utils/GraphTest.scala
+++ b/riff-raff/test/utils/GraphTest.scala
@@ -10,11 +10,12 @@ class GraphTest extends FunSuite with Matchers {
       new LocalDate(2013, 5, 3) -> 2
     )
 
-    Graph.zeroFillDays(statsWithMissingDays) should be (List(
-      new LocalDate(2013, 5, 1) -> 4,
-      new LocalDate(2013, 5, 2) -> 0,
-      new LocalDate(2013, 5, 3) -> 2
-    ))
+    Graph.zeroFillDays(statsWithMissingDays) should be(
+      List(
+        new LocalDate(2013, 5, 1) -> 4,
+        new LocalDate(2013, 5, 2) -> 0,
+        new LocalDate(2013, 5, 3) -> 2
+      ))
   }
 
 }

--- a/riff-raff/test/utils/VCSInfoTest.scala
+++ b/riff-raff/test/utils/VCSInfoTest.scala
@@ -4,15 +4,16 @@ import java.net.URI
 
 import org.scalatest.{FunSuite, ShouldMatchers}
 
-
 class VCSInfoTest extends FunSuite with ShouldMatchers {
   test("extracts details from Github HTTPS URL") {
-    val info = VCSInfo("https://github.com/guardian/contributions-frontend", "98a1cffadbe564d570b15c2113c07a28cbe835ee")
+    val info =
+      VCSInfo("https://github.com/guardian/contributions-frontend", "98a1cffadbe564d570b15c2113c07a28cbe835ee")
     info.get.baseUrl shouldBe new URI("https://github.com/guardian/contributions-frontend")
   }
 
   test("extracts details from Github git URL") {
-    val info = VCSInfo("git@github.com:guardian/contributions-frontend.git", "98a1cffadbe564d570b15c2113c07a28cbe835ee")
+    val info =
+      VCSInfo("git@github.com:guardian/contributions-frontend.git", "98a1cffadbe564d570b15c2113c07a28cbe835ee")
     info.get.baseUrl shouldBe new URI("https://github.com/guardian/contributions-frontend")
   }
 }


### PR DESCRIPTION
I ran this manually once and then did some fix-up of the `Param` definitions as, ironically, it made these less consistent.

I'm still not sure how I feel about this in general, but it does get rid of a decent chunk of noise and I think the enforcement of a newline in longer map/filter/groupBy type chains works well.

This doesn't integrate it into any build process, just does it as a one-off.