### PR TITLE
Deprecate deploy.json and add pauses as a forcing function for migration

### DIFF
--- a/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
+++ b/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
@@ -123,11 +123,11 @@ object S3JsonArtifact extends Loggable {
     reporter.warning(
       """DEPRECATED: The artifact.zip is now a legacy format - please switch to the new format (if you
         |are using sbt-riffraff-artifact then simply upgrade to >= 0.9.4, if you use the TeamCity upload plugin
-        |you'll need to use the riffRaffNotifyTeamcity task instead of the riffRaffArtifact task).""".stripMargin)
+        |you'll need to use the riffRaffNotifyTeamcity task instead of the riffRaffArtifact task). NOTE: Support will
+        |be removed at the end of September 2017.""".stripMargin)
     deprecatedPause.foreach { pause =>
       reporter.warning(
-        s"""Support will be removed at the end of September 2017. To persuade you to migrate we will now
-          |pause this deploy for $pause seconds whilst you reflect on your ways.""".stripMargin)
+        s"To persuade you to migrate we will now\npause this deploy for $pause seconds whilst you reflect on your ways.")
       Thread.sleep(pause * 1000)
     }
     reporter.info("Converting artifact.zip to S3 layout")

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -58,6 +58,8 @@ object AutoScaling  extends DeploymentType {
       |S3 bucket name to upload artifact into.
       |
       |The path in the bucket is `<stack>/<stage>/<packageName>/<fileName>`.
+      |
+      |Despite there being a default for this we are migrating to always requiring it to be specified.
     """.stripMargin,
     optionalInYaml = true
   ).defaultFromContext((_, target) => target.stack.nameOption.map(stackName => s"$stackName-dist").toRight("You must specify bucket explicitly when not using stacks"))

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Param.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Param.scala
@@ -41,8 +41,11 @@ case class Param[T](
 
     val maybeDefault = defaultValue.orElse(defaultFromContext.flatMap(_.right.toOption))
     (pkg.legacyConfig, maybeDefault, maybeValue) match {
-      case (false, Some(default), Some(value)) if default == value =>
+      // the bucket checks below are to aid migrating to this being a required field as we are simply guessing otherwise
+      case (false, Some(default), Some(value)) if default == value && name != "bucket" =>
         reporter.warning(s"Parameter $name is unnecessarily explicitly set to the default value of $default")
+      case (false, Some(_), None) if name == "bucket" =>
+        reporter.warning(s"Parameter bucket must always be explicitly set")
       case _ => // otherwise do nothing
     }
 

--- a/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
@@ -18,6 +18,8 @@ object SelfDeploy extends DeploymentType {
       |S3 bucket name to upload artifact into.
       |
       |The path in the bucket is `<stack>/<stage>/<packageName>/<fileName>`.
+      |
+      |Despite there being a default for this we are migrating to always requiring it to be specified.
     """.stripMargin
   ).defaultFromContext{ case (_, target) =>
     target.stack.nameOption.map(stackName => s"$stackName-dist").toRight("You must specify bucket explicitly when not using stacks")

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -34,7 +34,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
     ElasticSearch, S3, AutoScaling, Fastly, CloudFormation, Lambda, AmiCloudFormationParameter, SelfDeploy
   )
   val prismLookup = new PrismLookup(wsClient, conf.Configuration.lookup.prismUrl, conf.Configuration.lookup.timeoutSeconds.seconds)
-  val deploymentEngine = new DeploymentEngine(prismLookup, availableDeploymentTypes)
+  val deploymentEngine = new DeploymentEngine(prismLookup, availableDeploymentTypes, conf.Configuration.deprecation.pauseSeconds)
   val deployments = new Deployments(deploymentEngine)
   val continuousDeployment = new ContinuousDeployment(deployments)
   val previewCoordinator = new PreviewCoordinator(prismLookup, availableDeploymentTypes)

--- a/riff-raff/app/assets/stylesheets/magenta.less
+++ b/riff-raff/app/assets/stylesheets/magenta.less
@@ -209,3 +209,7 @@ div.deployment-target:target {
 .display-inline {
   display: inline;
 }
+
+tr.has-warnings {
+  background: repeating-linear-gradient( 45deg, #fcd7d7, #fcd7d7 10px, #dddddd 10px, #dddddd 20px );
+}

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -90,17 +90,22 @@ class Configuration(val application: String, val webappConfDirectory: String = "
 
   object continuousDeployment {
     lazy val enabled = configuration.getStringProperty("continuousDeployment.enabled", "false") == "true"
-    val dynamoClient = AmazonDynamoDBAsyncClientBuilder.standard()
-      .withCredentials(credentialsProviderChain(None, None))
-      .withRegion(Regions.getCurrentRegion.getName)
-      .withClientConfiguration(new ClientConfiguration())
-      .build()
+
   }
 
   object credentials {
     def lookupSecret(service: String, id:String): Option[String] = {
       configuration.getStringProperty("credentials.%s.%s" format (service, id))
     }
+  }
+
+  object dynamoDb {
+    lazy val regionName = configuration.getStringProperty("artifact.aws.region", "eu-west-1")
+    val client = AmazonDynamoDBAsyncClientBuilder.standard()
+      .withCredentials(credentialsProviderChain(None, None))
+      .withRegion(regionName)
+      .withClientConfiguration(new ClientConfiguration())
+      .build()
   }
 
   object freeze {

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -190,6 +190,10 @@ class Configuration(val application: String, val webappConfDirectory: String = "
     val token = configuration.getStringProperty("mixpanel.token")
   }
 
+  object deprecation {
+    val pauseSeconds = configuration.getIntegerProperty("deprecation.pauseSeconds")
+  }
+
   def credentialsProviderChain(accessKey: Option[String], secretKey: Option[String]): AWSCredentialsProviderChain =
     new AWSCredentialsProviderChain(
       new AWSCredentialsProvider {

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -198,7 +198,7 @@ class Configuration(val application: String, val webappConfDirectory: String = "
   object deprecation {
     def pauseSeconds:Option[Int] = {
       val days = new Period(new DateTime(2017,5,22,0,0,0), new DateTime()).toStandardDays.getDays
-      if (days > 0) Some(days) else None
+      if (days > 0) Some(math.max(60, days)) else None
     }
   }
 

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -8,12 +8,12 @@ import logback.LogbackLevelPage
 import com.gu.management.play.{Management => PlayManagement}
 import com.gu.conf.ConfigurationFactory
 import magenta._
-import controllers.{Logging, routes}
+import controllers.{routes, Logging}
 import lifecycle.{Lifecycle, ShutdownWhenInactive}
 import java.util.UUID
 
 import com.amazonaws.ClientConfiguration
-import com.amazonaws.regions.{Region, RegionUtils, Regions}
+import com.amazonaws.regions.{Region, Regions, RegionUtils}
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClientBuilder
 import com.amazonaws.services.ec2.AmazonEC2ClientBuilder
 import com.amazonaws.services.ec2.model.{DescribeTagsRequest, Filter}
@@ -29,7 +29,7 @@ import scala.collection.JavaConverters._
 import org.joda.time.format.ISODateTimeFormat
 import com.gu.googleauth.GoogleAuthConfig
 import deployment.actors.DeployMetricsActor
-
+import org.joda.time.{DateTime, Period}
 import riffraff.BuildInfo
 
 import scala.util.{Success, Try}
@@ -196,7 +196,10 @@ class Configuration(val application: String, val webappConfDirectory: String = "
   }
 
   object deprecation {
-    val pauseSeconds = configuration.getIntegerProperty("deprecation.pauseSeconds")
+    def pauseSeconds:Option[Int] = {
+      val days = new Period(new DateTime(2017,5,22,0,0,0), new DateTime()).toStandardDays.getDays
+      if (days > 0) Some(days) else None
+    }
   }
 
   def credentialsProviderChain(accessKey: Option[String], secretKey: Option[String]): AWSCredentialsProviderChain =

--- a/riff-raff/app/deployment/DeploymentEngine.scala
+++ b/riff-raff/app/deployment/DeploymentEngine.scala
@@ -12,7 +12,7 @@ import resources.PrismLookup
 
 import scala.collection.JavaConverters._
 
-class DeploymentEngine(prismLookup: PrismLookup, deploymentTypes: Seq[DeploymentType]) extends Logging {
+class DeploymentEngine(prismLookup: PrismLookup, deploymentTypes: Seq[DeploymentType], deprecatedPause: Option[Int]) extends Logging {
   import DeploymentEngine._
 
   private lazy val deploymentRunnerFactory = (context: ActorRefFactory, runnerName: String) => context.actorOf(
@@ -23,7 +23,7 @@ class DeploymentEngine(prismLookup: PrismLookup, deploymentTypes: Seq[Deployment
   private lazy val deployRunnerFactory = (context: ActorRefFactory, record: Record, deployCoordinator: ActorRef) =>
     context.actorOf(
       props = Props(
-        new DeployGroupRunner(record, deployCoordinator, deploymentRunnerFactory, stopFlagAgent, prismLookup, deploymentTypes)
+        new DeployGroupRunner(record, deployCoordinator, deploymentRunnerFactory, stopFlagAgent, prismLookup, deploymentTypes, deprecatedPause)
       ).withDispatcher("akka.deploy-dispatcher"),
       name = s"deployGroupRunner-${record.uuid.toString}"
     )

--- a/riff-raff/app/deployment/Deployments.scala
+++ b/riff-raff/app/deployment/Deployments.scala
@@ -128,10 +128,17 @@ object Deployments extends Logging with Lifecycle {
       recordAgent send { record =>
         val updated = record + wrapper
         DocumentStoreConverter.saveMessage(wrapper)
-        if (record.state != updated.state) DocumentStoreConverter.updateDeployStatus(updated)
-        if (record.totalTasks != updated.totalTasks || record.completedTasks != updated.completedTasks)
+        if (record.state != updated.state) {
+          DocumentStoreConverter.updateDeployStatus(updated)
+        }
+        if (record.totalTasks != updated.totalTasks ||
+            record.completedTasks != updated.completedTasks ||
+            record.hasWarnings != updated.hasWarnings) {
           DocumentStoreConverter.updateDeploySummary(updated)
-        if (updated.isDone) cleanup(record.uuid)
+        }
+        if (updated.isDone) {
+          cleanup(record.uuid)
+        }
         updated
       }
     }

--- a/riff-raff/app/deployment/LegacyPreview.scala
+++ b/riff-raff/app/deployment/LegacyPreview.scala
@@ -62,7 +62,7 @@ object LegacyPreview {
     if (yamlArtifact.deployObject.fetchContentAsString()(resources.artifactClient).isRight)
       throw new IllegalArgumentException("Tried to preview 'riff-raff.yaml' with old preview tool")
     val s3Artifact = S3JsonArtifact(build, artifact.aws.bucketName)
-    val json = S3JsonArtifact.fetchInputFile(s3Artifact)(resources.artifactClient, resources.reporter)
+    val json = S3JsonArtifact.fetchInputFile(s3Artifact, None)(resources.artifactClient, resources.reporter)
     json.fold[Project](e => resources.reporter.fail(s"Unable to build preview, $e"),
       JsonReader.buildProject(_, s3Artifact, deploymentTypes))
   }

--- a/riff-raff/app/deployment/filter.scala
+++ b/riff-raff/app/deployment/filter.scala
@@ -17,7 +17,8 @@ case class DeployFilter(
   stage: Option[String] = None,
   deployer: Option[String] = None,
   status: Option[RunState.Value] = None,
-  maxDaysAgo: Option[Int] = None ) extends QueryStringBuilder {
+  maxDaysAgo: Option[Int] = None,
+  hasWarnings: Option[Boolean] = None) extends QueryStringBuilder {
 
   lazy val queryStringParams: List[(String, String)] = {
     Nil ++
@@ -25,7 +26,8 @@ case class DeployFilter(
       stage.map("stage" -> _.toString) ++
       deployer.map("deployer" -> _.toString) ++
       status.map("status" -> _.toString) ++
-      maxDaysAgo.map("maxDaysAgo" -> _.toString)
+      maxDaysAgo.map("maxDaysAgo" -> _.toString) ++
+      hasWarnings.map("hasWarnings" -> _.toString)
   }
 
   def withProjectName(projectName: Option[String]) = this.copy(projectName=projectName)
@@ -33,6 +35,7 @@ case class DeployFilter(
   def withDeployer(deployer: Option[String]) = this.copy(deployer=deployer)
   def withStatus(status: Option[RunState.Value]) = this.copy(status=status)
   def withMaxDaysAgo(maxDaysAgo: Option[Int]) = this.copy(maxDaysAgo=maxDaysAgo)
+  def withHasWarnings(hasWarnings: Option[Boolean]) = this.copy(hasWarnings=hasWarnings)
 
   lazy val default = this == DeployFilter()
 
@@ -55,7 +58,8 @@ object DeployFilter {
       stage = param("stage"),
       deployer = param("deployer"),
       status = statusType,
-      maxDaysAgo = param("maxDaysAgo").map(_.toInt)
+      maxDaysAgo = param("maxDaysAgo").map(_.toInt),
+      hasWarnings = param("hasWarnings").map(_.toBoolean)
     )
 
     if (filter == DeployFilter()) None else Some(filter)

--- a/riff-raff/app/persistence/DynamoRepository.scala
+++ b/riff-raff/app/persistence/DynamoRepository.scala
@@ -9,7 +9,7 @@ import org.joda.time.DateTime
 
 trait DynamoRepository {
 
-  val client = Configuration.continuousDeployment.dynamoClient
+  val client = Configuration.dynamoDb.client
   def exec[A](ops: ScanamoOps[A]): A = Scanamo.exec(client)(ops)
   def tablePrefix: String
 

--- a/riff-raff/app/persistence/mapping.scala
+++ b/riff-raff/app/persistence/mapping.scala
@@ -79,7 +79,8 @@ case class DocumentConverter(deploy: DeployRecordDocument, logs: Seq[LogDocument
       Some(deploy.status),
       deploy.totalTasks,
       deploy.completedTasks,
-      deploy.lastActivityTime
+      deploy.lastActivityTime,
+      deploy.hasWarnings
     )
 
   lazy val messageWrappers: List[MessageWrapper] = {
@@ -110,7 +111,7 @@ trait DocumentStore {
   def writeDeploy(deploy: DeployRecordDocument) {}
   def writeLog(log: LogDocument) {}
   def updateStatus(uuid: UUID, status: RunState.Value) {}
-  def updateDeploySummary(uuid: UUID, totalTasks:Option[Int], completedTasks:Int, lastActivityTime:DateTime) {}
+  def updateDeploySummary(uuid: UUID, totalTasks:Option[Int], completedTasks:Int, lastActivityTime:DateTime, hasWarnings:Boolean) {}
   def readDeploy(uuid: UUID): Option[DeployRecordDocument] = None
   def readLogs(uuid: UUID): Iterable[LogDocument] = Nil
   def getDeployUUIDs(limit: Int = 0): Iterable[SimpleDeployDetail] = Nil
@@ -141,11 +142,11 @@ object DocumentStoreConverter extends Logging {
   }
 
   def updateDeploySummary(record: DeployRecord) {
-    updateDeploySummary(record.uuid, record.totalTasks, record.completedTasks, record.lastActivityTime)
+    updateDeploySummary(record.uuid, record.totalTasks, record.completedTasks, record.lastActivityTime, record.hasWarnings)
   }
 
-  def updateDeploySummary(uuid: UUID, totalTasks:Option[Int], completedTasks:Int, lastActivityTime:DateTime) {
-    documentStore.updateDeploySummary(uuid, totalTasks, completedTasks, lastActivityTime)
+  def updateDeploySummary(uuid: UUID, totalTasks:Option[Int], completedTasks:Int, lastActivityTime:DateTime, hasWarnings:Boolean) {
+    documentStore.updateDeploySummary(uuid, totalTasks, completedTasks, lastActivityTime, hasWarnings)
   }
 
   def updateDeployStatus(record: DeployRecord) {

--- a/riff-raff/app/persistence/mongodb.scala
+++ b/riff-raff/app/persistence/mongodb.scala
@@ -170,10 +170,10 @@ class MongoDatastore(database: MongoDB) extends DataStore with DocumentStore wit
     }
   }
 
-  override def updateDeploySummary(uuid: UUID, totalTasks:Option[Int], completedTasks:Int, lastActivityTime:DateTime) {
-    logAndSquashExceptions(Some(s"Updating summary of $uuid to total:$totalTasks, completed:$completedTasks, lastActivivty:$lastActivityTime"), ()) {
+  override def updateDeploySummary(uuid: UUID, totalTasks:Option[Int], completedTasks:Int, lastActivityTime:DateTime, hasWarnings:Boolean) {
+    logAndSquashExceptions(Some(s"Updating summary of $uuid to total:$totalTasks, completed:$completedTasks, lastActivity:$lastActivityTime, hasWarnings:$hasWarnings"), ()) {
       val fields =
-        List("completedTasks" -> completedTasks, "lastActivityTime" -> lastActivityTime) ++
+        List("completedTasks" -> completedTasks, "lastActivityTime" -> lastActivityTime, "hasWarnings" -> hasWarnings) ++
         totalTasks.map("totalTasks" ->)
       deployCollection.update(MongoDBObject("_id" -> uuid), $set(fields: _*), concern=WriteConcern.Safe)
     }

--- a/riff-raff/app/persistence/package.scala
+++ b/riff-raff/app/persistence/package.scala
@@ -15,7 +15,8 @@ object `package` {
         filter.projectName.map(p => ("parameters.projectName", s"(?i)$p".r)) ++
         filter.stage.map(("parameters.stage", _)) ++
         filter.deployer.map(("parameters.deployer", _)) ++
-        filter.status.map(s => ("status", s.toString))
+        filter.status.map(s => ("status", s.toString)) ++
+        filter.hasWarnings.map(hw => ("hasWarnings", hw))
       filter.maxDaysAgo match {
         case None => MongoDBObject(criteriaList)
 

--- a/riff-raff/app/persistence/representation.scala
+++ b/riff-raff/app/persistence/representation.scala
@@ -15,7 +15,8 @@ case class DeployRecordDocument(uuid:UUID,
                                 summarised: Option[Boolean] = None,
                                 totalTasks: Option[Int] = None,
                                 completedTasks: Option[Int] = None,
-                                lastActivityTime: Option[DateTime] = None)
+                                lastActivityTime: Option[DateTime] = None,
+                                hasWarnings: Option[Boolean] = None)
 
 object DeployRecordDocument extends MongoSerialisable[DeployRecordDocument] {
   def apply(uuid:String, startTime: DateTime, parameters: ParametersDocument, status: String): DeployRecordDocument = {
@@ -32,7 +33,7 @@ object DeployRecordDocument extends MongoSerialisable[DeployRecordDocument] {
           "status" -> a.status.toString
         ) ++ a.stringUUID.map("stringUUID" ->) ++ a.summarised.map("summarised" -> _) ++
              a.totalTasks.map("totalTasks" ->) ++ a.completedTasks.map("completedTasks" ->) ++
-             a.lastActivityTime.map("lastActivityTime" ->)
+             a.lastActivityTime.map("lastActivityTime" ->) ++ a.hasWarnings.map("hasWarnings" ->)
       fields.toMap
     }
     def fromDBO(dbo: MongoDBObject) =
@@ -46,7 +47,8 @@ object DeployRecordDocument extends MongoSerialisable[DeployRecordDocument] {
         summarised = dbo.getAs[Boolean]("summarised"),
         totalTasks = dbo.getAs[Int]("totalTasks"),
         completedTasks = dbo.getAs[Int]("completedTasks"),
-        lastActivityTime = dbo.getAs[DateTime]("lastActivityTime")
+        lastActivityTime = dbo.getAs[DateTime]("lastActivityTime"),
+        hasWarnings = dbo.getAs[Boolean]("hasWarnings")
       )
     )
   }

--- a/riff-raff/app/views/snippets/recordTable.scala.html
+++ b/riff-raff/app/views/snippets/recordTable.scala.html
@@ -28,7 +28,7 @@
     <tbody class="rowlink" data-provides="rowlink">
     @records.map{ record =>
         @defining(record.vcsInfo) { vcsInfo =>
-        <tr class="rowlink">
+        <tr class="rowlink@if(record.hasWarnings){ has-warnings}">
             <td><time class="makeRelativeDate" withinhours="24" datetime="@record.time">@utils.DateFormats.Medium.print(record.time)</time></td>
             <td><span class="label label-default">@record.deployerName</span></td>
             @if(allColumns) {

--- a/riff-raff/test/deployment/actors/DeployGroupRunnerTest.scala
+++ b/riff-raff/test/deployment/actors/DeployGroupRunnerTest.scala
@@ -113,7 +113,7 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
     val record = createRecord()
     val ref = system.actorOf(
       Props(new DeployGroupRunner(record, deployCoordinatorProbe.ref, deploymentRunnerFactory, stopFlagAgent,
-        prismLookup = null, deploymentTypes)),
+        prismLookup = null, deploymentTypes, None)),
       name=s"DeployGroupRunner-${record.uuid.toString}"
     )
     DRImpl(record, deployCoordinatorProbe, deploymentRunnerProbe, ref, stopFlagAgent)
@@ -130,7 +130,7 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
     val record = createRecord()
     val ref = TestActorRef(
       new DeployGroupRunner(record, deployCoordinatorProbe.ref, deploymentRunnerFactory, stopFlagAgent,
-        prismLookup = null, deploymentTypes),
+        prismLookup = null, deploymentTypes, None),
       name=s"DeployGroupRunner-${record.uuid.toString}"
     )
     DRwithUnderlying(record, deployCoordinatorProbe, deploymentRunnerProbe, ref, stopFlagAgent, ref.underlyingActor)


### PR DESCRIPTION
It's time to officially deprecate `deploy.json`!

A lot of people have already migrated and it is well testing. I've already created plenty of carrot with entertaining tech times, documentation and the validation tool - so now I'm suggesting a light touch stick. 

To that end I've:
 - added highlighting of deploys using deprecated features to the history screen (see below)
 - built functionality that will pause for an increasing number of seconds when deploys use `artifact.zip` or `deploy.json` (this will be 0 seconds until the 23rd of May and form then on will increase by 1 second per calendar day)

<img width="775" alt="screen shot 2017-05-08 at 17 02 49" src="https://cloud.githubusercontent.com/assets/1236466/25813821/e8c8dda0-3412-11e7-8e95-e0c7550ed28c.png">

I've set an explicit end of Sept 2017 date at which point we can start massively simplifying the codebase and mention this in the deprecation warnings.

I'll send some comms out around this explaining what is going to happen and when.

I've also (@adamnfish should like this) deprecated the ability to default a bucket name in an autoscaling deploy.