### PR TITLE
Deprecate another default

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -61,7 +61,8 @@ object AutoScaling  extends DeploymentType {
       |
       |Despite there being a default for this we are migrating to always requiring it to be specified.
     """.stripMargin,
-    optionalInYaml = true
+    optionalInYaml = true,
+    deprecatedDefault = true
   ).defaultFromContext((_, target) => target.stack.nameOption.map(stackName => s"$stackName-dist").toRight("You must specify bucket explicitly when not using stacks"))
   val secondsToWait = Param("secondsToWait", "Number of seconds to wait for instances to enter service").default(15 * 60)
   val healthcheckGrace = Param("healthcheckGrace", "Number of seconds to wait for the AWS api to stabilise").default(20)

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -44,7 +44,7 @@ object Lambda extends DeploymentType  {
   val prefixStackParam = Param[Boolean]("prefixStack",
     "If true then the values in the functionNames param will be prefixed with the name of the stack being deployed").defaultFromContext((pkg, _) => Right(!pkg.legacyConfig))
 
-  val fileNameParam = Param[String]("fileName", "The name of the archive of the function")
+  val fileNameParam = Param[String]("fileName", "The name of the archive of the function", deprecatedDefault = true)
     .defaultFromContext((pkg, _) => Right(s"${pkg.name}.zip"))
 
   val functionsParam = Param[Map[String, Map[String, String]]]("functions",

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Param.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Param.scala
@@ -27,7 +27,8 @@ case class Param[T](
   documentation: String = "_undocumented_",
   optionalInYaml: Boolean = false,
   defaultValue: Option[T] = None,
-  defaultValueFromContext: Option[(DeploymentPackage, DeployTarget) => Either[String,T]] = None
+  defaultValueFromContext: Option[(DeploymentPackage, DeployTarget) => Either[String,T]] = None,
+  deprecatedDefault: Boolean = false
 )(implicit register:ParamRegister) {
   register.add(this)
 
@@ -42,10 +43,10 @@ case class Param[T](
     val maybeDefault = defaultValue.orElse(defaultFromContext.flatMap(_.right.toOption))
     (pkg.legacyConfig, maybeDefault, maybeValue) match {
       // the bucket checks below are to aid migrating to this being a required field as we are simply guessing otherwise
-      case (false, Some(default), Some(value)) if default == value && name != "bucket" =>
+      case (false, Some(default), Some(value)) if default == value && !deprecatedDefault =>
         reporter.warning(s"Parameter $name is unnecessarily explicitly set to the default value of $default")
-      case (false, Some(_), None) if name == "bucket" =>
-        reporter.warning(s"Parameter bucket must always be explicitly set")
+      case (false, Some(_), None) if deprecatedDefault =>
+        reporter.warning(s"Parameter $name must always be explicitly set (the default is deprecated as it is quite magical™)")
       case _ => // otherwise do nothing
     }
 


### PR DESCRIPTION
We shouldn't have defaults for things that appear to be magical / surprising. This deprecates another example where this is currently a little too magical: the fileName of a lambda.

By deprecating it we don't break deploys but we do pave the way to best practices.