### PR TITLE
Add an explicit warning badge to make it clearer

### DIFF
--- a/riff-raff/app/assets/stylesheets/magenta.less
+++ b/riff-raff/app/assets/stylesheets/magenta.less
@@ -213,3 +213,7 @@ div.deployment-target:target {
 tr.has-warnings {
   background: repeating-linear-gradient( 45deg, #fcd7d7, #fcd7d7 10px, #dddddd 10px, #dddddd 20px );
 }
+
+.label-reporter-warning {
+  background: repeating-linear-gradient( 45deg, #af0000, #af0000 5px, #000000 5px, #000000 10px );
+}

--- a/riff-raff/app/views/snippets/recordTable.scala.html
+++ b/riff-raff/app/views/snippets/recordTable.scala.html
@@ -87,6 +87,7 @@
                 }
                 }
                 }
+                    @if(record.hasWarnings) { <br/><span class="label label-reporter-warning">Warnings encountered</span> }
                 }
             </td>
             @if(allColumns) {


### PR DESCRIPTION
Adds a little badge to the status column to make the warning highlighting clearer.

<img width="269" alt="screen shot 2017-05-09 at 14 54 58" src="https://cloud.githubusercontent.com/assets/1236466/25854344/927eca4e-34c7-11e7-90d4-570dcb3b32a9.png">
