### PR TITLE
Only consider reachable nodes when determining deployment completion

### DIFF
--- a/magenta-lib/src/main/scala/magenta/graph/Graph.scala
+++ b/magenta-lib/src/main/scala/magenta/graph/Graph.scala
@@ -373,6 +373,20 @@ case class Graph[T](edges: Set[Edge[T]]) {
     }, identity)
   }
 
+  def allSuccesors(node: Node[T]): Set[Node[T]] = {
+    successors(node) match {
+      case s if s.isEmpty => Set.empty
+      case nodesSuccessors => nodesSuccessors ++ nodesSuccessors.flatMap(allSuccesors)
+    }
+  }
+
+  /** Returns a copy of the graph with all successor of the given node removed
+    */
+  def removeSuccessorValueNodes(node: ValueNode[T]): Graph[T] = {
+    val toBeRemoved = allSuccesors(node).filter(_ != EndNode)
+    Graph(edges.filter(edge => !(toBeRemoved.contains(edge.from) || toBeRemoved.contains(edge.to))) + Edge(node, EndNode))
+  }
+
   lazy val toList: List[T] = nodeList.flatMap(_.maybeValue)
 
   override def toString: String = {

--- a/magenta-lib/src/test/scala/magenta/graph/GraphTest.scala
+++ b/magenta-lib/src/test/scala/magenta/graph/GraphTest.scala
@@ -259,4 +259,9 @@ class GraphTest extends FlatSpec with ShouldMatchers {
       one ~> three, one ~2~> four, two ~> three, two ~2~> four
     )
   }
+
+  "removeSuccesors" should "provide a copy of the graph with successors to a given node removed" in {
+    val graph: Graph[Int] = Graph.from(Seq(1, 2, 3)).joinParallel(Graph.from(Seq(4, 5)))
+    graph.removeSuccessorValueNodes(ValueNode(1)) shouldBe Graph.from(Seq(1)).joinParallel(Graph.from(Seq(4, 5)))
+  }
 }

--- a/riff-raff/app/deployment/actors/DeployGroupRunner.scala
+++ b/riff-raff/app/deployment/actors/DeployGroupRunner.scala
@@ -47,7 +47,9 @@ class DeployGroupRunner(
   var completed: Set[ValueNode[DeploymentTasks]] = Set.empty
   var failed: Set[ValueNode[DeploymentTasks]] = Set.empty
 
-  def deploymentGraph: Graph[DeploymentTasks] = deployContext.map(_.tasks).getOrElse(Graph.empty[DeploymentTasks])
+  def deploymentGraph: Graph[DeploymentTasks] = failed.foldLeft(deployContext.map(_.tasks).getOrElse(Graph.empty[DeploymentTasks])) {
+    (graph, failedNode) => graph.removeSuccessorValueNodes(failedNode)
+  }
   def allDeployments = deploymentGraph.nodes.filterValueNodes
 
   def isFinished: Boolean = allDeployments == completed ++ failed

--- a/riff-raff/test/deployment/Fixtures.scala
+++ b/riff-raff/test/deployment/Fixtures.scala
@@ -27,6 +27,10 @@ object Fixtures extends MockitoSugar {
     DeploymentGraph(twoTasks, "branch one") joinParallel DeploymentGraph(twoTasks, "branch two")
   }
 
+  val dependentGraph: Graph[DeploymentTasks] = {
+    (DeploymentGraph(twoTasks, "one") joinSeries DeploymentGraph(twoTasks, "two")) joinParallel DeploymentGraph(twoTasks, "branch two")
+  }
+
   def createRecord(
     projectName: String = "test",
     stage: String = "TEST",

--- a/riff-raff/test/deployment/actors/DeployGroupRunnerTest.scala
+++ b/riff-raff/test/deployment/actors/DeployGroupRunnerTest.scala
@@ -18,7 +18,7 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
   "DeployGroupRunnerTest" should "initalise the state from a set of tasks" in {
     val dr = createDeployRunnerWithUnderlying()
     prepare(dr, threeSimpleTasks)
-    dr.ul.allDeployments.size should be(1)
+    dr.ul.reachableDeployments.size should be(1)
     dr.ul.isExecuting should be(false)
   }
 


### PR DESCRIPTION
I believe this fixes #438. The new DeployGroupRunner test definitely produced the tell tale `DeployUnfinished` logging before the changes were made.