### PR TITLE
Fix a failed deploy

### DIFF
--- a/riff-raff/app/controllers/Application.scala
+++ b/riff-raff/app/controllers/Application.scala
@@ -55,6 +55,7 @@ object Menu {
     DropDownMenuItem("Documentation", Seq(
       SingleMenuItem("Deployment Types", routes.Application.documentation("magenta-lib/types")),
       SingleMenuItem("Validate configuration", routes.Application.validationForm),
+      SingleMenuItem("Fixing a failed deploy", routes.Application.documentation("howto/fix-a-failed-deploy")),
       SingleMenuItem("Everything else", routes.Application.documentation(""))
     ))
   )

--- a/riff-raff/app/views/deploy/logSummary.scala.html
+++ b/riff-raff/app/views/deploy/logSummary.scala.html
@@ -16,7 +16,7 @@
                             <div id="@id" class="collapse">
                                 <pre>@fail.detail.stackTrace</pre>
                             </div>
-                            <strong><a href="@routes.Application.documentation("howto/fix-a-failed-deploy")">Fixing a failed autoscaling deploy.</a></strong>
+                            <div><strong><a href="@routes.Application.documentation("howto/fix-a-failed-deploy")">Fixing a failed autoscaling deploy.</a></strong></div>
                         }
                     }
                 </div>

--- a/riff-raff/app/views/deploy/logSummary.scala.html
+++ b/riff-raff/app/views/deploy/logSummary.scala.html
@@ -16,7 +16,7 @@
                             <div id="@id" class="collapse">
                                 <pre>@fail.detail.stackTrace</pre>
                             </div>
-                            <strong><a href="@routes.Application.documentation("howto/fix-a-failed-deploy")">Fixing a failed deploy.</a></strong>
+                            <strong><a href="@routes.Application.documentation("howto/fix-a-failed-deploy")">Fixing a failed autoscaling deploy.</a></strong>
                         }
                     }
                 </div>

--- a/riff-raff/app/views/deploy/logSummary.scala.html
+++ b/riff-raff/app/views/deploy/logSummary.scala.html
@@ -16,6 +16,7 @@
                             <div id="@id" class="collapse">
                                 <pre>@fail.detail.stackTrace</pre>
                             </div>
+                            <strong><a href="@routes.Application.documentation("howto/fix-a-failed-deploy")">Fixing a failed deploy.</a></strong>
                         }
                     }
                 </div>

--- a/riff-raff/public/docs/howto/fix-a-failed-deploy.md
+++ b/riff-raff/public/docs/howto/fix-a-failed-deploy.md
@@ -9,13 +9,12 @@ the desired capacity stays the _same_ as the specified maximum capacity for the 
 state, Riff-Raff/Magenta will not be able to do any more automated deploys, because it can't double
 the desired capacity in excess of your configured max.
 
-You need to manually fix this problem, and this document gives some possible approaches for doing it.
 
 Once the ASG is back to it's normal size, do another automated deploy to verify that you can still
 deploy successfully, and that all live boxes are in the correct state.
 
 
-## A) Manually Kill Bad Boxes
+## Manually Kill Bad Boxes
 
 Use the AWS CLI [`terminate-instance-in-auto-scaling-group`](http://docs.aws.amazon.com/cli/latest/reference/autoscaling/terminate-instance-in-auto-scaling-group.html)
 command to kill bad boxes by instance-id (eg. `i-badbadba`), making sure you leave
@@ -26,14 +25,3 @@ $ aws autoscaling terminate-instance-in-auto-scaling-group --should-decrement-de
 ```
 
 Note that you must include `--should-decrement-desired-capacity`, otherwise the ASG will just bring up a new box.
-
-## B) Trust the ASG to Kill the Right Boxes
-
-If your Auto-Scaling Group has a termination policy of [`NewestInstance`](http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/AutoScalingBehavior.InstanceTermination.html#custom-termination-policy
-),
-you should theoretically be able to just set ASG desired capacity back to it's 'normal' value, and it will kill
-the newest boxes, which is _probably_ what you want.
-
-```
-$ aws autoscaling set-desired-capacity --auto-scaling-group-name Blarg-ASG --desired-capacity 3
-```


### PR DESCRIPTION
This adds a link to the fix a failed deploy documentation to the Documentation menu and the deployment page when it fails. And also only has one method to shrink an ASG. 

This is so (hopefully) when your deploy fails (hopefully not) the remediation pathway is just _there_ as a helpful reminder. Useful if you're not quite sure what the really long aws command needed is. (Especially if it's 3am on 247)

note: needs testing on CODE