### PR TITLE
Warn if we're attempting to upload 0 files

### DIFF
--- a/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
+++ b/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
@@ -72,7 +72,9 @@ sealed trait S3Error
 case class EmptyS3Location(location: S3Location) extends S3Error
 case class UnknownS3Error(exception: Throwable) extends S3Error
 
-case class S3Path(bucket: String, key: String) extends S3Location
+case class S3Path(bucket: String, key: String) extends S3Location {
+  def show(): String = s"Bucket: '$bucket', Key: '$key'"
+}
 
 object S3Path {
   def apply(location: S3Location, key: String): S3Path = {

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -53,6 +53,14 @@ case class S3Upload(
 
   // execute this task (should throw on failure)
   override def execute(reporter: DeployReporter, stopFlag: => Boolean) {
+    if (totalSize == 0) {
+      val locationDescription = (paths.map {
+        case (path: S3Path, _) => path.show()
+        case (location, _) => location.toString()
+      }).mkString("\n")
+      reporter.warning(s"No files found to upload in $locationDescription")
+    }
+
     val client = clientFactory(keyRing, region, S3.clientConfigurationNoRetry)
 
     reporter.verbose(s"Starting transfer of ${fileString(objectMappings.size)} ($totalSize bytes)")


### PR DESCRIPTION
If `riffraff.yaml` is misconfigured or similar, we should provide some diagnostic information, so that it can be easily corrected.

![image](https://user-images.githubusercontent.com/68329/28629662-f9bf85fa-721f-11e7-950d-bef0dce8e718.png)

Originally, I had made this an error, but figured it's possible that it's legitimate in some case, so backed down to a warning.
