### PR TITLE
Add deploy mechanism when you know region, stack, stage and app

### DIFF
--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -59,7 +59,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
   val previewController = new PreviewController(previewCoordinator, authAction, controllerComponents)(wsClient, executionContext)
   val hooksController = new HooksController(prismLookup, authAction, controllerComponents)
   val restrictionsController = new Restrictions(authAction, controllerComponents)
-  val targetController = new TargetController(authAction, controllerComponents)
+  val targetController = new TargetController(deployments, authAction, controllerComponents)
   val loginController = new Login(deployments, controllerComponents, authAction)
   val testingController = new Testing(prismLookup, authAction, controllerComponents)
 

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -1,4 +1,4 @@
-import ci.{Builds, CIBuildPoller, ContinuousDeployment}
+import ci.{Builds, CIBuildPoller, ContinuousDeployment, TargetResolver}
 import com.gu.googleauth.AuthAction
 import controllers._
 import deployment.preview.PreviewCoordinator
@@ -38,6 +38,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
   val deploymentEngine = new DeploymentEngine(prismLookup, availableDeploymentTypes, conf.Configuration.deprecation.pauseSeconds)
   val buildPoller = new CIBuildPoller(executionContext)
   val builds = new Builds(buildPoller)
+  val targetResolver = new TargetResolver(buildPoller, availableDeploymentTypes)
   val deployments = new Deployments(deploymentEngine, builds)
   val continuousDeployment = new ContinuousDeployment(buildPoller, deployments)
   val previewCoordinator = new PreviewCoordinator(prismLookup, availableDeploymentTypes)
@@ -58,6 +59,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
   val previewController = new PreviewController(previewCoordinator, authAction, controllerComponents)(wsClient, executionContext)
   val hooksController = new HooksController(prismLookup, authAction, controllerComponents)
   val restrictionsController = new Restrictions(authAction, controllerComponents)
+  val targetController = new TargetController(authAction, controllerComponents)
   val loginController = new Login(deployments, controllerComponents, authAction)
   val testingController = new Testing(prismLookup, authAction, controllerComponents)
 
@@ -78,6 +80,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
     continuousDeployController,
     hooksController,
     restrictionsController,
+    targetController,
     loginController,
     testingController,
     assets

--- a/riff-raff/app/AppLoader.scala
+++ b/riff-raff/app/AppLoader.scala
@@ -29,6 +29,8 @@ class AppLoader extends ApplicationLoader {
     val lifecycleSingletons = Seq(
       ScheduledAgent,
       components.deployments,
+      components.builds,
+      components.targetResolver,
       DeployMetrics,
       hooksClient,
       SummariseDeploysHousekeeping,

--- a/riff-raff/app/ci/CIBuild.scala
+++ b/riff-raff/app/ci/CIBuild.scala
@@ -6,6 +6,7 @@ import conf.Configuration
 import rx.lang.scala.Observable
 import org.joda.time.DateTime
 import controllers.Logging
+import magenta.Build
 import magenta.artifact.S3Object
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -17,6 +18,7 @@ trait CIBuild {
   def number: String
   def id: Long
   def startTime: DateTime
+  def toMagentaBuild: Build = Build(jobName, number)
 }
 
 object CIBuild {

--- a/riff-raff/app/ci/ContinuousDeployment.scala
+++ b/riff-raff/app/ci/ContinuousDeployment.scala
@@ -75,7 +75,7 @@ object ContinuousDeployment extends Logging {
     val (config,build) = configBuildTuple
     DeployParameters(
       Deployer("Continuous Deployment"),
-      MagentaBuild(build.jobName,build.number),
+      build.toMagentaBuild,
       Stage(config.stage),
       RecipeName(config.recipe)
     )

--- a/riff-raff/app/ci/TargetResolver.scala
+++ b/riff-raff/app/ci/TargetResolver.scala
@@ -1,0 +1,52 @@
+package ci
+
+import cats.data.Validated
+import conf.Configuration
+import controllers.Logging
+import lifecycle.Lifecycle
+import magenta.Build
+import magenta.artifact._
+import magenta.deployment_type.DeploymentType
+import magenta.graph.Graph
+import magenta.input.{All, Deployment}
+import magenta.input.resolver.Resolver
+import persistence.TargetDynamoRepository
+
+case class Target(region: String, stack: String, app: String)
+
+class TargetResolver(ciBuildPoller: CIBuildPoller, deploymentTypes: Seq[DeploymentType]) extends Lifecycle with Logging {
+  val poller = ciBuildPoller.newBuilds.subscribe { build =>
+    for {
+      yaml <- Validated.fromEither(fetchYaml(build.jobName, build.jobId))
+      deployGraph <- Resolver.resolveDeploymentGraph(yaml._2, deploymentTypes, All)
+      targets = extractTargets(deployGraph)
+    } {
+      targets.foreach{ t =>
+        TargetDynamoRepository.set(t, build.jobName)
+      }
+    }
+  }
+
+  def fetchYaml(name: String, id: String): Either[S3Error, (S3Path, String)] = {
+    val build = Build(name, id)
+    val artifact = S3YamlArtifact(build, Configuration.artifact.aws.bucketName)
+    val deployObjectPath = artifact.deployObject
+    val deployObjectContent = S3Location.fetchContentAsString(deployObjectPath)(Configuration.artifact.aws.client)
+    deployObjectContent.map(deployObjectPath -> _)
+  }
+
+  def extractTargets(graph: Graph[Deployment]): Set[Target] = {
+    graph.nodes.values.flatMap { deployment =>
+      for {
+        region <- deployment.regions.toList
+        stack <- deployment.stacks.toList
+      } yield Target(region, stack, deployment.app)
+    }
+  }
+
+  override def init() = {}
+
+  override def shutdown() = {
+    poller.unsubscribe()
+  }
+}

--- a/riff-raff/app/ci/TargetResolver.scala
+++ b/riff-raff/app/ci/TargetResolver.scala
@@ -1,14 +1,13 @@
 package ci
 
-import cats.data.Validated
+import cats.syntax.either._
 import conf.Configuration
 import controllers.Logging
 import lifecycle.Lifecycle
-import magenta.Build
 import magenta.artifact._
 import magenta.deployment_type.DeploymentType
 import magenta.graph.Graph
-import magenta.input.{All, Deployment}
+import magenta.input.{All, ConfigErrors, Deployment}
 import magenta.input.resolver.Resolver
 import persistence.TargetDynamoRepository
 
@@ -16,20 +15,37 @@ case class Target(region: String, stack: String, app: String)
 
 class TargetResolver(ciBuildPoller: CIBuildPoller, deploymentTypes: Seq[DeploymentType]) extends Lifecycle with Logging {
   val poller = ciBuildPoller.newBuilds.subscribe { build =>
-    for {
-      yaml <- Validated.fromEither(fetchYaml(build.jobName, build.jobId))
-      deployGraph <- Resolver.resolveDeploymentGraph(yaml._2, deploymentTypes, All)
+    val result = for {
+      yaml <- fetchYaml(build)
+      deployGraph <- Resolver.resolveDeploymentGraph(yaml._2, deploymentTypes, All).toEither
       targets = extractTargets(deployGraph)
-    } {
-      targets.foreach{ t =>
-        TargetDynamoRepository.set(t, build.jobName)
+    } yield {
+      targets.map{ t =>
+        Either.catchNonFatal(t -> TargetDynamoRepository.set(t, build.jobName, build.startTime))
       }
+    }
+    result match {
+      case Right(putResults) =>
+        putResults.foreach {
+          case Right((target, _)) => log.debug(s"Persisted $target for $build")
+          case Left(t) => log.warn(s"Error persisting target for $build", t)
+        }
+      case Left(error) =>
+        val message: (String, Option[Throwable]) = error match {
+          case EmptyS3Location(location) => s"Empty location: $location" -> None
+          case UnknownS3Error(exception) => s"Unknown S3 error" -> Some(exception)
+          case ConfigErrors(errors) => s"Configuration errors: ${errors.toList.mkString("; ")}" -> None
+          case _ => s"Unknown error" -> None
+        }
+        message match {
+          case (msg, Some(t)) => log.warn(s"Error resolving target for $build: $msg", t)
+          case (msg, None) => log.warn(s"Error resolving target for $build: $msg")
+        }
     }
   }
 
-  def fetchYaml(name: String, id: String): Either[S3Error, (S3Path, String)] = {
-    val build = Build(name, id)
-    val artifact = S3YamlArtifact(build, Configuration.artifact.aws.bucketName)
+  def fetchYaml(build: CIBuild): Either[S3Error, (S3Path, String)] = {
+    val artifact = S3YamlArtifact(build.toMagentaBuild, Configuration.artifact.aws.bucketName)
     val deployObjectPath = artifact.deployObject
     val deployObjectContent = S3Location.fetchContentAsString(deployObjectPath)(Configuration.artifact.aws.client)
     deployObjectContent.map(deployObjectPath -> _)

--- a/riff-raff/app/controllers/TargetController.scala
+++ b/riff-raff/app/controllers/TargetController.scala
@@ -2,23 +2,40 @@ package controllers
 
 import ci.Target
 import com.gu.googleauth.AuthAction
+import deployment.{DeployFilter, Deployments, PaginationView}
 import persistence.TargetDynamoRepository
 import play.api.i18n.I18nSupport
 import play.api.libs.ws.WSClient
 import play.api.mvc.{AnyContent, BaseController, ControllerComponents}
 
-class TargetController(authAction: AuthAction[AnyContent], val controllerComponents: ControllerComponents)(implicit val wsClient: WSClient)
+class TargetController(deployments: Deployments, authAction: AuthAction[AnyContent], val controllerComponents: ControllerComponents)(implicit val wsClient: WSClient)
   extends BaseController with Logging with I18nSupport {
 
-  def findDeployFor(region: String, stack: String, app: String) = authAction {
-    val targetIds = TargetDynamoRepository.getProjectName(Target(region, stack, app))
+  def findMatch(region: String, stack: String, app: String) = authAction {
+    val targetIds = TargetDynamoRepository.get(Target(region, stack, app))
     targetIds match {
       case Nil => NotFound(s"No project for $region, $stack, $app")
       case nonEmpty => Ok(nonEmpty.mkString("; "))
     }
   }
 
-  def deployFor(region: String, stack: String, app: String, stage: String) = authAction {
-    Ok("")
+  def findAppropriateDeploy(region: String, stack: String, app: String, stage: String) = authAction { request =>
+    val target = Target(region, stack, app)
+    val targetIds = TargetDynamoRepository.get(target)
+    targetIds match {
+      case singleton :: Nil => Redirect(routes.TargetController.selectRecentVersion(singleton.id, stage))
+      case Nil => NotFound(views.html.target.noMatchForTarget(target, request))
+      case multiple => Ok(views.html.target.selectTarget(target, multiple.sortBy(-_.lastSeen.getMillis), stage, request))
+    }
+  }
+
+  def selectRecentVersion(targetId: String, stage: String) = authAction { request =>
+    val maybeTargetId = TargetDynamoRepository.get(targetId)
+    maybeTargetId.map { targetId =>
+      // find recent deploys of this project / stage
+      val filter = DeployFilter(projectName = Some(s"^${targetId.projectName}$$"), stage = Some(stage))
+      val records = deployments.getDeploys(Some(filter), PaginationView(pageSize = Some(20))).reverse
+      Ok(views.html.target.selectVersion(targetId, stage, records, request))
+    }.getOrElse(NotFound(s"No target found for $targetId"))
   }
 }

--- a/riff-raff/app/controllers/TargetController.scala
+++ b/riff-raff/app/controllers/TargetController.scala
@@ -1,0 +1,17 @@
+package controllers
+
+import ci.Target
+import com.gu.googleauth.AuthAction
+import persistence.TargetDynamoRepository
+import play.api.i18n.I18nSupport
+import play.api.libs.ws.WSClient
+import play.api.mvc.{AnyContent, BaseController, ControllerComponents}
+
+class TargetController(authAction: AuthAction[AnyContent], val controllerComponents: ControllerComponents)(implicit val wsClient: WSClient)
+  extends BaseController with Logging with I18nSupport {
+
+  def findDeployFor(region: String, stack: String, app: String) = authAction {
+    val targetProject = TargetDynamoRepository.getId(Target(region, stack, app))
+    targetProject.fold(NotFound(s"No project for $region, $stack, $app"))(Ok(_))
+  }
+}

--- a/riff-raff/app/controllers/TargetController.scala
+++ b/riff-raff/app/controllers/TargetController.scala
@@ -12,7 +12,7 @@ class TargetController(deployments: Deployments, authAction: AuthAction[AnyConte
   extends BaseController with Logging with I18nSupport {
 
   def findMatch(region: String, stack: String, app: String) = authAction {
-    val targetIds = TargetDynamoRepository.get(Target(region, stack, app))
+    val targetIds = TargetDynamoRepository.find(Target(region, stack, app))
     targetIds match {
       case Nil => NotFound(s"No project for $region, $stack, $app")
       case nonEmpty => Ok(nonEmpty.mkString("; "))
@@ -21,7 +21,7 @@ class TargetController(deployments: Deployments, authAction: AuthAction[AnyConte
 
   def findAppropriateDeploy(region: String, stack: String, app: String, stage: String) = authAction { request =>
     val target = Target(region, stack, app)
-    val targetIds = TargetDynamoRepository.get(target)
+    val targetIds = TargetDynamoRepository.find(target)
     targetIds match {
       case singleton :: Nil => Redirect(routes.TargetController.selectRecentVersion(singleton.targetKey, singleton.projectName, stage))
       case Nil => NotFound(views.html.deployTarget.noMatchForTarget(target, request))

--- a/riff-raff/app/controllers/TargetController.scala
+++ b/riff-raff/app/controllers/TargetController.scala
@@ -24,8 +24,8 @@ class TargetController(deployments: Deployments, authAction: AuthAction[AnyConte
     val targetIds = TargetDynamoRepository.get(target)
     targetIds match {
       case singleton :: Nil => Redirect(routes.TargetController.selectRecentVersion(singleton.id, stage))
-      case Nil => NotFound(views.html.target.noMatchForTarget(target, request))
-      case multiple => Ok(views.html.target.selectTarget(target, multiple.sortBy(-_.lastSeen.getMillis), stage, request))
+      case Nil => NotFound(views.html.deployTarget.noMatchForTarget(target, request))
+      case multiple => Ok(views.html.deployTarget.selectTarget(target, multiple.sortBy(-_.lastSeen.getMillis), stage, request))
     }
   }
 
@@ -35,7 +35,7 @@ class TargetController(deployments: Deployments, authAction: AuthAction[AnyConte
       // find recent deploys of this project / stage
       val filter = DeployFilter(projectName = Some(s"^${targetId.projectName}$$"), stage = Some(stage))
       val records = deployments.getDeploys(Some(filter), PaginationView(pageSize = Some(20))).reverse
-      Ok(views.html.target.selectVersion(targetId, stage, records, request))
+      Ok(views.html.deployTarget.selectVersion(targetId, stage, records, request))
     }.getOrElse(NotFound(s"No target found for $targetId"))
   }
 }

--- a/riff-raff/app/controllers/TargetController.scala
+++ b/riff-raff/app/controllers/TargetController.scala
@@ -11,7 +11,14 @@ class TargetController(authAction: AuthAction[AnyContent], val controllerCompone
   extends BaseController with Logging with I18nSupport {
 
   def findDeployFor(region: String, stack: String, app: String) = authAction {
-    val targetProject = TargetDynamoRepository.getId(Target(region, stack, app))
-    targetProject.fold(NotFound(s"No project for $region, $stack, $app"))(Ok(_))
+    val targetIds = TargetDynamoRepository.getProjectName(Target(region, stack, app))
+    targetIds match {
+      case Nil => NotFound(s"No project for $region, $stack, $app")
+      case nonEmpty => Ok(nonEmpty.mkString("; "))
+    }
+  }
+
+  def deployFor(region: String, stack: String, app: String, stage: String) = authAction {
+    Ok("")
   }
 }

--- a/riff-raff/app/persistence/TargetDynamoRepository.scala
+++ b/riff-raff/app/persistence/TargetDynamoRepository.scala
@@ -27,7 +27,7 @@ object TargetDynamoRepository extends DynamoRepository {
     exec(table.get('targetKey -> targetKey and 'projectName -> projectName)).flatMap(_.toOption)
   }
 
-  def get(target: Target): List[TargetId] = {
+  def find(target: Target): List[TargetId] = {
     val key = TargetId.targetKey(target)
     exec(table.query('targetKey -> key))
       .flatMap(_.toOption)

--- a/riff-raff/app/persistence/TargetDynamoRepository.scala
+++ b/riff-raff/app/persistence/TargetDynamoRepository.scala
@@ -1,0 +1,29 @@
+package persistence
+
+import ci.Target
+import com.gu.scanamo.Table
+
+case class TargetId(key: String, region: String, stack: String, app: String, id: String)
+object TargetId {
+  def apply(tgt: Target, id: String): TargetId = TargetId(key(tgt), tgt.region, tgt.stack, tgt.app, id)
+  def key(tgt: Target) = s"${tgt.region}|${tgt.stack}|${tgt.app}"
+}
+
+object TargetDynamoRepository extends DynamoRepository {
+  def tablePrefix = "riffraff-targets"
+  val table = Table[TargetId](tableName)
+
+  import com.gu.scanamo.syntax._
+
+  /* not sure this is ideal, we only store one result and not that 'safely'... */
+  def set(target: Target, id: String): Unit = exec(table.put(TargetId(target, id)))
+  def getId(target: Target): Option[String] = {
+    val key = TargetId.key(target)
+    exec(table.get('id -> key)).flatMap(_.toOption).map(_.id)
+  }
+
+  def getAll: Seq[(Target, String)] =
+    exec(table.scan()).flatMap(_.toOption).map{ targetId =>
+      Target(targetId.region, targetId.stack, targetId.app) -> targetId.id
+    }
+}

--- a/riff-raff/app/persistence/TargetDynamoRepository.scala
+++ b/riff-raff/app/persistence/TargetDynamoRepository.scala
@@ -22,7 +22,11 @@ object TargetDynamoRepository extends DynamoRepository {
 
   def set(target: Target, projectName: String, lastSeen: DateTime): PutItemResult = exec(table.put(TargetId(target, projectName, lastSeen)))
 
-  def getProjectName(target: Target): List[TargetId] = {
+  def get(id: String): Option[TargetId] = {
+    exec(table.get('id -> id)).flatMap(_.toOption)
+  }
+
+  def get(target: Target): List[TargetId] = {
     val key = TargetId.targetKey(target)
     exec(table.index("riffraff-targets-targetKey").query('targetKey -> key)).flatMap(_.toOption)
   }

--- a/riff-raff/app/persistence/TargetDynamoRepository.scala
+++ b/riff-raff/app/persistence/TargetDynamoRepository.scala
@@ -5,31 +5,31 @@ import com.amazonaws.services.dynamodbv2.model.PutItemResult
 import com.gu.scanamo.Table
 import org.joda.time.DateTime
 
-case class TargetId(id: String, targetKey: String, region: String, stack: String, app: String, projectName: String, lastSeen: DateTime) {
+case class TargetId(targetKey: String, projectName: String, region: String, stack: String, app: String, lastSeen: DateTime) {
   def matches(target: Target): Boolean = region == target.region && stack == target.stack && app == target.app
 }
 object TargetId {
   def apply(tgt: Target, projectName: String, lastSeen: DateTime): TargetId =
-    TargetId(id(tgt, projectName), targetKey(tgt), tgt.region, tgt.stack, tgt.app, projectName, lastSeen)
+    TargetId(targetKey(tgt), projectName, tgt.region, tgt.stack, tgt.app, lastSeen)
   def targetKey(tgt: Target) = Seq(tgt.region,tgt.stack,tgt.app).mkString("|")
-  def id(tgt: Target, projectName: String) = Seq(tgt.region,tgt.stack,tgt.app,projectName).mkString("|")
 }
 
 object TargetDynamoRepository extends DynamoRepository {
-  def tablePrefix = "riffraff-targets"
+  def tablePrefix = "riffraff-target-ids"
   val table = Table[TargetId](tableName)
 
   import com.gu.scanamo.syntax._
 
-  def set(target: Target, projectName: String, lastSeen: DateTime): PutItemResult = exec(table.put(TargetId(target, projectName, lastSeen)))
+  def set(target: Target, projectName: String, lastSeen: DateTime): PutItemResult =
+    exec(table.put(TargetId(target, projectName, lastSeen)))
 
-  def get(id: String): Option[TargetId] = {
-    exec(table.get('id -> id)).flatMap(_.toOption)
+  def get(targetKey: String, projectName: String): Option[TargetId] = {
+    exec(table.get('targetKey -> targetKey and 'projectName -> projectName)).flatMap(_.toOption)
   }
 
   def get(target: Target): List[TargetId] = {
     val key = TargetId.targetKey(target)
-    exec(table.index("riffraff-targets-targetKey").query('targetKey -> key))
+    exec(table.query('targetKey -> key))
       .flatMap(_.toOption)
       .filter(_.matches(target)) // make sure this is not a weird collision due to use of separator in fields
   }

--- a/riff-raff/app/views/deployTarget/deployButton.scala.html
+++ b/riff-raff/app/views/deployTarget/deployButton.scala.html
@@ -1,0 +1,5 @@
+@import deployment.Record
+@(record: Record)
+
+<a class="btn btn-primary btn-xs" href="@routes.DeployController.deployAgainUuid(record.uuid.toString)">
+    Redeploy…</a>

--- a/riff-raff/app/views/deployTarget/noMatchForTarget.scala.html
+++ b/riff-raff/app/views/deployTarget/noMatchForTarget.scala.html
@@ -1,0 +1,12 @@
+@import ci.Target
+@(target: Target, request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity])
+
+@main("No match for target", request) {
+    <h3>No match found</h3>
+    <p>No match found for deploying <span class='label label-primary'><span class='glyphicon glyphicon-book'></span> @target.app</span>
+        in <span class='label label-info'>
+            <span class='glyphicon glyphicon-globe'></span> @target.region
+            <span class='glyphicon glyphicon-tasks'></span> @target.stack
+        </span>
+    </p>
+}

--- a/riff-raff/app/views/deployTarget/noMatchForTarget.scala.html
+++ b/riff-raff/app/views/deployTarget/noMatchForTarget.scala.html
@@ -9,4 +9,8 @@
             <span class='glyphicon glyphicon-tasks'></span> @target.stack
         </span>
     </p>
+    <p>
+        Not what you expected? Deploy targets are resolved and indexed when Riff-Raff discovers a brand new build. Try
+        kicking off a new CI build for the related project and then try refreshing this page.
+    </p>
 }

--- a/riff-raff/app/views/deployTarget/selectTarget.scala.html
+++ b/riff-raff/app/views/deployTarget/selectTarget.scala.html
@@ -29,7 +29,7 @@
                     <td>@targetId.projectName</td>
                     <td><time class="makeRelativeDate" withinhours="24" datetime="@targetId.lastSeen">@utils.DateFormats.Medium.print(targetId.lastSeen)</time></td>
                     <td>
-                        <a class="btn btn-primary btn-xs" href="@routes.TargetController.selectRecentVersion(targetId.id, stage)">Deploy…</a>
+                        <a class="btn btn-primary btn-xs" href="@routes.TargetController.selectRecentVersion(targetId.targetKey, targetId.projectName, stage)">Deploy…</a>
                     </td>
                 </tr>
     }

--- a/riff-raff/app/views/deployTarget/selectTarget.scala.html
+++ b/riff-raff/app/views/deployTarget/selectTarget.scala.html
@@ -1,0 +1,34 @@
+@import persistence.TargetId
+@import ci.Target
+@(target: Target, targetIds: List[TargetId], stage: String, request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity])
+
+@main("Select appropriate deploy project", request) {
+    <h3>Select appropriate deploy project</h3>
+    <p>Multiple matches found for <span class='label label-primary'><span class='glyphicon glyphicon-book'></span> @target.app</span>
+        in <span class='label label-info'>
+            <span class='glyphicon glyphicon-globe'></span> @target.region
+            <span class='glyphicon glyphicon-tasks'></span> @target.stack
+        </span>
+    </p>
+    <h4>Select from:</h4>
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>Project Name</th>
+                    <th>Last seen</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+    @targetIds.map { targetId =>
+                <tr>
+                    <td>@targetId.projectName</td>
+                    <td><time class="makeRelativeDate" withinhours="24" datetime="@targetId.lastSeen">@utils.DateFormats.Medium.print(targetId.lastSeen)</time></td>
+                    <td>
+                        <a class="btn btn-primary btn-xs" href="@routes.TargetController.selectRecentVersion(targetId.id, stage)">Deploy…</a>
+                    </td>
+                </tr>
+    }
+            </tbody>
+        </table>
+}

--- a/riff-raff/app/views/deployTarget/selectTarget.scala.html
+++ b/riff-raff/app/views/deployTarget/selectTarget.scala.html
@@ -10,6 +10,10 @@
             <span class='glyphicon glyphicon-tasks'></span> @target.stack
         </span>
     </p>
+    <p>
+        Multiple builds have been discovered that target this combination of region, stack and app. The most recent is
+        shown at the top of the list below.
+    </p>
     <h4>Select from:</h4>
         <table class="table table-striped">
             <thead>

--- a/riff-raff/app/views/deployTarget/selectVersion.scala.html
+++ b/riff-raff/app/views/deployTarget/selectVersion.scala.html
@@ -1,0 +1,17 @@
+@import persistence.TargetId
+@import deployment.Record
+@(targetId: TargetId, stage: String, records: List[Record], request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity])
+
+@main("Select build to deploy", request) {
+    <h3>Select build to redeploy to @stage</h3>
+    @if(records.nonEmpty) {
+        <h4>Last deploys of <em>@targetId.projectName</em> to @stage</h4>
+        @snippets.recordTable(records, None, allColumns = false, Some(("", views.html.deployTarget.deployButton.f)))
+    } else {
+        <div class="alert alert-danger" role="alert">
+            <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+            <span class="sr-only">Error:</span>
+            Riff Raff has not been used to deploy @targetId.projectName to @stage
+        </div>
+    }
+}

--- a/riff-raff/app/views/snippets/recordTable.scala.html
+++ b/riff-raff/app/views/snippets/recordTable.scala.html
@@ -1,4 +1,4 @@
-@(records: List[deployment.Record], maybeFilter: Option[deployment.DeployFilterPagination] = None, allColumns: Boolean = true)
+@(records: List[deployment.Record], maybeFilter: Option[deployment.DeployFilterPagination] = None, allColumns: Boolean = true, lastColumnContent: Option[(String, Record => Html)] = None)
 @import deployment._
 @import html.helper.magenta.htmlTooltip
 
@@ -22,6 +22,9 @@
         <th>Status</th>
         @if(allColumns) {
         <th></th>
+        }
+        @lastColumnContent.map { case (title, _) =>
+            <th>@title</th>
         }
     </tr>
     </thead>
@@ -132,6 +135,11 @@
                             }
                         </ul>
                     </div>
+                </td>
+            }
+            @lastColumnContent.map { case (_, content) =>
+                <td class="rowlink-skip">
+                    @content(record)
                 </td>
             }
         </tr>

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -75,6 +75,9 @@ POST        /deployment/restrictions/save                   controllers.Restrict
 GET         /deployment/restrictions/edit                   controllers.Restrictions.edit(id)
 POST        /deployment/restrictions/delete                 controllers.Restrictions.delete(id)
 
+# Target
+GET         /deployment/target                              controllers.TargetController.findDeployFor(region: String, stack: String, app: String)
+
 # authentication endpoints
 GET         /profile                                        controllers.Login.profile
 GET         /login                                          controllers.Login.login

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -78,7 +78,7 @@ POST        /deployment/restrictions/delete                 controllers.Restrict
 # Target
 GET         /deployment/target/find                         controllers.TargetController.findMatch(region: String, stack: String, app: String)
 GET         /deployment/target/deploy                       controllers.TargetController.findAppropriateDeploy(region: String, stack: String, app: String, stage: String)
-GET         /deployment/target/select                       controllers.TargetController.selectRecentVersion(targetId: String, stage: String)
+GET         /deployment/target/select                       controllers.TargetController.selectRecentVersion(targetKey: String, projectName: String, stage: String)
 
 # authentication endpoints
 GET         /profile                                        controllers.Login.profile

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -76,7 +76,9 @@ GET         /deployment/restrictions/edit                   controllers.Restrict
 POST        /deployment/restrictions/delete                 controllers.Restrictions.delete(id)
 
 # Target
-GET         /deployment/target                              controllers.TargetController.findDeployFor(region: String, stack: String, app: String)
+GET         /deployment/target/find                         controllers.TargetController.findMatch(region: String, stack: String, app: String)
+GET         /deployment/target/deploy                       controllers.TargetController.findAppropriateDeploy(region: String, stack: String, app: String, stage: String)
+GET         /deployment/target/select                       controllers.TargetController.selectRecentVersion(targetId: String, stage: String)
 
 # authentication endpoints
 GET         /profile                                        controllers.Login.profile


### PR DESCRIPTION
If you are armed with the region, stack, stage and app (RSSA) of an instance (say from AMIable telling you an AMI is out of date) then this provides a mechanism for locating the appropriate deploy.

There are two parts. 

1. A target resolver that
 - watches for new builds
 - resolves the deployment graph for each new build to figure out the SSA that it targets and stores the results in a dynamo table
2. a little frontend that
 - takes a RSSA
 - looks it up in the dynamo table
 - guides the user in selecting the best fit

The RSSA might be ambiguous, if so the user will be shown the options (this is ambiguous because of an error in a file):
<img width="745" alt="screen shot 2017-09-12 at 13 02 56" src="https://user-images.githubusercontent.com/1236466/30325262-f9b2e9e6-97bb-11e7-8b27-7de415add087.png">

Next, the most recent deploys are shown and the user is asked which should be redeployed:
<img width="738" alt="screen shot 2017-09-12 at 13 03 04" src="https://user-images.githubusercontent.com/1236466/30325266-fc6f6466-97bb-11e7-834e-170fafa495aa.png">

Finally, the confirmation screen that we all know and love:
<img width="730" alt="screen shot 2017-09-12 at 13 03 15" src="https://user-images.githubusercontent.com/1236466/30325267-fe207a0c-97bb-11e7-9dde-9713427b9353.png">

## Considerations
This will not work for projects that do not have recent builds. I did look at resolving the targets during deployment and storing them only for successful deploys but this made the code far more complicated.

## Todo
 - [x] At the moment the poop emoji 💩 appears in the URL for the second of these stages. Whist it was entertaining to use it as a separator in an internal key, this should probably be changed to another character