### PR TITLE
Add more troubleshooting detail for when deploys fail due to dependancy clash

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
@@ -11,6 +11,8 @@ object AmiCloudFormationParameter extends DeploymentType with CloudFormationDepl
       |Given AMI tags, this will resolve the latest matching AMI and update the AMI parameter
       |on the provided CloudFormation stack.
       |
+      |You will need to add this as a dependency to your autoscaling deploy in your riff-raff.yaml to guard against race conditions.
+      |
       |The set of AWS permissions needed to let RiffRaff do an AMI updates are:
       |
       |    {

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -13,7 +13,8 @@ object CloudFormation extends DeploymentType with CloudFormationDeploymentTypePa
       |NOTE: It is strongly recommended you do _NOT_ set a desired-capacity on auto-scaling groups, managed
       |with CloudFormation templates deployed in this way, as otherwise any deployment will reset the
       |capacity to this number, even if scaling actions have triggered, changing the capacity, in the
-      |mean-time.
+      |mean-time. Alternatively, you will need to add this as a dependency to your autoscaling deploy
+      |in your riff-raff.yaml.
       |
       |This deployment type is not currently recommended for continuous deployment, as CloudFormation
       |will fail if you try to update a CloudFormation stack with a configuration that matches its

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -16,6 +16,11 @@ object Lambda extends DeploymentType  {
       |
       |It is recommended to use the `bucket` parameter as storing the function code in S3 works much better when using
       |cloudformation.
+      |
+      |Ensure to add any relevant dependencies to your deploy in your riff-raff.yaml to guard against race conditions,
+      |such as a Riff-Raff Cloudformation update modifying your lambda at the same time this deployment type is running.
+      |
+      |
       """.stripMargin
 
   val regionsParam = Param[List[String]]("regions",

--- a/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
@@ -118,7 +118,7 @@ case class CullInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage,
     } catch {
       case e: AmazonServiceException if desiredSizeReset(e) => {
         reporter.warning("Your ASG desired size may have been reset. This may be because two parts of the deploy are attempting to modify a cloudformation stack simultaneously. Please check that appropriate dependencies are included in riff-raff.yaml, or ensure desiredSize isn't set in the Cloudformation.")
-        throw new ASGResetException(e)
+        throw new ASGResetException(s"Your ASG desired size may have been reset ${e.getErrorMessage}", e)
       }
     }
 
@@ -146,7 +146,7 @@ case class ResumeAlarmNotifications(pkg: DeploymentPackage, stage: Stage, stack:
   lazy val description = "Resuming Alarm Notifications - group will scale on any configured alarms"
 }
 
-class ASGResetException(val throwable: Throwable) extends Throwable("", throwable)
+class ASGResetException(message: String, throwable: Throwable) extends Throwable(message, throwable)
 
 trait ASGTask extends Task {
   def region: Region

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ Assuming you have a reasonably recent version of Java installed,
 
  * Create a basic configuration file at ~/.gu/riff-raff.properties (S3 and mongo config is probably the minimum)
  * Run the sbt script
- * enter `project riff-raff` at the SBT prompt
+ * enter `project riffraff` at the SBT prompt
  * enter `run` at the SBT prompt
  * visit http://localhost:9000/
  * Details of how to configure Riff-Raff can then be found at http://localhost:9000/docs/riffraff/properties 


### PR DESCRIPTION
If dependancies for certain deployment types are not stated in `riff-raff.yaml`, a race condition will be introduced that writes over the desiredSize for the ASG - causing the deploy to fail. This PR adds more detail to the docs and the error to give more clarity.

[Example failed deploy](https://riffraff.gutools.co.uk/deployment/view/684e0b13-3588-418e-8189-731fc276b381)