### PR TITLE
Add helpful emoji to the deployment notifications.

### DIFF
--- a/riff-raff/app/assets/javascripts/notifications.coffee
+++ b/riff-raff/app/assets/javascripts/notifications.coffee
@@ -8,8 +8,8 @@ checkStatus = () ->
     stage = window.riffraff.stage
     buildId = window.riffraff.buildId
     switch $('[data-run-state]').data('run-state')
-      when 'Failed' then notify('Deployment of ' + buildName + ' (' + buildId + ')' + ' in ' + stage + ' has failed!')
-      when 'Completed' then notify('Deployment of ' + buildName + ' (' + buildId + ')' + ' in ' + stage + ' has finished')
+      when 'Failed' then notify('❌ Deployment of ' + buildName + ' (' + buildId + ')' + ' in ' + stage + ' has failed!')
+      when 'Completed' then notify('👍 Deployment of ' + buildName + ' (' + buildId + ')' + ' in ' + stage + ' has succeeded')
 
 if !window.riffraff.isDone && window.autoRefresh
   Notification.requestPermission()


### PR DESCRIPTION
At the moment, we're liable to see notifications that end in "has f..." which is horribly ambiguous.
Open to other suggestions on how to fix this.