### PR TITLE
For lambda: when building the S3 key, use the app instead of pkg name

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -115,7 +115,7 @@ object Lambda extends DeploymentType  {
   }
 
   def makeS3Key(stack: Stack, params:DeployParameters, pkg:DeploymentPackage, fileName: String): String = {
-    List(stack.nameOption, Some(params.stage.name), Some(pkg.name), Some(fileName)).flatten.mkString("/")
+    List(stack.nameOption, Some(params.stage.name), pkg.apps.headOption.map(_.name), Some(fileName)).flatten.mkString("/")
   }
 
   val uploadLambda = Action("uploadLambda",


### PR DESCRIPTION
The 'package' name is essentially the deployment name (the key under deployments in riff-raff.yaml). The 'app' name is the same by default but can be overridden using the app key in a deployment or template.

When we generate the S3 key for uploading and updating a lambda, by using the app name instead of package name then it becomes possible to override the value, which in turns allows the lambda upload and update tasks to be split (so it can be put either side of a CFN update).

I've gone through all of the existing riff-raff.yamls that use the aws-lambda deployment type and confirmed that there will be no change of behaviour for any existing configurations.