### PR TITLE
Disable support for artifact.zip / deploy.json

### DIFF
--- a/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
+++ b/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
@@ -120,11 +120,10 @@ object S3JsonArtifact extends Loggable {
   }
 
   def convertFromZipBundle(artifact: S3JsonArtifact, deprecatedPause: Option[Int])(implicit client: AmazonS3, reporter: DeployReporter): Unit = {
-    reporter.warning(
-      """DEPRECATED: The artifact.zip is now a legacy format - please switch to the new format (if you
+    reporter.fail(
+      """NO LONGER SUPPORTED: The artifact.zip format is no longer supported - please switch to the new format (if you
         |are using sbt-riffraff-artifact then simply upgrade to >= 0.9.4, if you use the TeamCity upload plugin
-        |you'll need to use the riffRaffNotifyTeamcity task instead of the riffRaffArtifact task). NOTE: Support will
-        |be removed at the end of September 2017.""".stripMargin)
+        |you'll need to use the riffRaffNotifyTeamcity task instead of the riffRaffArtifact task).""".stripMargin)
     deprecatedPause.foreach { pause =>
       reporter.warning(
         s"To persuade you to migrate we will now\npause this deploy for $pause seconds whilst you reflect on your ways.")

--- a/riff-raff/app/deployment/actors/DeployGroupRunner.scala
+++ b/riff-raff/app/deployment/actors/DeployGroupRunner.scala
@@ -195,9 +195,9 @@ class DeployGroupRunner(
         val s3Artifact = S3JsonArtifact(record.parameters.build, bucketName)
         val json = S3JsonArtifact.fetchInputFile(s3Artifact, deprecatedPause)
         val project = json.map(JsonReader.buildProject(_, s3Artifact, deploymentTypes))
-        safeReporter.warning(
-          """DEPRECATED: deploy.json is no longer a supported format for deployment configuration. Please migrate to
-            |riff-raff.yaml. Support will be removed at the end of September 2017.""".stripMargin)
+        safeReporter.fail(
+          """NO LONGER SUPPORTED: deploy.json is no longer a supported format for deployment configuration. Please
+            |migrate to riff-raff.yaml.""".stripMargin)
         deprecatedPause.foreach { pause =>
           safeReporter.warning(s"To persuade you to migrate we will now pause this deploy for $pause seconds whilst you reflect on your ways.")
           Thread.sleep(pause * 1000)


### PR DESCRIPTION
There have been very few deploys that rely on the old formats in the last month. This fulfils the statement in the deprecation messages that support would be removed at the end of September.