### PR TITLE
Use automatic S3 encryption when uploading

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -122,6 +122,8 @@ case class PutReq(source: S3Object, target: S3Path, cacheControl: Option[String]
     cacheControl foreach metaData.setCacheControl
     metaData.setContentType(contentType.getOrElse(S3Upload.awsMimeTypeLookup(target.key)))
     metaData.setContentLength(source.size)
+    metaData.setSSEAlgorithm("aws:kms")
+
     val req = new PutObjectRequest(target.bucket, target.key, inputStream, metaData)
     if (publicReadAcl) req.withCannedAcl(PublicRead) else req
   }


### PR DESCRIPTION
The equivalent of setting `--sse aws:kms` on S3 uploads, meaning objects are encrypted using per-account [Amazon managed keys](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html). The keys are created automatically on demand.

For reference, you can mandate all uploads to a bucket are encrypted this way with policy:

```yaml
EnforceDistributionBucketEncryptionPolicy:
    Type: AWS::S3::BucketPolicy
    Properties:
      Bucket: !Ref DistributionBucket
      PolicyDocument:
        Id: EnforceDistributionBucketEncryptionPolicy
        Statement:
          - Effect: Deny
            Principal: "*"
            Action: s3:PutObject
            Resource: !Sub "arn:aws:s3:::${DistributionBucket}/*"
            Condition:
              StringNotEquals:
                "s3:x-amz-server-side-encryption": "aws:kms"
          - Effect: Deny
            Principal: "*"
            Action: s3:PutObject
            Resource: !Sub "arn:aws:s3:::${DistributionBucket}/*"
            Condition:
              "Null": # without quotes evaluates to empty string in YAML ARRRRGHGH
                "s3:x-amz-server-side-encryption": true
```

TODO before merge:

- [x] check a Lambda can be deployed from a bundle uploaded this way
- [x] check a normal S3 `GetObject` from the Java SDK works