### PR TITLE
Autoscaling: wait for stabilization rather than initial single check

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -102,7 +102,7 @@ object AutoScaling  extends DeploymentType {
     val parameters = target.parameters
     val stack = target.stack
     List(
-      CheckForStabilization(pkg, parameters.stage, stack, target.region),
+      WaitForStabilization(pkg, parameters.stage, stack, 5 * 60 * 1000, target.region),
       CheckGroupSize(pkg, parameters.stage, stack, target.region),
       SuspendAlarmNotifications(pkg, parameters.stage, stack, target.region),
       TagCurrentInstancesWithTerminationTag(pkg, parameters.stage, stack, target.region),

--- a/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
@@ -67,17 +67,6 @@ case class TerminationGrace(pkg: DeploymentPackage, stage: Stage, stack: Stack, 
   def description: String = s"Wait extra ${durationMillis}ms to let Load Balancer report correctly"
 }
 
-case class CheckForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling) {
-    val elbClient = ELB.client(keyRing, region)
-    ASG.isStabilized(asg, asgClient, elbClient) match {
-      case Left(reason) => reporter.fail(s"ASG not stable: $reason")
-      case Right(()) =>
-    }
-  }
-  lazy val description: String = "Check the desired number of hosts in both the ASG and ELB are up and that the number of hosts match"
-}
-
 case class WaitForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Stack, duration: Long, region: Region)(implicit val keyRing: KeyRing) extends ASGTask
     with SlowRepeatedPollingCheck {
 

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -29,7 +29,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
       deploymentTypes)
 
     AutoScaling.actionsMap("deploy").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack, region)) should be (List(
-      CheckForStabilization(p, PROD, UnnamedStack, Region("eu-west-1")),
+      WaitForStabilization(p, PROD, UnnamedStack, 5 * 60 * 1000, Region("eu-west-1")),
       CheckGroupSize(p, PROD, UnnamedStack, Region("eu-west-1")),
       SuspendAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1")),
       TagCurrentInstancesWithTerminationTag(p, PROD, UnnamedStack, Region("eu-west-1")),
@@ -75,7 +75,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
       deploymentTypes)
 
     AutoScaling.actionsMap("deploy").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient), DeployTarget(parameters(), UnnamedStack, region)) should be (List(
-      CheckForStabilization(p, PROD, UnnamedStack, Region("eu-west-1")),
+      WaitForStabilization(p, PROD, UnnamedStack, 5 * 60 * 1000, Region("eu-west-1")),
       CheckGroupSize(p, PROD, UnnamedStack, Region("eu-west-1")),
       SuspendAlarmNotifications(p, PROD, UnnamedStack, Region("eu-west-1")),
       TagCurrentInstancesWithTerminationTag(p, PROD, UnnamedStack, Region("eu-west-1")),


### PR DESCRIPTION
Riff-raff currently executes a initial single check to verify the ASG and ELB have the same number of instances.
In case the ASG is currently scaling up/down when ASG deploy is being started, the check fails and the deploy is terminated.
From now on Riff-raff will wait for the ASG to stabilize (for a short
period of time) before to fail the deploy rather than making a single check.
It shouldn't impact the deployment speed if the ASG is already in a stabilised state but it will help apps like frontend when scaling events happen on a regular basis during the day.

I picked `1 minutes` as the initial timeout so riff-raff doesn't wait to much in case something is wrong but still give a chance to the ASG to finally stabilised. Let me know what you think @sihil 