### PR TITLE
Fix Cloud Formation task when an account has over 100 stacks

### DIFF
--- a/magenta-lib/src/main/scala/magenta/Project.scala
+++ b/magenta-lib/src/main/scala/magenta/Project.scala
@@ -66,8 +66,11 @@ object HostList {
 }
 
 case class DeploymentResources(reporter: DeployReporter, lookup: Lookup, artifactClient: AmazonS3) {
-  def assembleKeyring(target: DeployTarget, pkg: DeploymentPackage): KeyRing =
-    lookup.keyRing(target.parameters.stage, pkg.apps.toSet, target.stack)
+  def assembleKeyring(target: DeployTarget, pkg: DeploymentPackage): KeyRing = {
+    val keyring = lookup.keyRing(target.parameters.stage, pkg.apps.toSet, target.stack)
+    reporter.verbose(s"Keyring for ${pkg.name} in ${target.stack.nameOption.getOrElse("")}/${target.region.name}: $keyring")
+    keyring
+  }
 }
 
 case class DeployTarget(parameters: DeployParameters, stack: Stack, region: Region)


### PR DESCRIPTION
@marialivia16 and I have figured out that the Riff-Raff cloud formation task can mistakenly believe that a stack doesn't exist if it happens to be on the second page of results from the API (which we don't check when we look it up by name).

The simple solution is to specify the name in the request so that the result set is not greater than one result. 

We also added some verbose logging of the assembled key rings that we used whilst debugging and think will be useful in other situations.