### PR TITLE
Update permissions required for an ASG deploy

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -29,9 +29,10 @@ object AutoScaling  extends DeploymentType {
       |            "autoscaling:TerminateInstanceInAutoScalingGroup",
       |            "ec2:CreateTags",
       |            "ec2:DescribeInstances",
-      |            "elb:DescribeInstanceHealth",
       |            "elasticloadbalancing:DescribeInstanceHealth",
-      |            "elasticloadbalancing:DeregisterInstancesFromLoadBalancer"
+      |            "elasticloadbalancing:DescribeTargetHealth",
+      |            "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+      |            "elasticloadbalancing:DeregisterTargets"
       |          ],
       |          "Effect": "Allow",
       |          "Resource": [


### PR DESCRIPTION
We recently moved an internal project to a blue/green deployment model using a EC2 [Application Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html) to switch between stages.

I found that I needed some additional IAM permissions to get the deploys to work with the new balancers. The AWS console also says that `elb:DescribeInstanceHealth` is unrecognised so I have removed it.