### PR TITLE
Scheduled deploys

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,6 +56,7 @@ object Dependencies {
     "com.adrianhurt" %% "play-bootstrap" % "1.2-P26-B3-RC2",
     "com.gu" %% "scanamo" % "0.9.5",
     "com.amazonaws" % "aws-java-sdk-dynamodb" % Versions.aws,
+    "org.quartz-scheduler" % "quartz" % "2.3.0",
     "org.webjars" %% "webjars-play" % "2.6.0",
     "org.webjars" % "jquery" % "3.1.1",
     "org.webjars" % "jquery-ui" % "1.12.1",

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -59,6 +59,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
   val previewController = new PreviewController(previewCoordinator, authAction, controllerComponents)(wsClient, executionContext)
   val hooksController = new HooksController(prismLookup, authAction, controllerComponents)
   val restrictionsController = new Restrictions(authAction, controllerComponents)
+  val scheduleController = new ScheduleController(authAction, controllerComponents, prismLookup)
   val targetController = new TargetController(deployments, authAction, controllerComponents)
   val loginController = new Login(deployments, controllerComponents, authAction)
   val testingController = new Testing(prismLookup, authAction, controllerComponents)
@@ -80,6 +81,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
     continuousDeployController,
     hooksController,
     restrictionsController,
+    scheduleController,
     targetController,
     loginController,
     testingController,

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -89,7 +89,10 @@ class Configuration(val application: String, val webappConfDirectory: String = "
 
   object continuousDeployment {
     lazy val enabled = configuration.getStringProperty("continuousDeployment.enabled", "false") == "true"
+  }
 
+  object scheduledDeployment {
+    lazy val enabled = configuration.getStringProperty("scheduledDeployment.enabled", "false") == "true"
   }
 
   object credentials {

--- a/riff-raff/app/controllers/Application.scala
+++ b/riff-raff/app/controllers/Application.scala
@@ -50,7 +50,8 @@ object Menu {
       SingleMenuItem("Hooks", routes.HooksController.list()),
       SingleMenuItem("Authorisation", routes.Login.authList(), enabled = conf.Configuration.auth.whitelist.useDatabase),
       SingleMenuItem("API keys", routes.Api.listKeys()),
-      SingleMenuItem("Restrictions", routes.Restrictions.list())
+      SingleMenuItem("Restrictions", routes.Restrictions.list()),
+      SingleMenuItem("Schedules", routes.ScheduleController.list())
     )),
     DropDownMenuItem("Documentation", Seq(
       SingleMenuItem("Deployment Types", routes.Application.documentation("magenta-lib/types")),

--- a/riff-raff/app/controllers/ScheduleController.scala
+++ b/riff-raff/app/controllers/ScheduleController.scala
@@ -1,0 +1,89 @@
+package controllers
+
+import play.api.mvc.{AnyContent, BaseController, ControllerComponents}
+import play.api.data.Forms._
+import play.api.data.Form
+import play.api.i18n.I18nSupport
+import play.api.libs.ws.WSClient
+import java.util.UUID
+
+import org.joda.time.DateTime
+import ci.{ContinuousDeploymentConfig, Trigger}
+import com.gu.googleauth.AuthAction
+import controllers.ContinuousDeployController.ConfigForm
+import controllers.ScheduleController.Schedule
+import persistence.{ContinuousDeploymentConfigRepository, ScheduleRepository}
+import resources.PrismLookup
+import schedule.ScheduleConfig
+
+class ScheduleController(authAction: AuthAction[AnyContent], val controllerComponents: ControllerComponents, prismLookup: PrismLookup)(implicit val wsClient: WSClient)
+  extends BaseController with Logging with I18nSupport {
+
+  import ScheduleController.ScheduleForm
+
+  val scheduleForm = Form[ScheduleForm](
+    mapping(
+      "id" -> uuid,
+      "projectName" -> nonEmptyText,
+      "stage" -> nonEmptyText,
+      "schedule" -> nonEmptyText.transform[Schedule](Schedule.apply, _.expression),
+      "enabled" -> boolean
+    )(ScheduleForm.apply)(ScheduleForm.unapply)
+  )
+
+  def list = authAction { implicit request =>
+    val schedules = ScheduleRepository.getScheduleList()
+    Ok(views.html.schedule.list(request, schedules))
+  }
+
+  def form = authAction { implicit request =>
+    Ok(views.html.schedule.form(
+      scheduleForm.fill(ScheduleForm(UUID.randomUUID(), "", "", Schedule(""), enabled = true)), prismLookup
+    ))
+  }
+
+  def save = authAction { implicit request =>
+    scheduleForm.bindFromRequest().fold(
+      formWithErrors => Ok(views.html.schedule.form(formWithErrors, prismLookup)),
+      form => {
+        ScheduleRepository.setSchedule(form.toConfig(new DateTime(), request.user.fullName))
+        Redirect(routes.ScheduleController.list())
+      }
+    )
+  }
+
+  def edit(id: String) = authAction { implicit request =>
+    ScheduleRepository.getSchedule(UUID.fromString(id))
+        .fold(NotFound(s"Schedule with ID $id doesn't exist"))(
+          config => Ok(views.html.schedule.form(scheduleForm.fill(ScheduleForm(config)), prismLookup))
+        )
+  }
+
+  def delete(id: String) = authAction { implicit request =>
+    Form("action" -> nonEmptyText).bindFromRequest().fold(
+      errors => {},
+      {
+        case "delete" =>
+          ScheduleRepository.deleteSchedule(UUID.fromString(id))
+      }
+    )
+    Redirect(routes.ScheduleController.list())
+  }
+
+}
+
+object ScheduleController {
+
+  case class Schedule(expression: String)
+
+  case class ScheduleForm(id: UUID, projectName: String, stage: String, schedule: Schedule, enabled: Boolean) {
+    def toConfig(lastEdited: DateTime, user: String): ScheduleConfig =
+      ScheduleConfig(id, projectName, stage, schedule, enabled, lastEdited, user)
+  }
+  object ScheduleForm {
+    def apply(config: ScheduleConfig): ScheduleForm =
+      ScheduleForm(config.id, config.projectName, config.stage, config.schedule, config.enabled)
+  }
+
+}
+

--- a/riff-raff/app/controllers/ScheduleController.scala
+++ b/riff-raff/app/controllers/ScheduleController.scala
@@ -1,32 +1,42 @@
 package controllers
 
-import play.api.mvc.{AnyContent, BaseController, ControllerComponents}
-import play.api.data.Forms._
-import play.api.data.Form
-import play.api.i18n.I18nSupport
-import play.api.libs.ws.WSClient
+import java.text.ParseException
 import java.util.UUID
 
-import org.joda.time.DateTime
-import ci.{ContinuousDeploymentConfig, Trigger}
 import com.gu.googleauth.AuthAction
-import controllers.ContinuousDeployController.ConfigForm
-import controllers.ScheduleController.Schedule
-import persistence.{ContinuousDeploymentConfigRepository, ScheduleRepository}
+import org.joda.time.DateTime
+import org.quartz.CronExpression
+import persistence.ScheduleRepository
+import play.api.data.Form
+import play.api.data.Forms._
+import play.api.data.validation.{Constraint, Invalid, Valid}
+import play.api.i18n.I18nSupport
+import play.api.libs.ws.WSClient
+import play.api.mvc.{AnyContent, BaseController, ControllerComponents}
 import resources.PrismLookup
-import schedule.ScheduleConfig
+import schedule.{DeployScheduler, ScheduleConfig}
 
-class ScheduleController(authAction: AuthAction[AnyContent], val controllerComponents: ControllerComponents, prismLookup: PrismLookup)(implicit val wsClient: WSClient)
+import scala.util.{Failure, Success, Try}
+
+class ScheduleController(authAction: AuthAction[AnyContent], val controllerComponents: ControllerComponents,
+                         prismLookup: PrismLookup, deployScheduler: DeployScheduler)(implicit val wsClient: WSClient)
   extends BaseController with Logging with I18nSupport {
 
   import ScheduleController.ScheduleForm
+
+  val quartzExpressionConstraint: Constraint[String] = Constraint("quartz.expression"){ expression =>
+    Try(CronExpression.validateExpression(expression)) match {
+      case Success(()) => Valid
+      case Failure(pe:ParseException) => Invalid(s"Invalid Quartz expression: ${pe.getMessage}")
+    }
+  }
 
   val scheduleForm = Form[ScheduleForm](
     mapping(
       "id" -> uuid,
       "projectName" -> nonEmptyText,
       "stage" -> nonEmptyText,
-      "schedule" -> nonEmptyText.transform[Schedule](Schedule.apply, _.expression),
+      "schedule" -> nonEmptyText.verifying(quartzExpressionConstraint),
       "enabled" -> boolean
     )(ScheduleForm.apply)(ScheduleForm.unapply)
   )
@@ -38,7 +48,7 @@ class ScheduleController(authAction: AuthAction[AnyContent], val controllerCompo
 
   def form = authAction { implicit request =>
     Ok(views.html.schedule.form(
-      scheduleForm.fill(ScheduleForm(UUID.randomUUID(), "", "", Schedule(""), enabled = true)), prismLookup
+      scheduleForm.fill(ScheduleForm(UUID.randomUUID(), "", "", "", enabled = true)), prismLookup
     ))
   }
 
@@ -46,7 +56,9 @@ class ScheduleController(authAction: AuthAction[AnyContent], val controllerCompo
     scheduleForm.bindFromRequest().fold(
       formWithErrors => Ok(views.html.schedule.form(formWithErrors, prismLookup)),
       form => {
-        ScheduleRepository.setSchedule(form.toConfig(new DateTime(), request.user.fullName))
+        val config = form.toConfig(new DateTime(), request.user.fullName)
+        ScheduleRepository.setSchedule(config)
+        deployScheduler.reschedule(config)
         Redirect(routes.ScheduleController.list())
       }
     )
@@ -64,7 +76,9 @@ class ScheduleController(authAction: AuthAction[AnyContent], val controllerCompo
       errors => {},
       {
         case "delete" =>
-          ScheduleRepository.deleteSchedule(UUID.fromString(id))
+          val uuid = UUID.fromString(id)
+          ScheduleRepository.deleteSchedule(uuid)
+          deployScheduler.unschedule(uuid)
       }
     )
     Redirect(routes.ScheduleController.list())
@@ -74,15 +88,13 @@ class ScheduleController(authAction: AuthAction[AnyContent], val controllerCompo
 
 object ScheduleController {
 
-  case class Schedule(expression: String)
-
-  case class ScheduleForm(id: UUID, projectName: String, stage: String, schedule: Schedule, enabled: Boolean) {
+  case class ScheduleForm(id: UUID, projectName: String, stage: String, schedule: String, enabled: Boolean) {
     def toConfig(lastEdited: DateTime, user: String): ScheduleConfig =
       ScheduleConfig(id, projectName, stage, schedule, enabled, lastEdited, user)
   }
   object ScheduleForm {
     def apply(config: ScheduleConfig): ScheduleForm =
-      ScheduleForm(config.id, config.projectName, config.stage, config.schedule, config.enabled)
+      ScheduleForm(config.id, config.projectName, config.stage, config.scheduleExpression, config.enabled)
   }
 
 }

--- a/riff-raff/app/deployment/model.scala
+++ b/riff-raff/app/deployment/model.scala
@@ -14,6 +14,7 @@ sealed trait RequestSource
 case class UserRequestSource(user: UserIdentity) extends RequestSource
 case object ContinuousDeploymentRequestSource extends RequestSource
 case class ApiRequestSource(key: ApiKey) extends RequestSource
+case object ScheduleRequestSource extends RequestSource
 
 case class Error(message: String) extends AnyVal
 

--- a/riff-raff/app/persistence/ScheduleRepository.scala
+++ b/riff-raff/app/persistence/ScheduleRepository.scala
@@ -1,0 +1,30 @@
+package persistence
+
+import java.util.UUID
+
+import ci.Trigger
+import com.gu.scanamo.syntax._
+import com.gu.scanamo.{DynamoFormat, Table}
+import schedule.ScheduleConfig
+
+object ScheduleRepository extends DynamoRepository {
+
+  implicit val triggerModeFormat =
+    DynamoFormat.coercedXmap[Trigger.Mode, String, NoSuchElementException](Trigger.withName)(_.toString)
+
+  override val tablePrefix = "schedule-config"
+
+  val table = Table[ScheduleConfig](tableName)
+
+  def getScheduleList(): List[ScheduleConfig] =
+    exec(table.scan()).flatMap(_.toOption)
+
+  def getSchedule(id: UUID): Option[ScheduleConfig] =
+    exec(table.get('id -> id)).flatMap(_.toOption)
+
+  def setSchedule(schedule: ScheduleConfig): Unit =
+    exec(table.put(schedule))
+
+  def deleteSchedule(id: UUID): Unit =
+    exec(table.delete('id -> id))
+}

--- a/riff-raff/app/schedule/DeployJob.scala
+++ b/riff-raff/app/schedule/DeployJob.scala
@@ -1,0 +1,58 @@
+package schedule
+
+import conf.Configuration
+import controllers.Logging
+import deployment._
+import magenta.{Build, Deployer, DeployParameters, Stage}
+import org.quartz.{Job, JobDataMap, JobExecutionContext}
+import schedule.DeployScheduler.JobDataKeys
+
+import scala.annotation.tailrec
+import scala.util.Try
+
+class DeployJob extends Job with Logging {
+  private def getAs[T](key: String)(implicit jobDataMap: JobDataMap): T = jobDataMap.get(key).asInstanceOf[T]
+
+  override def execute(context: JobExecutionContext): Unit = {
+    implicit val jobDataMap = context.getJobDetail.getJobDataMap
+    val deployments = getAs[Deployments](JobDataKeys.Deployments)
+    val projectName = getAs[String](JobDataKeys.ProjectName)
+    val stage = getAs[String](JobDataKeys.Stage)
+
+    getLastDeploy(deployments, projectName, stage) match {
+      case Left(error) => log.warn(error)
+      case Right(record) =>
+        val params = DeployParameters(
+          Deployer("Scheduled Deployment"),
+          Build(projectName, record.parameters.build.id),
+          Stage(stage)
+        )
+        if (Configuration.scheduledDeployment.enabled) {
+          deployments.deploy(params, ScheduleRequestSource)
+        } else {
+          log.info(s"Scheduled deployments disabled. Would have deployed $params")
+        }
+    }
+  }
+
+  @tailrec
+  private def getLastDeploy(deployments: Deployments, projectName: String, stage: String, attempts: Int = 5): Either[String, Record] = {
+    if (attempts == 0) {
+      Left(s"Didn't find any deploys for $projectName / $stage")
+    } else {
+      val filter = DeployFilter(
+        projectName = Some(projectName),
+        stage = Some(stage)
+      )
+      val pagination = PaginationView().withPageSize(Some(1))
+
+      val result = Try(deployments.getDeploys(Some(filter), pagination).headOption).toOption.flatten
+      result match {
+        case Some(record) => Right(record)
+        case None =>
+          Thread.sleep(1000)
+          getLastDeploy(deployments, projectName, stage, attempts-1)
+      }
+    }
+  }
+}

--- a/riff-raff/app/schedule/DeployScheduler.scala
+++ b/riff-raff/app/schedule/DeployScheduler.scala
@@ -1,0 +1,75 @@
+package schedule
+
+import java.util.UUID
+
+import deployment.Deployments
+import org.quartz.CronScheduleBuilder._
+import org.quartz.JobBuilder._
+import org.quartz.TriggerBuilder._
+import org.quartz.impl.StdSchedulerFactory
+import org.quartz.{JobDataMap, JobKey, TriggerKey}
+import play.api.Logger
+import schedule.DeployScheduler.JobDataKeys
+
+class DeployScheduler(deployments: Deployments) {
+
+  private val scheduler = StdSchedulerFactory.getDefaultScheduler
+
+  def initialise(schedules: Iterable[ScheduleConfig]): Unit = {
+    schedules.foreach(scheduleDeploy)
+  }
+
+  def reschedule(schedule: ScheduleConfig): Unit = {
+    // Delete any job and trigger that we may have previously created
+    unschedule(schedule.id)
+    scheduleDeploy(schedule)
+  }
+
+  def unschedule(id: UUID): Unit = {
+    scheduler.deleteJob(jobKey(id))
+  }
+
+  private def scheduleDeploy(scheduleConfig: ScheduleConfig): Unit = {
+    val id = scheduleConfig.id
+    if (scheduleConfig.enabled) {
+      val jobDetail = newJob(classOf[DeployJob])
+        .withIdentity(jobKey(id))
+        .usingJobData(buildJobDataMap(scheduleConfig))
+        .build()
+      val trigger = newTrigger()
+        .withIdentity(triggerKey(id))
+        .withSchedule(cronSchedule(scheduleConfig.scheduleExpression))
+        .build()
+      scheduler.scheduleJob(jobDetail, trigger)
+      Logger.info(s"Scheduled [$id] to deploy with schedule [${scheduleConfig.scheduleExpression}]")
+    } else {
+      Logger.info(s"NOT scheduling disabled schedule [$id] to deploy with schedule [${scheduleConfig.scheduleExpression}]")
+    }
+  }
+
+  def start(): Unit = scheduler.start()
+
+  def shutdown(): Unit = scheduler.shutdown()
+
+  private def jobKey(id: UUID): JobKey = new JobKey(id.toString)
+  private def triggerKey(id: UUID): TriggerKey = new TriggerKey(id.toString)
+
+  private def buildJobDataMap(scheduleConfig: ScheduleConfig): JobDataMap = {
+    val map = new JobDataMap()
+    map.put(JobDataKeys.Deployments, deployments)
+    map.put(JobDataKeys.ProjectName, scheduleConfig.projectName)
+    map.put(JobDataKeys.Stage, scheduleConfig.stage)
+    map
+  }
+
+}
+
+object DeployScheduler {
+
+  object JobDataKeys {
+    val Deployments = "deployments"
+    val ProjectName = "projectName"
+    val Stage = "stage"
+  }
+
+}

--- a/riff-raff/app/schedule/ScheduleConfig.scala
+++ b/riff-raff/app/schedule/ScheduleConfig.scala
@@ -1,0 +1,8 @@
+package schedule
+
+import java.util.UUID
+
+import controllers.ScheduleController.Schedule
+import org.joda.time.DateTime
+
+case class ScheduleConfig(id: UUID, projectName: String, stage: String, schedule: Schedule, enabled: Boolean, lastEdited: DateTime, user: String)

--- a/riff-raff/app/schedule/ScheduleConfig.scala
+++ b/riff-raff/app/schedule/ScheduleConfig.scala
@@ -2,7 +2,6 @@ package schedule
 
 import java.util.UUID
 
-import controllers.ScheduleController.Schedule
 import org.joda.time.DateTime
 
-case class ScheduleConfig(id: UUID, projectName: String, stage: String, schedule: Schedule, enabled: Boolean, lastEdited: DateTime, user: String)
+case class ScheduleConfig(id: UUID, projectName: String, stage: String, scheduleExpression: String, enabled: Boolean, lastEdited: DateTime, user: String)

--- a/riff-raff/app/views/schedule/form.scala.html
+++ b/riff-raff/app/views/schedule/form.scala.html
@@ -1,0 +1,41 @@
+@(configForm: Form[controllers.ScheduleController.ScheduleForm], prismLookup: resources.PrismLookup)(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], messages: Messages)
+@import b3.vertical.fieldConstructor
+@import helper.CSRF
+
+@main("Schedule", request, List("form-autocomplete")) {
+
+    <h2>Schedule Configuration</h2>
+    <hr/>
+
+    @b3.form(action=routes.ScheduleController.save) {
+        @CSRF.formField
+        @snippets.inputHidden(configForm("id"))
+
+        @if(configForm.hasGlobalErrors) {
+            <div class="alert alert-danger">
+                <h4>Error</h4>
+                <ul>
+                @configForm.globalErrors.map { error =>
+                    <li>@error.message</li>
+                }
+                </ul>
+            </div>
+        }
+
+        @b3.text(configForm("projectName"), 'id -> "projectInput", Symbol("data-url") -> "/deployment/request/autoComplete/project", '_label -> "Project Name")
+        @b3.select(
+            configForm("stage"),
+            options = helper.options(prismLookup.stages.toList),
+            '_default -> "--- Choose a stage ---",
+            '_label -> "Stage",
+            '_error -> configForm.globalError.map(_.withMessage("Please select deployment stage"))
+        )
+        @b3.text(configForm("schedule"), '_label -> "Schedule expression")
+        @b3.checkbox(configForm("enabled"), '_label -> "Schedule Enabled")
+
+        <div class="actions">
+            <button name="action" type="submit" value="save" class="btn btn-primary">Save</button> or
+            <a href="@routes.ScheduleController.list()" class="btn btn-danger">Cancel</a>
+        </div>
+    }
+}

--- a/riff-raff/app/views/schedule/form.scala.html
+++ b/riff-raff/app/views/schedule/form.scala.html
@@ -31,6 +31,9 @@
             '_error -> configForm.globalError.map(_.withMessage("Please select deployment stage"))
         )
         @b3.text(configForm("schedule"), '_label -> "Schedule expression")
+        <p>This should be a weird Quartz cron expression
+            (<a href="http://www.quartz-scheduler.org/documentation/quartz-2.2.x/tutorials/crontrigger.html">docs</a>)
+            (<a href="http://www.freeformatter.com/cron-expression-generator-quartz.html">online evaluator</a>)</p>
         @b3.checkbox(configForm("enabled"), '_label -> "Schedule Enabled")
 
         <div class="actions">

--- a/riff-raff/app/views/schedule/list.scala.html
+++ b/riff-raff/app/views/schedule/list.scala.html
@@ -31,7 +31,7 @@
                         <td>@utils.DateFormats.Short.print(config.lastEdited) by <span class="label label-default">@config.user</span></td>
                         <td>@config.projectName</td>
                         <td>@config.stage</td>
-                        <td>@config.schedule.expression</td>
+                        <td>@config.scheduleExpression</td>
                         <td>@config.enabled</td>
                         <td>
                             <a class="btn btn-default btn-xs" href="@routes.ScheduleController.edit(config.id.toString)"><i class="glyphicon glyphicon-edit"></i> Edit</a>

--- a/riff-raff/app/views/schedule/list.scala.html
+++ b/riff-raff/app/views/schedule/list.scala.html
@@ -1,0 +1,51 @@
+@import _root_.schedule.ScheduleConfig
+@(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], configs: Seq[ScheduleConfig])
+
+@import org.joda.time.format.DateTimeFormat._
+@import ci.Trigger._
+@import helper.CSRF
+
+    @main("Schedule Configurations", request) {
+        <h2>Schedule Configurations</h2>
+        <hr/>
+        <p><a class="btn btn-primary" href="@routes.ScheduleController.form()"><i class="glyphicon glyphicon-plus glyphicon glyphicon-white"></i> Add new schedule</a></p>
+        <div class="content">
+        @if(configs.isEmpty) {
+            <div class="alert alert-warning"><strong>No configurations.</strong></div>
+        } else {
+            <table class="table table-condensed">
+                <thead>
+                    <tr>
+                        <th>Last edited</th>
+                        <th>Project Name</th>
+                        <th>Target Stage</th>
+                        <th>Schedule</th>
+                        <th>Enabled?</th>
+                        <th></th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                @for(config <- configs) {
+                    <tr @if(!config.enabled){ class="danger" }>
+                        <td>@utils.DateFormats.Short.print(config.lastEdited) by <span class="label label-default">@config.user</span></td>
+                        <td>@config.projectName</td>
+                        <td>@config.stage</td>
+                        <td>@config.schedule.expression</td>
+                        <td>@config.enabled</td>
+                        <td>
+                            <a class="btn btn-default btn-xs" href="@routes.ScheduleController.edit(config.id.toString)"><i class="glyphicon glyphicon-edit"></i> Edit</a>
+                        </td>
+                        <td>
+                        @helper.form(action=routes.ScheduleController.delete(config.id.toString), 'class -> "form-make-inline") {
+                            @CSRF.formField
+                            <button class="btn btn-xs btn-danger" name="action" value="delete"><i class="glyphicon glyphicon-trash glyphicon glyphicon-white"></i> Delete</button>
+                        }
+                        </td>
+                    </tr>
+                }
+                </tbody>
+            </table>
+        }
+        </div>
+    }

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -75,6 +75,13 @@ POST        /deployment/restrictions/save                   controllers.Restrict
 GET         /deployment/restrictions/edit                   controllers.Restrictions.edit(id)
 POST        /deployment/restrictions/delete                 controllers.Restrictions.delete(id)
 
+# Schedules
+GET         /deployment/schedule                            controllers.ScheduleController.list
+GET         /deployment/schedule/new                        controllers.ScheduleController.form
+POST        /deployment/schedule/save                       controllers.ScheduleController.save
+GET         /deployment/schedule/:id/edit                   controllers.ScheduleController.edit(id)
+POST        /deployment/schedule/:id/delete                 controllers.ScheduleController.delete(id)
+
 # Target
 GET         /deployment/target/find                         controllers.TargetController.findMatch(region: String, stack: String, app: String)
 GET         /deployment/target/deploy                       controllers.TargetController.findAppropriateDeploy(region: String, stack: String, app: String, stage: String)

--- a/riff-raff/test/schedule/DeployJobTest.scala
+++ b/riff-raff/test/schedule/DeployJobTest.scala
@@ -1,0 +1,44 @@
+package schedule
+
+import java.util.UUID
+
+import deployment.{DeployRecord, Error}
+import magenta.{Build, Deployer, DeployParameters, RunState, Stage}
+import org.joda.time.DateTime
+import org.scalatest.{EitherValues, FlatSpec, Matchers}
+
+class DeployJobTest extends FlatSpec with Matchers with EitherValues {
+  val uuid = UUID.fromString("7fa2ee0a-8d90-4f7e-a38b-185f36fbc5aa")
+  "createDeployParameters" should "return params if valid" in {
+    val record = new DeployRecord(
+      new DateTime(),
+      uuid,
+      DeployParameters(Deployer("Bob"), Build("testProject", "1"), Stage("TEST")),
+      recordState = Some(RunState.Completed)
+    )
+    DeployJob.createDeployParameters(record, true) shouldBe
+      Right(DeployParameters(Deployer("Scheduled Deployment"), Build("testProject", "1"), Stage("TEST")))
+  }
+
+  it should "produce an error if the last deploy didn't complete" in {
+    val record = new DeployRecord(
+      new DateTime(),
+      uuid,
+      DeployParameters(Deployer("Bob"), Build("testProject", "1"), Stage("TEST")),
+      recordState = Some(RunState.Failed)
+    )
+    DeployJob.createDeployParameters(record, true) shouldBe
+      Left(Error("Skipping scheduled deploy as deploy record 7fa2ee0a-8d90-4f7e-a38b-185f36fbc5aa has status Failed"))
+  }
+
+  it should "produce an error if scheduled deploys are disabled" in {
+    val record = new DeployRecord(
+      new DateTime(),
+      uuid,
+      DeployParameters(Deployer("Bob"), Build("testProject", "1"), Stage("TEST")),
+      recordState = Some(RunState.Completed)
+    )
+    DeployJob.createDeployParameters(record, false) shouldBe
+      Left(Error("Scheduled deployments disabled. Would have deployed DeployParameters(Deployer(Scheduled Deployment),Build(testProject,1),Stage(TEST),RecipeName(default),List(),List(),All)"))
+  }
+}


### PR DESCRIPTION
Pulled this together this afternoon with @nicl 

This introduces scheduled deploys to Riff-Raff. This allows you to configure a project to deploy automatically according to a pre-determined schedule.

The aim of scheduled deploys is to have a mechanism for automatically updating AMIs even when a project is not actively being worked on.

Some details:
 - schedules are expressed as quartz cron expressions (as per AMIgo)
 - a scheduled deploy will re-deploy the most recent deploy to the specified stage
 - a scheduled deploy is skipped if there is no previous deploy or the most recent deploy failed or is still running

Possible future improvements:
 - only deploy if the most recent deploy was X days ago
 - something other than quartz crons for configuring

Scheduling screen:
<img width="949" alt="screen shot 2018-01-17 at 18 26 00" src="https://user-images.githubusercontent.com/1236466/35059688-e8bbbaf8-fbb3-11e7-93bd-a768f5f6e21e.png">

Deploy is run by a "scheduled deploy" user:
<img width="953" alt="screen shot 2018-01-17 at 18 26 36" src="https://user-images.githubusercontent.com/1236466/35059716-fe1ab534-fbb3-11e7-9e45-54cca74abeea.png">

