### PR TITLE
Add support for AMIgo based encrypted AMIs

### DIFF
--- a/magenta-lib/src/main/scala/magenta/Lookup.scala
+++ b/magenta-lib/src/main/scala/magenta/Lookup.scala
@@ -21,7 +21,7 @@ trait Lookup {
   def stages: Seq[String]
   def data: DataLookup
   def keyRing(stage: Stage, apps: Set[App], stack: Stack): KeyRing
-  def getLatestAmi(region: String)(tags: Map[String, String]): Option[String]
+  def getLatestAmi(accountNumber: Option[String], tagFilter: Map[String, String] => Boolean)(region: String)(tags: Map[String, String]): Option[String]
 }
 
 trait SecretProvider {

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
@@ -58,7 +58,7 @@ object AmiCloudFormationParameter extends DeploymentType with CloudFormationDepl
           target.region,
           cloudFormationStackLookupStrategy,
           amiParameterMap,
-          resources.lookup.getLatestAmi,
+          getLatestAmi(pkg, target, reporter, resources.lookup),
           target.parameters.stage,
           target.stack
         ),

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -75,7 +75,7 @@ object CloudFormation extends DeploymentType with CloudFormationDeploymentTypePa
           S3Path(pkg.s3Package, templatePath(pkg, target, reporter)),
           params,
           amiParameterMap,
-          resources.lookup.getLatestAmi,
+          getLatestAmi(pkg, target, reporter, resources.lookup),
           target.parameters.stage,
           target.stack,
           createStackIfAbsent(pkg, target, reporter),

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -54,8 +54,7 @@ object S3 extends AWS {
     */
   def accountSpecificBucket(prefix: String, s3Client: AmazonS3, stsClient: AWSSecurityTokenService,
     region: Region, reporter: DeployReporter, deleteAfterDays: Option[Int] = None): String = {
-    val callerIdentityResponse = stsClient.getCallerIdentity(new GetCallerIdentityRequest())
-    val accountNumber = callerIdentityResponse.getAccount
+    val accountNumber = STS.getAccountNumber(stsClient)
     val bucketName = s"$prefix-$accountNumber-${region.name}"
     if (!s3Client.doesBucketExist(bucketName)) {
       reporter.info(s"Creating bucket for this account and region: $bucketName ${region.name}")
@@ -441,6 +440,11 @@ object STS extends AWS {
       .withClientConfiguration(clientConfiguration)
       .withRegion(region.name)
       .build()
+  }
+
+  def getAccountNumber(stsClient: AWSSecurityTokenService): String = {
+    val callerIdentityResponse = stsClient.getCallerIdentity(new GetCallerIdentityRequest())
+    callerIdentityResponse.getAccount
   }
 }
 

--- a/magenta-lib/src/test/scala/magenta/fixtures/package.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/package.scala
@@ -95,7 +95,7 @@ package object fixtures {
 
       def keyRing(stage: Stage, apps: Set[App], stack: Stack) = KeyRing()
 
-      def getLatestAmi(region: String)(tags: Map[String, String]): Option[String] = ???
+      def getLatestAmi(accountNumber: Option[String], tagFilter: Map[String, String] => Boolean)(region: String)(tags: Map[String, String]): Option[String] = ???
     }
   }
 

--- a/riff-raff/app/resources/PrismLookup.scala
+++ b/riff-raff/app/resources/PrismLookup.scala
@@ -183,8 +183,8 @@ class PrismLookup(wsClient: WSClient, url: String, timeout: Duration) extends Lo
   private def get(accountNumber: Option[String], region: String, tags: Map[String, String]): Seq[Image] = {
     val params: Seq[(String, String)] =
       tags.map { case (key, value) => s"tags.${key.urlEncode}" -> value }.toSeq ++
-      accountNumber.map(acc => "meta.origin.accountNumber" -> acc) :+
-      "region" -> region
+      accountNumber.map(acc => "meta.origin.accountNumber" -> acc) ++
+      Map("region" -> region, "state" -> "available")
     val paramsQueryString = params.map { case (k,v) => s"$k=${v.urlEncode}" }.mkString("&")
     prism.get(s"/images?$paramsQueryString"){ json =>
       (json \ "data" \ "images").as[Seq[Image]]

--- a/riff-raff/app/resources/PrismLookup.scala
+++ b/riff-raff/app/resources/PrismLookup.scala
@@ -18,7 +18,7 @@ import utils.Json._
 
 import scala.util.{Failure, Success, Try}
 
-case class Image(imageId: String, creationDate: DateTime)
+case class Image(imageId: String, creationDate: DateTime, tags: Map[String, String])
 object Image {
   implicit val formats = Json.format[Image]
 }
@@ -180,13 +180,17 @@ class PrismLookup(wsClient: WSClient, url: String, timeout: Duration) extends Lo
       conf.Configuration.credentials.lookupSecret(service, account)
   }
 
-  private def get(region: String, tags: Map[String, String]): Seq[Image] = {
-    val params = tags.map{ case (key, value) => s"tags.${key.urlEncode}=${value.urlEncode}" }.mkString("&")
-    prism.get(s"/images?region=${region.urlEncode}&$params"){ json =>
+  private def get(accountNumber: Option[String], region: String, tags: Map[String, String]): Seq[Image] = {
+    val params: Seq[(String, String)] =
+      tags.map { case (key, value) => s"tags.${key.urlEncode}" -> value }.toSeq ++
+      accountNumber.map(acc => "meta.origin.accountNumber" -> acc) :+
+      "region" -> region
+    val paramsQueryString = params.map { case (k,v) => s"$k=${v.urlEncode}" }.mkString("&")
+    prism.get(s"/images?$paramsQueryString"){ json =>
       (json \ "data" \ "images").as[Seq[Image]]
     }
   }
-  def getLatestAmi(region: String)(tags: Map[String, String]): Option[String] =
-    get(region, tags).sortBy(-_.creationDate.getMillis).headOption.map(_.imageId)
+  def getLatestAmi(accountNumber: Option[String], tagFilter: Map[String, String] => Boolean)(region: String)(tags: Map[String, String]): Option[String] =
+    get(accountNumber, region, tags).filter(image => tagFilter(image.tags)).sortBy(-_.creationDate.getMillis).headOption.map(_.imageId)
 
 }

--- a/riff-raff/test/lookup/PrismLookupTest.scala
+++ b/riff-raff/test/lookup/PrismLookupTest.scala
@@ -1,5 +1,6 @@
 package lookup
 
+import magenta.deployment_type.CloudFormationDeploymentTypeParameters
 import org.joda.time.DateTime
 import org.scalatest.{FlatSpec, Matchers}
 import play.api
@@ -43,14 +44,14 @@ class PrismLookupTest extends FlatSpec with Matchers {
 
   "PrismLookup" should "return latest image" in {
     val images = List(
-      Image("test-ami", new DateTime(2017,3,2,13,32,0)),
-      Image("test-later-ami", new DateTime(2017,4,2,13,32,0)),
-      Image("test-later-still-ami", new DateTime(2017,5,2,13,32,0)),
-      Image("test-early-ami", new DateTime(2017,1,2,13,32,0))
+      Image("test-ami", new DateTime(2017,3,2,13,32,0), Map.empty),
+      Image("test-later-ami", new DateTime(2017,4,2,13,32,0), Map.empty),
+      Image("test-later-still-ami", new DateTime(2017,5,2,13,32,0), Map.empty),
+      Image("test-early-ami", new DateTime(2017,1,2,13,32,0), Map.empty)
     )
     withPrismClient(images) { client =>
       val lookup = new PrismLookup(client, "", 10 seconds)
-      val result = lookup.getLatestAmi("bob")(Map.empty)
+      val result = lookup.getLatestAmi(None, _ => true)("bob")(Map.empty)
       result shouldBe Some("test-later-still-ami")
     }
   }
@@ -58,7 +59,7 @@ class PrismLookupTest extends FlatSpec with Matchers {
   it should "narrows ami query by region" in {
     val (result, request) = withPrismClient(Nil) { client =>
       val lookup = new PrismLookup(client, "", 10 seconds)
-      lookup.getLatestAmi("bob")(Map.empty)
+      lookup.getLatestAmi(None, _ => true)("bob")(Map.empty)
     }
     result shouldBe None
     request.flatMap(_.getQueryString("region")) shouldBe Some("bob")
@@ -67,12 +68,26 @@ class PrismLookupTest extends FlatSpec with Matchers {
   it should "correctly query using the tags" in {
     val (result, request) = withPrismClient(Nil) { client =>
       val lookup = new PrismLookup(client, "", 10 seconds)
-      lookup.getLatestAmi("bob")(Map("tagName" -> "tagValue?", "tagName*" -> "tagValue2"))
+      lookup.getLatestAmi(None, _ => true)("bob")(Map("tagName" -> "tagValue?", "tagName*" -> "tagValue2"))
     }
     request.map(_.queryString) shouldBe Some(Map(
       "region" -> ArrayBuffer("bob"),
       "tags.tagName" -> ArrayBuffer("tagValue?"),
       "tags.tagName*" -> ArrayBuffer("tagValue2")
     ))
+  }
+
+  it should "correctly filter out images that are encrypted" in {
+    val images = List(
+      Image("test-ami", new DateTime(2017,3,2,13,32,0), Map.empty),
+      Image("test-later-ami", new DateTime(2017,4,2,13,32,0), Map("Encrypted" -> "very")),
+      Image("test-later-still-ami", new DateTime(2017,5,2,13,32,0), Map("Encrypted" -> "true")),
+      Image("test-early-ami", new DateTime(2017,1,2,13,32,0), Map.empty)
+    )
+    withPrismClient(images) { client =>
+      val lookup = new PrismLookup(client, "", 10 seconds)
+      val result = lookup.getLatestAmi(None, CloudFormationDeploymentTypeParameters.unencryptedTagFilter)("bob")(Map.empty)
+      result shouldBe Some("test-ami")
+    }
   }
 }

--- a/riff-raff/test/lookup/PrismLookupTest.scala
+++ b/riff-raff/test/lookup/PrismLookupTest.scala
@@ -72,6 +72,7 @@ class PrismLookupTest extends FlatSpec with Matchers {
     }
     request.map(_.queryString) shouldBe Some(Map(
       "region" -> ArrayBuffer("bob"),
+      "state" -> ArrayBuffer("available"),
       "tags.tagName" -> ArrayBuffer("tagValue?"),
       "tags.tagName*" -> ArrayBuffer("tagValue2")
     ))


### PR DESCRIPTION
With https://github.com/guardian/amigo/pull/164 it has become necessary to add a little more functionality to Riff-Raff to correctly identify a suitable AMI (encrypted AMIs must be in the same account as they are used). A new boolean parameter `amiEncrypted` has been introduced to support this.

Most importantly we don't want Riff-Raff to inadvertently pick up an encrypted AMI when one had not been requested. If it tried to do this and picked an AMI from a different account it would not work. At all. As such, when `amiEncrypted=false` (the default) we only consider AMIs that either have no `Encrypted` tag or those that have an `Encrypted=false` tag.

When we set `amiEncrypted=true` Riff-Raff does two things:
 - only considers owned by the AWS account ID belonging to the AWS credentials being used to update the CFN stack - this is done by adding a `meta.origin.accountNumber` filter to the prism request
 - adds a tag filter of `Encrypted=true` which is set by the AMIgo copy lambda - this can be overridden by specifying the tag explicitly but for convenience is set to `true`