### PR TITLE
Tidy up implementation and sort scheduled jobs listing

### DIFF
--- a/riff-raff/app/controllers/ScheduleController.scala
+++ b/riff-raff/app/controllers/ScheduleController.scala
@@ -87,7 +87,7 @@ class ScheduleController(authAction: AuthAction[AnyContent], val controllerCompo
         case "delete" =>
           val uuid = UUID.fromString(id)
           ScheduleRepository.deleteSchedule(uuid)
-          deployScheduler.unschedule(uuid)
+          deployScheduler.cancel(uuid)
       }
     )
     Redirect(routes.ScheduleController.list())

--- a/riff-raff/app/schedule/DeployScheduler.scala
+++ b/riff-raff/app/schedule/DeployScheduler.scala
@@ -2,16 +2,16 @@ package schedule
 
 import java.util.{TimeZone, UUID}
 
+import controllers.Logging
 import deployment.Deployments
 import org.quartz.CronScheduleBuilder._
 import org.quartz.JobBuilder._
 import org.quartz.TriggerBuilder._
 import org.quartz.impl.StdSchedulerFactory
 import org.quartz.{JobDataMap, JobKey, TriggerKey}
-import play.api.Logger
 import schedule.DeployScheduler.JobDataKeys
 
-class DeployScheduler(deployments: Deployments) {
+class DeployScheduler(deployments: Deployments) extends Logging {
 
   private val scheduler = StdSchedulerFactory.getDefaultScheduler
 
@@ -21,11 +21,11 @@ class DeployScheduler(deployments: Deployments) {
 
   def reschedule(schedule: ScheduleConfig): Unit = {
     // Delete any job and trigger that we may have previously created
-    unschedule(schedule.id)
+    cancel(schedule.id)
     scheduleDeploy(schedule)
   }
 
-  def unschedule(id: UUID): Unit = {
+  def cancel(id: UUID): Unit = {
     scheduler.deleteJob(jobKey(id))
   }
 
@@ -43,9 +43,9 @@ class DeployScheduler(deployments: Deployments) {
         )
         .build()
       scheduler.scheduleJob(jobDetail, trigger)
-      Logger.info(s"Scheduled [$id] to deploy with schedule [${scheduleConfig.scheduleExpression} in ${scheduleConfig.timezone}]")
+      log.info(s"Scheduled [$id] to deploy with schedule [${scheduleConfig.scheduleExpression} in ${scheduleConfig.timezone}]")
     } else {
-      Logger.info(s"NOT scheduling disabled schedule [$id] to deploy with schedule [${scheduleConfig.scheduleExpression} in ${scheduleConfig.timezone}]")
+      log.info(s"NOT scheduling disabled schedule [$id] to deploy with schedule [${scheduleConfig.scheduleExpression} in ${scheduleConfig.timezone}]")
     }
   }
 

--- a/riff-raff/app/views/schedule/list.scala.html
+++ b/riff-raff/app/views/schedule/list.scala.html
@@ -26,7 +26,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                @for(config <- configs) {
+                @for(config <- configs.sortBy(c => (c.projectName, c.stage))) {
                     <tr @if(!config.enabled){ class="danger" }>
                         <td>@utils.DateFormats.Short.print(config.lastEdited) by <span class="label label-default">@config.user</span></td>
                         <td>@config.projectName</td>


### PR DESCRIPTION
This switches to the normal logger, renames the unschedule method and also sorts scheduled jobs by project and then stage (should this really sort by schedule expression to allow people to space out the schedule???)