### PR TITLE
Expose build duration in seconds

### DIFF
--- a/riff-raff/app/controllers/api.scala
+++ b/riff-raff/app/controllers/api.scala
@@ -265,7 +265,8 @@ class Api(deployments: Deployments, deploymentTypes: Seq[DeploymentType], authAc
       "recipe" -> deploy.parameters.recipe.name,
       "status" -> deploy.state.toString,
       "logURL" -> routes.DeployController.viewUUID(deploy.uuid.toString).absoluteURL(),
-      "tags" -> toJson(deploy.allMetaData)
+      "tags" -> toJson(deploy.allMetaData),
+      "durationSeconds" -> deploy.timeTaken.toStandardSeconds.getSeconds
     )
 
 


### PR DESCRIPTION
I want to ingest this into a Kibana stack we have so that we can track our deploy times over time.

**Note: not yet tested other than it compiles.**