### PR TITLE
Scheduled deploy cooldown

### DIFF
--- a/riff-raff/app/controllers/ScheduleController.scala
+++ b/riff-raff/app/controllers/ScheduleController.scala
@@ -9,7 +9,7 @@ import org.quartz.CronExpression
 import persistence.ScheduleRepository
 import play.api.data.Form
 import play.api.data.Forms._
-import play.api.data.validation.{Constraint, Invalid, Valid}
+import play.api.data.validation.{Constraint, Constraints, Invalid, Valid}
 import play.api.i18n.I18nSupport
 import play.api.libs.ws.WSClient
 import play.api.mvc.{AnyContent, BaseController, ControllerComponents}
@@ -47,7 +47,7 @@ class ScheduleController(authAction: AuthAction[AnyContent], val controllerCompo
       "schedule" -> nonEmptyText.verifying(quartzExpressionConstraint),
       "timezone" -> nonEmptyText.verifying(timezoneConstraint),
       "enabled" -> boolean,
-      "cooldownDays" -> optional(number)
+      "cooldownDays" -> optional(number.verifying(Constraints.min(1)))
     )(ScheduleForm.apply)(ScheduleForm.unapply)
   )
 

--- a/riff-raff/app/schedule/DeployScheduler.scala
+++ b/riff-raff/app/schedule/DeployScheduler.scala
@@ -61,6 +61,7 @@ class DeployScheduler(deployments: Deployments) extends Logging {
     map.put(JobDataKeys.Deployments, deployments)
     map.put(JobDataKeys.ProjectName, scheduleConfig.projectName)
     map.put(JobDataKeys.Stage, scheduleConfig.stage)
+    map.put(JobDataKeys.CoolDownDays, scheduleConfig.cooldownDays)
     map
   }
 
@@ -72,6 +73,7 @@ object DeployScheduler {
     val Deployments = "deployments"
     val ProjectName = "projectName"
     val Stage = "stage"
+    val CoolDownDays = "cooldownDays"
   }
 
 }

--- a/riff-raff/app/schedule/ScheduleConfig.scala
+++ b/riff-raff/app/schedule/ScheduleConfig.scala
@@ -6,4 +6,5 @@ import org.joda.time.DateTime
 
 case class ScheduleConfig(id: UUID, projectName: String, stage: String,
                           scheduleExpression: String, timezone: String,
-                          enabled: Boolean, lastEdited: DateTime, user: String)
+                          enabled: Boolean, lastEdited: DateTime, user: String,
+                          cooldownDays: Option[Int])

--- a/riff-raff/app/views/schedule/form.scala.html
+++ b/riff-raff/app/views/schedule/form.scala.html
@@ -44,8 +44,7 @@
             '_error -> configForm.globalError.map(_.withMessage("Please select a valid timezone for the schedule"))
         )
         @b3.text(configForm("cooldownDays"), '_label -> "Cooldown days")
-        <p>How many days must have elapsed since the last deploy (manual or automatic) in order to do an automatic
-           deploy. Set to 14 for GDPR compliance.</p>
+        <p>How many days must have elapsed since the last deploy (manual or automatic) in order to do an automatic deploy.</p>
         @b3.checkbox(configForm("enabled"), '_label -> "Schedule Enabled")
 
         <div class="actions">

--- a/riff-raff/app/views/schedule/form.scala.html
+++ b/riff-raff/app/views/schedule/form.scala.html
@@ -43,6 +43,9 @@
             '_label -> "Schedule timezone",
             '_error -> configForm.globalError.map(_.withMessage("Please select a valid timezone for the schedule"))
         )
+        @b3.text(configForm("cooldownDays"), '_label -> "Cooldown days")
+        <p>How many days must have elapsed since the last deploy (manual or automatic) in order to do an automatic
+           deploy. Set to 14 for GDPR compliance.</p>
         @b3.checkbox(configForm("enabled"), '_label -> "Schedule Enabled")
 
         <div class="actions">

--- a/riff-raff/app/views/schedule/list.scala.html
+++ b/riff-raff/app/views/schedule/list.scala.html
@@ -20,6 +20,7 @@
                         <th>Project Name</th>
                         <th>Target Stage</th>
                         <th>Schedule</th>
+                        <th>Cool-down Days</th>
                         <th>Enabled?</th>
                         <th></th>
                         <th></th>
@@ -32,6 +33,7 @@
                         <td>@config.projectName</td>
                         <td>@config.stage</td>
                         <td>@config.scheduleExpression (@config.timezone)</td>
+                        <td>@config.cooldownDays</td>
                         <td>@config.enabled</td>
                         <td>
                             <a class="btn btn-default btn-xs" href="@routes.ScheduleController.edit(config.id.toString)"><i class="glyphicon glyphicon-edit"></i> Edit</a>

--- a/riff-raff/test/schedule/DeployJobTest.scala
+++ b/riff-raff/test/schedule/DeployJobTest.scala
@@ -8,37 +8,42 @@ import org.joda.time.DateTime
 import org.scalatest.{EitherValues, FlatSpec, Matchers}
 
 class DeployJobTest extends FlatSpec with Matchers with EitherValues {
-  val uuid = UUID.fromString("7fa2ee0a-8d90-4f7e-a38b-185f36fbc5aa")
+  private val uuid = UUID.fromString("7fa2ee0a-8d90-4f7e-a38b-185f36fbc5aa")
+  private val bobsProject = DeployParameters(Deployer("Bob"), Build("testProject", "1"), Stage("TEST"))
+  private val bobsSuccessfulDeploy = DeployRecord(new DateTime(), uuid, bobsProject, recordState = Some(RunState.Completed))
+
   "createDeployParameters" should "return params if valid" in {
-    val record = new DeployRecord(
-      new DateTime(),
-      uuid,
-      DeployParameters(Deployer("Bob"), Build("testProject", "1"), Stage("TEST")),
-      recordState = Some(RunState.Completed)
-    )
-    DeployJob.createDeployParameters(record, true) shouldBe
+    runAgainst(bobsSuccessfulDeploy) shouldBe
       Right(DeployParameters(Deployer("Scheduled Deployment"), Build("testProject", "1"), Stage("TEST")))
   }
 
   it should "produce an error if the last deploy didn't complete" in {
-    val record = new DeployRecord(
-      new DateTime(),
-      uuid,
-      DeployParameters(Deployer("Bob"), Build("testProject", "1"), Stage("TEST")),
-      recordState = Some(RunState.Failed)
-    )
-    DeployJob.createDeployParameters(record, true) shouldBe
+    val bobsFailedDeploy = bobsSuccessfulDeploy.copy(recordState = Some(RunState.Failed))
+
+    runAgainst(bobsFailedDeploy) shouldBe
       Left(Error("Skipping scheduled deploy as deploy record 7fa2ee0a-8d90-4f7e-a38b-185f36fbc5aa has status Failed"))
   }
 
   it should "produce an error if scheduled deploys are disabled" in {
-    val record = new DeployRecord(
-      new DateTime(),
-      uuid,
-      DeployParameters(Deployer("Bob"), Build("testProject", "1"), Stage("TEST")),
-      recordState = Some(RunState.Completed)
-    )
-    DeployJob.createDeployParameters(record, false) shouldBe
+    runAgainst(bobsSuccessfulDeploy, enabled = false) shouldBe
       Left(Error("Scheduled deployments disabled. Would have deployed DeployParameters(Deployer(Scheduled Deployment),Build(testProject,1),Stage(TEST),RecipeName(default),List(),List(),All)"))
+  }
+
+  it should "produce an error if still within the cool-down days" in {
+    val now = new DateTime()
+    val lastDeploy = bobsSuccessfulDeploy.copy(time = now.minusDays(4))
+
+    runAgainst(lastDeploy, cooldownDays = Some(14)).isLeft should be(true)
+  }
+
+  it should "return params if outside the cool-down days" in {
+    val now = new DateTime()
+    val lastDeploy = bobsSuccessfulDeploy.copy(time = now.minusDays(15))
+
+    runAgainst(lastDeploy, cooldownDays = Some(14)).isRight should be(true)
+  }
+
+  private def runAgainst(lastDeploy: DeployRecord, enabled: Boolean = true, cooldownDays: Option[Int] = None) = {
+    DeployJob.createDeployParameters(lastDeploy, enabled, now = new DateTime(), cooldownDays)
   }
 }


### PR DESCRIPTION
Adds an optional "Cool-down Days" period to scheduled launch. If a project has been deployed in the last N days then the scheduled deploy is skipped.

The use case here is for critical yet regularly deployed apps like Composer. The chances are the project has been deployed recently and every scheduled deploy is risk (albeit small risk). As such we can achieve GDPR compliance by scheduling a deploy every week unless it has been deployed in the last 7 days.

I'd especially welcome feedback about the time ranges involved (eg are days the right unit?) and if there's interplay between the quartz expression and cool-down period that would be dangerous enough to require guards.