### PR TITLE
Deal with invalid date time format and log build.json parsing errors

### DIFF
--- a/riff-raff/app/utils/Json.scala
+++ b/riff-raff/app/utils/Json.scala
@@ -4,6 +4,8 @@ import org.joda.time.format.ISODateTimeFormat
 import play.api.libs.json._
 import org.joda.time.DateTime
 
+import scala.util.{Failure, Success, Try}
+
 object Json {
   implicit object DefaultJodaDateWrites extends Writes[org.joda.time.DateTime] {
     def writes(d: org.joda.time.DateTime): JsValue = JsString(ISODateTimeFormat.dateTime.print(d))
@@ -11,7 +13,12 @@ object Json {
   implicit object DefaultJodaDateReads extends Reads[org.joda.time.DateTime] {
     def reads(json: JsValue): JsResult[DateTime] = {
       json match {
-        case JsString(dateTime) => JsSuccess(ISODateTimeFormat.dateTime.parseDateTime(dateTime))
+        case JsString(dateTimeStr) =>
+          val attemptParse = Try(ISODateTimeFormat.dateTime.parseDateTime(dateTimeStr))
+          attemptParse match {
+            case Success(dateTime) => JsSuccess(dateTime)
+            case Failure(t) => JsError(t.getMessage)
+          }
         case _ => JsError("DateTime can only be extracted from a JsString")
       }
     }


### PR DESCRIPTION
We've seen a `build.json` with a badly formatted date. This should deal more gracefully with that and provide logging to track down the offending file.