### PR TITLE
Make it easy to rotate the Play Application Secret

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,6 +50,7 @@ object Dependencies {
     "com.gu" %% "management-logback" % Versions.guardianManagement,
     "com.gu" %% "configuration" % "4.2",
     "com.gu" %% "play-googleauth" % "0.7.0",
+    "com.gu.play-secret-rotation" %% "aws-parameterstore" % "0.7",
     "org.mongodb" %% "casbah" % "3.1.1",
     "com.typesafe.akka" %% "akka-agent" % "2.5.3",
     "org.pegdown" % "pegdown" % "1.6.0",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val guardianManagement = "5.37"
     val jackson = "2.8.2"
     // keep in sync with plugin
-    val play = "2.6.0"
+    val play = "2.6.9"
   }
 
   val commonDeps = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
 // keep in sync with the play version in Dependencies
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.9")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.0")

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -81,6 +81,8 @@ class Configuration(val application: String, val webappConfDirectory: String = "
     lazy val domain: String = configuration.getStringProperty("auth.domain").getOrException("No auth domain configured")
     lazy val googleAuthConfig = GoogleAuthConfig(auth.clientId, auth.clientSecret, auth.redirectUrl, auth.domain)
     lazy val superusers: List[String] = configuration.getStringPropertiesSplitByComma("auth.superusers")
+    lazy val secretStateSupplierKeyName: String = configuration.getStringProperty("auth.secretStateSupplier.keyName", "/RiffRaff/PlayApplicationSecret")
+    lazy val secretStateSupplierRegion: String = configuration.getStringProperty("auth.secretStateSupplier.region", "eu-west-1")
   }
 
   object concurrency {
@@ -200,7 +202,7 @@ class Configuration(val application: String, val webappConfDirectory: String = "
     }
   }
 
-  def credentialsProviderChain(accessKey: Option[String], secretKey: Option[String]): AWSCredentialsProviderChain =
+  def credentialsProviderChain(accessKey: Option[String], secretKey: Option[String]): AWSCredentialsProviderChain = {
     new AWSCredentialsProviderChain(
       new AWSCredentialsProvider {
         override def getCredentials: AWSCredentials = (for {
@@ -215,6 +217,7 @@ class Configuration(val application: String, val webappConfDirectory: String = "
       new ProfileCredentialsProvider("deployTools"),
       InstanceProfileCredentialsProvider.getInstance()
     )
+  }
 
   def awsRegion(name: String): Region = RegionUtils.getRegion(name)
 

--- a/riff-raff/conf/application.conf
+++ b/riff-raff/conf/application.conf
@@ -3,12 +3,6 @@
 
 play.application.name="riff-raff"
 
-# Secret key
-# ~~~~~
-# The secret key is used to secure cryptographics functions.
-# If you deploy your application to several instances be sure to use the same key!
-play.crypto.secret="foUsKP^2=ZKkDaCF^c6Y6b:i:WS30CO4sBMY6>s6aAS63sO/cEV9H0^EB`/cQC4<"
-
 # The application languages
 # ~~~~~
 play.i18n.langs = [ "en" ]


### PR DESCRIPTION
The Play Application Secret is used to sign the `PLAY_SESSION` cookie:

https://www.playframework.com/documentation/2.6.x/ApplicationSecret

Any attacker possessing the Play Application Secret can easily craft a signed `PLAY_SESSION` cookie masquerading as any legitimate user they desire. Assuming network access to Riff-Raff, they can then deploy any version of any app with the elevated privileges of that user.

This change updates Riff-Raff to use the our new library for rotating Play secrets without downtime: https://github.com/guardian/play-secret-rotation

The cloudformation for the Guardian's instance of Riff-Raff isn't in this repository, but an update to the EC2 instance IAM policy is also required, adding AWS Parameter Store and KMS permissions as defined in:

https://github.com/guardian/play-secret-rotation/tree/b6e646df/aws-parameterstore#play-server

### TODO before merge:

- [x] Create Play Application Secret in AWS Parameter Store 
- [x] Update CloudFormation Template
- [x] Check on CODE
- [x] CloudForm PROD
