### PR TITLE
[WIP] Enable lookup of Lambdas by tag when updating

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -12,6 +12,7 @@ import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest}
 import com.amazonaws.util.IOUtils
 import com.gu.management.Loggable
 import magenta.artifact._
+import magenta.deployment_type.{LambdaFunction, LambdaFunctionName, LambdaFunctionTags}
 import magenta.deployment_type.param_reads.PatternValue
 import okhttp3._
 
@@ -218,15 +219,25 @@ object ChangeSwitch {
   val client = new OkHttpClient()
 }
 
-case class UpdateS3Lambda(functionName: String, s3Bucket: String, s3Key: String, region: Region)(implicit val keyRing: KeyRing) extends Task {
-  def description = s"Updating $functionName Lambda using S3 $s3Bucket:$s3Key"
+case class UpdateS3Lambda(function: LambdaFunction, s3Bucket: String, s3Key: String, region: Region)(implicit val keyRing: KeyRing) extends Task {
+  def description = s"Updating $function Lambda using S3 $s3Bucket:$s3Key"
   def verbose = description
 
   override def execute(reporter: DeployReporter, stopFlag: => Boolean) {
     val client = Lambda.makeLambdaClient(keyRing, region)
-    reporter.verbose(s"Starting update $functionName Lambda")
+
+    val functionName: String = function match {
+      case LambdaFunctionName(name) => name
+      case LambdaFunctionTags(tags) =>
+        val functionConfig = Lambda.findFunctionByTags(tags, reporter, client)
+        functionConfig.map(_.getFunctionName).getOrElse{
+          reporter.fail(s"Failed to find any function with tags $tags")
+        }
+    }
+
+    reporter.verbose(s"Starting update $function Lambda")
     client.updateFunctionCode(Lambda.lambdaUpdateFunctionCodeRequest(functionName, s3Bucket, s3Key))
-    reporter.verbose(s"Finished update $functionName Lambda")
+    reporter.verbose(s"Finished update $function Lambda")
   }
 
 }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -135,7 +135,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
     val p = DeploymentPackage("myapp", app1, data, "aws-lambda", S3Path("artifact-bucket", "test/123"), deploymentTypes)
 
     Lambda.actionsMap("updateLambda").taskGenerator(p, DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), stack, region)) should be (
-      List(UpdateS3Lambda("myLambda", "artifact-bucket", "test-stack/CODE/the_role/lambda.zip", defaultRegion)
+      List(UpdateS3Lambda(LambdaFunctionName("myLambda"), "artifact-bucket", "test-stack/CODE/the_role/lambda.zip", defaultRegion)
       ))
   }
 
@@ -153,7 +153,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
 
     val thrown = the[FailException] thrownBy {
       Lambda.actionsMap("updateLambda").taskGenerator(p, DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), stack, region)) should be (
-        List(UpdateS3Lambda("myLambda", "artifact-bucket", "test-stack/CODE/the_role/lambda.zip", defaultRegion)
+        List(UpdateS3Lambda(LambdaFunctionName("myLambda"), "artifact-bucket", "test-stack/CODE/the_role/lambda.zip", defaultRegion)
         ))
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val aws = "1.11.106"
+    val aws = "1.11.358"
     val guardianManagement = "5.37"
     val jackson = "2.8.2"
     // keep in sync with plugin


### PR DESCRIPTION
This is a work in progress PR to enable deploying to lambdas that are identified using tags.

At present none of the Riff-Raff users have the right permissions, so this will not work.