### PR TITLE
Remove old riff-raff artifacts that are not used

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import Helpers._
 val commonSettings = Seq(
   organization := "com.gu",
   scalaVersion := "2.12.2",
-  scalacOptions ++= Seq("-deprecation", "-feature","-language:postfixOps,reflectiveCalls,implicitConversions"
+  scalacOptions ++= Seq("-deprecation", "-feature", "-language:postfixOps,reflectiveCalls,implicitConversions", "-Ypartial-unification"
 //    , "-Xfatal-warnings" TODO: Akka Agents have been deprecated. Once they have been replaced we can re-enable, but that's not trivial
   ),
   scalacOptions in(Compile, doc) ++= Seq(

--- a/magenta-lib/src/test/scala/magenta/deployment_type/ParamTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/ParamTest.scala
@@ -29,7 +29,7 @@ class ParamTest extends FlatSpec with Matchers with MockitoSugar {
     val param = Param[String]("test")
 
     register.paramsList.size shouldBe 1
-    register.paramsList should contain("test" -> param)
+    register.paramsList shouldBe Map("test" -> param)
   }
 
   it should "extract a value from a package using get" in {

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentResolverTest.scala
@@ -20,8 +20,8 @@ class DeploymentResolverTest extends FlatSpec with Matchers with ValidatedValues
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (1)
-    deployments.head should have (
+    deployments.size should be(1)
+    deployments.head should have(
       'type ("testType"),
       'stacks (NEL.of("testStack")),
       'regions (NEL.of("eu-west-1")),
@@ -46,8 +46,8 @@ class DeploymentResolverTest extends FlatSpec with Matchers with ValidatedValues
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (1)
-    deployments.head should have (
+    deployments.size should be(1)
+    deployments.head should have(
       'type ("testType"),
       'stacks (NEL.of("stack1", "stack2")),
       'regions (NEL.of("oceania-south-1")),
@@ -75,8 +75,8 @@ class DeploymentResolverTest extends FlatSpec with Matchers with ValidatedValues
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (1)
-    deployments.head should have (
+    deployments.size should be(1)
+    deployments.head should have(
       'type ("testType"),
       'stacks (NEL.of("testStack")),
       'regions (NEL.of("eurasia-north-1")),
@@ -106,8 +106,8 @@ class DeploymentResolverTest extends FlatSpec with Matchers with ValidatedValues
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (1)
-    deployments.head should have (
+    deployments.size should be(1)
+    deployments.head should have(
       'type ("testType"),
       'stacks (NEL.of("testStack")),
       'regions (NEL.of("eu-west-1")),
@@ -136,7 +136,7 @@ class DeploymentResolverTest extends FlatSpec with Matchers with ValidatedValues
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (1)
+    deployments.size should be(1)
     deployments.head should have(
       'stacks (NEL.of("deployment-stack")),
       'regions (NEL.of("deployment-region"))
@@ -159,7 +159,7 @@ class DeploymentResolverTest extends FlatSpec with Matchers with ValidatedValues
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (1)
+    deployments.size should be(1)
     deployments.head should have(
       'stacks (NEL.of("template-stack")),
       'regions (NEL.of("template-region"))
@@ -180,7 +180,7 @@ class DeploymentResolverTest extends FlatSpec with Matchers with ValidatedValues
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (1)
+    deployments.size should be(1)
     deployments.head should have(
       'stacks (NEL.of("global-stack")),
       'regions (NEL.of("global-region"))
@@ -206,7 +206,7 @@ class DeploymentResolverTest extends FlatSpec with Matchers with ValidatedValues
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (1)
+    deployments.size should be(1)
     deployments.head should have(
       'stacks (NEL.of("nested-template-stack")),
       'regions (NEL.of("template-region"))
@@ -242,15 +242,17 @@ class DeploymentResolverTest extends FlatSpec with Matchers with ValidatedValues
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (1)
+    deployments.size should be(1)
     val deployment = deployments.head
     deployment.parameters.size should be(6)
-    deployment.parameters should contain("nestedParameter" -> JsNumber(1984))
-    deployment.parameters should contain("templateParameter" -> JsNumber(2016))
-    deployment.parameters should contain("deploymentParameter" -> JsNumber(1234))
-    deployment.parameters should contain("commonParameter" -> JsString("template"))
-    deployment.parameters should contain("allParameter" -> JsString("deployment"))
-    deployment.parameters should contain("sandwichParameter" -> JsString("deployment"))
+    deployment.parameters shouldBe Map(
+      "nestedParameter" -> JsNumber(1984),
+      "templateParameter" -> JsNumber(2016),
+      "deploymentParameter" -> JsNumber(1234),
+      "commonParameter" -> JsString("template"),
+      "allParameter" -> JsString("deployment"),
+      "sandwichParameter" -> JsString("deployment")
+    )
   }
 
   it should "not default actions, app and contentDirectory if specified in template" in {
@@ -270,7 +272,7 @@ class DeploymentResolverTest extends FlatSpec with Matchers with ValidatedValues
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (1)
+    deployments.size should be(1)
     deployments.head should have(
       'app ("templateApp"),
       'actions (Some(NEL.of("templateAction"))),
@@ -303,7 +305,7 @@ class DeploymentResolverTest extends FlatSpec with Matchers with ValidatedValues
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (4)
+    deployments.size should be(4)
     val deployment = deployments.find(_.name == "test").get
     deployment.dependencies should be(List("deployment-dep"))
   }
@@ -330,7 +332,7 @@ class DeploymentResolverTest extends FlatSpec with Matchers with ValidatedValues
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (3)
+    deployments.size should be(3)
     val deployment = deployments.find(_.name == "test").get
     deployment.dependencies should be(List("template-dep"))
   }
@@ -354,7 +356,7 @@ class DeploymentResolverTest extends FlatSpec with Matchers with ValidatedValues
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val deployments = yaml.andThen(DeploymentResolver.resolve).valid
-    deployments.size should be (2)
+    deployments.size should be(2)
     val deployment = deployments.find(_.name == "test").get
     deployment.dependencies should be(List("nested-dep"))
   }
@@ -376,7 +378,7 @@ class DeploymentResolverTest extends FlatSpec with Matchers with ValidatedValues
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val configErrors = yaml.andThen(DeploymentResolver.resolve).invalid
-    configErrors.errors.toList.size should be (1)
+    configErrors.errors.toList.size should be(1)
     configErrors.errors.head should be(ConfigError("test", "Template with name nonExistentTemplate does not exist"))
   }
 
@@ -392,7 +394,7 @@ class DeploymentResolverTest extends FlatSpec with Matchers with ValidatedValues
       """.stripMargin
     val yaml = RiffRaffYamlReader.fromString(yamlString)
     val configErrors = yaml.andThen(DeploymentResolver.resolve).invalid
-    configErrors.errors.toList.size should be (1)
+    configErrors.errors.toList.size should be(1)
     configErrors.errors.head should be(ConfigError("test", "Missing deployment dependencies missing-dep"))
 
   }

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -73,7 +73,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
   val deployments = new Deployments(deploymentEngine, builds)
   val continuousDeployment = new ContinuousDeployment(buildPoller, deployments)
   val previewCoordinator = new PreviewCoordinator(prismLookup, availableDeploymentTypes)
-  val housekeeper = new ArtifactHousekeeping(deployments)
+  val artifactHousekeeper = new ArtifactHousekeeping(deployments)
 
   val authAction = new AuthAction[AnyContent](
     conf.Configuration.auth.googleAuthConfig, routes.Login.loginAction(), controllerComponents.parsers.default)(executionContext)
@@ -110,7 +110,8 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
     SummariseDeploysHousekeeping,
     continuousDeployment,
     managementServer,
-    shutdownWhenInactive
+    shutdownWhenInactive,
+    artifactHousekeeper
   )
 
   log.info(s"Calling init() on Lifecycle singletons: ${lifecycleSingletons.map(_.getClass.getName).mkString(", ")}")
@@ -136,7 +137,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
   val scheduleController = new ScheduleController(authAction, controllerComponents, prismLookup, deployScheduler)
   val targetController = new TargetController(deployments, authAction, controllerComponents)
   val loginController = new Login(deployments, controllerComponents, authAction)
-  val testingController = new Testing(prismLookup, authAction, controllerComponents, housekeeper)
+  val testingController = new Testing(prismLookup, authAction, controllerComponents, artifactHousekeeper)
 
   override lazy val httpErrorHandler = new DefaultHttpErrorHandler(environment, configuration, sourceMapper, Some(router)) {
     override def onServerError(request: RequestHeader, t: Throwable): Future[Result] = {

--- a/riff-raff/app/AppLoader.scala
+++ b/riff-raff/app/AppLoader.scala
@@ -19,39 +19,6 @@ class AppLoader extends ApplicationLoader {
 
     val components = new AppComponents(context)
 
-    val hooksClient = new HooksClient(components.wsClient, components.executionContext)
-    val shutdownWhenInactive = new ShutdownWhenInactive(components.deployments)
-
-    // the management server takes care of shutting itself down with a lifecycle hook
-    val management = new conf.Management(shutdownWhenInactive, components.deployments)
-    val managementServer = new RiffRaffManagementServer(management.applicationName, management.pages, Logger("ManagementServer"))
-
-    val lifecycleSingletons = Seq(
-      ScheduledAgent,
-      components.deployments,
-      components.builds,
-      components.targetResolver,
-      DeployMetrics,
-      hooksClient,
-      SummariseDeploysHousekeeping,
-      components.continuousDeployment,
-      managementServer,
-      shutdownWhenInactive
-    )
-
-    Logger.info(s"Calling init() on Lifecycle singletons: ${lifecycleSingletons.map(_.getClass.getName).mkString(", ")}")
-    lifecycleSingletons.foreach(_.init())
-
-    context.lifecycle.addStopHook(() => Future {
-      lifecycleSingletons.reverse.foreach { singleton =>
-        try {
-          singleton.shutdown()
-        } catch {
-          case NonFatal(e) => Logger.error("Caught unhandled exception whilst calling shutdown() on Lifecycle singleton", e)
-        }
-      }
-    }(ExecutionContext.global))
-
     components.application
   }
 

--- a/riff-raff/app/AppLoader.scala
+++ b/riff-raff/app/AppLoader.scala
@@ -1,14 +1,5 @@
-import conf.DeployMetrics
-import lifecycle.ShutdownWhenInactive
-import notification.HooksClient
-import persistence.SummariseDeploysHousekeeping
 import play.api.ApplicationLoader.Context
-import play.api.{Application, ApplicationLoader, Logger, LoggerConfigurator}
-import riffraff.RiffRaffManagementServer
-import utils.ScheduledAgent
-
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.control.NonFatal
+import play.api.{Application, ApplicationLoader, LoggerConfigurator}
 
 class AppLoader extends ApplicationLoader {
 

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -124,6 +124,19 @@ class Configuration(val application: String, val webappConfDirectory: String = "
     lazy val summariseDeploysAfterDays = configuration.getIntegerProperty("housekeeping.summariseDeploysAfterDays", 90)
     lazy val hour = configuration.getIntegerProperty("housekeeping.hour", 4)
     lazy val minute = configuration.getIntegerProperty("housekeeping.minute", 0)
+    object tagOldArtifacts {
+      lazy val enabled = configuration.getStringProperty("housekeeping.tagOldArtifacts.enabled", "false") == "true"
+      lazy val tagKey = configuration.getStringProperty("housekeeping.tagOldArtifacts.tagKey", "housekeeping")
+      lazy val tagValue = configuration.getStringProperty("housekeeping.tagOldArtifacts.tagValue", "delete")
+      // this should be a few days longer than the expiration age of the riffraff-builds bucket (28 days by default)
+      //  so that it is less likely that a user will try and deploy a build that has since been removed
+      lazy val minimumAgeDays = configuration.getIntegerProperty("housekeeping.tagOldArtifacts.minimumAgeDay", 40)
+      // the number to scan (we look at this number of most recent deploys to figure out what to keep, anything older
+      // than this will not be considered)
+      lazy val numberToScan = configuration.getIntegerProperty("housekeeping.tagOldArtifacts.numberToScan", 50)
+      // the number of artifacts to keep per stage
+      lazy val numberToKeep = configuration.getIntegerProperty("housekeeping.tagOldArtifacts.numberToKeep", 5)
+    }
   }
 
   object logging {

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -125,6 +125,9 @@ class Configuration(val application: String, val webappConfDirectory: String = "
     lazy val hour = configuration.getIntegerProperty("housekeeping.hour", 4)
     lazy val minute = configuration.getIntegerProperty("housekeeping.minute", 0)
     object tagOldArtifacts {
+      lazy val hourOfDay = configuration.getIntegerProperty("housekeeping.tagOldArtifacts.hourOfDay", 2)
+      lazy val minuteOfHour = configuration.getIntegerProperty("housekeeping.tagOldArtifacts.minuteOfHour", 0)
+
       lazy val enabled = configuration.getStringProperty("housekeeping.tagOldArtifacts.enabled", "false") == "true"
       lazy val tagKey = configuration.getStringProperty("housekeeping.tagOldArtifacts.tagKey", "housekeeping")
       lazy val tagValue = configuration.getStringProperty("housekeeping.tagOldArtifacts.tagValue", "delete")

--- a/riff-raff/app/controllers/Testing.scala
+++ b/riff-raff/app/controllers/Testing.scala
@@ -31,13 +31,6 @@ class Testing(prismLookup: PrismLookup,
   extends BaseController with Logging with I18nSupport with LogAndSquashBehaviour {
   import Testing._
 
-  def doHousekeeping = authAction { implicit request =>
-    Future{
-      houseKeeping.housekeepArtifacts(new DateTime())
-    }(scala.concurrent.ExecutionContext.Implicits.global)
-    Ok("Kicked off housekeeping")
-  }
-
   def reportTestPartial(take: Int, verbose: Boolean) = Action { implicit request =>
     val logUUID = UUID.randomUUID()
     val parameters = DeployParameters(Deployer("Simon Hildrew"), Build("tools::deploy", "131"), Stage("DEV"), All)

--- a/riff-raff/app/controllers/Testing.scala
+++ b/riff-raff/app/controllers/Testing.scala
@@ -17,6 +17,7 @@ import play.api.i18n.I18nSupport
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import resources.PrismLookup
+import utils.LogAndSquashBehaviour
 
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.Future
@@ -27,7 +28,7 @@ class Testing(prismLookup: PrismLookup,
               authAction: AuthAction[AnyContent],
               val controllerComponents: ControllerComponents,
               houseKeeping: ArtifactHousekeeping)(implicit val wsClient: WSClient)
-  extends BaseController with Logging with I18nSupport {
+  extends BaseController with Logging with I18nSupport with LogAndSquashBehaviour {
   import Testing._
 
   def doHousekeeping = authAction { implicit request =>
@@ -127,7 +128,7 @@ class Testing(prismLookup: PrismLookup,
   def S3LatencyList(limit:Int, csv: Boolean) = authAction { implicit request =>
     val filter = DeployFilter.fromRequest
     val pagination = PaginationView.fromRequest
-    val allDeploys = DocumentStoreConverter.getDeployList(filter, pagination, fetchLog = true)
+    val allDeploys = DocumentStoreConverter.getDeployList(filter, pagination, fetchLog = true).logAndSquashException(Nil)
     val times = allDeploys.map { deploy =>
       val taskRunLines = deploy.messages.flatMap { message =>
         message.stack.top match {

--- a/riff-raff/app/deployment/Deployments.scala
+++ b/riff-raff/app/deployment/Deployments.scala
@@ -188,12 +188,13 @@ class Deployments(deploymentEngine: DeploymentEngine, builds: Builds)(implicit v
     }
   }
   def getControllerDeploys: Iterable[Record] = { library().values.map{ _() } }
-  def getDatastoreDeploys(filter:Option[DeployFilter] = None, pagination: PaginationView, fetchLogs: Boolean): Iterable[Record] =
+  def getDatastoreDeploys(filter:Option[DeployFilter] = None, pagination: PaginationView, fetchLogs: Boolean): Either[Throwable, List[Record]] = {
     DocumentStoreConverter.getDeployList(filter, pagination, fetchLogs)
+  }
 
-  def getDeploys(filter:Option[DeployFilter] = None, pagination: PaginationView = PaginationView(), fetchLogs: Boolean = false): List[Record] = {
+  def getDeploys(filter:Option[DeployFilter] = None, pagination: PaginationView = PaginationView(), fetchLogs: Boolean = false): Either[Throwable, List[Record]] = {
     require(!fetchLogs || pagination.pageSize.isDefined, "Too much effort required to fetch complete record with no pagination")
-    getDatastoreDeploys(filter, pagination, fetchLogs=fetchLogs).toList.sortWith{ _.time.getMillis < _.time.getMillis }
+    getDatastoreDeploys(filter, pagination, fetchLogs=fetchLogs).map(_.sortWith{ _.time.getMillis < _.time.getMillis })
   }
 
   def getLastCompletedDeploys(project: String): Map[String, Record] = {

--- a/riff-raff/app/housekeeping/ArtifactHousekeeping.scala
+++ b/riff-raff/app/housekeeping/ArtifactHousekeeping.scala
@@ -6,6 +6,7 @@ import conf.Configuration
 import controllers.Logging
 import deployment.{DeployFilter, Deployments, PaginationView}
 import lifecycle.Lifecycle
+import magenta.RunState
 import org.joda.time.{DateTime, Duration, LocalTime}
 import utils.{DailyScheduledAgentUpdate, ScheduledAgent}
 
@@ -69,7 +70,7 @@ class ArtifactHousekeeping(deployments: Deployments) extends Logging with Lifecy
   def getBuildIdsToKeep(projectName: String): Either[Throwable, List[String]] = {
     for {
       deployList <- deployments.getDeploys(
-        filter = Some(DeployFilter(projectName = Some(s"^$projectName$$"))),
+        filter = Some(DeployFilter(projectName = Some(s"^$projectName$$"), status = Some(RunState.Completed))),
         pagination = PaginationView(pageSize = Some(Configuration.housekeeping.tagOldArtifacts.numberToScan))
       )
     } yield {

--- a/riff-raff/app/housekeeping/ArtifactHousekeeping.scala
+++ b/riff-raff/app/housekeeping/ArtifactHousekeeping.scala
@@ -1,0 +1,107 @@
+package housekeeping
+
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.{ListObjectsV2Request, ObjectTagging, SetObjectTaggingRequest, Tag}
+import com.gu.management.Loggable
+import conf.Configuration
+import deployment.{DeployFilter, Deployments, PaginationView}
+import org.joda.time.{DateTime, Duration}
+
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+
+class ArtifactHousekeeping(deployments: Deployments) extends Loggable {
+  private val s3Client = Configuration.artifact.aws.client
+  private val artifactBucketName = Configuration.artifact.aws.bucketName
+  private val NUMBER_OF_ARTIFACTS_TO_KEEP = 5
+  private val MINIMUM_ARTIFACT_AGE_DAYS = 40
+
+  @tailrec
+  private def pagedAwsRequest[T](continuationToken: Option[String] = None, acc: List[T] = Nil)(f: Option[String] => (List[T], Option[String])): List[T] = {
+    val (values: List[T], nextToken: Option[String]) = f(continuationToken)
+    val ts = acc ::: values
+    nextToken match {
+      case token @ Some(_) => pagedAwsRequest(token, ts)(f)
+      case None => ts
+    }
+  }
+
+  def getProjectNames(client: AmazonS3, bucket: String) = {
+    pagedAwsRequest(){ token =>
+      val request = new ListObjectsV2Request()
+        .withDelimiter("/")
+        .withBucketName(artifactBucketName)
+        .withContinuationToken(token.orNull)
+      val result = client.listObjectsV2(request)
+      result.getCommonPrefixes.asScala.toList.map(_.stripSuffix("/")) -> Option(result.getNextContinuationToken)
+    }
+  }
+
+  def getBuildIds(client: AmazonS3, bucket: String, projectName: String) = {
+    val prefix = s"$projectName/"
+    pagedAwsRequest(){ token =>
+      val request = new ListObjectsV2Request()
+        .withDelimiter("/")
+        .withBucketName(artifactBucketName)
+        .withPrefix(prefix)
+        .withContinuationToken(token.orNull)
+      val result = client.listObjectsV2(request)
+      result.getCommonPrefixes.asScala.toList.map(_.stripPrefix(prefix).stripSuffix("/")) -> Option(result.getNextContinuationToken)
+    }
+  }
+
+  def getBuildIdsToKeep(projectName: String) = {
+    val deployList = deployments.getDeploys(
+      filter = Some(DeployFilter(projectName = Some(s"^$projectName$$"))),
+      pagination = PaginationView(pageSize=Some(50))
+    )
+    val perStageDeploys = deployList.groupBy(_.stage).values
+    val deploysToKeep = perStageDeploys.flatMap(_.sortBy(-_.time.getMillis).take(NUMBER_OF_ARTIFACTS_TO_KEEP))
+    deploysToKeep.map(_.buildId)
+  }
+
+  def cleanUpTheBuilds(client: AmazonS3, bucket: String, projectName: String, buildsToDelete: Set[String], now: DateTime): Unit = {
+    val tag = new ObjectTagging(List(new Tag("housekeeping", "delete")).asJava)
+    buildsToDelete.foreach { buildId =>
+      logger.info(s"Tagging build ID $buildId")
+      val objects = pagedAwsRequest() { token =>
+        val request = new ListObjectsV2Request()
+          .withDelimiter("/")
+          .withBucketName(artifactBucketName)
+          .withPrefix(s"$projectName/$buildId/")
+          .withContinuationToken(token.orNull)
+        val result = client.listObjectsV2(request)
+        result.getObjectSummaries.asScala.toList -> Option(result.getNextContinuationToken)
+      }
+
+      val objectsToTag = objects.filter { obj =>
+        val age = new Duration(new DateTime(obj.getLastModified), now)
+        age.getStandardDays > MINIMUM_ARTIFACT_AGE_DAYS
+      }
+
+      objectsToTag.foreach { obj =>
+        logger.info(s"Tagging ${obj.getKey}")
+        val request = new SetObjectTaggingRequest(bucket, obj.getKey, tag)
+        client.setObjectTagging(request)
+      }
+      Thread.sleep(500)
+    }
+  }
+
+  def housekeepArtifacts(now: DateTime) = {
+    logger.info("Running housekeeping")
+    val projectNames = getProjectNames(s3Client, artifactBucketName)
+    projectNames.foreach { name =>
+      logger.info(s"Housekeeping project '$name'")
+      val buildIdsForProject = getBuildIds(s3Client, artifactBucketName, name).toSet
+      val buildIdsToKeep = getBuildIdsToKeep(name).toSet
+      val missingBuilds = buildIdsToKeep -- buildIdsForProject
+      if (missingBuilds.nonEmpty) {
+        logger.error("Some builds we wanted to keep were not found, possible something is awry.")
+      } else {
+        val buildsToDelete = buildIdsForProject -- buildIdsToKeep
+        cleanUpTheBuilds(s3Client, artifactBucketName, name, buildsToDelete, now)
+      }
+    }
+  }
+}

--- a/riff-raff/app/housekeeping/ArtifactHousekeeping.scala
+++ b/riff-raff/app/housekeeping/ArtifactHousekeeping.scala
@@ -10,12 +10,7 @@ import org.joda.time.{DateTime, Duration}
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 
-class ArtifactHousekeeping(deployments: Deployments) extends Loggable {
-  private val s3Client = Configuration.artifact.aws.client
-  private val artifactBucketName = Configuration.artifact.aws.bucketName
-  private val NUMBER_OF_ARTIFACTS_TO_KEEP = 5
-  private val MINIMUM_ARTIFACT_AGE_DAYS = 40
-
+object ArtifactHousekeeping {
   @tailrec
   private def pagedAwsRequest[T](continuationToken: Option[String] = None, acc: List[T] = Nil)(f: Option[String] => (List[T], Option[String])): List[T] = {
     val (values: List[T], nextToken: Option[String]) = f(continuationToken)
@@ -30,7 +25,7 @@ class ArtifactHousekeeping(deployments: Deployments) extends Loggable {
     pagedAwsRequest(){ token =>
       val request = new ListObjectsV2Request()
         .withDelimiter("/")
-        .withBucketName(artifactBucketName)
+        .withBucketName(bucket)
         .withContinuationToken(token.orNull)
       val result = client.listObjectsV2(request)
       result.getCommonPrefixes.asScala.toList.map(_.stripSuffix("/")) -> Option(result.getNextContinuationToken)
@@ -42,29 +37,35 @@ class ArtifactHousekeeping(deployments: Deployments) extends Loggable {
     pagedAwsRequest(){ token =>
       val request = new ListObjectsV2Request()
         .withDelimiter("/")
-        .withBucketName(artifactBucketName)
+        .withBucketName(bucket)
         .withPrefix(prefix)
         .withContinuationToken(token.orNull)
       val result = client.listObjectsV2(request)
       result.getCommonPrefixes.asScala.toList.map(_.stripPrefix(prefix).stripSuffix("/")) -> Option(result.getNextContinuationToken)
     }
   }
+}
+
+class ArtifactHousekeeping(deployments: Deployments) extends Loggable {
+  private val s3Client = Configuration.artifact.aws.client
+  private val artifactBucketName = Configuration.artifact.aws.bucketName
 
   def getBuildIdsToKeep(projectName: String) = {
     val deployList = deployments.getDeploys(
       filter = Some(DeployFilter(projectName = Some(s"^$projectName$$"))),
-      pagination = PaginationView(pageSize=Some(50))
+      pagination = PaginationView(pageSize=Some(Configuration.housekeeping.tagOldArtifacts.numberToScan))
     )
     val perStageDeploys = deployList.groupBy(_.stage).values
-    val deploysToKeep = perStageDeploys.flatMap(_.sortBy(-_.time.getMillis).take(NUMBER_OF_ARTIFACTS_TO_KEEP))
+    val deploysToKeep = perStageDeploys.flatMap(_.sortBy(-_.time.getMillis).take(Configuration.housekeeping.tagOldArtifacts.numberToKeep))
     deploysToKeep.map(_.buildId)
   }
 
   def cleanUpTheBuilds(client: AmazonS3, bucket: String, projectName: String, buildsToDelete: Set[String], now: DateTime): Unit = {
-    val tag = new ObjectTagging(List(new Tag("housekeeping", "delete")).asJava)
+    val tag = new Tag(Configuration.housekeeping.tagOldArtifacts.tagKey, Configuration.housekeeping.tagOldArtifacts.tagValue)
+    val taggingObj = new ObjectTagging(List(tag).asJava)
     buildsToDelete.foreach { buildId =>
       logger.info(s"Tagging build ID $buildId")
-      val objects = pagedAwsRequest() { token =>
+      val objects = ArtifactHousekeeping.pagedAwsRequest() { token =>
         val request = new ListObjectsV2Request()
           .withDelimiter("/")
           .withBucketName(artifactBucketName)
@@ -76,12 +77,12 @@ class ArtifactHousekeeping(deployments: Deployments) extends Loggable {
 
       val objectsToTag = objects.filter { obj =>
         val age = new Duration(new DateTime(obj.getLastModified), now)
-        age.getStandardDays > MINIMUM_ARTIFACT_AGE_DAYS
+        age.getStandardDays > Configuration.housekeeping.tagOldArtifacts.minimumAgeDays
       }
 
       objectsToTag.foreach { obj =>
         logger.info(s"Tagging ${obj.getKey}")
-        val request = new SetObjectTaggingRequest(bucket, obj.getKey, tag)
+        val request = new SetObjectTaggingRequest(bucket, obj.getKey, taggingObj)
         client.setObjectTagging(request)
       }
       Thread.sleep(500)
@@ -89,19 +90,23 @@ class ArtifactHousekeeping(deployments: Deployments) extends Loggable {
   }
 
   def housekeepArtifacts(now: DateTime) = {
-    logger.info("Running housekeeping")
-    val projectNames = getProjectNames(s3Client, artifactBucketName)
-    projectNames.foreach { name =>
-      logger.info(s"Housekeeping project '$name'")
-      val buildIdsForProject = getBuildIds(s3Client, artifactBucketName, name).toSet
-      val buildIdsToKeep = getBuildIdsToKeep(name).toSet
-      val missingBuilds = buildIdsToKeep -- buildIdsForProject
-      if (missingBuilds.nonEmpty) {
-        logger.error("Some builds we wanted to keep were not found, possible something is awry.")
-      } else {
-        val buildsToDelete = buildIdsForProject -- buildIdsToKeep
-        cleanUpTheBuilds(s3Client, artifactBucketName, name, buildsToDelete, now)
+    if (Configuration.housekeeping.tagOldArtifacts.enabled) {
+      logger.info("Running housekeeping")
+      val projectNames = ArtifactHousekeeping.getProjectNames(s3Client, artifactBucketName)
+      projectNames.foreach { name =>
+        logger.info(s"Housekeeping project '$name'")
+        val buildIdsForProject = ArtifactHousekeeping.getBuildIds(s3Client, artifactBucketName, name).toSet
+        val buildIdsToKeep = getBuildIdsToKeep(name).toSet
+        val missingBuilds = buildIdsToKeep -- buildIdsForProject
+        if (missingBuilds.nonEmpty) {
+          logger.error("Some builds we wanted to keep were not found, possible something is awry.")
+        } else {
+          val buildsToDelete = buildIdsForProject -- buildIdsToKeep
+          cleanUpTheBuilds(s3Client, artifactBucketName, name, buildsToDelete, now)
+        }
       }
+    } else {
+      logger.info("Artifact housekeeping not enabled - skipping")
     }
   }
 }

--- a/riff-raff/app/persistence/mongodb.scala
+++ b/riff-raff/app/persistence/mongodb.scala
@@ -14,6 +14,7 @@ import org.joda.time.{DateTime, Period}
 import com.mongodb.casbah.query.Imports._
 import com.mongodb.util.JSON
 import notification.HookConfig
+import cats.syntax.either._
 
 trait MongoSerialisable[A] {
 
@@ -206,7 +207,7 @@ class MongoDatastore(database: MongoDB) extends DataStore with DocumentStore wit
     }
   }
 
-  override def getDeploys(filter: Option[DeployFilter], pagination: PaginationView) = logAndSquashExceptions[Iterable[DeployRecordDocument]](None,Nil){
+  override def getDeploys(filter: Option[DeployFilter], pagination: PaginationView): Either[Throwable, Iterable[DeployRecordDocument]] = Either.catchNonFatal {
     val criteria = filter.map(_.criteria).getOrElse(MongoDBObject())
     val cursor = deployCollection.find(criteria).sort(MongoDBObject("startTime" -> -1)).pagination(pagination)
     cursor.toIterable.flatMap { DeployRecordDocument.fromDBO(_) }

--- a/riff-raff/app/schedule/DeployJob.scala
+++ b/riff-raff/app/schedule/DeployJob.scala
@@ -6,6 +6,7 @@ import deployment._
 import magenta.{Deployer, DeployParameters, RunState}
 import org.quartz.{Job, JobDataMap, JobExecutionContext}
 import schedule.DeployScheduler.JobDataKeys
+import utils.LogAndSquashBehaviour
 
 import scala.annotation.tailrec
 import scala.util.Try
@@ -31,7 +32,7 @@ class DeployJob extends Job with Logging {
   }
 }
 
-object DeployJob {
+object DeployJob extends Logging with LogAndSquashBehaviour {
   def createDeployParameters(lastDeploy: Record, scheduledDeploysEnabled: Boolean): Either[Error, DeployParameters] = {
     lastDeploy.state match {
       case RunState.Completed =>
@@ -61,7 +62,7 @@ object DeployJob {
       )
       val pagination = PaginationView().withPageSize(Some(1))
 
-      val result = Try(deployments.getDeploys(Some(filter), pagination).headOption).toOption.flatten
+      val result = Try(deployments.getDeploys(Some(filter), pagination).logAndSquashException(Nil).headOption).toOption.flatten
       result match {
         case Some(record) => Right(record)
         case None =>

--- a/riff-raff/app/utils/LogAndSquashBehaviour.scala
+++ b/riff-raff/app/utils/LogAndSquashBehaviour.scala
@@ -1,0 +1,19 @@
+package utils
+
+import play.api.Logger
+
+trait LogAndSquashBehaviour {
+  val log: Logger
+
+  implicit class RichEitherThrowable[T](either: Either[Throwable, T]) {
+    def logAndSquashException(default: T, message: Option[String] = None): T = {
+      either match {
+        case Right(t) => t
+        case Left(throwable) =>
+          val errorMessage = "Squashing uncaught exception%s" format message.map("whilst %s" format _).getOrElse("")
+          log.error(errorMessage, throwable)
+          default
+      }
+    }
+  }
+}

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -119,7 +119,6 @@ GET         /testing/view/:uuid                             controllers.Testing.
 GET         /testing/addStringUUID                          controllers.Testing.transferAllUUIDs
 GET         /testing/testcharset                            controllers.Testing.testcharset
 GET         /testing/deployinfo                             controllers.Testing.hosts
-GET         /testing/doHousekeeping                         controllers.Testing.doHousekeeping
 GET         /builds                                         controllers.DeployController.builds
 
 # Javascript routing

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -119,6 +119,7 @@ GET         /testing/view/:uuid                             controllers.Testing.
 GET         /testing/addStringUUID                          controllers.Testing.transferAllUUIDs
 GET         /testing/testcharset                            controllers.Testing.testcharset
 GET         /testing/deployinfo                             controllers.Testing.hosts
+GET         /testing/doHousekeeping                         controllers.Testing.doHousekeeping
 GET         /builds                                         controllers.DeployController.builds
 
 # Javascript routing

--- a/riff-raff/test/housekeeping/ArtifactHousekeepingTest.scala
+++ b/riff-raff/test/housekeeping/ArtifactHousekeepingTest.scala
@@ -133,38 +133,4 @@ class ArtifactHousekeepingTest extends FlatSpec with Matchers with MockitoSugar 
     verify(artifactClientMock, times(1)).listObjectsV2(any[ListObjectsV2Request])
     result.map(_.getKey) shouldEqual List("object-x0", "object-x1", "object-x2")
   }
-
-  "tagBuilds" should "not call setObjectTagging, and return zero when there are no builds to tag" in {
-    val artifactClientMock: AmazonS3 = mock[AmazonS3Client]
-    val deploymentsMock = mock[Deployments]
-    val artifactHousekeeping = new ArtifactHousekeeping(deploymentsMock)
-
-    when(artifactClientMock.listObjectsV2(any[ListObjectsV2Request])) thenReturn mockListObjectsV2Result(List())
-
-    val result = artifactHousekeeping.tagBuilds(artifactClientMock, "bucket-name", "project-name", Set(), housekeepingDate)
-    verify(artifactClientMock, times(0)).setObjectTagging(any[SetObjectTaggingRequest])
-    result shouldEqual 0
-  }
-
-  it should "call setObjectTagging for each object, then return the number of builds that have been tagged" in {
-    val artifactClientMock: AmazonS3 = mock[AmazonS3Client]
-    val deploymentsMock = mock[Deployments]
-    val artifactHousekeeping = new ArtifactHousekeeping(deploymentsMock)
-
-    when(artifactClientMock.listObjectsV2(any[ListObjectsV2Request])) thenReturn mockListObjectsV2Result(
-      List(
-        ObjectSummary(s"object-1", "project-name", oldDate),
-        ObjectSummary(s"object-2", "project-name", oldDate)
-      ))
-
-    val result = artifactHousekeeping.tagBuilds(artifactClientMock, "bucket-name", "project-name", Set("11", "12"), housekeepingDate)
-    verify(artifactClientMock, times(4)).setObjectTagging(any[SetObjectTaggingRequest])
-    result shouldEqual 2
-  }
-
-  "ArtifactHousekeeping" should "do nothing and return zero if not enabled" in {
-    val deploymentsMock = mock[Deployments]
-    val artifactHousekeeping = new ArtifactHousekeeping(deploymentsMock)
-    artifactHousekeeping.housekeepArtifacts(housekeepingDate) shouldEqual 0
-  }
 }

--- a/riff-raff/test/housekeeping/ArtifactHousekeepingTest.scala
+++ b/riff-raff/test/housekeeping/ArtifactHousekeepingTest.scala
@@ -1,0 +1,102 @@
+package housekeeping
+
+import java.util.UUID
+
+import com.amazonaws.services.s3.model.{ListObjectsV2Request, ListObjectsV2Result}
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
+import deployment._
+import magenta.{Build, DeployParameters, Deployer, RunState, Stage}
+import org.joda.time.{DateTime, DateTimeZone}
+import org.mockito.Matchers.any
+import org.mockito.Mockito._
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.JavaConverters._
+
+class ArtifactHousekeepingTest extends FlatSpec with Matchers with MockitoSugar {
+
+  val oldDate = new DateTime(2018, 5, 12, 0, 0, 0, DateTimeZone.UTC)
+  val newDate = new DateTime(2018, 6, 20, 0, 0, 0, DateTimeZone.UTC)
+
+  def fixtureRecord(date: DateTime, stageName: String, buildNumber: String): Record = DeployRecord(
+    date,
+    UUID.fromString("7fa2ee0a-8d90-4f7e-a38b-185f36fbc5aa"),
+    DeployParameters(Deployer("anon"), Build("testProject", buildNumber), Stage(stageName)),
+    recordState = Some(RunState.Completed)
+  )
+
+  val oldDeploys: List[Record] = List.tabulate(6)(
+    n => fixtureRecord(oldDate.plusHours(n), "PROD", s"2$n")
+  ) ++ List.tabulate(6)(
+    n => fixtureRecord(oldDate.plusHours(n), "CODE", s"1$n")
+  )
+  val newDeploys: List[Record] = List.tabulate(6)(
+    n => fixtureRecord(newDate.plusHours(n), "PROD", s"1$n")
+  ) ++ List.tabulate(6)(
+    n => fixtureRecord(newDate.plusHours(n), "CODE", s"2$n")
+  )
+
+
+  "getProjectNames" should "make a single listObjectsV2 request and return the project names" in {
+    val artifactClientMock: AmazonS3 = mock[AmazonS3Client]
+    val listObjectsResult: ListObjectsV2Result = new ListObjectsV2Result()
+    listObjectsResult.setCommonPrefixes(List("project-name-1/", "project-name-2/", "project-name-3/").asJava)
+    when(artifactClientMock.listObjectsV2(any[ListObjectsV2Request])) thenReturn listObjectsResult
+
+    val result = ArtifactHousekeeping.getProjectNames(artifactClientMock, "bucket-name")
+    verify(artifactClientMock, times(1)).listObjectsV2(any[ListObjectsV2Request])
+    result shouldEqual List("project-name-1", "project-name-2", "project-name-3")
+  }
+
+  "getBuildIds" should "make a single listObjectsV2 request and return the build IDs" in {
+    val artifactClientMock: AmazonS3 = mock[AmazonS3Client]
+    val listObjectsResult: ListObjectsV2Result = new ListObjectsV2Result()
+    listObjectsResult.setCommonPrefixes(List("project-name/10/", "project-name/11/", "project-name/12/").asJava)
+    when(artifactClientMock.listObjectsV2(any[ListObjectsV2Request])) thenReturn listObjectsResult
+
+    val result = ArtifactHousekeeping.getBuildIds(artifactClientMock, "bucket-name", "project-name")
+    verify(artifactClientMock, times(1)).listObjectsV2(any[ListObjectsV2Request])
+    result shouldEqual List("10", "11", "12")
+  }
+
+  "getBuildIdsToKeep" should "find the most recent builds for each stage" in {
+    val deploymentsMock = mock[Deployments]
+    when (deploymentsMock.getDeploys(any[Option[DeployFilter]], any[PaginationView], any[Boolean])) thenReturn
+      Right(oldDeploys ++ newDeploys)
+
+    val result = ArtifactHousekeeping.getBuildIdsToKeep(deploymentsMock, "testProject")
+    val recentCodeDeploys = List("25", "24", "23", "22", "21")
+    val recentProdDeploys = List("15", "14", "13", "12", "11")
+    result shouldEqual Right(recentProdDeploys ++ recentCodeDeploys)
+
+  }
+
+  it should "find and keep the build irrespective of the buildNumber, if it has been recently deployed" in {
+    val deploymentsMock = mock[Deployments]
+    val oldBuildToProd = List(fixtureRecord(newDate.plusHours(23), "PROD", "10"))
+    when (deploymentsMock.getDeploys(any[Option[DeployFilter]], any[PaginationView], any[Boolean])) thenReturn
+      Right(oldDeploys ++ newDeploys ++ oldBuildToProd)
+
+    val result = ArtifactHousekeeping.getBuildIdsToKeep(deploymentsMock, "testProject")
+    val recentCodeDeploys = List("25", "24", "23", "22", "21")
+    val recentProdDeploys = List("10", "15", "14", "13", "12")
+    result shouldEqual Right(recentProdDeploys ++ recentCodeDeploys)
+  }
+
+  it should "find all the deploys if there are fewer than the configured limit" in {
+    val deploymentsMock = mock[Deployments]
+    val deploys = List(
+      fixtureRecord(oldDate, "PROD", "2"),
+      fixtureRecord(oldDate, "CODE", "3"),
+      fixtureRecord(oldDate, "CODE", "4"),
+      fixtureRecord(oldDate, "CODE", "5")
+    )
+    when (deploymentsMock.getDeploys(any[Option[DeployFilter]], any[PaginationView], any[Boolean])) thenReturn
+      Right(deploys)
+
+    val result = ArtifactHousekeeping.getBuildIdsToKeep(deploymentsMock, "testProject")
+    result shouldEqual Right(List("2", "3", "4", "5"))
+  }
+
+}


### PR DESCRIPTION
The aim of this PR is to delete old and unused Riff-Raff artifacts.

The strategy is:
 - list all of the project names in the root of the S3 bucket
 - for each project name
   - find builds we should keep:
     - query the riff-raff DB for the last 50 successful deploys of that project
     - find the most recent 5 for each stage in the results
     - make a list of builds to keep by combining the list above
   - tag builds that we don't want to keep:
     - get a complete list of all builds in the bucket
     - compute `allBuilds - buildsToKeep`
     - tag all objects under each `${project}/${buildId}` prefix
 - Modify the lifecycle policy on the artifact bucket to remove files that are older than 40 days **_AND_** tagged

TODO
------
 - [x] Set up configuration so this is only ever run in PROD (everywhere uses the PROD artifacts, but their own DB) - default off, switch on in PROD
 - [x] Set this up to run on a schedule
 - [x] Ensure it won't run multiple times
 - [x] Add a lifecycle policy that actually tidies up the files
 - [x] Check with @jorgeazevedo that he's not relying on the contents of the bucket
 - [x] Deal with DB errors
 - [x] Add some tests to convince ourselves that this won't delete active artifacts
 - [x] Check if we need to de-tag anything tagged during development and testing
 - [ ] Enable this feature in the PROD configuration file
 - [ ] Apply the lifecycle policy from https://github.com/guardian/deploy-tools-platform/pull/121