### PR TITLE
Skip tagging if the list of builds to keep is an empty list

### DIFF
--- a/riff-raff/app/housekeeping/ArtifactHousekeeping.scala
+++ b/riff-raff/app/housekeeping/ArtifactHousekeeping.scala
@@ -125,7 +125,7 @@ class ArtifactHousekeeping(deployments: Deployments) extends Logging with Lifecy
           case Left(_) =>
             log.warn(s"Failed to get list of builds to keep for project $name - not housekeeping this project")
             0
-          case Right(buildIdsToKeep) =>
+          case Right(buildIdsToKeep) if buildIdsToKeep.nonEmpty =>
             val buildIdsToKeepSet = buildIdsToKeep.toSet
             log.info(s"Keeping ${buildIdsToKeepSet.size} builds of $name (${buildIdsToKeepSet.toList.sorted})")
             val missingBuilds = buildIdsToKeepSet -- buildIdsForProject
@@ -136,6 +136,9 @@ class ArtifactHousekeeping(deployments: Deployments) extends Logging with Lifecy
               val buildsToTag = buildIdsForProject -- buildIdsToKeepSet
               tagBuilds(s3Client, artifactBucketName, name, buildsToTag, now)
             }
+          case Right(_) =>
+            log.error(s"List of builds to keep for project $name was empty, possible something is awry. Skipping tagging.")
+            0
         }
       }
       val numberOfTaggedBuilds = taggedBuilds.sum


### PR DESCRIPTION
Optional since maybe we do want to tag everything for deletion if a project has never been deployed?  

However, just in case the check on the builds to keep list returns an empty list rather than an error, maybe we want to skip tagging of it for now?

This did manage to happen on PROD last night:

`h.ArtifactHousekeeping - Keeping 0 builds of <projectName> (List())`

Discuss! 

..Either way, this probably needs to get merged and deployed to PROD before tonight 😈 🔥 🔥 

