### PR TITLE
Switch the Guardian github repo to HTTPS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val commonSettings = Seq(
   version := "1.0",
   resolvers ++= Seq(
     "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/",
-    "Guardian Github Releases" at "http://guardian.github.com/maven/repo-releases"
+    "Guardian Github Releases" at "https://guardian.github.io/maven/repo-releases"
   )
 )
 


### PR DESCRIPTION
Another repo that needs to be updated in order to compile now HTTP has been switched off.