### PR TITLE
Cleanup some MongoDB code before the big move

### DIFF
--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -210,12 +210,6 @@ class Configuration(val application: String, val webappConfDirectory: String = "
     }
   }
 
-  object target {
-    object aws {
-      lazy val deployJsonRegionName = configuration.getStringProperty("target.aws.deployJsonRegion", "eu-west-1")
-    }
-  }
-
   object deprecation {
     def pauseSeconds: Option[Int] = {
       val days = Days.daysBetween(new DateTime(2017,5,22,0,0,0), new DateTime()).getDays

--- a/riff-raff/app/persistence/datastore.scala
+++ b/riff-raff/app/persistence/datastore.scala
@@ -28,23 +28,35 @@ trait DataStore extends DocumentStore {
 
   def collectionStats:Map[String, CollectionStats] = Map.empty
 
-  def getAuthorisation(email: String): Option[AuthorisationRecord] = None
-  def getAuthorisationList:List[AuthorisationRecord] = Nil
-  def setAuthorisation(auth: AuthorisationRecord) {}
-  def deleteAuthorisation(email: String) {}
+  def getAuthorisation(email: String): Option[AuthorisationRecord]
+  def getAuthorisationList:List[AuthorisationRecord]
+  def setAuthorisation(auth: AuthorisationRecord): Unit
+  def deleteAuthorisation(email: String): Unit
 
-  def createApiKey(newKey: ApiKey) {}
-  def getApiKeyList:Iterable[ApiKey] = Nil
-  def getApiKey(key: String): Option[ApiKey] = None
-  def getAndUpdateApiKey(key: String, counter: Option[String] = None): Option[ApiKey] = None
-  def getApiKeyByApplication(application: String): Option[ApiKey] = None
-  def deleteApiKey(key: String) {}
-
+  def createApiKey(newKey: ApiKey): Unit
+  def getApiKeyList:Iterable[ApiKey]
+  def getApiKey(key: String): Option[ApiKey]
+  def getAndUpdateApiKey(key: String, counter: Option[String] = None): Option[ApiKey]
+  def getApiKeyByApplication(application: String): Option[ApiKey]
+  def deleteApiKey(key: String): Unit
 }
 
 object Persistence extends Logging {
 
-  object NoOpDataStore extends DataStore with Logging {}
+  object NoOpDataStore extends DataStore with Logging {
+    def getAuthorisation(email: String) = None
+    def getAuthorisationList = Nil
+    def setAuthorisation(auth: AuthorisationRecord) {}
+    def deleteAuthorisation(email: String) {}
+
+    def createApiKey(newKey: ApiKey) {}
+    def getApiKeyList = Nil
+    def getApiKey(key: String) = None
+    def getAndUpdateApiKey(key: String, counter: Option[String] = None) = None
+    def getApiKeyByApplication(application: String) = None
+    def deleteApiKey(key: String) {}
+
+  }
 
   lazy val store: DataStore = {
     val dataStore = MongoDatastore.buildDatastore().getOrElse(NoOpDataStore)

--- a/riff-raff/app/persistence/datastore.scala
+++ b/riff-raff/app/persistence/datastore.scala
@@ -40,9 +40,6 @@ trait DataStore extends DocumentStore {
   def getApiKeyByApplication(application: String): Option[ApiKey] = None
   def deleteApiKey(key: String) {}
 
-  def writeKey(key:String, value:String) {}
-  def readKey(key:String): Option[String] = None
-  def deleteKey(key: String) {}
 }
 
 object Persistence extends Logging {

--- a/riff-raff/app/persistence/mongodb.scala
+++ b/riff-raff/app/persistence/mongodb.scala
@@ -63,7 +63,6 @@ class MongoDatastore(database: MongoDB) extends DataStore with DocumentStore wit
   val deployLogCollection = getCollection("deployV2Logs")
   val authCollection = getCollection("auth")
   val apiKeyCollection = getCollection("apiKeys")
-  val keyValuesCollection = getCollection("keyValues")
 
   val collections = List(deployCollection, deployLogCollection, authCollection, apiKeyCollection)
 
@@ -290,31 +289,6 @@ class MongoDatastore(database: MongoDB) extends DataStore with DocumentStore wit
       case 0.0 =>
         val errorMessage = result.as[String]("errmsg")
         throw new IllegalArgumentException(s"Failed to execute mongo query: $errorMessage")
-    }
-  }
-
-  override def writeKey(key: String, value: String) {
-    logAndSquashExceptions[Unit](Some(s"Writing value $value for key $key"), ()) {
-      keyValuesCollection.findAndModify(
-        query = MongoDBObject("key" -> key),
-        update = MongoDBObject("key" -> key, "value" -> value),
-        upsert = true,
-        fields = MongoDBObject(),
-        sort = MongoDBObject(),
-        remove = false,
-        returnNew = false
-      )
-    }
-  }
-
-  override def readKey(key: String): Option[String] =
-    logAndSquashExceptions[Option[String]](Some(s"Retrieving value for key $key"), None) {
-      keyValuesCollection.findOne(MongoDBObject("key" -> key)).flatMap(_.getAs[String]("value"))
-    }
-
-  override def deleteKey(key: String) {
-    logAndSquashExceptions[Unit](Some(s"Deleting key value pair for key $key"), ()) {
-      keyValuesCollection.findAndRemove(MongoDBObject("key" -> key))
     }
   }
 

--- a/riff-raff/test/RepresentationTest.scala
+++ b/riff-raff/test/RepresentationTest.scala
@@ -165,35 +165,6 @@ class RepresentationTest extends FlatSpec with Matchers with Utilities with Pers
     ungratedApiKey should be(Some(apiKey))
   }
 
-  "ContinuousDeploymentConfig" should "never change without careful thought and testing of migration" in {
-    val uuid = UUID.fromString("ae46a1c9-7762-4f05-9f32-6d6cd8c496c7")
-    val lastTime = new DateTime(2013,1,8,17,20,0)
-    val configDump = """{ "_id" : { "$uuid" : "ae46a1c9-7762-4f05-9f32-6d6cd8c496c7"} , "projectName" : "test::project" , "stage" : "TEST" , "branchMatcher" : "^master$" , "enabled" : true , "user" : "Test user" , "lastEdited" : { "$date" : "2013-01-08T17:20:00.000Z"}}"""
-    val configV2Dump = """{ "_id" : { "$uuid" : "ae46a1c9-7762-4f05-9f32-6d6cd8c496c7"} , "projectName" : "test::project" , "stage" : "TEST" , "branchMatcher" : "^master$" , "triggerMode" : 1 , "user" : "Test user" , "lastEdited" : { "$date" : "2013-01-08T17:20:00.000Z"}}"""
-
-    val config = ContinuousDeploymentConfig(uuid, "test::project", "TEST", Some("^master$"), Trigger.SuccessfulBuild, "Test user", lastTime)
-    val gratedConfig = config.toDBO
-
-    val jsonConfig = JSON.serialize(gratedConfig)
-    val diff = compareJson(configV2Dump, jsonConfig)
-    diff.toString should be("[ ]")
-    // TODO - check ordering as well?
-    //jsonConfig should be(configDump)
-
-    val ungratedDBObject = JSON.parse(configDump).asInstanceOf[DBObject]
-    ungratedDBObject.toString should be(configDump)
-
-    val ungratedConfig = ContinuousDeploymentConfig.fromDBO(new MongoDBObject(ungratedDBObject))
-    ungratedConfig should be(Some(config))
-
-    val ungratedV2DBObject = JSON.parse(configV2Dump).asInstanceOf[DBObject]
-    ungratedV2DBObject.toString should be(configV2Dump)
-
-    val ungratedV2Config = ContinuousDeploymentConfig.fromDBO(new MongoDBObject(ungratedV2DBObject))
-    ungratedV2Config should be(Some(config))
-
-  }
-
   "DeploymentSelectorDocument" should "not change AllDocument without careful thought and testing of migration" in {
     val allDump =
       """{ "_typeHint" : "persistence.AllDocument$"}"""


### PR DESCRIPTION
The related collections have been dropped in MongoDB. I have move the declarations for `NoOpDataStore` because as we start writing a `DataStore` for Postgres, it will be nice if the compiler lets us know if something is missing.