### PR TITLE
Create a simple JSON schema definition for riff-raff.yaml

### DIFF
--- a/contrib/riff-raff-yaml-schema.json
+++ b/contrib/riff-raff-yaml-schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/guardian/riff-raff/master/contrib/riff-raff-yaml-schema.json",
+  "title": "Riff-Raff deployment",
+  "definitions": {
+    "stacks": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^(.*)$"
+      },
+      "uniqueItems": true,
+    },
+    "regions": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^(.*)$"
+      },
+      "uniqueItems": true,
+    },
+    "deployment-or-template": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "title": "The type of the deployment",
+          "examples": [
+            "aws-s3",
+            "cloud-formation"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "title": "The name of a template to inherit properties from"
+        },
+        "stacks": { "$ref": "#/definitions/stacks" },
+        "regions": { "$ref": "#/definitions/regions" },
+        "app": {
+          "title": "Override the name of the app (defaults to the name of the deployment)",
+          "type": "string"
+        },
+        "contentDirectory": {
+          "title": "Override the directory suffix used to find the files for this deployment (defaults to the deployment name)",
+          "type": "string"
+        },
+        "dependencies": {
+          "title": "List of deployments that must be completed before this deployment starts",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "parameters": {
+          "type": "object",
+          "title": "Parameters for the deployment type",
+          "uniqueItems": true
+        }
+      },
+      "oneOf": [
+        {
+          "required": ["type"],
+          "not": { "required": ["template"] }
+        },
+        {
+          "required": ["template"],
+          "not": { "required": ["type"] }
+        }
+      ]
+    }
+  },
+  "type": "object",
+  "required": [
+    "deployments"
+  ],
+  "properties": {
+    "stacks": { "$ref": "#/definitions/stacks" },
+    "regions": { "$ref": "#/definitions/regions" },
+    "templates": {
+      "patternProperties": {
+        "^.*$": { "$ref": "#/definitions/deployment-or-template" }
+      },
+      "additionalProperties": false
+    },
+    "deployments": {
+      "patternProperties": {
+        "^.*$": { "$ref": "#/definitions/deployment-or-template" }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/magenta-lib/src/main/scala/magenta/input/package.scala
+++ b/magenta-lib/src/main/scala/magenta/input/package.scala
@@ -10,10 +10,11 @@ package object input {
       case m: MethodSymbol if m.isCaseAccessor => m.name.decodedName.toString
     }.toSet
     def reads(json: JsValue): JsResult[T] = {
+      def fieldNames(map: Map[String, _]): Set[String] = map.keySet.filterNot(_.startsWith("$"))
       val caseClassFields = classFields[T]
       json match {
-        case JsObject(fields) if (fields.keySet -- caseClassFields).nonEmpty =>
-          JsError(s"Unexpected fields provided: ${(fields.keySet -- caseClassFields).mkString(", ")}")
+        case JsObject(fields) if (fieldNames(fields.toMap) -- caseClassFields).nonEmpty =>
+          JsError(s"Unexpected fields provided: ${(fieldNames(fields.toMap) -- caseClassFields).mkString(", ")}")
         case _ => underlyingReads.reads(json)
       }
     }


### PR DESCRIPTION
IntelliJ and other editors have sprouted support for validating YAML files with JSON schema. This is a schema file that can be referred to in JSON or YAML using `$schema` (although IntelliJ doesn't yet appear to automagically pick this up when it's YAML).

As well as the schema file we modify Riff-Raff to ignore properties that start with a `$` character to allow the `$schema` and `$id` fields to be specified if so desired.

![screen shot 2018-10-30 at 10 56 21](https://user-images.githubusercontent.com/1236466/47713580-8acd8380-dc32-11e8-8e2e-aa5b5ac4d87b.png)