### PR TITLE
Switch the redirect targets to fix behaviour

### DIFF
--- a/riff-raff/app/controllers/authentication.scala
+++ b/riff-raff/app/controllers/authentication.scala
@@ -128,6 +128,6 @@ class Login(deployments: Deployments, val controllerComponents: ControllerCompon
 
   override def authConfig: GoogleAuthConfig = auth.googleAuthConfig
 
-  override val failureRedirectTarget: Call = routes.Application.index()
-  override val defaultRedirectTarget: Call = routes.Login.login()
+  override val failureRedirectTarget: Call = routes.Login.login()
+  override val defaultRedirectTarget: Call = routes.Application.index()
 }


### PR DESCRIPTION
This should redirect people from login to the main index on successful login and also redirect people who failed to login back to the login screen and display the error.