### PR TITLE
De-duplicate log entries when reading from the DB

### DIFF
--- a/riff-raff/app/persistence/mapping.scala
+++ b/riff-raff/app/persistence/mapping.scala
@@ -159,7 +159,7 @@ object DocumentStoreConverter extends Logging {
   }
 
   def getDeployDocument(uuid:UUID) = documentStore.readDeploy(uuid)
-  def getDeployLogs(uuid:UUID) = documentStore.readLogs(uuid)
+  def getDeployLogs(uuid:UUID) = documentStore.readLogs(uuid).toList.distinctOn(log => (log.deploy, log.id))
 
   def getDeploy(uuid:UUID, fetchLog: Boolean = true): Option[DeployRecord] = {
     try {

--- a/riff-raff/app/persistence/package.scala
+++ b/riff-raff/app/persistence/package.scala
@@ -37,14 +37,14 @@ object `package` {
 
   implicit class richList[T](list: List[T]) {
     def distinctOn[N](f: T => N): List[T] = {
-      list.foldLeft((Set.empty[N], List.empty[T])){ case ((distinctElements, acc), item) =>
+      list.foldRight((Set.empty[N], List.empty[T])){ case (item, (distinctElements, acc)) =>
           val element = f(item)
           if (distinctElements.contains(element)) {
             distinctElements -> acc
           } else {
             (distinctElements + element) -> (item :: acc)
           }
-      }._2.reverse
+      }._2
     }
   }
 }

--- a/riff-raff/app/persistence/package.scala
+++ b/riff-raff/app/persistence/package.scala
@@ -1,12 +1,12 @@
 package persistence
 
-import magenta._
-import deployment.{PaginationView, DeployFilter}
 import com.mongodb.casbah.commons.MongoDBObject
 import com.mongodb.casbah.Imports._
 import com.mongodb.DBObject
 import com.mongodb.casbah.MongoCursor
-import org.joda.time.{LocalDate, DateMidnight}
+import deployment.{DeployFilter, PaginationView}
+import magenta._
+import org.joda.time.LocalDate
 
 object `package` {
   implicit class deployFilter2Criteria(filter: DeployFilter) {
@@ -33,5 +33,18 @@ object `package` {
 
   implicit class message2MessageDocument(message: Message) {
     def asMessageDocument: MessageDocument = MessageDocument(message)
+  }
+
+  implicit class richList[T](list: List[T]) {
+    def distinctOn[N](f: T => N): List[T] = {
+      list.foldLeft((Set.empty[N], List.empty[T])){ case ((distinctElements, acc), item) =>
+          val element = f(item)
+          if (distinctElements.contains(element)) {
+            distinctElements -> acc
+          } else {
+            (distinctElements + element) -> (item :: acc)
+          }
+      }._2.reverse
+    }
   }
 }

--- a/riff-raff/test/RepresentationTest.scala
+++ b/riff-raff/test/RepresentationTest.scala
@@ -194,4 +194,18 @@ class RepresentationTest extends FlatSpec with Matchers with Utilities with Pers
     ungratedDeployKeys shouldBe keysSelectorDocument
   }
 
+  "Rich list" should "retain the order of a list" in {
+    case class Monkey(name: String, age: Int)
+    val monkies = List(Monkey("fred", 1), Monkey("bob", 2), Monkey("marjorie", 3))
+    val distinctMonkies = monkies.distinctOn(identity)
+    distinctMonkies shouldBe monkies
+  }
+
+  it should "remove duplicates later in the list" in {
+    case class Monkey(name: String, age: Int)
+    val monkies = List(Monkey("fred", 1), Monkey("bob", 2), Monkey("marjorie", 3), Monkey("bob", 3))
+    val distinctMonkies = monkies.distinctOn(_.name)
+    distinctMonkies shouldBe List(Monkey("fred", 1), Monkey("bob", 2), Monkey("marjorie", 3))
+  }
+
 }

--- a/riff-raff/test/RepresentationTest.scala
+++ b/riff-raff/test/RepresentationTest.scala
@@ -205,7 +205,7 @@ class RepresentationTest extends FlatSpec with Matchers with Utilities with Pers
     case class Monkey(name: String, age: Int)
     val monkies = List(Monkey("fred", 1), Monkey("bob", 2), Monkey("marjorie", 3), Monkey("bob", 3))
     val distinctMonkies = monkies.distinctOn(_.name)
-    distinctMonkies shouldBe List(Monkey("fred", 1), Monkey("bob", 2), Monkey("marjorie", 3))
+    distinctMonkies shouldBe List(Monkey("fred", 1), Monkey("marjorie", 3), Monkey("bob", 3))
   }
 
 }


### PR DESCRIPTION
I've noticed a number of duplicated log lines which are causing chaos in the log viewer. I suspect that this is down to our policy of trying Mongo updates repeatedly if we get an error, meaning that we ensure that a log line is successfully written at the cost of introducing duplicates in the case that it has written successfully but still threw an error.

The proper fix is to switch from inserts to upserts to ensure that any deduplication happens in the DB. However this can't be done until duplicates have already been removed so this is a short term kludge to fix the immediate problem by filtering out duplicates on read.