### PR TITLE
Consider optional lists in configuration

### DIFF
--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -40,7 +40,7 @@ object Config extends Logging {
 
   private def getString(path: String): String = configuration.getString(path)
   private def getStringOpt(path: String): Option[String] = Try(configuration.getString(path)).toOption
-  private def getStringList(path: String): List[String] = Try(configuration.getString(path)).toOption.map(_.split(",").map(_.trim).toList).getOrElse(List.empty)
+  private def getStringList(path: String): List[String] = getStringOpt(path).map(_.split(",").map(_.trim).toList).getOrElse(List.empty)
   private def getBooleanOpt(path: String): Option[Boolean] = Try(configuration.getBoolean(path)).toOption
   private def getIntOpt(path: String): Option[Int] = Try(configuration.getInt(path)).toOption
 

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -40,7 +40,7 @@ object Config extends Logging {
 
   private def getString(path: String): String = configuration.getString(path)
   private def getStringOpt(path: String): Option[String] = Try(configuration.getString(path)).toOption
-  private def getStringList(path: String): List[String] = configuration.getString(path).split(",").map(_.trim).toList
+  private def getStringList(path: String): List[String] = Try(configuration.getString(path)).toOption.map(_.split(",").map(_.trim).toList).getOrElse(List.empty)
   private def getBooleanOpt(path: String): Option[Boolean] = Try(configuration.getBoolean(path)).toOption
   private def getIntOpt(path: String): Option[Int] = Try(configuration.getInt(path)).toOption
 


### PR DESCRIPTION
We've changed the way we read config and in the process we managed to make any list property required, resulting in continuous deployment being broken. This fixes it by defaulting to an empty list when a list property is missing from the config file.