### PR TITLE
Fix scheduled deployment

### DIFF
--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -118,7 +118,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
     new HstsFilter()(executionContext)
   ) // TODO (this would require an upgrade of the management-play lib) ++ PlayRequestMetrics.asFilters
 
-  val deployScheduler = new DeployScheduler(deployments)
+  val deployScheduler = new DeployScheduler(config, deployments)
   log.info("Starting deployment scheduler")
   deployScheduler.start()
   applicationLifecycle.addStopHook { () =>

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -127,7 +127,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
   }
   deployScheduler.initialise(new ScheduleRepository(config).getScheduleList())
 
-  val hooksClient = new HooksClient(datastore, wsClient, executionContext)
+  val hooksClient = new HooksClient(datastore, hookConfigRepository, wsClient, executionContext)
   val shutdownWhenInactive = new ShutdownWhenInactive(deployments)
 
   // the management server takes care of shutting itself down with a lifecycle hook

--- a/riff-raff/app/notification/hooks.scala
+++ b/riff-raff/app/notification/hooks.scala
@@ -81,10 +81,10 @@ object HookConfig {
     HookConfig(UUID.randomUUID(), projectName, stage, url, enabled, new DateTime(), updatedBy)
 }
 
-class HooksClient(datastore: DataStore, wsClient: WSClient, executionContext: ExecutionContext) extends Lifecycle with Logging {
+class HooksClient(datastore: DataStore, hookConfigRepository: HookConfigRepository, wsClient: WSClient, executionContext: ExecutionContext) extends Lifecycle with Logging {
   lazy val system = ActorSystem("notify")
   val actor = try {
-    Some(system.actorOf(Props(classOf[HooksClientActor], datastore, wsClient, executionContext), "hook-client"))
+    Some(system.actorOf(Props(classOf[HooksClientActor], datastore, hookConfigRepository, wsClient, executionContext), "hook-client"))
   } catch {
     case t:Throwable =>
       log.error("Failed to start HookClient", t)

--- a/riff-raff/app/schedule/DeployScheduler.scala
+++ b/riff-raff/app/schedule/DeployScheduler.scala
@@ -2,6 +2,7 @@ package schedule
 
 import java.util.{TimeZone, UUID}
 
+import conf.Config
 import controllers.Logging
 import deployment.Deployments
 import org.quartz.CronScheduleBuilder._
@@ -11,7 +12,7 @@ import org.quartz.impl.StdSchedulerFactory
 import org.quartz.{JobDataMap, JobKey, TriggerKey}
 import schedule.DeployScheduler.JobDataKeys
 
-class DeployScheduler(deployments: Deployments) extends Logging {
+class DeployScheduler(config: Config, deployments: Deployments) extends Logging {
 
   private val scheduler = StdSchedulerFactory.getDefaultScheduler
 
@@ -59,6 +60,7 @@ class DeployScheduler(deployments: Deployments) extends Logging {
   private def buildJobDataMap(scheduleConfig: ScheduleConfig): JobDataMap = {
     val map = new JobDataMap()
     map.put(JobDataKeys.Deployments, deployments)
+    map.put(JobDataKeys.ScheduledDeploymentEnabled, config.scheduledDeployment.enabled)
     map.put(JobDataKeys.ProjectName, scheduleConfig.projectName)
     map.put(JobDataKeys.Stage, scheduleConfig.stage)
     map
@@ -70,6 +72,7 @@ object DeployScheduler {
 
   object JobDataKeys {
     val Deployments = "deployments"
+    val ScheduledDeploymentEnabled = "ScheduledDeploymentEnabled"
     val ProjectName = "projectName"
     val Stage = "stage"
   }


### PR DESCRIPTION
During the config refactoring we broke the way we were sending params to the job when scheduling deployments. This should fix it.