### PR TITLE
Fix search by project name

### DIFF
--- a/riff-raff/app/controllers/DeployController.scala
+++ b/riff-raff/app/controllers/DeployController.scala
@@ -140,7 +140,7 @@ class DeployController(config: Config,
       val restrictions = maybeStage.toSeq.flatMap { stage =>
         RestrictionChecker.configsThatPreventDeployment(restrictionConfigDynamoRepository, project, stage, UserRequestSource(request.user))
       }
-      val filter = DeployFilter(projectName = Some(s"$project"), stage = maybeStage)
+      val filter = DeployFilter(projectName = Some(project), stage = maybeStage)
       val records = deployments.getDeploys(Some(filter), PaginationView(pageSize = Some(5)), fetchLogs = false).logAndSquashException(Nil).reverse
       Ok(views.html.deploy.deployHistory(project, maybeStage, records, restrictions))
     }

--- a/riff-raff/app/deployment/filter.scala
+++ b/riff-raff/app/deployment/filter.scala
@@ -35,7 +35,10 @@ case class DeployFilter(
   }
 
   lazy val sqlParams: List[SQLSyntax] = List(
-    projectName.map(pn => sqls"content->'parameters'->>'projectName' = $pn"),
+    projectName.map { pn =>
+      val likeString = s"%$pn%"
+      sqls"content->'parameters'->>'projectName' ilike $likeString"
+    },
     stage.map(s => sqls"content->'parameters'->>'stage' = $s"),
     deployer.map(d => sqls"content->'parameters'->>'deployer' = $d"),
     status.map(s => sqls"content->>'status' = ${s.entryName}"),

--- a/riff-raff/app/persistence/package.scala
+++ b/riff-raff/app/persistence/package.scala
@@ -14,7 +14,7 @@ object `package` {
   implicit class deployFilter2Criteria(filter: DeployFilter) {
     def criteria: DBObject = {
       val criteriaList: List[(String, Any)] = Nil ++
-        filter.projectName.map(p => ("parameters.projectName", s"(?i)^$p$$".r)) ++
+        filter.projectName.map(p => ("parameters.projectName", s"(?i)$p".r)) ++
         filter.stage.map(("parameters.stage", _)) ++
         filter.deployer.map(("parameters.deployer", _)) ++
         filter.status.map(s => ("status", s.toString)) ++

--- a/riff-raff/test/postgres/PostgresDatastoreTest.scala
+++ b/riff-raff/test/postgres/PostgresDatastoreTest.scala
@@ -162,6 +162,20 @@ class PostgresDatastoreTest extends FreeSpec with Matchers with DockerTestKit wi
       }
     }
 
+    "get deploys using partial projectName filter" in {
+      withFixture {
+        withDeploys(2) { deploys =>
+          val deploy = deploys.head
+
+          val deployFilter = DeployFilter(projectName = Some("project-name"))
+          val dbDeploys = datastore.getDeploys(Some(deployFilter), PaginationView(pageSize = Some(20), page = 1))
+
+          dbDeploys.right.get.size shouldBe 2
+          dbDeploys.right.get.head.parameters.projectName.startsWith("project-name") shouldBe true
+        }
+      }
+    }
+
     "get deploys using all filters, but no pagination" in {
       withFixture {
         withDeploys(2) { deploys =>


### PR DESCRIPTION
We introduced a regression when merging the Postgres API regarding searching for projects on the history page. We should be able to search for a substring of the project name. I've also added a test in postgres for it.