### PR TITLE
Few changes to migration

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -81,9 +81,8 @@ object Dependencies {
   )
 
   lazy val migrationDeps = Seq(
-    jdbc,
-    "org.scalaz"        %% "scalaz-zio"         % "0.5.3",
-    "org.scalaz"        %% "scalaz-zio-interop-shared" % "0.5.3",
+    "org.scalaz"        %% "scalaz-zio"         % "0.6.3",
+    "org.scalaz"        %% "scalaz-zio-interop-shared" % "0.6.3",
     "org.scalacheck"    %% "scalacheck"         % "1.14.0" % Test
   )
 }

--- a/riff-raff/app/controllers/MigrationController.scala
+++ b/riff-raff/app/controllers/MigrationController.scala
@@ -66,10 +66,10 @@ class MigrationController(
     val rts = new RTS {}
 
     val ioprogram: IO[MigrationError, List[List[PreviewResponse]]] = 
-      IO.foreach(List("apiKeys", "auth", "deployV2", "deployV2Logs")) { mongoTable =>
+      IO.foreach(List("deployV2", "deployV2Logs")) { mongoTable =>
         mongoTable match {
-          case "apiKeys"      => run(mongoTable, MongoRetriever.apiKeyRetriever(datastore), settings.limit)
-          case "auth"         => run(mongoTable, MongoRetriever.authRetriever(datastore), settings.limit)
+          // case "apiKeys"      => run(mongoTable, MongoRetriever.apiKeyRetriever(datastore), settings.limit)
+          // case "auth"         => run(mongoTable, MongoRetriever.authRetriever(datastore), settings.limit)
           case "deployV2"     => run(mongoTable, MongoRetriever.deployRetriever(datastore), settings.limit)
           case "deployV2Logs" => run(mongoTable, MongoRetriever.logRetriever(datastore), settings.limit)
           case _ =>

--- a/riff-raff/app/controllers/MigrationController.scala
+++ b/riff-raff/app/controllers/MigrationController.scala
@@ -94,8 +94,8 @@ class MigrationController(
   ): IO[MigrationError, List[PreviewResponse]] =
     for {
       vals <- PreviewInterpreter.migrate(retriever, limit)
-      (_, reader, writer, r1, r2) = vals
+      (_, reader, writer, r1) = vals
       _ <- reader.join
       responses <- writer.join
-    } yield r1 :: r2 :: responses
+    } yield r1 :: responses
 }

--- a/riff-raff/app/controllers/MigrationController.scala
+++ b/riff-raff/app/controllers/MigrationController.scala
@@ -65,7 +65,7 @@ class MigrationController(
   def dryRun(settings: MigrationParameters) = AuthAction.async { implicit request => 
     val rts = new RTS {}
 
-    val ioprogram: IO[MigrationError, List[List[PreviewResponse]]] = 
+    val ioprogram: IO[MigrationError, List[PreviewResponse]] = 
       IO.foreach(List("deployV2", "deployV2Logs")) { mongoTable =>
         mongoTable match {
           // case "apiKeys"      => run(mongoTable, MongoRetriever.apiKeyRetriever(datastore), settings.limit)
@@ -91,11 +91,11 @@ class MigrationController(
     mongoTable: String, 
     retriever: MongoRetriever[A], 
     limit: Option[Int]
-  ): IO[MigrationError, List[PreviewResponse]] =
+  ): IO[MigrationError, PreviewResponse] =
     for {
       vals <- PreviewInterpreter.migrate(retriever, limit)
       (_, reader, writer, r1) = vals
       _ <- reader.join
       responses <- writer.join
-    } yield r1 :: responses
+    } yield PreviewInterpreter.combine(responses, r1)
 }

--- a/riff-raff/app/controllers/MigrationController.scala
+++ b/riff-raff/app/controllers/MigrationController.scala
@@ -26,8 +26,6 @@ class MigrationController(
   val config: Config
 ) extends BaseController with Logging with I18nSupport with LogAndSquashBehaviour {
 
-  val WINDOW_SIZE = 100
-
   def form = AuthAction { implicit request =>
     Ok(views.html.migrations.form(MigrationParameters.form, datastore.collectionStats)(config, menu))
   }

--- a/riff-raff/app/migration/Migration.scala
+++ b/riff-raff/app/migration/Migration.scala
@@ -47,8 +47,8 @@ class Migration(config: Config, datastore: DataStore) extends Lifecycle with Log
     val promise = Promise[Unit]()
 
     rts.unsafeRunAsync(ioprogram) {
-      case ExitResult.Succeeded(_) => promise.success(())
-      case ExitResult.Failed(t) => promise.failure(new FiberFailure(t))
+      case Exit.Success(_) => promise.success(())
+      case Exit.Failure(t) => promise.failure(new FiberFailure(t))
     }
 
     promise.future

--- a/riff-raff/app/migration/Migration.scala
+++ b/riff-raff/app/migration/Migration.scala
@@ -40,7 +40,7 @@ class Migration(config: Config, datastore: DataStore) extends Lifecycle with Log
     } { _ => 
       // run("apiKeys", MongoRetriever.apiKeyRetriever(datastore), settings.limit) *>
       //   run("auth", MongoRetriever.authRetriever(datastore), settings.limit) *>
-        run("deployV2", MongoRetriever.deployRetriever(datastore), settings.limit) *>
+        // run("deployV2", MongoRetriever.deployRetriever(datastore), settings.limit) *>
         run("deployV2Logs", MongoRetriever.logRetriever(datastore), settings.limit)
     }
 

--- a/riff-raff/app/migration/Migration.scala
+++ b/riff-raff/app/migration/Migration.scala
@@ -69,7 +69,7 @@ class Migration(config: Config, datastore: DataStore) extends Lifecycle with Log
     }
 
   def monitor(mongoTable: String, counter: Ref[Int]): IO[Nothing, Unit] =
-    (counter.get.flatMap { n => IO.sync { status += mongoTable -> 100 / n } } *> IO.sleep(Migration.interval))
+    (counter.get.flatMap { n => IO.sync { status += mongoTable -> 100 / Math.max(n, 1) } } *> IO.sleep(Migration.interval))
       .forever
       .ensuring(IO.sync(status.foreach { case (k, v) => status += k -> 100 }))
 

--- a/riff-raff/app/migration/Migration.scala
+++ b/riff-raff/app/migration/Migration.scala
@@ -58,7 +58,7 @@ class Migration(config: Config, datastore: DataStore) extends Lifecycle with Log
     (for {
       _ <- IO.sync(log.info(s"Migrating $mongoTable..."))
       vals <- MigrateInterpreter.migrate(retriever, limit)
-      (counter, reader, writer, _, _) = vals
+      (counter, reader, writer, _) = vals
       progress <- monitor(mongoTable, counter).fork
       _ <- Fiber.joinAll(reader :: writer :: Nil)
       _ <- progress.interrupt

--- a/riff-raff/app/migration/Migration.scala
+++ b/riff-raff/app/migration/Migration.scala
@@ -38,8 +38,8 @@ class Migration(config: Config, datastore: DataStore) extends Lifecycle with Log
     ) { _ => 
       Postgres.disconnect
     } { _ => 
-      run("apiKeys", MongoRetriever.apiKeyRetriever(datastore), settings.limit) *>
-        run("auth", MongoRetriever.authRetriever(datastore), settings.limit) *>
+      // run("apiKeys", MongoRetriever.apiKeyRetriever(datastore), settings.limit) *>
+      //   run("auth", MongoRetriever.authRetriever(datastore), settings.limit) *>
         run("deployV2", MongoRetriever.deployRetriever(datastore), settings.limit) *>
         run("deployV2Logs", MongoRetriever.logRetriever(datastore), settings.limit)
     }

--- a/riff-raff/app/migration/Migrator.scala
+++ b/riff-raff/app/migration/Migrator.scala
@@ -10,26 +10,24 @@ trait Migrator[Response] {
 
   def WINDOW_SIZE: Int
 
-  def dropTable(pgTable: ToPostgres[_]): IO[MigrationError, Response]
-  def createTable(pgTable: ToPostgres[_]): IO[MigrationError, Response]
+  def deleteTable(pgTable: ToPostgres[_]): IO[MigrationError, Response]
   def insertAll[A](pgTable: ToPostgres[A], records: List[A]): IO[MigrationError, Response]
   
   def migrate[A: MongoFormat: ToPostgres](
     retriever: MongoRetriever[A], 
     limit: Option[Int]
-  ): IO[MigrationError, (Ref[Int], Fiber[MigrationError, _], Fiber[MigrationError, List[Response]], Response, Response)] =
+  ): IO[MigrationError, (Ref[Int], Fiber[MigrationError, _], Fiber[MigrationError, List[Response]], Response)] =
     for {
       // n is the maximum number of items we want to retrieve, by default the whole table
       n <- retriever.getCount.map(max => limit.map(Math.min(max, _)).getOrElse(max))
       window = Math.min(n, WINDOW_SIZE)
       cpt <- Ref.make(n)
-      r1 <- dropTable(ToPostgres[A])
-      r2 <- createTable(ToPostgres[A])
+      r <- deleteTable(ToPostgres[A])
       // we're going to paginate through the results to reduce memory overhead
       q <- Queue.bounded[A](window * 10)
       f1 <- retriever.getAllItems(q, window, n).fork
       f2 <- insertAllItems(q, cpt, window).fork
-    } yield (cpt, f1, f2, r1, r2)
+    } yield (cpt, f1, f2, r)
 
   def insertAllItems[A: ToPostgres](queue: Queue[A], counter: Ref[Int], window: Int): IO[MigrationError, List[Response]] = {
     def loop(resps: List[Response]): IO[MigrationError, List[Response]] = {

--- a/riff-raff/app/migration/Migrator.scala
+++ b/riff-raff/app/migration/Migrator.scala
@@ -26,7 +26,7 @@ trait Migrator[Response] {
       r1 <- dropTable(ToPostgres[A])
       r2 <- createTable(ToPostgres[A])
       // we're going to paginate through the results to reduce memory overhead
-      q <- Queue.bounded[A](window)
+      q <- Queue.bounded[A](window * 10)
       f1 <- retriever.getAllItems(q, window, n).fork
       f2 <- insertAllItems(q, cpt, window).fork
     } yield (cpt, f1, f2, r1, r2)

--- a/riff-raff/app/migration/Migrator.scala
+++ b/riff-raff/app/migration/Migrator.scala
@@ -47,6 +47,7 @@ trait Migrator[Response] extends controllers.Logging {
 
       for {
         n <- counter.get
+        _ <- IO.sync(log.info(s"$n items remaining to insert"))
         rs <- if (n <= 0)
           IO.succeed(resps)
         else {

--- a/riff-raff/app/migration/Migrator.scala
+++ b/riff-raff/app/migration/Migrator.scala
@@ -6,7 +6,7 @@ import persistence.MongoFormat
 import cats._, cats.implicits._
 import scalaz.zio.{ Fiber, IO, App, Ref, Queue, Exit }
 
-trait Migrator[Response] {
+trait Migrator[Response] extends controllers.Logging {
 
   def WINDOW_SIZE: Int
 
@@ -20,6 +20,7 @@ trait Migrator[Response] {
     for {
       // n is the maximum number of items we want to retrieve, by default the whole table
       n <- retriever.getCount.map(max => limit.map(Math.min(max, _)).getOrElse(max))
+      _ <- IO.sync(log.info(s"$n items to migrate"))
       window = Math.min(n, WINDOW_SIZE)
       cpt <- Ref.make(n)
       r <- deleteTable(ToPostgres[A])

--- a/riff-raff/app/migration/data/MongoRetriever.scala
+++ b/riff-raff/app/migration/data/MongoRetriever.scala
@@ -45,7 +45,7 @@ object MongoRetriever {
   def logRetriever(datastore: DataStore)(implicit F0: MongoFormat[LogDocument]) = new MongoRetriever[LogDocument] {
     val deployLogDateFrom = new DateTime("2019-02-18T00:00:00.000Z")
     val F = F0
-    val getCount = IO.blocking(datastore.countLogsFromDate()).mapError(DatabaseError)
+    val getCount = IO.blocking(datastore.collectionStats.get("deployV2Logs").map(_.documentCount.toInt).getOrElse(0)).mapError(DatabaseError)
     def getItems(pagination: PaginationView) =
       IO.blocking { datastore.readAllLogs(pagination) }.absolve.mapError(DatabaseError)
   }

--- a/riff-raff/app/migration/data/MongoRetriever.scala
+++ b/riff-raff/app/migration/data/MongoRetriever.scala
@@ -2,6 +2,7 @@ package migration.data
 
 import controllers.{ ApiKey, AuthorisationRecord }
 import deployment.PaginationView
+import java.util.UUID
 import persistence.{ DataStore, DeployRecordDocument, LogDocument, MongoFormat }
 import scalaz.zio.{IO, Queue}
 import org.joda.time.DateTime
@@ -11,14 +12,16 @@ trait MongoRetriever[A] {
 
   def getCount: IO[MigrationError, Int]
 
-  def getItems(pagination: PaginationView): IO[MigrationError, Iterable[A]]
+  def getItems(pagination: PaginationView, startId: Option[UUID]): IO[MigrationError, Iterable[A]]
+
+  def getId(value: Option[A]): Option[UUID]
 
   def getAllItems(queue: Queue[A], size: Int, max: Int): IO[MigrationError, _] = {
-    def loop(page: Int, max: Int): IO[MigrationError, _] =
+    def loop(page: Int, max: Int, startId: Option[UUID]): IO[MigrationError, _] =
       if (max <= 0)
         IO.unit
       else
-        getItems(PaginationView(Some(size), page))
+        getItems(PaginationView(Some(size), page), startId)
           // `size` may be larger than `max`, 
           .map(_.take(max))
           .flatMap { items =>
@@ -27,10 +30,10 @@ trait MongoRetriever[A] {
             if (items.size < size)
               queue.offerAll(items)
             else
-              queue.offerAll(items) *> loop(page + 1, max - items.size)
+              queue.offerAll(items) *> loop(page + 1, max - items.size, getId(items.lastOption))
           }
 
-    loop(1, max)
+    loop(1, max, None)
   }
 }
 
@@ -38,7 +41,8 @@ object MongoRetriever {
   def deployRetriever(datastore: DataStore)(implicit F0: MongoFormat[DeployRecordDocument]) = new MongoRetriever[DeployRecordDocument] {
     val F = F0
     val getCount = IO.blocking(datastore.collectionStats.get("deployV2").map(_.documentCount.toInt).getOrElse(0)).mapError(DatabaseError)
-    def getItems(pagination: PaginationView) =
+    def getId(value: Option[DeployRecordDocument]) = None
+    def getItems(pagination: PaginationView, startId: Option[UUID]) =
       IO.blocking { datastore.getDeploys(None, pagination) }.absolve.mapError(DatabaseError)
     }
     
@@ -46,21 +50,24 @@ object MongoRetriever {
     val deployLogDateFrom = new DateTime("2019-02-18T00:00:00.000Z")
     val F = F0
     val getCount = IO.blocking(datastore.collectionStats.get("deployV2Logs").map(_.documentCount.toInt).getOrElse(0)).mapError(DatabaseError)
-    def getItems(pagination: PaginationView) =
-      IO.blocking { datastore.readAllLogs(pagination) }.absolve.mapError(DatabaseError)
+    def getId(value: Option[LogDocument]) = value.map(_.id)
+    def getItems(pagination: PaginationView, startId: Option[UUID]) =
+      IO.blocking { datastore.readAllLogs(pagination.pageSize.get, startId) }.absolve.mapError(DatabaseError)
   }
   
   def authRetriever(datastore: DataStore)(implicit F0: MongoFormat[AuthorisationRecord]) = new MongoRetriever[AuthorisationRecord] {
     val F = F0
     val getCount = IO.blocking(datastore.collectionStats.get("auth").map(_.documentCount.toInt).getOrElse(0)).mapError(DatabaseError)
-    def getItems(pagination: PaginationView) =
+    def getId(value: Option[AuthorisationRecord]) = None
+    def getItems(pagination: PaginationView, startId: Option[UUID]) =
       IO.blocking { datastore.getAuthorisationList(Some(pagination)) }.absolve.mapError(DatabaseError)
   }
   
   def apiKeyRetriever(datastore: DataStore)(implicit F0: MongoFormat[ApiKey]) = new MongoRetriever[ApiKey] {
     val F = F0
     val getCount = IO.blocking(datastore.collectionStats.get("apiKeys").map(_.documentCount.toInt).getOrElse(0)).mapError(DatabaseError)
-    def getItems(pagination: PaginationView) =
+    def getId(value: Option[ApiKey]) = None
+    def getItems(pagination: PaginationView, startId: Option[UUID]) =
       IO.blocking { datastore.getApiKeyList(Some(pagination)) }.absolve.mapError(DatabaseError)
   }
 

--- a/riff-raff/app/migration/data/MongoRetriever.scala
+++ b/riff-raff/app/migration/data/MongoRetriever.scala
@@ -38,28 +38,28 @@ object MongoRetriever {
     val F = F0
     val getCount = IO.sync(datastore.collectionStats.get("deployV2").map(_.documentCount.toInt).getOrElse(0))
     def getItems(pagination: PaginationView) =
-      IO.flatten(IO.sync(IO.fromEither { datastore.getDeploys(None, pagination) })).unyielding.mapError(DatabaseError)
+      IO.blocking { datastore.getDeploys(None, pagination) }.absolve.mapError(DatabaseError)
     }
     
   def logRetriever(datastore: DataStore)(implicit F0: MongoFormat[LogDocument]) = new MongoRetriever[LogDocument] {
     val F = F0
     val getCount = IO.sync(datastore.collectionStats.get("deployV2Logs").map(_.documentCount.toInt).getOrElse(0))
     def getItems(pagination: PaginationView) =
-      IO.flatten(IO.sync(IO.fromEither { datastore.readAllLogs(pagination) })).unyielding.mapError(DatabaseError)
+      IO.blocking { datastore.readAllLogs(pagination) }.absolve.mapError(DatabaseError)
   }
   
   def authRetriever(datastore: DataStore)(implicit F0: MongoFormat[AuthorisationRecord]) = new MongoRetriever[AuthorisationRecord] {
     val F = F0
     val getCount = IO.sync(datastore.collectionStats.get("auth").map(_.documentCount.toInt).getOrElse(0))
     def getItems(pagination: PaginationView) =
-      IO.flatten(IO.sync(IO.fromEither { datastore.getAuthorisationList(Some(pagination)) })).unyielding.mapError(DatabaseError)
+      IO.blocking { datastore.getAuthorisationList(Some(pagination)) }.absolve.mapError(DatabaseError)
   }
   
   def apiKeyRetriever(datastore: DataStore)(implicit F0: MongoFormat[ApiKey]) = new MongoRetriever[ApiKey] {
     val F = F0
     val getCount = IO.sync(datastore.collectionStats.get("apiKeys").map(_.documentCount.toInt).getOrElse(0))
     def getItems(pagination: PaginationView) =
-      IO.flatten(IO.sync(IO.fromEither { datastore.getApiKeyList(Some(pagination)) })).unyielding.mapError(DatabaseError)
+      IO.blocking { datastore.getApiKeyList(Some(pagination)) }.absolve.mapError(DatabaseError)
   }
 
 }

--- a/riff-raff/app/migration/data/MongoRetriever.scala
+++ b/riff-raff/app/migration/data/MongoRetriever.scala
@@ -7,7 +7,7 @@ import persistence.{ DataStore, DeployRecordDocument, LogDocument, MongoFormat }
 import scalaz.zio.{IO, Queue}
 import org.joda.time.DateTime
 
-trait MongoRetriever[A] {
+trait MongoRetriever[A] extends controllers.Logging {
   implicit def F: MongoFormat[A]
 
   def getCount: IO[MigrationError, Int]
@@ -21,6 +21,7 @@ trait MongoRetriever[A] {
       if (max <= 0)
         IO.unit
       else
+        IO.sync(log.info(s"Getting ${size} items starting at ${startId}")) *>
         getItems(PaginationView(Some(size), page), startId)
           // `size` may be larger than `max`, 
           .map(_.take(max))

--- a/riff-raff/app/migration/data/MongoRetriever.scala
+++ b/riff-raff/app/migration/data/MongoRetriever.scala
@@ -38,28 +38,28 @@ object MongoRetriever {
     val F = F0
     val getCount = IO.sync(datastore.collectionStats.get("deployV2").map(_.documentCount.toInt).getOrElse(0))
     def getItems(pagination: PaginationView) =
-      IO.flatten(IO.sync(IO.fromEither { datastore.getDeploys(None, pagination) })).unyielding.leftMap(DatabaseError)
+      IO.flatten(IO.sync(IO.fromEither { datastore.getDeploys(None, pagination) })).unyielding.mapError(DatabaseError)
     }
     
   def logRetriever(datastore: DataStore)(implicit F0: MongoFormat[LogDocument]) = new MongoRetriever[LogDocument] {
     val F = F0
     val getCount = IO.sync(datastore.collectionStats.get("deployV2Logs").map(_.documentCount.toInt).getOrElse(0))
     def getItems(pagination: PaginationView) =
-      IO.flatten(IO.sync(IO.fromEither { datastore.readAllLogs(pagination) })).unyielding.leftMap(DatabaseError)
+      IO.flatten(IO.sync(IO.fromEither { datastore.readAllLogs(pagination) })).unyielding.mapError(DatabaseError)
   }
   
   def authRetriever(datastore: DataStore)(implicit F0: MongoFormat[AuthorisationRecord]) = new MongoRetriever[AuthorisationRecord] {
     val F = F0
     val getCount = IO.sync(datastore.collectionStats.get("auth").map(_.documentCount.toInt).getOrElse(0))
     def getItems(pagination: PaginationView) =
-      IO.flatten(IO.sync(IO.fromEither { datastore.getAuthorisationList(Some(pagination)) })).unyielding.leftMap(DatabaseError)
+      IO.flatten(IO.sync(IO.fromEither { datastore.getAuthorisationList(Some(pagination)) })).unyielding.mapError(DatabaseError)
   }
   
   def apiKeyRetriever(datastore: DataStore)(implicit F0: MongoFormat[ApiKey]) = new MongoRetriever[ApiKey] {
     val F = F0
     val getCount = IO.sync(datastore.collectionStats.get("apiKeys").map(_.documentCount.toInt).getOrElse(0))
     def getItems(pagination: PaginationView) =
-      IO.flatten(IO.sync(IO.fromEither { datastore.getApiKeyList(Some(pagination)) })).unyielding.leftMap(DatabaseError)
+      IO.flatten(IO.sync(IO.fromEither { datastore.getApiKeyList(Some(pagination)) })).unyielding.mapError(DatabaseError)
   }
 
 }

--- a/riff-raff/app/migration/data/MongoRetriever.scala
+++ b/riff-raff/app/migration/data/MongoRetriever.scala
@@ -4,11 +4,12 @@ import controllers.{ ApiKey, AuthorisationRecord }
 import deployment.PaginationView
 import persistence.{ DataStore, DeployRecordDocument, LogDocument, MongoFormat }
 import scalaz.zio.{IO, Queue}
+import org.joda.time.DateTime
 
 trait MongoRetriever[A] {
   implicit def F: MongoFormat[A]
 
-  def getCount: IO[Nothing, Int]
+  def getCount: IO[MigrationError, Int]
 
   def getItems(pagination: PaginationView): IO[MigrationError, Iterable[A]]
 
@@ -36,28 +37,29 @@ trait MongoRetriever[A] {
 object MongoRetriever {
   def deployRetriever(datastore: DataStore)(implicit F0: MongoFormat[DeployRecordDocument]) = new MongoRetriever[DeployRecordDocument] {
     val F = F0
-    val getCount = IO.sync(datastore.collectionStats.get("deployV2").map(_.documentCount.toInt).getOrElse(0))
+    val getCount = IO.blocking(datastore.collectionStats.get("deployV2").map(_.documentCount.toInt).getOrElse(0)).mapError(DatabaseError)
     def getItems(pagination: PaginationView) =
       IO.blocking { datastore.getDeploys(None, pagination) }.absolve.mapError(DatabaseError)
     }
     
   def logRetriever(datastore: DataStore)(implicit F0: MongoFormat[LogDocument]) = new MongoRetriever[LogDocument] {
+    val deployLogDateFrom = new DateTime("2019-02-18T00:00:00.000Z")
     val F = F0
-    val getCount = IO.sync(datastore.collectionStats.get("deployV2Logs").map(_.documentCount.toInt).getOrElse(0))
+    val getCount = IO.blocking(datastore.countLogsFromDate()).mapError(DatabaseError)
     def getItems(pagination: PaginationView) =
       IO.blocking { datastore.readAllLogs(pagination) }.absolve.mapError(DatabaseError)
   }
   
   def authRetriever(datastore: DataStore)(implicit F0: MongoFormat[AuthorisationRecord]) = new MongoRetriever[AuthorisationRecord] {
     val F = F0
-    val getCount = IO.sync(datastore.collectionStats.get("auth").map(_.documentCount.toInt).getOrElse(0))
+    val getCount = IO.blocking(datastore.collectionStats.get("auth").map(_.documentCount.toInt).getOrElse(0)).mapError(DatabaseError)
     def getItems(pagination: PaginationView) =
       IO.blocking { datastore.getAuthorisationList(Some(pagination)) }.absolve.mapError(DatabaseError)
   }
   
   def apiKeyRetriever(datastore: DataStore)(implicit F0: MongoFormat[ApiKey]) = new MongoRetriever[ApiKey] {
     val F = F0
-    val getCount = IO.sync(datastore.collectionStats.get("apiKeys").map(_.documentCount.toInt).getOrElse(0))
+    val getCount = IO.blocking(datastore.collectionStats.get("apiKeys").map(_.documentCount.toInt).getOrElse(0)).mapError(DatabaseError)
     def getItems(pagination: PaginationView) =
       IO.blocking { datastore.getApiKeyList(Some(pagination)) }.absolve.mapError(DatabaseError)
   }

--- a/riff-raff/app/migration/data/MongoRetriever.scala
+++ b/riff-raff/app/migration/data/MongoRetriever.scala
@@ -51,7 +51,7 @@ object MongoRetriever {
     val deployLogDateFrom = new DateTime("2019-02-18T00:00:00.000Z")
     val F = F0
     val getCount = IO.blocking(datastore.collectionStats.get("deployV2Logs").map(_.documentCount.toInt).getOrElse(0)).mapError(DatabaseError)
-    def getId(value: Option[LogDocument]) = value.map(_.id)
+    def getId(value: Option[LogDocument]) = value.map(_.deploy)
     def getItems(pagination: PaginationView, startId: Option[UUID]) =
       IO.blocking { datastore.readAllLogs(pagination.pageSize.get, startId) }.absolve.mapError(DatabaseError)
   }

--- a/riff-raff/app/migration/data/ToPostgres.scala
+++ b/riff-raff/app/migration/data/ToPostgres.scala
@@ -10,8 +10,7 @@ trait ToPostgres[A] {
   def json(a: A): JsValue
   def tableName: String
   def id: String
-  def drop: SQL[Nothing, NoExtractor]
-  def create: SQL[Nothing, NoExtractor]
+  def delete: SQL[Nothing, NoExtractor]
   def insert(key: K, json: String): SQL[Nothing, NoExtractor]
 }
 

--- a/riff-raff/app/migration/data/package.scala
+++ b/riff-raff/app/migration/data/package.scala
@@ -22,16 +22,12 @@ package object data {
     val tableName = "apiKey"
     val id = "id"
     val idType = ColString(32, false)
-    val drop = sql"DROP TABLE IF EXISTS apiKey"
-    def create = 
-      DB localTx { implicit session =>
-        sql"CREATE TABLE apiKey (key varchar(32) PRIMARY KEY, content jsonb NOT NULL)".execute.apply()
-        sql"CREATE INDEX ON apiKey ((content ->> 'application'))".execute.apply()
-      }
+    def delete =
+      sql"DELETE FROM apiKey"
     def insert(key: K, json: String): SQL[Nothing, NoExtractor] =
       sql"INSERT INTO apiKey VALUES ($key, $json::jsonb) ON CONFLICT (key) DO UPDATE SET content = $json::jsonb"
   }
-
+    
   implicit val authPE: ToPostgres[AuthorisationRecord] = new ToPostgres[AuthorisationRecord] {
     type K = String
     def key(a: AuthorisationRecord) = a.email
@@ -39,11 +35,8 @@ package object data {
     val tableName = "auth"
     val id = "email"
     val idType = ColString(100, true)
-    val drop = sql"DROP TABLE IF EXISTS auth"
-    def create = 
-      DB autoCommit { implicit session =>
-        sql"CREATE TABLE auth (email varchar(100) PRIMARY KEY, content jsonb NOT NULL)".execute.apply()
-      }
+    def delete =
+      sql"DELETE FROM auth"
     def insert(key: K, json: String): SQL[Nothing, NoExtractor] =
       sql"INSERT INTO auth VALUES ($key, $json::jsonb) ON CONFLICT (email) DO UPDATE SET content = $json::jsonb"
   }
@@ -55,15 +48,8 @@ package object data {
     val tableName = "deploy"
     val id = "id"
     val idType = ColUUID
-    val drop = sql"DROP TABLE IF EXISTS deploy"
-    def create = 
-      DB localTx { implicit session =>
-        sql"CREATE TABLE deploy (id uuid PRIMARY KEY, content jsonb NOT NULL)".execute.apply()
-        sql"CREATE INDEX ON deploy ((content ->> 'startTime'))".execute.apply()
-        sql"CREATE INDEX ON deploy ((content ->> 'status'))".execute.apply()
-        sql"CREATE INDEX ON deploy ((content -> 'parameters' ->> 'projectName'))".execute.apply()
-      }
-    
+    def delete =
+      sql"DELETE FROM deploy"
     def insert(key: K, json: String): SQL[Nothing, NoExtractor] =
       sql"INSERT INTO deploy VALUES ($key::uuid, $json::jsonb) ON CONFLICT (id) DO UPDATE SET content = $json::jsonb"
   }
@@ -75,14 +61,8 @@ package object data {
     val tableName = "deployLog"
     val id = "id"
     val idType = ColUUID
-    val drop = sql"DROP TABLE IF EXISTS deployLog"
-    def create = 
-      DB localTx { implicit session =>
-        sql"CREATE TABLE deployLog (id uuid PRIMARY KEY, content jsonb NOT NULL)".execute.apply()
-        sql"CREATE INDEX ON deployLog ((content ->> 'time'))".execute.apply()
-        sql"CREATE INDEX ON deployLog ((content ->> 'deploy'))".execute.apply()
-      }
-
+    def delete =
+      sql"DELETE FROM deployLog"
     def insert(key: K, json: String): SQL[Nothing, NoExtractor] =
       sql"INSERT INTO deployLog VALUES ($key::uuid, $json::jsonb) ON CONFLICT (id) DO UPDATE SET content = $json::jsonb"
   }

--- a/riff-raff/app/migration/data/package.scala
+++ b/riff-raff/app/migration/data/package.scala
@@ -25,8 +25,8 @@ package object data {
     val drop = sql"DROP TABLE IF EXISTS apiKey"
     def create = 
       DB localTx { implicit session =>
-        sql"CREATE TABLE apiKey (key varchar(32) PRIMARY KEY, content jsonb NOT NULL)"
-        sql"CREATE INDEX ON apiKey ((content ->> 'application'))"
+        sql"CREATE TABLE apiKey (key varchar(32) PRIMARY KEY, content jsonb NOT NULL)".execute.apply()
+        sql"CREATE INDEX ON apiKey ((content ->> 'application'))".execute.apply()
       }
     def insert(key: K, json: String): SQL[Nothing, NoExtractor] =
       sql"INSERT INTO apiKey VALUES ($key, $json::jsonb) ON CONFLICT (key) DO UPDATE SET content = $json::jsonb"
@@ -42,7 +42,7 @@ package object data {
     val drop = sql"DROP TABLE IF EXISTS auth"
     def create = 
       DB autoCommit { implicit session =>
-        sql"CREATE TABLE auth (email varchar(100) PRIMARY KEY, content jsonb NOT NULL)"
+        sql"CREATE TABLE auth (email varchar(100) PRIMARY KEY, content jsonb NOT NULL)".execute.apply()
       }
     def insert(key: K, json: String): SQL[Nothing, NoExtractor] =
       sql"INSERT INTO auth VALUES ($key, $json::jsonb) ON CONFLICT (email) DO UPDATE SET content = $json::jsonb"
@@ -58,10 +58,10 @@ package object data {
     val drop = sql"DROP TABLE IF EXISTS deploy"
     def create = 
       DB localTx { implicit session =>
-        sql"CREATE TABLE deploy (id uuid PRIMARY KEY, content jsonb NOT NULL)"
-        sql"CREATE INDEX ON deploy ((content ->> 'startTime'))"
-        sql"CREATE INDEX ON deploy ((content ->> 'status'))"
-        sql"CREATE INDEX ON deploy ((content -> 'parameters' ->> 'projectName'))"
+        sql"CREATE TABLE deploy (id uuid PRIMARY KEY, content jsonb NOT NULL)".execute.apply()
+        sql"CREATE INDEX ON deploy ((content ->> 'startTime'))".execute.apply()
+        sql"CREATE INDEX ON deploy ((content ->> 'status'))".execute.apply()
+        sql"CREATE INDEX ON deploy ((content -> 'parameters' ->> 'projectName'))".execute.apply()
       }
     
     def insert(key: K, json: String): SQL[Nothing, NoExtractor] =
@@ -78,9 +78,9 @@ package object data {
     val drop = sql"DROP TABLE IF EXISTS deployLog"
     def create = 
       DB localTx { implicit session =>
-        sql"CREATE TABLE deployLog (id uuid PRIMARY KEY, content jsonb NOT NULL)"
-        sql"CREATE INDEX ON deployLog ((content ->> 'time'))"
-        sql"CREATE INDEX ON deployLog ((content ->> 'deploy'))"
+        sql"CREATE TABLE deployLog (id uuid PRIMARY KEY, content jsonb NOT NULL)".execute.apply()
+        sql"CREATE INDEX ON deployLog ((content ->> 'time'))".execute.apply()
+        sql"CREATE INDEX ON deployLog ((content ->> 'deploy'))".execute.apply()
       }
 
     def insert(key: K, json: String): SQL[Nothing, NoExtractor] =

--- a/riff-raff/app/migration/dsl/interpreters/MigrateInterpreter.scala
+++ b/riff-raff/app/migration/dsl/interpreters/MigrateInterpreter.scala
@@ -12,17 +12,13 @@ object MigrateInterpreter extends Migrator[Unit] with controllers.Logging {
   
   val WINDOW_SIZE = 1000
 
-  def dropTable(pgTable: ToPostgres[_]): IO[MigrationError, Unit] =
-    IO.sync(log.info("Dropping table")) *>
+  def deleteTable(pgTable: ToPostgres[_]): IO[MigrationError, Unit] =
+    IO.sync(log.info("Creating table")) *>
       IO.blocking {
         DB autoCommit { implicit session =>
-          pgTable.drop.execute.apply()
+          pgTable.delete.execute.apply()
         }
-        ()
-      } mapError(DatabaseError(_))
-
-  def createTable(pgTable: ToPostgres[_]): IO[MigrationError, Unit] =
-    IO.sync(log.info("Creating table")) *> IO.blocking(pgTable.create).void.mapError(DatabaseError(_))
+      }.void mapError(DatabaseError(_))
 
   def insertAll[A](pgTable: ToPostgres[A], records: List[A]): IO[MigrationError, Unit] =
     IO.sync(log.info(s"Inserting ${records.length} items")) *>

--- a/riff-raff/app/migration/dsl/interpreters/MigrateInterpreter.scala
+++ b/riff-raff/app/migration/dsl/interpreters/MigrateInterpreter.scala
@@ -10,7 +10,7 @@ import scalikejdbc._
 
 object MigrateInterpreter extends Migrator[Unit] with controllers.Logging {
   
-  val WINDOW_SIZE = 3000
+  val WINDOW_SIZE = 1000
 
   def zero = ()
   def combine(r1: Unit, r2: Unit) = ()

--- a/riff-raff/app/migration/dsl/interpreters/MigrateInterpreter.scala
+++ b/riff-raff/app/migration/dsl/interpreters/MigrateInterpreter.scala
@@ -22,13 +22,7 @@ object MigrateInterpreter extends Migrator[Unit] with controllers.Logging {
       } mapError(DatabaseError(_))
 
   def createTable(pgTable: ToPostgres[_]): IO[MigrationError, Unit] =
-    IO.sync(log.info("Creating table")) *>
-      IO.blocking {
-        DB autoCommit { implicit session =>
-          pgTable.create.execute.apply()
-        }
-        ()
-      } mapError(DatabaseError(_))
+    IO.sync(log.info("Creating table")) *> IO.blocking(pgTable.create).void.mapError(DatabaseError(_))
 
   def insertAll[A](pgTable: ToPostgres[A], records: List[A]): IO[MigrationError, Unit] =
     IO.sync(log.info(s"Inserting ${records.length} items")) *>

--- a/riff-raff/app/migration/dsl/interpreters/MigrateInterpreter.scala
+++ b/riff-raff/app/migration/dsl/interpreters/MigrateInterpreter.scala
@@ -26,7 +26,7 @@ object MigrateInterpreter extends Migrator[Unit] with controllers.Logging {
   def insertAll[A](pgTable: ToPostgres[A], records: List[A]): IO[MigrationError, Unit] = {
     val keyJsonPairs = records.map(rec => pgTable.key(rec) -> Json.stringify(pgTable.json(rec)))
     IO.sync(log.info(s"Inserting ${records.length} items")) *>
-      IO.foreach(keyJsonPairs.grouped(10).toList) { records10 =>
+      IO.foreach(keyJsonPairs.grouped(100).toList) { records10 =>
         IO.blocking {
           DB localTx { implicit session =>
             records10.foreach { case (key, json) => pgTable.insert(key, json).update.apply() }

--- a/riff-raff/app/migration/dsl/interpreters/MigrateInterpreter.scala
+++ b/riff-raff/app/migration/dsl/interpreters/MigrateInterpreter.scala
@@ -12,6 +12,9 @@ object MigrateInterpreter extends Migrator[Unit] with controllers.Logging {
   
   val WINDOW_SIZE = 1000
 
+  def zero = ()
+  def combine(r1: Unit, r2: Unit) = ()
+
   def deleteTable(pgTable: ToPostgres[_]): IO[MigrationError, Unit] =
     IO.sync(log.info("Creating table")) *>
       IO.blocking {

--- a/riff-raff/app/migration/dsl/interpreters/MigrateInterpreter.scala
+++ b/riff-raff/app/migration/dsl/interpreters/MigrateInterpreter.scala
@@ -10,7 +10,7 @@ import scalikejdbc._
 
 object MigrateInterpreter extends Migrator[Unit] with controllers.Logging {
   
-  val WINDOW_SIZE = 1000
+  val WINDOW_SIZE = 3000
 
   def zero = ()
   def combine(r1: Unit, r2: Unit) = ()

--- a/riff-raff/app/migration/dsl/interpreters/Postgre.scala
+++ b/riff-raff/app/migration/dsl/interpreters/Postgre.scala
@@ -10,7 +10,7 @@ object Postgres {
     IO.syncThrowable {
       Class.forName("org.postgresql.Driver")
       ConnectionPool.singleton(db, user, password)
-    } leftMap(DatabaseError(_))
+    } mapError(DatabaseError(_))
 
   val disconnect: IO[Nothing, Unit] = IO.sync(ConnectionPool.closeAll())
 }

--- a/riff-raff/app/migration/dsl/interpreters/PreviewInterpreter.scala
+++ b/riff-raff/app/migration/dsl/interpreters/PreviewInterpreter.scala
@@ -16,13 +16,13 @@ object PreviewInterpreter extends Migrator[PreviewResponse] {
   val WINDOW_SIZE = 1000
 
   def dropTable(pgTable: ToPostgres[_]) =
-    IO.now(DropTable(pgTable.drop.statement))
+    IO.succeed(DropTable(pgTable.drop.statement))
 
   def createTable(pgTable: ToPostgres[_]) =
-    IO.now(CreateTable(pgTable.create.statement))
+    IO.succeed(CreateTable(pgTable.create.statement))
 
   def insertAll[A](pgTable: ToPostgres[A], records: List[A]) =
-    IO.traverse(records){ record =>
-      IO.now(pgTable.insert(pgTable.key(record), Json.stringify(pgTable.json(record))).statement)
+    IO.foreach(records){ record =>
+      IO.succeed(pgTable.insert(pgTable.key(record), Json.stringify(pgTable.json(record))).statement)
     }.map(InsertValues("", _))
 }

--- a/riff-raff/app/migration/dsl/interpreters/PreviewInterpreter.scala
+++ b/riff-raff/app/migration/dsl/interpreters/PreviewInterpreter.scala
@@ -15,11 +15,8 @@ object PreviewInterpreter extends Migrator[PreviewResponse] {
 
   val WINDOW_SIZE = 1000
 
-  def dropTable(pgTable: ToPostgres[_]) =
-    IO.succeed(DropTable(pgTable.drop.statement))
-
-  def createTable(pgTable: ToPostgres[_]) =
-    IO.succeed(CreateTable(pgTable.create.statement))
+  def deleteTable(pgTable: ToPostgres[_]) =
+    IO.succeed(CreateTable(pgTable.delete.statement))
 
   def insertAll[A](pgTable: ToPostgres[A], records: List[A]) =
     IO.foreach(records){ record =>

--- a/riff-raff/app/migration/dsl/interpreters/PreviewInterpreter.scala
+++ b/riff-raff/app/migration/dsl/interpreters/PreviewInterpreter.scala
@@ -10,10 +10,17 @@ sealed abstract class PreviewResponse
 final case class DropTable(sql: String) extends PreviewResponse
 final case class CreateTable(sql: String) extends PreviewResponse
 final case class InsertValues(prelude: String, values: List[String]) extends PreviewResponse
+final case class Queries(qs: List[PreviewResponse]) extends PreviewResponse
 
 object PreviewInterpreter extends Migrator[PreviewResponse] {
-
+  
   val WINDOW_SIZE = 1000
+  
+  def zero = Queries(Nil)
+  def combine(r1: PreviewResponse, r2: PreviewResponse) = r1 match {
+    case Queries(qs) => Queries(r2 :: qs)
+    case x => Queries(x :: r2 :: Nil)
+  }
 
   def deleteTable(pgTable: ToPostgres[_]) =
     IO.succeed(CreateTable(pgTable.delete.statement))

--- a/riff-raff/app/persistence/mapping.scala
+++ b/riff-raff/app/persistence/mapping.scala
@@ -112,6 +112,7 @@ trait DocumentStore {
   def readDeploy(uuid: UUID): Option[DeployRecordDocument] = None
   def readLogs(uuid: UUID): List[LogDocument] = Nil
   def readAllLogs(pagination: PaginationView): Either[Throwable, Iterable[LogDocument]] = Right(Nil)
+  def countLogsFromDate(): Int = 0
   def getDeployUUIDs(limit: Int = 0): List[SimpleDeployDetail] = Nil
   def getDeploys(filter: Option[DeployFilter], pagination: PaginationView): Either[Throwable, List[DeployRecordDocument]] = Right(Nil)
   def countDeploys(filter: Option[DeployFilter]): Int = 0

--- a/riff-raff/app/persistence/mapping.scala
+++ b/riff-raff/app/persistence/mapping.scala
@@ -12,6 +12,7 @@ import magenta.ContextMessage._
 import magenta._
 import magenta.input.{All, DeploymentKey, DeploymentKeysSelector}
 import org.joda.time.DateTime
+import org.bson.types.ObjectId
 import persistence.DeploymentSelectorDocument._
 
 case class RecordConverter(uuid:UUID, startTime:DateTime, params: ParametersDocument, status:RunState, messages:List[MessageWrapper] = Nil) extends Logging {
@@ -111,7 +112,7 @@ trait DocumentStore {
   def updateDeploySummary(uuid: UUID, totalTasks:Option[Int], completedTasks:Int, lastActivityTime:DateTime, hasWarnings:Boolean): Unit
   def readDeploy(uuid: UUID): Option[DeployRecordDocument] = None
   def readLogs(uuid: UUID): List[LogDocument] = Nil
-  def readAllLogs(pageSize: Int, startId: Option[UUID]): Either[Throwable, Iterable[LogDocument]] = Right(Nil)
+  def readAllLogs(pageSize: Int, startId: Option[ObjectId]): Either[Throwable, (Iterable[LogDocument], Option[ObjectId])] = Right((Nil, None))
   def countLogsFromDate(): Int = 0
   def getDeployUUIDs(limit: Int = 0): List[SimpleDeployDetail] = Nil
   def getDeploys(filter: Option[DeployFilter], pagination: PaginationView): Either[Throwable, List[DeployRecordDocument]] = Right(Nil)

--- a/riff-raff/app/persistence/mapping.scala
+++ b/riff-raff/app/persistence/mapping.scala
@@ -111,7 +111,7 @@ trait DocumentStore {
   def updateDeploySummary(uuid: UUID, totalTasks:Option[Int], completedTasks:Int, lastActivityTime:DateTime, hasWarnings:Boolean): Unit
   def readDeploy(uuid: UUID): Option[DeployRecordDocument] = None
   def readLogs(uuid: UUID): List[LogDocument] = Nil
-  def readAllLogs(pagination: PaginationView): Either[Throwable, Iterable[LogDocument]] = Right(Nil)
+  def readAllLogs(pageSize: Int, startId: Option[UUID]): Either[Throwable, Iterable[LogDocument]] = Right(Nil)
   def countLogsFromDate(): Int = 0
   def getDeployUUIDs(limit: Int = 0): List[SimpleDeployDetail] = Nil
   def getDeploys(filter: Option[DeployFilter], pagination: PaginationView): Either[Throwable, List[DeployRecordDocument]] = Right(Nil)

--- a/riff-raff/app/persistence/mongodb.scala
+++ b/riff-raff/app/persistence/mongodb.scala
@@ -192,8 +192,10 @@ class MongoDatastore(config: Config, database: MongoDB) extends DataStore(config
     }
 
   val deployLogDateFrom = new DateTime("2019-02-18T00:00:00.000Z")
-  override def readAllLogs(pagination: PaginationView): Either[Throwable, Iterable[LogDocument]] = Either.catchNonFatal {
-    val cursor = deployLogCollection.find().pagination(pagination)
+  override def readAllLogs(pageSize: Int, startId: Option[UUID]): Either[Throwable, Iterable[LogDocument]] = Either.catchNonFatal {
+    val cursor = startId.fold(deployLogCollection.find())(startId => deployLogCollection.find(MongoDBObject(
+      "_id" -> MongoDBObject("$gt" -> startId)
+    ))).sort(MongoDBObject("_id" -> 1)).limit(pageSize)
     cursor.toIterable.flatMap { LogDocument.fromDBO(_) }
   }
 

--- a/riff-raff/app/persistence/mongodb.scala
+++ b/riff-raff/app/persistence/mongodb.scala
@@ -193,9 +193,7 @@ class MongoDatastore(config: Config, database: MongoDB) extends DataStore(config
 
   val deployLogDateFrom = new DateTime("2019-02-18T00:00:00.000Z")
   override def readAllLogs(pagination: PaginationView): Either[Throwable, Iterable[LogDocument]] = Either.catchNonFatal {
-    val cursor = deployLogCollection.find(MongoDBObject(
-      "time" -> MongoDBObject("$gte" -> deployLogDateFrom)
-    )).sort(MongoDBObject("time" -> -1)).pagination(pagination)
+    val cursor = deployLogCollection.find().pagination(pagination)
     cursor.toIterable.flatMap { LogDocument.fromDBO(_) }
   }
 

--- a/riff-raff/app/persistence/mongodb.scala
+++ b/riff-raff/app/persistence/mongodb.scala
@@ -191,8 +191,11 @@ class MongoDatastore(config: Config, database: MongoDB) extends DataStore(config
       deployLogCollection.find(criteria).toList.flatMap(LogDocument.fromDBO(_))
     }
 
+  val deployLogDateFrom = new DateTime("2019-02-18T00:00:00.000Z")
   override def readAllLogs(pagination: PaginationView): Either[Throwable, Iterable[LogDocument]] = Either.catchNonFatal {
-    val cursor = deployLogCollection.find().sort(MongoDBObject("time" -> -1)).pagination(pagination)
+    val cursor = deployLogCollection.find(MongoDBObject(
+      "time" -> MongoDBObject("$gte" -> deployLogDateFrom)
+    )).sort(MongoDBObject("time" -> -1)).pagination(pagination)
     cursor.toIterable.flatMap { LogDocument.fromDBO(_) }
   }
 

--- a/riff-raff/app/persistence/mongodb.scala
+++ b/riff-raff/app/persistence/mongodb.scala
@@ -200,9 +200,9 @@ class MongoDatastore(config: Config, database: MongoDB) extends DataStore(config
   }
 
   override def countLogsFromDate(): Int = {
-    deployLogCollection.find(MongoDBObject(
+    deployLogCollection.count(MongoDBObject(
       "time" -> MongoDBObject("$gte" -> deployLogDateFrom)
-    )).count()
+    ))
   }
 
   override def getDeployUUIDs(limit: Int = 0) = logAndSquashExceptions[List[SimpleDeployDetail]](None,Nil){

--- a/riff-raff/app/persistence/mongodb.scala
+++ b/riff-raff/app/persistence/mongodb.scala
@@ -199,6 +199,12 @@ class MongoDatastore(config: Config, database: MongoDB) extends DataStore(config
     cursor.toIterable.flatMap { LogDocument.fromDBO(_) }
   }
 
+  override def countLogsFromDate(): Int = {
+    deployLogCollection.find(MongoDBObject(
+      "time" -> MongoDBObject("$gte" -> deployLogDateFrom)
+    )).count()
+  }
+
   override def getDeployUUIDs(limit: Int = 0) = logAndSquashExceptions[List[SimpleDeployDetail]](None,Nil){
     val cursor = deployCollection.find(MongoDBObject(), MongoDBObject("_id" -> 1, "startTime" -> 1)).sort(MongoDBObject("startTime" -> -1))
     val limitedCursor = if (limit == 0) cursor else cursor.limit(limit)

--- a/riff-raff/app/persistence/mongodb.scala
+++ b/riff-raff/app/persistence/mongodb.scala
@@ -194,8 +194,8 @@ class MongoDatastore(config: Config, database: MongoDB) extends DataStore(config
   val deployLogDateFrom = new DateTime("2019-02-18T00:00:00.000Z")
   override def readAllLogs(pageSize: Int, startId: Option[UUID]): Either[Throwable, Iterable[LogDocument]] = Either.catchNonFatal {
     val cursor = startId.fold(deployLogCollection.find())(startId => deployLogCollection.find(MongoDBObject(
-      "id" -> MongoDBObject("$gt" -> startId)
-    ))).sort(MongoDBObject("id" -> 1)).limit(pageSize)
+      "deploy" -> MongoDBObject("$gt" -> startId)
+    ))).sort(MongoDBObject("deploy" -> 1)).limit(pageSize)
     cursor.toIterable.flatMap { LogDocument.fromDBO(_) }
   }
 

--- a/riff-raff/app/persistence/mongodb.scala
+++ b/riff-raff/app/persistence/mongodb.scala
@@ -194,8 +194,8 @@ class MongoDatastore(config: Config, database: MongoDB) extends DataStore(config
   val deployLogDateFrom = new DateTime("2019-02-18T00:00:00.000Z")
   override def readAllLogs(pageSize: Int, startId: Option[UUID]): Either[Throwable, Iterable[LogDocument]] = Either.catchNonFatal {
     val cursor = startId.fold(deployLogCollection.find())(startId => deployLogCollection.find(MongoDBObject(
-      "_id" -> MongoDBObject("$gt" -> startId)
-    ))).sort(MongoDBObject("_id" -> 1)).limit(pageSize)
+      "id" -> MongoDBObject("$gt" -> startId)
+    ))).sort(MongoDBObject("id" -> 1)).limit(pageSize)
     cursor.toIterable.flatMap { LogDocument.fromDBO(_) }
   }
 

--- a/riff-raff/app/persistence/mongodb.scala
+++ b/riff-raff/app/persistence/mongodb.scala
@@ -13,6 +13,7 @@ import controllers.{ApiKey, AuthorisationRecord, Logging, SimpleDeployDetail}
 import deployment.{DeployFilter, PaginationView}
 import magenta.RunState
 import org.joda.time.{DateTime, Period}
+import org.bson.types.MinKey
 
 trait MongoSerialisable[A] {
 
@@ -192,11 +193,11 @@ class MongoDatastore(config: Config, database: MongoDB) extends DataStore(config
     }
 
   val deployLogDateFrom = new DateTime("2019-02-18T00:00:00.000Z")
-  override def readAllLogs(pageSize: Int, startId: Option[UUID]): Either[Throwable, Iterable[LogDocument]] = Either.catchNonFatal {
-    val cursor = startId.fold(deployLogCollection.find())(startId => deployLogCollection.find(MongoDBObject(
-      "deploy" -> MongoDBObject("$gt" -> startId)
-    ))).sort(MongoDBObject("deploy" -> 1)).limit(pageSize)
-    cursor.toIterable.flatMap { LogDocument.fromDBO(_) }
+  override def readAllLogs(pageSize: Int, startId: Option[ObjectId]): Either[Throwable, (Iterable[LogDocument], Option[ObjectId])] = Either.catchNonFatal {
+    val cursor = deployLogCollection.find(MongoDBObject(
+      "_id" -> MongoDBObject("$gt" -> startId.getOrElse(new MinKey()))
+    )).sort(MongoDBObject("_id" -> 1)).limit(pageSize).toIterable
+    (cursor.flatMap { LogDocument.fromDBO(_) }, cursor.lastOption.map(_.as[ObjectId]("_id")))
   }
 
   override def countLogsFromDate(): Int = {

--- a/riff-raff/app/views/migrations/preview.scala.html
+++ b/riff-raff/app/views/migrations/preview.scala.html
@@ -1,27 +1,26 @@
 @import conf.Config
 @import migration.dsl.interpreters._
-@(responsess: List[List[PreviewResponse]])(config: Config, appMenu: Menu)(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity])
+@(responses: List[PreviewResponse])(config: Config, appMenu: Menu)(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity])
 
 @main(s"Postgres Migration preview", request) {
   <h2>Migration preview</h2>
 
   <div class="content">
       <pre>
-        @responsess.map { responses =>
-          @responses.map {
-            case DropTable(sql) => { 
-              @sql 
-            }
-            case CreateTable(sql) => { 
-              @sql 
-            }
-            case InsertValues(prelude, values) => {
-              @prelude
-              @values.map { value =>
-                @value
-              }
+        @responses.map {
+          case DropTable(sql) => { 
+            @sql 
+          }
+          case CreateTable(sql) => { 
+            @sql 
+          }
+          case InsertValues(prelude, values) => {
+            @prelude
+            @values.map { value =>
+              @value
             }
           }
+          case Queries(qs) => { }
         }
       </pre>
   </div>


### PR DESCRIPTION
The most important change is that the mongo queries were running on a yielding thread pool, which is bounded by the number of CPUs. They now run on an unbounded pool suited for synchronous, blocking IO.