### PR TITLE
Instantiate the metrics scheduler only once

### DIFF
--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -24,9 +24,9 @@ import magenta.Message._
 import magenta._
 import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.{DateTime, Days}
-import persistence.{DataStore, CollectionStats}
+import persistence.{CollectionStats, DataStore}
 import riffraff.BuildInfo
-import utils.{ScheduledAgent, UnnaturalOrdering}
+import utils.{PeriodicScheduledAgentUpdate, ScheduledAgent, UnnaturalOrdering}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -309,13 +309,14 @@ object TaskMetrics {
   val all = Seq(TaskTimer, TaskStartLatency, TasksRunning)
 }
 
+object DatastoreRequest extends TimingMetric(
+  "performance",
+  "database_requests",
+  "Database requests",
+  "outgoing requests to the database"
+)
+
 class DatastoreMetrics(config: Config, datastore: DataStore) {
-  object DatastoreRequest extends TimingMetric(
-    "performance",
-    "database_requests",
-    "Database requests",
-    "outgoing requests to the database"
-  )
   val collectionStats = ScheduledAgent(5 seconds, 5 minutes, Map.empty[String, CollectionStats]) { _ =>  datastore.collectionStats }
   def dataSize: Long = collectionStats().values.map(_.dataSize).foldLeft(0L)(_ + _)
   def storageSize: Long = collectionStats().values.map(_.storageSize).foldLeft(0L)(_ + _)

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -317,7 +317,9 @@ object DatastoreRequest extends TimingMetric(
 )
 
 class DatastoreMetrics(config: Config, datastore: DataStore) {
-  val collectionStats = ScheduledAgent(5 seconds, 5 minutes, Map.empty[String, CollectionStats]) { _ =>  datastore.collectionStats }
+  val update: PeriodicScheduledAgentUpdate[Map[String, CollectionStats]] = PeriodicScheduledAgentUpdate(5 seconds, 5 minutes){ _ => datastore.collectionStats }
+  val collectionStats = ScheduledAgent(Map.empty[String, CollectionStats], update)
+
   def dataSize: Long = collectionStats().values.map(_.dataSize).foldLeft(0L)(_ + _)
   def storageSize: Long = collectionStats().values.map(_.storageSize).foldLeft(0L)(_ + _)
   def deployCollectionCount: Long = collectionStats().get("deploy").map(_.documentCount).getOrElse(0L)

--- a/riff-raff/app/persistence/datastore.scala
+++ b/riff-raff/app/persistence/datastore.scala
@@ -2,7 +2,7 @@ package persistence
 
 import java.util.UUID
 
-import conf.{Config, DatastoreMetrics}
+import conf.{Config, DatastoreMetrics, DatastoreRequest}
 import controllers.{ApiKey, AuthorisationRecord, Logging}
 import org.joda.time.DateTime
 import play.api.Logger
@@ -48,7 +48,7 @@ abstract class DataStore(config: Config) extends DocumentStore with Retriable {
         Left(t)
     }
 
-  def run[T](block: => T): T = new DatastoreMetrics(config, this).DatastoreRequest.measure(block)
+  def run[T](block: => T): T = DatastoreRequest.measure(block)
 
   def collectionStats: Map[String, CollectionStats] = Map.empty
 

--- a/riff-raff/app/utils/ScheduledAgent.scala
+++ b/riff-raff/app/utils/ScheduledAgent.scala
@@ -10,14 +10,6 @@ import org.joda.time.{DateTime, Interval, LocalDate, LocalTime}
 object ScheduledAgent extends Lifecycle {
   val scheduleSystem = ActorSystem("scheduled-agent")
 
-  def apply[T](initialDelay: FiniteDuration, frequency: FiniteDuration)(block: => T): ScheduledAgent[T] = {
-    ScheduledAgent(initialDelay, frequency, block)(_ => block)
-  }
-
-  def apply[T](initialDelay: FiniteDuration, frequency: FiniteDuration, initialValue: T)(block: T => T): ScheduledAgent[T] = {
-    ScheduledAgent(initialValue, PeriodicScheduledAgentUpdate(block, initialDelay, frequency))
-  }
-
   def apply[T](initialValue: T, updates: ScheduledAgentUpdate[T]*): ScheduledAgent[T] = {
     new ScheduledAgent(scheduleSystem, initialValue, updates:_*)
   }


### PR DESCRIPTION
Following the config migration we were instantiating one metrics object per postgres request 😱 