### PR TITLE
Add index for startTime with timestamp conversion.

### DIFF
--- a/riff-raff/conf/evolutions/default/3.sql
+++ b/riff-raff/conf/evolutions/default/3.sql
@@ -1,0 +1,17 @@
+# Index required efficient for queries on startTime timestamp field
+
+# --- !Ups
+
+CREATE OR REPLACE FUNCTION f_starttime_timestamp(text)
+  RETURNS timestamptz AS
+$$SELECT to_timestamp($1, 'YYYY-MM-DDTHH:MI:SS.MS')$$  -- adapt to your needs
+  LANGUAGE sql IMMUTABLE;
+
+CREATE INDEX deploy_startTime_timestamp ON deploy (f_starttime_timestamp(content ->> 'startTime'));
+
+
+# --- !Downs
+
+DROP INDEX deploy_startTime_timestamp;
+
+


### PR DESCRIPTION
Currently we have some slow queries as they are taking place on the startTime field as a TIMESTAMP value. Currently we only have an index for startTime as a TEXT value. This rectifies that, following suggestion here https://stackoverflow.com/questions/29757374/create-timestamp-index-from-json-on-postgresql#comment47648833_29757374 

https://github.com/guardian/riff-raff/pull/533 modifies the app to start using the new function this evolution adds.