### PR TITLE
Use sql function to convert startTime to TIMESTAMP when running queries

### DIFF
--- a/riff-raff/app/deployment/filter.scala
+++ b/riff-raff/app/deployment/filter.scala
@@ -44,7 +44,7 @@ case class DeployFilter(
     status.map(s => sqls"content->>'status' = ${s.entryName}"),
     maxDaysAgo.map { days =>
       val dateTime = LocalDate.now.minusDays(days).toDateTimeAtCurrentTime
-      sqls"(content->>'startTime')::TIMESTAMP > $dateTime::TIMESTAMP"
+      sqls"f_starttime_timestamp(content->>'startTime') > $dateTime::TIMESTAMP"
     },
     hasWarnings.map(hw => sqls"content->>'hasWarnings' = ${hw.toString}")
   ).flatten

--- a/riff-raff/app/persistence/postgresdb.scala
+++ b/riff-raff/app/persistence/postgresdb.scala
@@ -142,7 +142,7 @@ class PostgresDatastore(config: Config) extends DataStore(config) with Logging {
     DB readOnly { implicit session =>
       val whereFilters: SQLSyntax = filter.map(_.postgresFilters).getOrElse(sqls"")
       val paginationFilters = pagination.pageSize.fold(sqls"")(size => sqls"OFFSET ${size*(pagination.page-1)} LIMIT $size")
-      sql"SELECT content FROM deploy $whereFilters ORDER BY content->>'startTime' DESC $paginationFilters".map(DeployRecordDocument(_)).list.apply()
+      sql"SELECT content FROM deploy $whereFilters ORDER BY (content->>'startTime')::TIMESTAMP DESC $paginationFilters".map(DeployRecordDocument(_)).list.apply()
     }
   }
 


### PR DESCRIPTION
https://github.com/guardian/riff-raff/pull/532/files adds a new index - this changes modifies the app to make use of the same timestamp conversion function as is used in the index (otherwise the index will not be used)>