### PR TITLE
Notify when both continuous and scheduled deployment fail

### DIFF
--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -12,7 +12,7 @@ import deployment.{DeploymentEngine, Deployments}
 import housekeeping.ArtifactHousekeeping
 import lifecycle.ShutdownWhenInactive
 import magenta.deployment_type._
-import notification.{HooksClient, ScheduledDeployFailureNotifications}
+import notification.{HooksClient, DeployFailureNotifications}
 import persistence._
 import play.api.ApplicationLoader.Context
 import play.api.db.evolutions.EvolutionsComponents
@@ -111,7 +111,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
   val continuousDeployment = new ContinuousDeployment(config, changeFreeze, buildPoller, deployments, continuousDeploymentConfigRepository)
   val previewCoordinator = new PreviewCoordinator(config,prismLookup, availableDeploymentTypes)
   val artifactHousekeeper = new ArtifactHousekeeping(config, deployments)
-  val scheduledDeployNotifier = new ScheduledDeployFailureNotifications(config, availableDeploymentTypes, targetResolver)
+  val scheduledDeployNotifier = new DeployFailureNotifications(config, availableDeploymentTypes, targetResolver)
 
   val authAction = new AuthAction[AnyContent](
     googleAuthConfig, routes.Login.loginAction(), controllerComponents.parsers.default)(executionContext)

--- a/riff-raff/app/ci/ContinuousDeployment.scala
+++ b/riff-raff/app/ci/ContinuousDeployment.scala
@@ -69,6 +69,7 @@ class ContinuousDeployment(config: Config,
 }
 
 object ContinuousDeployment extends Logging with Retriable {
+  val deployer = Deployer("Continuous Deployment")
 
   def getMatchesForSuccessfulBuilds(build: CIBuild, configs: Iterable[ContinuousDeploymentConfig]): Iterable[(ContinuousDeploymentConfig, CIBuild)] = {
     configs.flatMap { config =>
@@ -80,7 +81,7 @@ object ContinuousDeployment extends Logging with Retriable {
   def getDeployParams(configBuildTuple:(ContinuousDeploymentConfig, CIBuild)): DeployParameters = {
     val (config,build) = configBuildTuple
     DeployParameters(
-      Deployer("Continuous Deployment"),
+      deployer,
       build.toMagentaBuild,
       Stage(config.stage)
     )


### PR DESCRIPTION
Ronseal.

We had an issue in Ed Tools that would have been caught sooner had we noticed that a deploy triggered from a GitHub merge had failed.