### PR TITLE
Upgrade to AWS SDK v2

### DIFF
--- a/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
+++ b/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
@@ -1,10 +1,9 @@
 package magenta.artifact
 
-import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model._
 import com.gu.management.Loggable
 import magenta.Build
-import play.api.libs.json.{JsonValidationError, JsPath}
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model._
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
@@ -18,32 +17,33 @@ trait S3Location {
   def relativeTo(path: S3Location): String = {
     key.stripPrefix(path.key).stripPrefix("/")
   }
-  def fetchContentAsString()(implicit client: AmazonS3) = S3Location.fetchContentAsString(this)
-  def listAll()(implicit client: AmazonS3) = S3Location.listObjects(this)
+  def fetchContentAsString()(implicit client: S3Client): Either[S3Error, String] = S3Location.fetchContentAsString(this)
+  def listAll()(implicit client: S3Client): Seq[S3Object] = S3Location.listObjects(this)
 }
 
 object S3Location extends Loggable {
-  def listAll(bucket: String)(implicit s3Client: AmazonS3): Seq[S3Object] = listObjects(bucket, None)
+  def listAll(bucket: String)(implicit s3Client: S3Client): Seq[S3Object] = listObjects(bucket, None)
 
-  def listObjects(location: S3Location)(implicit s3Client: AmazonS3): Seq[S3Object] =
+  def listObjects(location: S3Location)(implicit s3Client: S3Client): Seq[S3Object] =
     listObjects(location.bucket, Some(location.key))
 
   val maxKeysInBucketListing = 1000 // AWS won't return more than this, even if you set the parameter to a larger value
 
-  private def listObjects(bucket: String, prefix: Option[String])(implicit s3Client: AmazonS3): Seq[S3Object] = {
-    def request(continuationToken: Option[String]) = new ListObjectsV2Request()
-      .withBucketName(bucket)
-      .withPrefix(prefix.orNull)
-      .withMaxKeys(maxKeysInBucketListing)
-      .withContinuationToken(continuationToken.orNull)
+  private def listObjects(bucket: String, prefix: Option[String])(implicit s3Client: S3Client): Seq[S3Object] = {
+    def request(continuationToken: Option[String]): ListObjectsV2Request = ListObjectsV2Request.builder()
+      .bucket(bucket)
+      .prefix(prefix.orNull)
+      .maxKeys(maxKeysInBucketListing)
+      .continuationToken(continuationToken.orNull)
+      .build()
 
     @tailrec
-    def pageListings(acc: Seq[ListObjectsV2Result], previousListing: ListObjectsV2Result): Seq[ListObjectsV2Result] = {
+    def pageListings(acc: Seq[ListObjectsV2Response], previousListing: ListObjectsV2Response): Seq[ListObjectsV2Response] = {
       if (!previousListing.isTruncated) {
         acc
       } else {
         val listing = s3Client.listObjectsV2(
-          request(Some(previousListing.getNextContinuationToken))
+          request(Some(previousListing.nextContinuationToken))
         )
         pageListings(acc :+ listing, listing)
       }
@@ -52,14 +52,15 @@ object S3Location extends Loggable {
     val initialListing = s3Client.listObjectsV2(request(None))
     for {
       summaries <- pageListings(Seq(initialListing), initialListing)
-      summary <- summaries.getObjectSummaries.asScala
-    } yield S3Object(summary.getBucketName, summary.getKey, summary.getSize)
+      summary <- summaries.contents.asScala
+    } yield S3Object(bucket, summary.key, summary.size)
   }
 
-  def fetchContentAsString(location: S3Location)(implicit client:AmazonS3): Either[S3Error, String] = {
+  def fetchContentAsString(location: S3Location)(implicit client: S3Client): Either[S3Error, String] = {
     import cats.syntax.either._
-    Either.catchNonFatal(client.getObjectAsString(location.bucket, location.key)).leftMap {
-      case e: AmazonS3Exception if e.getStatusCode == 404 => EmptyS3Location(location)
+    val getObjRequest = GetObjectRequest.builder().bucket(location.bucket).key(location.key).build()
+    Either.catchNonFatal(client.getObjectAsBytes(getObjRequest).asUtf8String).leftMap {
+      case e: S3Exception if e.statusCode == 404 => EmptyS3Location(location)
       case e => UnknownS3Error(e)
     }
   }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -1,10 +1,9 @@
 package magenta.deployment_type
 
-import com.amazonaws.regions.{Region => AwsRegion, Regions => AwsRegions}
-import com.amazonaws.services.s3.AmazonS3
-import magenta.{DeploymentPackage, DeployParameters, DeployReporter, DeployTarget, KeyRing, Region, Stack}
 import magenta.artifact.S3Path
 import magenta.tasks.{S3Upload, UpdateS3Lambda}
+import magenta.{DeployParameters, DeployReporter, DeployTarget, DeploymentPackage, KeyRing, Region, Stack}
+import software.amazon.awssdk.services.s3.S3Client
 
 object Lambda extends DeploymentType  {
   val name = "aws-lambda"
@@ -97,7 +96,7 @@ object Lambda extends DeploymentType  {
       |Uploads the lambda code to S3.
     """.stripMargin){ (pkg, resources, target) =>
     implicit val keyRing: KeyRing = resources.assembleKeyring(target, pkg)
-    implicit val artifactClient: AmazonS3 = resources.artifactClient
+    implicit val artifactClient: S3Client = resources.artifactClient
     lambdaToProcess(pkg, target, resources.reporter).map { lambda =>
       val s3Key = makeS3Key(target.stack, target.parameters, pkg, lambda.fileName)
       S3Upload(
@@ -124,7 +123,7 @@ object Lambda extends DeploymentType  {
       |As a result you can bundle stage specific configuration into the respective files.
     """.stripMargin){ (pkg, resources, target) =>
     implicit val keyRing: KeyRing = resources.assembleKeyring(target, pkg)
-    implicit val artifactClient: AmazonS3 = resources.artifactClient
+    implicit val artifactClient: S3Client = resources.artifactClient
     lambdaToProcess(pkg, target, resources.reporter).map { lambda =>
         val s3Key = makeS3Key(target.stack, target.parameters, pkg, lambda.fileName)
         UpdateS3Lambda(

--- a/magenta-lib/src/main/scala/magenta/package.scala
+++ b/magenta-lib/src/main/scala/magenta/package.scala
@@ -2,8 +2,10 @@ package magenta
 
 import java.io.Closeable
 
-import com.amazonaws.{AmazonClientException, ClientConfiguration}
 import com.gu.management.Loggable
+import software.amazon.awssdk.awscore.exception.AwsServiceException
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
+import software.amazon.awssdk.core.retry.{RetryPolicy, RetryPolicyContext}
 
 import scala.annotation.tailrec
 import scala.math.Ordering.OptionOrdering
@@ -44,18 +46,22 @@ object `package` extends Loggable {
   }
 
   @tailrec
-  def retryOnException[T](config: ClientConfiguration, currentAttempt: Int = 1)(f: => T): T = {
-    val policy = config.getRetryPolicy
-    val retries = policy.getMaxErrorRetry
+  def retryOnException[T](config: ClientOverrideConfiguration, currentAttempt: Int = 1)(f: => T): T = {
+    val policy: RetryPolicy = config.retryPolicy.get
+    val retries = policy.numRetries
 
-    // use the client config retry logic - we pass in null for the request as no SDK implementations actually use it
-    def shouldRetryFor(ace: AmazonClientException) = policy.getRetryCondition.shouldRetry(null, ace, currentAttempt)
+    // use the client config retry logic
+    def shouldRetryFor(ase: AwsServiceException): Boolean = {
+      val retryContext = RetryPolicyContext.builder().exception(ase).retriesAttempted(currentAttempt).build()
+      policy.retryCondition.shouldRetry(retryContext)
+    }
 
     Try(f) match {
       case Success(result) => result
-      case Failure(exception:AmazonClientException) if currentAttempt <= retries && shouldRetryFor(exception) =>
+      case Failure(exception: AwsServiceException) if currentAttempt <= retries && shouldRetryFor(exception) =>
         // use client config to calculate delay - pass in null for request as no SDK implementations actually use it
-        val delay = policy.getBackoffStrategy.delayBeforeNextRetry(null, exception, currentAttempt)
+        val retryContext = RetryPolicyContext.builder().exception(exception).retriesAttempted(currentAttempt).build()
+        val delay = policy.backoffStrategy.computeDelayBeforeNextRetry(retryContext).getSeconds
         logger.warn(s"Client exception encountered, retrying in ${delay}ms")
         Thread.sleep(delay)
         retryOnException(config, currentAttempt + 1)(f)

--- a/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
@@ -1,19 +1,20 @@
 package magenta.tasks
 
-import com.amazonaws.AmazonServiceException
-import com.amazonaws.services.autoscaling.AmazonAutoScaling
-import com.amazonaws.services.autoscaling.model.{AutoScalingGroup, LifecycleState, SetInstanceProtectionRequest}
 import magenta.{KeyRing, Stage, _}
+import software.amazon.awssdk.awscore.exception.AwsServiceException
+import software.amazon.awssdk.services.autoscaling.AutoScalingClient
+import software.amazon.awssdk.services.autoscaling.model.{AutoScalingGroup, LifecycleState, SetInstanceProtectionRequest}
+import software.amazon.awssdk.services.ec2.Ec2Client
 
 import scala.collection.JavaConverters._
 
 case class CheckGroupSize(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling) {
-    val doubleCapacity = asg.getDesiredCapacity * 2
-    reporter.verbose(s"ASG desired = ${asg.getDesiredCapacity}; ASG max = ${asg.getMaxSize}; Target = $doubleCapacity")
-    if (asg.getMaxSize < doubleCapacity) {
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AutoScalingClient) {
+    val doubleCapacity = asg.desiredCapacity * 2
+    reporter.verbose(s"ASG desired = ${asg.desiredCapacity}; ASG max = ${asg.maxSize}; Target = $doubleCapacity")
+    if (asg.maxSize < doubleCapacity) {
       reporter.fail(
-        s"Autoscaling group does not have the capacity to deploy current max = ${asg.getMaxSize} - desired max = $doubleCapacity"
+        s"Autoscaling group does not have the capacity to deploy current max = ${asg.maxSize} - desired max = $doubleCapacity"
       )
     }
   }
@@ -22,11 +23,11 @@ case class CheckGroupSize(pkg: DeploymentPackage, stage: Stage, stack: Stack, re
 }
 
 case class TagCurrentInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling) {
-    if (asg.getInstances.asScala.nonEmpty) {
-      implicit val ec2Client = EC2.makeEc2Client(keyRing, region)
-      reporter.verbose(s"Tagging ${asg.getInstances.asScala.toList.map(_.getInstanceId).mkString(", ")}")
-      EC2.setTag(asg.getInstances.asScala.toList, "Magenta", "Terminate", ec2Client)
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AutoScalingClient) {
+    if (asg.instances.asScala.nonEmpty) {
+      implicit val ec2Client: Ec2Client = EC2.makeEc2Client(keyRing, region)
+      reporter.verbose(s"Tagging ${asg.instances.asScala.toList.map(_.instanceId).mkString(", ")}")
+      EC2.setTag(asg.instances.asScala.toList, "Magenta", "Terminate", ec2Client)
     } else {
       reporter.verbose(s"No instances to tag")
     }
@@ -36,15 +37,16 @@ case class TagCurrentInstancesWithTerminationTag(pkg: DeploymentPackage, stage: 
 }
 
 case class ProtectCurrentInstances(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling) {
-    val instances = asg.getInstances.asScala.toList
-    val instancesInService = instances.filter(_.getLifecycleState == LifecycleState.InService.toString)
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AutoScalingClient) {
+    val instances = asg.instances.asScala.toList
+    val instancesInService = instances.filter(_.lifecycleState == LifecycleState.IN_SERVICE)
     if (instancesInService.nonEmpty) {
-      val instanceIds = instancesInService.map(_.getInstanceId)
-      val request = new SetInstanceProtectionRequest()
-        .withAutoScalingGroupName(asg.getAutoScalingGroupName)
-        .withInstanceIds(instanceIds: _*)
-        .withProtectedFromScaleIn(true)
+      val instanceIds = instancesInService.map(_.instanceId)
+      val request = SetInstanceProtectionRequest.builder()
+        .autoScalingGroupName(asg.autoScalingGroupName)
+        .instanceIds(instanceIds: _*)
+        .protectedFromScaleIn(true)
+        .build()
       asgClient.setInstanceProtection(request)
     } else {
       reporter.verbose(s"No instances to protect")
@@ -56,18 +58,18 @@ case class ProtectCurrentInstances(pkg: DeploymentPackage, stage: Stage, stack: 
 
 case class DoubleSize(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
 
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling) {
-    val targetCapacity = asg.getDesiredCapacity * 2
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AutoScalingClient) {
+    val targetCapacity = asg.desiredCapacity * 2
     reporter.verbose(s"Doubling capacity to $targetCapacity")
-    ASG.desiredCapacity(asg.getAutoScalingGroupName, targetCapacity, asgClient)
+    ASG.desiredCapacity(asg.autoScalingGroupName, targetCapacity, asgClient)
   }
 
   lazy val description = s"Double the size of the auto-scaling group in $stage, $stack for app ${pkg.app}"
 }
 
 sealed abstract class Pause(durationMillis: Long)(implicit val keyRing: KeyRing) extends ASGTask {
-  def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling): Unit = {
-    if (asg.getDesiredCapacity == 0 && asg.getInstances.isEmpty)
+  def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AutoScalingClient): Unit = {
+    if (asg.desiredCapacity == 0 && asg.instances.isEmpty)
       reporter.verbose("Skipping pause as there are no instances and desired capacity is zero")
     else
       Thread.sleep(durationMillis)
@@ -89,18 +91,18 @@ case class TerminationGrace(pkg: DeploymentPackage, stage: Stage, stack: Stack, 
 case class WaitForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Stack, duration: Long, region: Region)(implicit val keyRing: KeyRing) extends ASGTask
     with SlowRepeatedPollingCheck {
 
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling) {
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AutoScalingClient) {
     val elbClient = ELB.client(keyRing, region)
     check(reporter, stopFlag) {
       try {
-        ASG.isStabilized(ASG.refresh(asg, asgClient), asgClient, elbClient) match {
+        ASG.isStabilized(ASG.refresh(asg, asgClient), elbClient) match {
           case Left(reason) =>
             reporter.verbose(reason)
             false
           case Right(()) => true
         }
       } catch {
-        case e: AmazonServiceException if isRateExceeded(e) => {
+        case e: AwsServiceException if isRateExceeded(e) => {
           reporter.info(e.getMessage)
           false
         }
@@ -108,29 +110,28 @@ case class WaitForStabilization(pkg: DeploymentPackage, stage: Stage, stack: Sta
     }
 
     //found this out by good old trial and error
-    def isRateExceeded(e: AmazonServiceException) = e.getStatusCode == 400 && e.getErrorCode == "Throttling"
+    def isRateExceeded(e: AwsServiceException) = e.statusCode == 400 && e.isThrottlingException
   }
 
   lazy val description: String = "Check the desired number of hosts in both the ASG and ELB are up and that the number of hosts match"
 }
 
 case class CullInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling) {
-    implicit val ec2Client = EC2.makeEc2Client(keyRing, region)
-    implicit val elbClient = ELB.client(keyRing, region)
-    val instancesToKill = asg.getInstances.asScala.filter(instance => EC2.hasTag(instance, "Magenta", "Terminate", ec2Client))
-    val orderedInstancesToKill = instancesToKill.transposeBy(_.getAvailabilityZone)
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AutoScalingClient) {
+    implicit val ec2Client: Ec2Client = EC2.makeEc2Client(keyRing, region)
+    implicit val elbClient: ELB.Client = ELB.client(keyRing, region)
+    val instancesToKill = asg.instances.asScala.filter(instance => EC2.hasTag(instance, "Magenta", "Terminate", ec2Client))
+    val orderedInstancesToKill = instancesToKill.transposeBy(_.availabilityZone)
     try {
-      reporter.verbose(s"Culling instances: ${orderedInstancesToKill.map(_.getInstanceId).mkString(", ")}")
+      reporter.verbose(s"Culling instances: ${orderedInstancesToKill.map(_.instanceId).mkString(", ")}")
       orderedInstancesToKill.foreach(instance => ASG.cull(asg, instance, asgClient, elbClient))
     } catch {
-      case e: AmazonServiceException if desiredSizeReset(e) => {
+      case e: AwsServiceException if desiredSizeReset(e) =>
         reporter.warning("Your ASG desired size may have been reset. This may be because two parts of the deploy are attempting to modify a cloudformation stack simultaneously. Please check that appropriate dependencies are included in riff-raff.yaml, or ensure desiredSize isn't set in the Cloudformation.")
-        throw new ASGResetException(s"Your ASG desired size may have been reset ${e.getErrorMessage}", e)
-      }
+        throw new ASGResetException(s"Your ASG desired size may have been reset ${e.getMessage}", e)
     }
 
-    def desiredSizeReset(e: AmazonServiceException) = e.getStatusCode == 400 && e.getErrorCode == "ValidationError"
+    def desiredSizeReset(e: AwsServiceException) = e.statusCode == 400 && e.awsErrorDetails().toString.contains("ValidationError")
   }
 
   lazy val description = "Terminate instances with the termination tag for this deploy"
@@ -138,8 +139,8 @@ case class CullInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage,
 
 case class SuspendAlarmNotifications(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
 
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling) {
-    ASG.suspendAlarmNotifications(asg.getAutoScalingGroupName, asgClient)
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AutoScalingClient) {
+    ASG.suspendAlarmNotifications(asg.autoScalingGroupName, asgClient)
   }
 
   lazy val description = "Suspending Alarm Notifications - group will no longer scale on any configured alarms"
@@ -147,8 +148,8 @@ case class SuspendAlarmNotifications(pkg: DeploymentPackage, stage: Stage, stack
 
 case class ResumeAlarmNotifications(pkg: DeploymentPackage, stage: Stage, stack: Stack, region: Region)(implicit val keyRing: KeyRing) extends ASGTask {
 
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling) {
-    ASG.resumeAlarmNotifications(asg.getAutoScalingGroupName, asgClient)
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AutoScalingClient) {
+    ASG.resumeAlarmNotifications(asg.autoScalingGroupName, asgClient)
   }
 
   lazy val description = "Resuming Alarm Notifications - group will scale on any configured alarms"
@@ -162,7 +163,7 @@ trait ASGTask extends Task {
   def stage: Stage
   def stack: Stack
 
-  def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling)
+  def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AutoScalingClient)
 
   override def execute(reporter: DeployReporter, stopFlag: => Boolean) {
     val asgClient = ASG.makeAsgClient(keyRing, region)

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -2,43 +2,41 @@ package magenta.tasks
 
 import java.nio.ByteBuffer
 
-import com.amazonaws.{AmazonClientException, AmazonWebServiceRequest, ClientConfiguration}
-import com.amazonaws.auth.{AWSCredentialsProvider, AWSCredentialsProviderChain, BasicAWSCredentials}
-import com.amazonaws.regions.{Region => AwsRegion}
-import com.amazonaws.retry.{PredefinedRetryPolicies, RetryPolicy}
-import com.amazonaws.retry.PredefinedRetryPolicies.SDKDefaultRetryCondition
-import com.amazonaws.services.autoscaling.{AmazonAutoScaling, AmazonAutoScalingClientBuilder}
-import com.amazonaws.services.autoscaling.model.{Instance => ASGInstance, _}
-import com.amazonaws.services.cloudformation.{AmazonCloudFormation, AmazonCloudFormationClientBuilder}
-import com.amazonaws.services.cloudformation.model.{Stack => AmazonStack, Tag => CfnTag, _}
-import com.amazonaws.services.ec2.{AmazonEC2, AmazonEC2ClientBuilder}
-import com.amazonaws.services.ec2.model.{CreateTagsRequest, DescribeInstancesRequest, Tag => EC2Tag}
-import com.amazonaws.services.elasticloadbalancing.{AmazonElasticLoadBalancing => ClassicELB, AmazonElasticLoadBalancingClientBuilder => ClassicELBBuilder}
-import com.amazonaws.services.elasticloadbalancing.model.{Instance => ELBInstance, _}
-import com.amazonaws.services.elasticloadbalancingv2.{AmazonElasticLoadBalancing => ApplicationELB, AmazonElasticLoadBalancingClientBuilder => ApplicationELBBuilder}
-import com.amazonaws.services.elasticloadbalancingv2.model.{Tag => _, _}
-import com.amazonaws.services.lambda.{AWSLambda, AWSLambdaClientBuilder}
-import com.amazonaws.services.lambda.model.UpdateFunctionCodeRequest
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
-import com.amazonaws.services.s3.model.{BucketLifecycleConfiguration, CreateBucketRequest}
-import com.amazonaws.services.s3.model.BucketLifecycleConfiguration.Rule
-import com.amazonaws.services.securitytoken.{AWSSecurityTokenService, AWSSecurityTokenServiceClientBuilder}
-import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest
-import com.gu.management.Loggable
-import magenta.{App, DeploymentPackage, DeployReporter, KeyRing, Region, Stack, Stage}
-
 import cats.implicits._
+import com.gu.management.Loggable
+import magenta.{App, DeployReporter, DeploymentPackage, KeyRing, Region, Stack, Stage}
+import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, AwsCredentials, AwsCredentialsProvider, AwsCredentialsProviderChain}
+import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
+import software.amazon.awssdk.core.retry.backoff.BackoffStrategy
+import software.amazon.awssdk.core.retry.conditions.RetryCondition
+import software.amazon.awssdk.core.retry.{RetryPolicy, RetryPolicyContext}
+import software.amazon.awssdk.services.autoscaling.AutoScalingClient
+import software.amazon.awssdk.services.autoscaling.model.{Instance => ASGInstance, _}
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient
+import software.amazon.awssdk.services.cloudformation.model.{Stack => AmazonStack, Tag => CfnTag, _}
+import software.amazon.awssdk.services.ec2.Ec2Client
+import software.amazon.awssdk.services.ec2.model.{CreateTagsRequest, DescribeInstancesRequest, Tag => EC2Tag}
+import software.amazon.awssdk.services.elasticloadbalancing.model.{DeregisterInstancesFromLoadBalancerRequest, DescribeInstanceHealthRequest, Instance => ELBInstance}
+import software.amazon.awssdk.services.elasticloadbalancing.{ElasticLoadBalancingClient => ClassicELB}
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.{DeregisterTargetsRequest, DescribeTargetHealthRequest, TargetDescription, TargetHealthStateEnum}
+import software.amazon.awssdk.services.elasticloadbalancingv2.{ElasticLoadBalancingV2Client => ApplicationELB}
+import software.amazon.awssdk.services.lambda.LambdaClient
+import software.amazon.awssdk.services.lambda.model.UpdateFunctionCodeRequest
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model._
+import software.amazon.awssdk.services.sts.StsClient
+import software.amazon.awssdk.services.sts.model.GetCallerIdentityRequest
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
-import scala.util.Try
 
 object S3 extends AWS {
-  def makeS3client(keyRing: KeyRing, region: Region, config: ClientConfiguration = clientConfiguration): AmazonS3 =
-    AmazonS3ClientBuilder.standard()
-      .withCredentials(provider(keyRing))
-      .withClientConfiguration(config)
-      .withRegion(region.name)
+  def makeS3client(keyRing: KeyRing, region: Region, config: ClientOverrideConfiguration = clientConfiguration): S3Client =
+    S3Client.builder()
+      .region(region.awsRegion)
+      .credentialsProvider(provider(keyRing))
+      .overrideConfiguration(config)
       .build()
 
   /**
@@ -54,28 +52,31 @@ object S3 extends AWS {
     *
     * @return
     */
-  def accountSpecificBucket(prefix: String, s3Client: AmazonS3, stsClient: AWSSecurityTokenService,
+  def accountSpecificBucket(prefix: String, s3Client: S3Client, stsClient: StsClient,
     region: Region, reporter: DeployReporter, deleteAfterDays: Option[Int] = None): String = {
     val accountNumber = STS.getAccountNumber(stsClient)
     val bucketName = s"$prefix-$accountNumber-${region.name}"
-    if (!s3Client.doesBucketExist(bucketName)) {
+    if (!s3Client.listBuckets.buckets.asScala.exists(b => b.name == bucketName)) {
       reporter.info(s"Creating bucket for this account and region: $bucketName ${region.name}")
       val createBucketRequest = region.name match {
-        case "us-east-1" => new CreateBucketRequest(bucketName) // this needs to be special cased as setting this explicitly blows up
-        case otherRegion => new CreateBucketRequest(bucketName, otherRegion)
+        case "us-east-1" => CreateBucketRequest.builder.bucket(bucketName).build() // this needs to be special cased as setting this explicitly blows up
+        case otherRegion => CreateBucketRequest.builder.bucket(bucketName).build() //TODO: is this pattern match needed?
       }
       s3Client.createBucket(createBucketRequest)
       deleteAfterDays.foreach { days =>
         val daysString = s"$days day${if(days==1) "" else "s"}"
         reporter.info(s"Creating lifecycle rule on bucket that deletes objects after $daysString")
-        s3Client.setBucketLifecycleConfiguration(
-          bucketName,
-          new BucketLifecycleConfiguration().withRules(
-            new Rule()
-              .withId(s"Rule to delete objects after $daysString")
-              .withStatus(BucketLifecycleConfiguration.ENABLED)
-              .withExpirationInDays(days)
-          )
+        s3Client.putBucketLifecycleConfiguration(
+          PutBucketLifecycleConfigurationRequest.builder().bucket(bucketName).lifecycleConfiguration(
+            BucketLifecycleConfiguration.builder()
+              .rules(
+                LifecycleRule.builder()
+                  .id(s"Rule to delete objects after $daysString")
+                  .status(ExpirationStatus.ENABLED)
+                  .expiration(LifecycleExpiration.builder().days(days).build())
+                  .build())
+                .build())
+            .build()
         )
       }
     }
@@ -84,55 +85,51 @@ object S3 extends AWS {
 }
 
 object Lambda extends AWS {
-  def makeLambdaClient(keyRing: KeyRing, region: Region): AWSLambda =
-    AWSLambdaClientBuilder.standard()
-    .withCredentials(provider(keyRing))
-    .withClientConfiguration(clientConfiguration)
-    .withRegion(region.name)
+  def makeLambdaClient(keyRing: KeyRing, region: Region): LambdaClient =
+    LambdaClient.builder()
+    .credentialsProvider(provider(keyRing))
+    .overrideConfiguration(clientConfiguration)
+    .region(region.awsRegion)
     .build()
 
-  def lambdaUpdateFunctionCodeRequest(functionName: String, buffer: ByteBuffer): UpdateFunctionCodeRequest = {
-    val request = new UpdateFunctionCodeRequest
-    request.withFunctionName(functionName)
-    request.withZipFile(buffer)
-    request
-  }
+  def lambdaUpdateFunctionCodeRequest(functionName: String, buffer: ByteBuffer): UpdateFunctionCodeRequest =
+    UpdateFunctionCodeRequest.builder().functionName(functionName).zipFile(SdkBytes.fromByteBuffer(buffer)).build()
 
-  def lambdaUpdateFunctionCodeRequest(functionName: String, s3Bucket: String, s3Key: String): UpdateFunctionCodeRequest = {
-    new UpdateFunctionCodeRequest()
-      .withFunctionName(functionName)
-      .withS3Bucket(s3Bucket)
-      .withS3Key(s3Key)
-  }
+  def lambdaUpdateFunctionCodeRequest(functionName: String, s3Bucket: String, s3Key: String): UpdateFunctionCodeRequest =
+    UpdateFunctionCodeRequest.builder()
+      .functionName(functionName)
+      .s3Bucket(s3Bucket)
+      .s3Key(s3Key)
+      .build()
 }
 
 object ASG extends AWS {
-  def makeAsgClient(keyRing: KeyRing, region: Region): AmazonAutoScaling =
-    AmazonAutoScalingClientBuilder.standard()
-      .withCredentials(provider(keyRing))
-      .withClientConfiguration(clientConfiguration)
-      .withRegion(region.name)
+  def makeAsgClient(keyRing: KeyRing, region: Region): AutoScalingClient =
+    AutoScalingClient.builder()
+      .credentialsProvider(provider(keyRing))
+      .overrideConfiguration(clientConfiguration)
+      .region(region.awsRegion)
       .build()
 
-  def desiredCapacity(name: String, capacity: Int, client: AmazonAutoScaling) =
+  def desiredCapacity(name: String, capacity: Int, client: AutoScalingClient) =
     client.setDesiredCapacity(
-      new SetDesiredCapacityRequest().withAutoScalingGroupName(name).withDesiredCapacity(capacity)
+      SetDesiredCapacityRequest.builder().autoScalingGroupName(name).desiredCapacity(capacity).build()
     )
 
-  def maxCapacity(name: String, capacity: Int, client: AmazonAutoScaling) =
+  def maxCapacity(name: String, capacity: Int, client: AutoScalingClient) =
     client.updateAutoScalingGroup(
-      new UpdateAutoScalingGroupRequest().withAutoScalingGroupName(name).withMaxSize(capacity))
+      UpdateAutoScalingGroupRequest.builder().autoScalingGroupName(name).maxSize(capacity).build()
+    )
 
   /**
     * Check status of all ELBs, or all instance states if there are no ELBs
     */
-  def isStabilized(asg: AutoScalingGroup, asgClient: AmazonAutoScaling,
-    elbClient: ELB.Client): Either[String, Unit] = {
+  def isStabilized(asg: AutoScalingGroup, elbClient: ELB.Client): Either[String, Unit] = {
 
     def matchCapacityAndState(states: List[String], desiredState: String, checkDescription: Option[String]): Either[String, Unit] = {
       val descriptionWithPrecedingSpace = checkDescription.map(d => s" $d").getOrElse("")
-      if (states.size != asg.getDesiredCapacity)
-        Left(s"Number of$descriptionWithPrecedingSpace instances (${states.size}) and ASG desired capacity (${asg.getDesiredCapacity}) don't match")
+      if (states.size != asg.desiredCapacity)
+        Left(s"Number of$descriptionWithPrecedingSpace instances (${states.size}) and ASG desired capacity (${asg.desiredCapacity}) don't match")
       else if (!states.forall(_ == desiredState))
         Left(s"Only ${states.count(_ == desiredState)} of ${states.size}$descriptionWithPrecedingSpace instances $desiredState")
       else
@@ -146,7 +143,7 @@ object ASG extends AWS {
 
     def checkTargetGroup(arn: String): Either[String, Unit] = {
       val elbHealth = ELB.targetInstancesHealth(arn, elbClient.application)
-      matchCapacityAndState(elbHealth, TargetHealthStateEnum.Healthy.toString, Some("V2 ELB"))
+      matchCapacityAndState(elbHealth, TargetHealthStateEnum.HEALTHY.toString, Some("V2 ELB"))
     }
 
     val classicElbNames = elbNames(asg)
@@ -158,54 +155,57 @@ object ASG extends AWS {
         _ <- targetGroupArns.map(checkTargetGroup).sequence
       } yield ()
     } else {
-      val instanceStates = asg.getInstances.asScala.toList.map(_.getLifecycleState)
-      matchCapacityAndState(instanceStates, LifecycleState.InService.toString, None)
+      val instanceStates = asg.instances.asScala.toList.map(_.lifecycleStateAsString)
+      matchCapacityAndState(instanceStates, LifecycleState.IN_SERVICE.toString, None)
     }
   }
 
-  def elbNames(asg: AutoScalingGroup): List[String] = asg.getLoadBalancerNames.asScala.toList
+  def elbNames(asg: AutoScalingGroup): List[String] = asg.loadBalancerNames.asScala.toList
 
-  def elbTargetArns(asg: AutoScalingGroup): List[String] = asg.getTargetGroupARNs.asScala.toList
+  def elbTargetArns(asg: AutoScalingGroup): List[String] = asg.targetGroupARNs.asScala.toList
 
-  def cull(asg: AutoScalingGroup, instance: ASGInstance, asgClient: AmazonAutoScaling, elbClient: ELB.Client) = {
+  def cull(asg: AutoScalingGroup, instance: ASGInstance, asgClient: AutoScalingClient, elbClient: ELB.Client): TerminateInstanceInAutoScalingGroupResponse = {
     ELB.deregister(elbNames(asg), elbTargetArns(asg), instance, elbClient)
 
     asgClient.terminateInstanceInAutoScalingGroup(
-      new TerminateInstanceInAutoScalingGroupRequest()
-        .withInstanceId(instance.getInstanceId).withShouldDecrementDesiredCapacity(true)
+      TerminateInstanceInAutoScalingGroupRequest.builder()
+        .instanceId(instance.instanceId)
+        .shouldDecrementDesiredCapacity(true)
+        .build()
     )
   }
 
-  def refresh(asg: AutoScalingGroup, client: AmazonAutoScaling) =
+  def refresh(asg: AutoScalingGroup, client: AutoScalingClient): AutoScalingGroup =
     client.describeAutoScalingGroups(
-      new DescribeAutoScalingGroupsRequest().withAutoScalingGroupNames(asg.getAutoScalingGroupName)
-    ).getAutoScalingGroups.asScala.head
+      DescribeAutoScalingGroupsRequest.builder().autoScalingGroupNames(asg.autoScalingGroupName()).build()
+    ).autoScalingGroups.asScala.head
 
-  def suspendAlarmNotifications(name: String, client: AmazonAutoScaling) = client.suspendProcesses(
-    new SuspendProcessesRequest().withAutoScalingGroupName(name).withScalingProcesses("AlarmNotification")
-  )
+  def suspendAlarmNotifications(name: String, client: AutoScalingClient): SuspendProcessesResponse =
+    client.suspendProcesses(
+      SuspendProcessesRequest.builder().autoScalingGroupName(name).scalingProcesses("AlarmNotification").build()
+    )
 
-  def resumeAlarmNotifications(name: String, client: AmazonAutoScaling) = client.resumeProcesses(
-    new ResumeProcessesRequest().withAutoScalingGroupName(name).withScalingProcesses("AlarmNotification")
-  )
+  def resumeAlarmNotifications(name: String, client: AutoScalingClient): ResumeProcessesResponse =
+    client.resumeProcesses(
+      ResumeProcessesRequest.builder().autoScalingGroupName(name).scalingProcesses("AlarmNotification").build()
+    )
 
-  def groupForAppAndStage(pkg: DeploymentPackage, stage: Stage, stack: Stack, client: AmazonAutoScaling,
-    reporter: DeployReporter): AutoScalingGroup = {
+  def groupForAppAndStage(pkg: DeploymentPackage, stage: Stage, stack: Stack, client: AutoScalingClient, reporter: DeployReporter): AutoScalingGroup = {
     case class ASGMatch(app:App, matches:List[AutoScalingGroup])
 
     implicit class RichAutoscalingGroup(asg: AutoScalingGroup) {
-      def hasTag(key: String, value: String) = asg.getTags.asScala exists { tag =>
-        tag.getKey == key && tag.getValue == value
+      def hasTag(key: String, value: String): Boolean = asg.tags.asScala.exists { tag =>
+        tag.key == key && tag.value == value
       }
       def matchApp(app: App, stack: Stack): Boolean = hasTag("Stack", stack.name) && hasTag("App", app.name)
     }
 
     def listAutoScalingGroups(nextToken: Option[String] = None): List[AutoScalingGroup] = {
-      val request = new DescribeAutoScalingGroupsRequest()
-      nextToken.foreach(request.setNextToken)
-      val result = client.describeAutoScalingGroups(request)
-      val autoScalingGroups = result.getAutoScalingGroups.asScala.toList
-      Option(result.getNextToken) match {
+      val request = DescribeAutoScalingGroupsRequest.builder()
+      nextToken.foreach(request.nextToken)
+      val result = client.describeAutoScalingGroups(request.build())
+      val autoScalingGroups = result.autoScalingGroups.asScala.toList
+      Option(result.nextToken) match {
         case None => autoScalingGroups
         case token: Some[String] => autoScalingGroups ++ listAutoScalingGroups(token)
       }
@@ -222,10 +222,10 @@ object ASG extends AWS {
       case None =>
         reporter.fail(s"No autoscaling group found in ${stage.name} with tags matching package ${pkg.name}")
       case Some(ASGMatch(_, List(singleGroup))) =>
-        reporter.verbose(s"Using group ${singleGroup.getAutoScalingGroupName} (${singleGroup.getAutoScalingGroupARN})")
+        reporter.verbose(s"Using group ${singleGroup.autoScalingGroupName} (${singleGroup.autoScalingGroupARN})")
         singleGroup
       case Some(ASGMatch(app, groupList)) =>
-        reporter.fail(s"More than one autoscaling group match for $app in ${stage.name} (${groupList.map(_.getAutoScalingGroupARN).mkString(", ")}). Failing fast since this may be non-deterministic.")
+        reporter.fail(s"More than one autoscaling group match for $app in ${stage.name} (${groupList.map(_.autoScalingGroupARN).mkString(", ")}). Failing fast since this may be non-deterministic.")
     }
   }
 }
@@ -238,67 +238,74 @@ object ELB extends AWS {
     Client(classicClient(keyRing, region), applicationClient(keyRing, region))
 
   def classicClient(keyRing: KeyRing, region: Region): ClassicELB =
-    ClassicELBBuilder.standard()
-      .withCredentials(provider(keyRing))
-      .withClientConfiguration(clientConfiguration)
-      .withRegion(region.name)
+    ClassicELB.builder()
+      .credentialsProvider(provider(keyRing))
+      .overrideConfiguration(clientConfiguration)
+      .region(region.awsRegion)
       .build()
 
   def applicationClient(keyRing: KeyRing, region: Region): ApplicationELB =
-    ApplicationELBBuilder.standard()
-      .withCredentials(provider(keyRing))
-      .withClientConfiguration(clientConfiguration)
-      .withRegion(region.name)
+    ApplicationELB.builder()
+      .credentialsProvider(provider(keyRing))
+      .overrideConfiguration(clientConfiguration)
+      .region(region.awsRegion)
       .build()
 
   def targetInstancesHealth(targetARN: String, client: ApplicationELB): List[String] =
-    client.describeTargetHealth(new DescribeTargetHealthRequest().withTargetGroupArn(targetARN))
-      .getTargetHealthDescriptions.asScala.toList.map(_.getTargetHealth.getState)
+    client.describeTargetHealth(DescribeTargetHealthRequest.builder().targetGroupArn(targetARN).build())
+      .targetHealthDescriptions.asScala.toList.map(_.targetHealth.state.toString)
 
   def instanceHealth(elbName: String, client: ClassicELB): List[String] =
-    client.describeInstanceHealth(new DescribeInstanceHealthRequest(elbName))
-      .getInstanceStates.asScala.toList.map(_.getState)
+    client.describeInstanceHealth(DescribeInstanceHealthRequest.builder().loadBalancerName(elbName).build())
+      .instanceStates.asScala.toList.map(_.state)
 
   def deregister(elbName: List[String], elbTargetARN: List[String], instance: ASGInstance, client: Client) = {
     elbName.foreach(name =>
       client.classic.deregisterInstancesFromLoadBalancer(
-        new DeregisterInstancesFromLoadBalancerRequest().withLoadBalancerName(name)
-          .withInstances(new ELBInstance().withInstanceId(instance.getInstanceId))))
+        DeregisterInstancesFromLoadBalancerRequest.builder()
+          .loadBalancerName(name)
+          .instances(ELBInstance.builder().instanceId(instance.instanceId).build())
+          .build()
+      ))
     elbTargetARN.foreach(arn =>
       client.application.deregisterTargets(
-        new DeregisterTargetsRequest().withTargetGroupArn(arn)
-          .withTargets(new TargetDescription().withId(instance.getInstanceId))))
+        DeregisterTargetsRequest.builder()
+          .targetGroupArn(arn)
+          .targets(TargetDescription.builder().id(instance.instanceId).build())
+          .build()
+      ))
   }
 }
 
 object EC2 extends AWS {
-  def makeEc2Client(keyRing: KeyRing, region: Region): AmazonEC2 = {
-    AmazonEC2ClientBuilder.standard()
-      .withCredentials(provider(keyRing))
-      .withClientConfiguration(clientConfiguration)
-      .withRegion(region.name)
+  def makeEc2Client(keyRing: KeyRing, region: Region): Ec2Client = {
+    Ec2Client.builder()
+      .credentialsProvider(provider(keyRing))
+      .overrideConfiguration(clientConfiguration)
+      .region(region.awsRegion)
       .build()
   }
 
-  def setTag(instances: List[ASGInstance], key: String, value: String, client: AmazonEC2) {
-    val request = new CreateTagsRequest().
-      withResources(instances map { _.getInstanceId } asJavaCollection).
-      withTags(new EC2Tag(key, value))
+  def setTag(instances: List[ASGInstance], key: String, value: String, client: Ec2Client) {
+    val request = CreateTagsRequest.builder()
+      .resources(instances.map(_.instanceId).asJavaCollection)
+      .tags(EC2Tag.builder().key(key).value(value).build())
+        .build()
 
     client.createTags(request)
   }
 
-  def hasTag(instance: ASGInstance, key: String, value: String, client: AmazonEC2): Boolean = {
-    describe(instance, client).getTags.asScala exists { tag =>
-      tag.getKey == key && tag.getValue == value
+  def hasTag(instance: ASGInstance, key: String, value: String, client: Ec2Client): Boolean = {
+    describe(instance, client).tags.asScala.exists { tag =>
+      tag.key == key && tag.value == value
     }
   }
 
-  def describe(instance: ASGInstance, client: AmazonEC2) = client.describeInstances(
-    new DescribeInstancesRequest().withInstanceIds(instance.getInstanceId)
-  ).getReservations.asScala.flatMap(_.getInstances.asScala).head
+  def describe(instance: ASGInstance, client: Ec2Client) = client.describeInstances(
+    DescribeInstancesRequest.builder().instanceIds(instance.instanceId).build()
+  ).reservations.asScala.flatMap(_.instances.asScala).head
 
-  def apply(instance: ASGInstance, client: AmazonEC2) = describe(instance, client)
+  def apply(instance: ASGInstance, client: Ec2Client) = describe(instance, client)
 }
 
 object CloudFormation extends AWS {
@@ -310,93 +317,92 @@ object CloudFormation extends AWS {
   case class TemplateBody(body: String) extends Template
   case class TemplateUrl(url: String) extends Template
 
-  val CAPABILITY_NAMED_IAM = "CAPABILITY_NAMED_IAM"
-
-  def makeCfnClient(keyRing: KeyRing, region: Region): AmazonCloudFormation = {
-    AmazonCloudFormationClientBuilder.standard()
-      .withCredentials(provider(keyRing))
-      .withClientConfiguration(clientConfiguration)
-      .withRegion(region.name)
+  def makeCfnClient(keyRing: KeyRing, region: Region): CloudFormationClient = {
+    CloudFormationClient.builder()
+      .credentialsProvider(provider(keyRing))
+      .overrideConfiguration(clientConfiguration)
+      .region(region.awsRegion)
       .build()
   }
 
-  def validateTemplate(template: Template, client: AmazonCloudFormation) = {
+  def validateTemplate(template: Template, client: CloudFormationClient) = {
     val request = template match {
-      case TemplateBody(body) => new ValidateTemplateRequest().withTemplateBody(body)
-      case TemplateUrl(url) => new ValidateTemplateRequest().withTemplateURL(url)
+      case TemplateBody(body) => ValidateTemplateRequest.builder().templateBody(body)
+      case TemplateUrl(url) => ValidateTemplateRequest.builder().templateURL(url)
     }
-    client.validateTemplate(request)
+    client.validateTemplate(request.build())
   }
 
-  def updateStackParams(name: String, parameters: Map[String, ParameterValue], client: AmazonCloudFormation) =
+  def updateStackParams(name: String, parameters: Map[String, ParameterValue], client: CloudFormationClient): UpdateStackResponse =
     client.updateStack(
-      new UpdateStackRequest()
-        .withStackName(name)
-        .withCapabilities(CAPABILITY_NAMED_IAM)
-        .withUsePreviousTemplate(true)
-        .withParameters(
-          parameters map {
-            case (k, SpecifiedValue(v)) => new Parameter().withParameterKey(k).withParameterValue(v)
-            case (k, UseExistingValue) => new Parameter().withParameterKey(k).withUsePreviousValue(true)
-          } toSeq: _*
+      UpdateStackRequest.builder()
+        .stackName(name)
+        .capabilities(Capability.CAPABILITY_NAMED_IAM)
+        .usePreviousTemplate(true)
+        .parameters(
+          parameters.map {
+            case (k, SpecifiedValue(v)) => Parameter.builder().parameterKey(k).parameterValue(v).build()
+            case (k, UseExistingValue) => Parameter.builder().parameterKey(k).usePreviousValue(true).build()
+          }.toSeq: _*
         )
+        .build()
     )
 
   def createChangeSet(reporter: DeployReporter, name: String, tpe: ChangeSetType, stackName: String, maybeTags: Option[Map[String, String]],
-                      template: Template, parameters: Iterable[Parameter], client: AmazonCloudFormation): Unit = {
+                      template: Template, parameters: Iterable[Parameter], client: CloudFormationClient): Unit = {
 
-    val request = new CreateChangeSetRequest()
-      .withChangeSetName(name)
-      .withChangeSetType(tpe)
-      .withStackName(stackName)
-      .withCapabilities(CAPABILITY_NAMED_IAM)
-      .withParameters(parameters.toSeq.asJava)
+    val request = CreateChangeSetRequest.builder()
+      .changeSetName(name)
+      .changeSetType(tpe)
+      .stackName(stackName)
+      .capabilities(Capability.CAPABILITY_NAMED_IAM)
+      .parameters(parameters.toSeq.asJava)
 
     val tags: Iterable[CfnTag] = maybeTags
       .getOrElse(Map.empty)
-      .map  { case (key, value) => new CfnTag().withKey(key).withValue(value) }
+      .map  { case (key, value) => CfnTag.builder().key(key).value(value).build() }
 
-    request.withTags(tags.toSeq: _*)
+    request.tags(tags.toSeq: _*)
 
     val requestWithTemplate = template match {
-      case TemplateBody(body) => request.withTemplateBody(body)
-      case TemplateUrl(url) => request.withTemplateURL(url)
+      case TemplateBody(body) => request.templateBody(body)
+      case TemplateUrl(url) => request.templateURL(url)
     }
 
-    client.createChangeSet(requestWithTemplate)
+    client.createChangeSet(requestWithTemplate.build())
   }
 
-  def describeStack(name: String, client: AmazonCloudFormation) =
+  def describeStack(name: String, client: CloudFormationClient) =
     try {
       client.describeStacks(
-        new DescribeStacksRequest().withStackName(name)
-      ).getStacks.asScala.headOption
+        DescribeStacksRequest.builder().stackName(name).build()
+      ).stacks.asScala.headOption
     } catch {
-      case acfe:AmazonCloudFormationException
-        if acfe.getErrorCode == "ValidationError" && acfe.getErrorMessage.contains("does not exist") => None
+      case acfe: CloudFormationException
+        if acfe.awsErrorDetails.errorCode == "ValidationError" && acfe.awsErrorDetails.errorMessage.contains("does not exist") => None
     }
 
-  def describeStackEvents(name: String, client: AmazonCloudFormation) =
+  def describeStackEvents(name: String, client: CloudFormationClient) =
     client.describeStackEvents(
-      new DescribeStackEventsRequest().withStackName(name)
+      DescribeStackEventsRequest.builder().stackName(name).build()
     )
 
-  def findStackByTags(tags: Map[String, String], reporter: DeployReporter, client: AmazonCloudFormation): Option[AmazonStack] = {
+  def findStackByTags(tags: Map[String, String], reporter: DeployReporter, client: CloudFormationClient): Option[AmazonStack] = {
 
     def tagsMatch(stack: AmazonStack): Boolean =
-      tags.forall { case (key, value) => stack.getTags.asScala.exists(t => t.getKey == key && t.getValue == value) }
+      tags.forall { case (key, value) => stack.tags.asScala.exists(t => t.key == key && t.value == value) }
 
     @tailrec
     def recur(nextToken: Option[String] = None, existingStacks: List[AmazonStack] = Nil): List[AmazonStack] = {
-      val request = new DescribeStacksRequest().withNextToken(nextToken.orNull)
+      val request = DescribeStacksRequest.builder().nextToken(nextToken.orNull).build()
       val response = client.describeStacks(request)
 
-      val stacks = response.getStacks.asScala.foldLeft(existingStacks) {
+      val stacks = response.stacks.asScala.foldLeft(existingStacks) {
         case (agg, stack) if tagsMatch(stack) => stack :: agg
         case (agg, _) => agg
       }
 
-      Option(response.getNextToken) match {
+      Option(response.nextToken) match {
         case None => stacks
         case token => recur(token, stacks)
       }
@@ -404,78 +410,83 @@ object CloudFormation extends AWS {
 
     recur() match {
       case cfnStack :: Nil =>
-        reporter.verbose(s"Found stack ${cfnStack.getStackName} (${cfnStack.getStackId})")
+        reporter.verbose(s"Found stack ${cfnStack.stackName} (${cfnStack.stackId})")
         Some(cfnStack)
       case Nil =>
         None
       case multipleStacks =>
-        reporter.fail(s"More than one cloudformation stack match for $tags (matched ${multipleStacks.map(_.getStackName).mkString(", ")}). Failing fast since this may be non-deterministic.")
+        reporter.fail(s"More than one cloudformation stack match for $tags (matched ${multipleStacks.map(_.stackName).mkString(", ")}). Failing fast since this may be non-deterministic.")
     }
   }
 }
 
 object STS extends AWS {
-  def makeSTSclient(keyRing: KeyRing, region: Region): AWSSecurityTokenService = {
-    AWSSecurityTokenServiceClientBuilder.standard()
-      .withCredentials(provider(keyRing))
-      .withClientConfiguration(clientConfiguration)
-      .withRegion(region.name)
+  def makeSTSclient(keyRing: KeyRing, region: Region): StsClient = {
+    StsClient.builder()
+      .credentialsProvider(provider(keyRing))
+      .overrideConfiguration(clientConfiguration)
+      .region(region.awsRegion)
       .build()
   }
 
-  def getAccountNumber(stsClient: AWSSecurityTokenService): String = {
-    val callerIdentityResponse = stsClient.getCallerIdentity(new GetCallerIdentityRequest())
-    callerIdentityResponse.getAccount
+  def getAccountNumber(stsClient: StsClient): String = {
+    val callerIdentityResponse = stsClient.getCallerIdentity(GetCallerIdentityRequest.builder().build())
+    callerIdentityResponse.account
   }
 }
 
 trait AWS extends Loggable {
-  lazy val accessKey = Option(System.getenv.get("aws_access_key")).getOrElse{
+  lazy val accessKey: String = Option(System.getenv.get("aws_access_key")).getOrElse{
     sys.error("Cannot authenticate, 'aws_access_key' must be set as a system property")
   }
-  lazy val secretAccessKey = Option(System.getenv.get("aws_secret_access_key")).getOrElse{
+  lazy val secretAccessKey: String = Option(System.getenv.get("aws_secret_access_key")).getOrElse{
     sys.error("Cannot authenticate, aws_secret_access_key' must be set as a system property")
   }
 
-  lazy val envCredentials = new BasicAWSCredentials(accessKey, secretAccessKey)
+  lazy val envCredentials: AwsBasicCredentials = AwsBasicCredentials.create(accessKey, secretAccessKey)
 
-  def provider(keyRing: KeyRing): AWSCredentialsProvider = new AWSCredentialsProviderChain(
-    new AWSCredentialsProvider {
-      def refresh() {}
-      def getCredentials = keyRing.apiCredentials.get("aws") map {
-          credentials => new BasicAWSCredentials(credentials.id,credentials.secret)
-      } get
+  def provider(keyRing: KeyRing): AwsCredentialsProviderChain = AwsCredentialsProviderChain.builder().credentialsProviders(
+    new AwsCredentialsProvider {
+      override def resolveCredentials(): AwsCredentials = keyRing.apiCredentials.get("aws").map { credentials =>
+        AwsBasicCredentials.create(credentials.id,credentials.secret)
+      }.get
     },
-    new AWSCredentialsProvider {
-      def refresh() {}
-      def getCredentials = envCredentials
+    new AwsCredentialsProvider {
+      override def resolveCredentials(): AwsCredentials = envCredentials
     }
-  )
+  ).build()
 
   /* A retry condition that logs errors */
-  class LoggingRetryCondition extends SDKDefaultRetryCondition {
+  class LoggingRetryCondition extends RetryCondition {
     private def exceptionInfo(e: Throwable): String = {
       s"${e.getClass.getName} ${e.getMessage} Cause: ${Option(e.getCause).map(e => exceptionInfo(e))}"
     }
-
-    override def shouldRetry(originalRequest: AmazonWebServiceRequest, exception: AmazonClientException, retriesAttempted: Int): Boolean = {
-      val willRetry = super.shouldRetry(originalRequest, exception, retriesAttempted)
+    override def shouldRetry(context: RetryPolicyContext): Boolean = {
+      //TODO: super.shouldRetry here?
+      val willRetry = shouldRetry(context)
       if (willRetry) {
-        logger.warn(s"AWS SDK retry $retriesAttempted: ${Option(originalRequest).map(_.getClass.getName)} threw ${exceptionInfo(exception)}")
+        logger.warn(s"AWS SDK retry ${context.retriesAttempted}: ${Option(context.originalRequest).map(_.getClass.getName)} threw ${exceptionInfo(context.exception)}")
       } else {
-        logger.warn(s"Encountered fatal exception during AWS API call", exception)
-        Option(exception.getCause).foreach(t => logger.warn(s"Cause of fatal exception", t))
+        logger.warn(s"Encountered fatal exception during AWS API call", context.exception)
+        Option(context.exception.toBuilder.cause).foreach(t => logger.warn(s"Cause of fatal exception", t))
       }
       willRetry
     }
   }
-  val clientConfiguration = new ClientConfiguration().
-    withRetryPolicy(new RetryPolicy(
-      new LoggingRetryCondition(),
-      PredefinedRetryPolicies.DEFAULT_BACKOFF_STRATEGY,
-      20,
-      false
-    ))
 
-  val clientConfigurationNoRetry = new ClientConfiguration().withRetryPolicy(PredefinedRetryPolicies.NO_RETRY_POLICY)
+  val clientConfiguration: ClientOverrideConfiguration =
+    ClientOverrideConfiguration.builder()
+      .retryPolicy(
+        RetryPolicy.builder()
+          .retryCondition(new LoggingRetryCondition())
+          .backoffStrategy(BackoffStrategy.defaultStrategy())
+          .numRetries(20)
+          .build()
+    ).build()
+
+  val clientConfigurationNoRetry: ClientOverrideConfiguration =
+    ClientOverrideConfiguration.builder()
+      .retryPolicy(
+        RetryPolicy.none()
+      ).build()
 }

--- a/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
@@ -1,10 +1,11 @@
 package magenta.tasks
 
-import com.amazonaws.services.cloudformation.model._
-import com.amazonaws.services.s3.AmazonS3
 import magenta.artifact.S3Path
 import magenta.tasks.UpdateCloudFormationTask._
 import magenta.{DeployReporter, KeyRing, Region}
+import software.amazon.awssdk.services.cloudformation.model.ChangeSetStatus._
+import software.amazon.awssdk.services.cloudformation.model.{Change, DeleteChangeSetRequest, DescribeChangeSetRequest, ExecuteChangeSetRequest}
+import software.amazon.awssdk.services.s3.S3Client
 
 import scala.collection.JavaConverters._
 import scala.util.{Success, Try}
@@ -14,7 +15,7 @@ class CreateChangeSetTask(
                            templatePath: S3Path,
                            stackLookup: CloudFormationStackMetadata,
                            val unresolvedParameters: CloudFormationParameters
-)(implicit val keyRing: KeyRing, artifactClient: AmazonS3) extends Task {
+)(implicit val keyRing: KeyRing, artifactClient: S3Client) extends Task {
 
   override def execute(reporter: DeployReporter, stopFlag: => Boolean) = if (!stopFlag) {
     val cfnClient = CloudFormation.makeCfnClient(keyRing, region)
@@ -47,7 +48,7 @@ class CheckChangeSetCreatedTask(
                                  region: Region,
                                  stackLookup: CloudFormationStackMetadata,
                                  override val duration: Long
-)(implicit val keyRing: KeyRing, artifactClient: AmazonS3) extends Task with RepeatedPollingCheck {
+)(implicit val keyRing: KeyRing, artifactClient: S3Client) extends Task with RepeatedPollingCheck {
 
   override def execute(reporter: DeployReporter, stopFlag: => Boolean): Unit = {
     check(reporter, stopFlag) {
@@ -56,16 +57,14 @@ class CheckChangeSetCreatedTask(
       val (stackName, _) = stackLookup.lookup(reporter, cfnClient)
       val changeSetName = stackLookup.changeSetName
 
-      val request = new DescribeChangeSetRequest().withChangeSetName(changeSetName).withStackName(stackName)
+      val request = DescribeChangeSetRequest.builder().changeSetName(changeSetName).stackName(stackName).build()
       val response = cfnClient.describeChangeSet(request)
 
-      shouldStopWaiting(response.getStatus, response.getStatusReason, response.getChanges.asScala, reporter)
+      shouldStopWaiting(response.status.toString, response.statusReason, response.changes.asScala, reporter)
     }
   }
 
   def shouldStopWaiting(status: String, statusReason: String, changes: Iterable[Change], reporter: DeployReporter): Boolean = {
-    import ChangeSetStatus._
-
     Try(valueOf(status)) match {
       case Success(CREATE_COMPLETE) => true
       case Success(FAILED) if changes.isEmpty => true
@@ -85,24 +84,24 @@ class CheckChangeSetCreatedTask(
 class ExecuteChangeSetTask(
                             region: Region,
                             stackLookup: CloudFormationStackMetadata,
-)(implicit val keyRing: KeyRing, artifactClient: AmazonS3) extends Task {
+)(implicit val keyRing: KeyRing, artifactClient: S3Client) extends Task {
   override def execute(reporter: DeployReporter, stopFlag: => Boolean): Unit = {
     val cfnClient = CloudFormation.makeCfnClient(keyRing, region)
 
     val (stackName, _) = stackLookup.lookup(reporter, cfnClient)
     val changeSetName = stackLookup.changeSetName
 
-    val describeRequest = new DescribeChangeSetRequest().withChangeSetName(changeSetName).withStackName(stackName)
+    val describeRequest = DescribeChangeSetRequest.builder().changeSetName(changeSetName).stackName(stackName).build()
     val describeResponse = cfnClient.describeChangeSet(describeRequest)
 
-    if(describeResponse.getChanges.isEmpty) {
+    if(describeResponse.changes.isEmpty) {
       reporter.info(s"No changes to perform for $changeSetName on stack $stackName")
     } else {
-      describeResponse.getChanges.asScala.foreach { change =>
-        reporter.verbose(s"${change.getType} - ${change.getResourceChange}")
+      describeResponse.changes.asScala.foreach { change =>
+        reporter.verbose(s"${change.`type`} - ${change.resourceChange}")
       }
 
-      val request = new ExecuteChangeSetRequest().withChangeSetName(changeSetName).withStackName(stackName)
+      val request = ExecuteChangeSetRequest.builder().changeSetName(changeSetName).stackName(stackName).build()
       cfnClient.executeChangeSet(request)
     }
   }
@@ -114,14 +113,14 @@ class ExecuteChangeSetTask(
 class DeleteChangeSetTask(
                            region: Region,
                            stackLookup: CloudFormationStackMetadata,
-)(implicit val keyRing: KeyRing, artifactClient: AmazonS3) extends Task {
+)(implicit val keyRing: KeyRing, artifactClient: S3Client) extends Task {
   override def execute(reporter: DeployReporter, stopFlag: => Boolean): Unit = {
     val cfnClient = CloudFormation.makeCfnClient(keyRing, region)
 
     val (stackName, _) = stackLookup.lookup(reporter, cfnClient)
     val changeSetName = stackLookup.changeSetName
 
-    val request = new DeleteChangeSetRequest().withChangeSetName(changeSetName).withStackName(stackName)
+    val request = DeleteChangeSetRequest.builder().changeSetName(changeSetName).stackName(stackName).build()
     cfnClient.deleteChangeSet(request)
   }
 

--- a/magenta-lib/src/main/scala/magenta/tasks/ElasticSearchTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ElasticSearchTasks.scala
@@ -2,12 +2,13 @@ package magenta.tasks
 
 import java.net.ConnectException
 
-import com.amazonaws.services.autoscaling.AmazonAutoScaling
-import com.amazonaws.services.autoscaling.model.{AutoScalingGroup, Instance}
 import magenta.{DeploymentPackage, KeyRing, Stage, _}
 import okhttp3._
 import org.json4s._
 import play.api.libs.json.Json
+import software.amazon.awssdk.services.autoscaling.AutoScalingClient
+import software.amazon.awssdk.services.autoscaling.model.{AutoScalingGroup, Instance}
+import software.amazon.awssdk.services.ec2.Ec2Client
 
 import scala.collection.JavaConverters._
 
@@ -21,14 +22,14 @@ case class WaitForElasticSearchClusterGreen(pkg: DeploymentPackage, stage: Stage
       |Requires access to port 9200 on cluster members.
     """.stripMargin
 
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling) {
-    implicit val ec2Client = EC2.makeEc2Client(keyRing, region)
-    val instance = EC2(asg.getInstances.asScala.headOption.getOrElse {
-      throw new IllegalArgumentException("Auto-scaling group: %s had no instances" format (asg))
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AutoScalingClient) {
+    implicit val ec2Client: Ec2Client = EC2.makeEc2Client(keyRing, region)
+    val instance = EC2(asg.instances.asScala.headOption.getOrElse {
+      throw new IllegalArgumentException(s"Auto-scaling group: $asg had no instances")
     }, ec2Client)
-    val node = ElasticSearchNode(instance.getPublicDnsName)
+    val node = ElasticSearchNode(instance.publicDnsName)
     check(reporter, stopFlag) {
-      node.inHealthyClusterOfSize(ASG.refresh(asg, asgClient).getDesiredCapacity)
+      node.inHealthyClusterOfSize(ASG.refresh(asg, asgClient).desiredCapacity)
     }
   }
 }
@@ -37,28 +38,28 @@ case class CullElasticSearchInstancesWithTerminationTag(pkg: DeploymentPackage, 
                                                        (implicit val keyRing: KeyRing)
   extends ASGTask with RepeatedPollingCheck{
 
-  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AmazonAutoScaling) {
-    implicit val ec2Client = EC2.makeEc2Client(keyRing, region)
-    implicit val elbClient = ELB.client(keyRing, region)
-    val newNode = asg.getInstances.asScala.filterNot(EC2.hasTag(_, "Magenta", "Terminate", ec2Client)).head
-    val newESNode = ElasticSearchNode(EC2(newNode, ec2Client).getPublicDnsName)
+  override def execute(asg: AutoScalingGroup, reporter: DeployReporter, stopFlag: => Boolean, asgClient: AutoScalingClient) {
+    implicit val ec2Client: Ec2Client = EC2.makeEc2Client(keyRing, region)
+    implicit val elbClient: ELB.Client = ELB.client(keyRing, region)
+    val newNode = asg.instances.asScala.filterNot(EC2.hasTag(_, "Magenta", "Terminate", ec2Client)).head
+    val newESNode = ElasticSearchNode(EC2(newNode, ec2Client).publicDnsName)
 
     def cullInstance(instance: Instance) {
-        val node = ElasticSearchNode(EC2(instance, ec2Client).getPublicDnsName)
+        val node = ElasticSearchNode(EC2(instance, ec2Client).publicDnsName)
         check(reporter, stopFlag) {
-          newESNode.inHealthyClusterOfSize(ASG.refresh(asg, asgClient).getDesiredCapacity)
+          newESNode.inHealthyClusterOfSize(ASG.refresh(asg, asgClient).desiredCapacity)
         }
         if (!stopFlag) {
           node.shutdown()
           check(reporter, stopFlag) {
-            newESNode.inHealthyClusterOfSize(ASG.refresh(asg, asgClient).getDesiredCapacity - 1)
+            newESNode.inHealthyClusterOfSize(ASG.refresh(asg, asgClient).desiredCapacity - 1)
           }
         }
         if (!stopFlag) ASG.cull(asg, instance, asgClient, elbClient)
     }
 
-    val instancesToKill = asg.getInstances.asScala.filter(instance => EC2.hasTag(instance, "Magenta", "Terminate", ec2Client))
-    val orderedInstancesToKill = instancesToKill.transposeBy(_.getAvailabilityZone)
+    val instancesToKill = asg.instances.asScala.filter(instance => EC2.hasTag(instance, "Magenta", "Terminate", ec2Client))
+    val orderedInstancesToKill = instancesToKill.transposeBy(_.availabilityZone)
     orderedInstancesToKill.foreach(cullInstance)
   }
 

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -283,8 +283,7 @@ class CheckUpdateEventsTask(
       lastSeenEvent match {
         case None =>
           events.find(updateStart(stackName)) foreach (e => {
-            val millis: Long = e.timestamp().toEpochMilli
-            val age = new Duration(new DateTime(millis), new DateTime()).getStandardSeconds
+            val age = new Duration(new DateTime(e.timestamp().toEpochMilli), new DateTime()).getStandardSeconds
             if (age > 30) {
               reporter.verbose("No recent IN_PROGRESS events found (nothing within last 30 seconds)")
             } else {

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -283,7 +283,8 @@ class CheckUpdateEventsTask(
       lastSeenEvent match {
         case None =>
           events.find(updateStart(stackName)) foreach (e => {
-            val age = new Duration(new DateTime(e.timestamp.toEpochMilli), new DateTime()).getStandardSeconds
+            val millis: Long = e.timestamp().toEpochMilli
+            val age = new Duration(new DateTime(millis), new DateTime()).getStandardSeconds
             if (age > 30) {
               reporter.verbose("No recent IN_PROGRESS events found (nothing within last 30 seconds)")
             } else {

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -283,7 +283,7 @@ class CheckUpdateEventsTask(
       lastSeenEvent match {
         case None =>
           events.find(updateStart(stackName)) foreach (e => {
-            val age = new Duration(new DateTime(e.timestamp), new DateTime()).getStandardSeconds
+            val age = new Duration(new DateTime(e.timestamp.toEpochMilli), new DateTime()).getStandardSeconds
             if (age > 30) {
               reporter.verbose("No recent IN_PROGRESS events found (nothing within last 30 seconds)")
             } else {

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -1,14 +1,16 @@
 package magenta.tasks
 
-import com.amazonaws.services.cloudformation.AmazonCloudFormation
-import com.amazonaws.services.cloudformation.model.{AmazonCloudFormationException, ChangeSetType, Parameter, StackEvent}
-import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.securitytoken.AWSSecurityTokenService
 import magenta.deployment_type.CloudFormationDeploymentTypeParameters._
 import magenta.tasks.CloudFormation._
 import magenta.tasks.UpdateCloudFormationTask.{CloudFormationStackLookupStrategy, LookupByName, LookupByTags, TemplateParameter}
 import magenta.{DeployReporter, DeployTarget, DeploymentPackage, KeyRing, Region, Stack, Stage}
 import org.joda.time.{DateTime, Duration}
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient
+import software.amazon.awssdk.services.cloudformation.model.{ChangeSetType, CloudFormationException, Parameter, StackEvent}
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.{GetObjectRequest, PutObjectRequest}
+import software.amazon.awssdk.services.sts.StsClient
 
 import scala.collection.JavaConverters._
 
@@ -27,7 +29,7 @@ trait RetryCloudFormationUpdate {
         Some(theUpdate)
       } catch {
         // this isn't great, but it seems to be the best that we can realistically do
-        case e:AmazonCloudFormationException if e.getErrorMessage.matches("^Stack:.* is in [A-Z_]* state and can not be updated.") =>
+        case e: CloudFormationException if e.awsErrorDetails.errorMessage.matches("^Stack:.* is in [A-Z_]* state and can not be updated.") =>
           if (stopFlag) {
             reporter.info("Abandoning remaining checks as stop flag has been set")
             None
@@ -42,9 +44,9 @@ trait RetryCloudFormationUpdate {
               reporter.fail(s"Update is still running after $duration milliseconds (tried $currentAttempt times) - aborting")
             }
           }
-        case e:AmazonCloudFormationException =>
+        case e: CloudFormationException =>
           // this might be useful for debugging in the future if a message is seen that we don't catch
-          reporter.verbose(e.getErrorMessage)
+          reporter.verbose(e.awsErrorDetails.errorMessage)
           throw e
       }
     }
@@ -55,13 +57,13 @@ trait RetryCloudFormationUpdate {
 class CloudFormationStackMetadata(val strategy: CloudFormationStackLookupStrategy, val changeSetName: String, createStackIfAbsent: Boolean) {
   import CloudFormationStackMetadata._
 
-  def lookup(reporter: DeployReporter, cfnClient: AmazonCloudFormation): (String, ChangeSetType) = {
+  def lookup(reporter: DeployReporter, cfnClient: CloudFormationClient): (String, ChangeSetType) = {
     val existingStack = strategy match {
       case LookupByName(name) => CloudFormation.describeStack(name, cfnClient)
       case LookupByTags(tags) => CloudFormation.findStackByTags(tags, reporter, cfnClient)
     }
 
-    val stackName = existingStack.map(_.getStackName).getOrElse(getNewStackName(strategy))
+    val stackName = existingStack.map(_.stackName).getOrElse(getNewStackName(strategy))
     val changeSetType = getChangeSetType(stackName, existingStack.nonEmpty, createStackIfAbsent, reporter)
 
     (stackName, changeSetType)
@@ -99,9 +101,9 @@ class CloudFormationParameters(stack: Stack, stage: Stage, region: Region,
                                latestImage: String => String => Map[String,String] => Option[String]) {
   import CloudFormationParameters._
 
-  def resolve(template: Template, accountNumber: String, changeSetType: ChangeSetType, reporter: DeployReporter, cfnClient: AmazonCloudFormation): Iterable[Parameter] = {
-    val templateParameters = CloudFormation.validateTemplate(template, cfnClient).getParameters.asScala
-      .map(tp => TemplateParameter(tp.getParameterKey, Option(tp.getDefaultValue).isDefined))
+  def resolve(template: Template, accountNumber: String, changeSetType: ChangeSetType, reporter: DeployReporter, cfnClient: CloudFormationClient): Iterable[Parameter] = {
+    val templateParameters = CloudFormation.validateTemplate(template, cfnClient).parameters.asScala
+      .map(tp => TemplateParameter(tp.parameterKey, Option(tp.defaultValue).isDefined))
 
     val resolvedAmiParameters: Map[String, String] = amiParameterMap.flatMap { case (name, tags) =>
       latestImage(accountNumber)(region.name)(tags).map(name -> _)
@@ -116,13 +118,13 @@ object CloudFormationParameters {
   def convertParameters(parameters: Map[String, ParameterValue], tpe: ChangeSetType, reporter: DeployReporter): Iterable[Parameter] = {
     parameters map {
       case (k, SpecifiedValue(v)) =>
-        new Parameter().withParameterKey(k).withParameterValue(v)
+        Parameter.builder().parameterKey(k).parameterValue(v).build()
 
       case (k, UseExistingValue) if tpe == ChangeSetType.CREATE =>
         reporter.fail(s"Missing parameter value for parameter $k: all must be specified when creating a stack. Subsequent updates will reuse existing parameter values where possible.")
 
       case (k, UseExistingValue) =>
-        new Parameter().withParameterKey(k).withUsePreviousValue(true)
+        Parameter.builder().parameterKey(k).usePreviousValue(true).build()
     }
   }
 
@@ -170,16 +172,20 @@ object UpdateCloudFormationTask {
     }
   }
 
-  def processTemplate(stackName: String, templateBody: String, s3Client: AmazonS3, stsClient: AWSSecurityTokenService,
-    region: Region, reporter: DeployReporter): Template = {
+  def processTemplate(stackName: String, templateBody: String, s3Client: S3Client, stsClient: StsClient,
+                      region: Region, reporter: DeployReporter): Template = {
     val templateTooBigForSdkUpload = templateBody.length > 51200
 
     if (templateTooBigForSdkUpload) {
       val bucketName = S3.accountSpecificBucket("riff-raff-cfn-templates", s3Client, stsClient, region, reporter, Some(1))
       val keyName = s"$stackName-${new DateTime().getMillis}"
       reporter.verbose(s"Uploading template as $keyName to S3 bucket $bucketName")
-      s3Client.putObject(bucketName, keyName, templateBody)
-      val url = s3Client.getUrl(bucketName, keyName)
+      val request = PutObjectRequest.builder()
+        .bucket(bucketName)
+        .key(keyName)
+        .build()
+      s3Client.putObject(request, RequestBody.fromString(templateBody))
+      val url = s3Client.getObject(GetObjectRequest.builder().bucket(bucketName).key(keyName).build())
       TemplateUrl(url.toString)
     } else {
       TemplateBody(templateBody)
@@ -209,14 +215,14 @@ case class UpdateAmiCloudFormationParameterTask(
       reporter.fail(s"Could not find CloudFormation stack $cloudFormationStackLookupStrategy")
     }
 
-    val existingParameters: Map[String, ParameterValue] = cfStack.getParameters.asScala.map(_.getParameterKey -> UseExistingValue).toMap
+    val existingParameters: Map[String, ParameterValue] = cfStack.parameters.asScala.map(_.parameterKey -> UseExistingValue).toMap
 
     val resolvedAmiParameters: Map[String, ParameterValue] = amiParameterMap.flatMap { case(parameterName, amiTags) =>
-      if (!cfStack.getParameters.asScala.exists(_.getParameterKey == parameterName)) {
-        reporter.fail(s"stack ${cfStack.getStackName} does not have an $parameterName parameter to update")
+      if (!cfStack.parameters.asScala.exists(_.parameterKey == parameterName)) {
+        reporter.fail(s"stack ${cfStack.stackName} does not have an $parameterName parameter to update")
       }
 
-      val currentAmi = cfStack.getParameters.asScala.find(_.getParameterKey == parameterName).get.getParameterValue
+      val currentAmi = cfStack.parameters.asScala.find(_.parameterKey == parameterName).get.parameterValue
       val accountNumber = STS.getAccountNumber(STS.makeSTSclient(keyRing, region))
       val maybeNewAmi = latestImage(accountNumber)(region.name)(amiTags)
       maybeNewAmi match {
@@ -228,7 +234,7 @@ case class UpdateAmiCloudFormationParameterTask(
           Some(parameterName -> SpecifiedValue(newAmi))
         case None =>
           val tagsStr = amiTags.map { case (k, v) => s"$k: $v" }.mkString(", ")
-          reporter.fail(s"Failed to resolve AMI for ${cfStack.getStackName} parameter $parameterName with tags: $tagsStr")
+          reporter.fail(s"Failed to resolve AMI for ${cfStack.stackName} parameter $parameterName with tags: $tagsStr")
       }
     }
 
@@ -236,7 +242,7 @@ case class UpdateAmiCloudFormationParameterTask(
       val newParameters = existingParameters ++ resolvedAmiParameters
       reporter.info(s"Updating cloudformation stack params: $newParameters")
       updateWithRetry(reporter, stopFlag) {
-        CloudFormation.updateStackParams(cfStack.getStackName, newParameters, cfnClient)
+        CloudFormation.updateStackParams(cfStack.stackName, newParameters, cfnClient)
       }
     } else {
       reporter.info(s"All AMIs the same as current AMIs. No update to perform.")
@@ -267,17 +273,17 @@ class CheckUpdateEventsTask(
       case strategy @ LookupByTags(tags) =>
         val stack = CloudFormation.findStackByTags(tags, reporter, cfnClient)
           .getOrElse(reporter.fail(s"Could not find CloudFormation stack $strategy"))
-        stack.getStackName
+        stack.stackName
     }
 
     def check(lastSeenEvent: Option[StackEvent]): Unit = {
       val result = CloudFormation.describeStackEvents(stackName, cfnClient)
-      val events = result.getStackEvents.asScala
+      val events = result.stackEvents.asScala
 
       lastSeenEvent match {
         case None =>
           events.find(updateStart(stackName)) foreach (e => {
-            val age = new Duration(new DateTime(e.getTimestamp), new DateTime()).getStandardSeconds
+            val age = new Duration(new DateTime(e.timestamp), new DateTime()).getStandardSeconds
             if (age > 30) {
               reporter.verbose("No recent IN_PROGRESS events found (nothing within last 30 seconds)")
             } else {
@@ -286,7 +292,7 @@ class CheckUpdateEventsTask(
             }
           })
         case Some(event) =>
-          val newEvents = events.takeWhile(_.getTimestamp.after(event.getTimestamp))
+          val newEvents = events.takeWhile(_.timestamp.isAfter(event.timestamp))
           newEvents.reverse.foreach(reportEvent(reporter, _))
 
           if (!newEvents.exists(e => updateComplete(stackName)(e) || failed(e)) && !stopFlag) {
@@ -301,21 +307,21 @@ class CheckUpdateEventsTask(
 
   object StackEvent {
     def reportEvent(reporter: DeployReporter, e: StackEvent): Unit = {
-      reporter.info(s"${e.getLogicalResourceId} (${e.getResourceType}): ${e.getResourceStatus}")
-      if (e.getResourceStatusReason != null) reporter.verbose(e.getResourceStatusReason)
+      reporter.info(s"${e.logicalResourceId} (${e.resourceType}): ${e.resourceType}")
+      if (e.resourceStatusReason != null) reporter.verbose(e.resourceStatusReason)
     }
     def isStackEvent(stackName: String)(e: StackEvent): Boolean =
-      e.getResourceType == "AWS::CloudFormation::Stack" && e.getLogicalResourceId == stackName
+      e.resourceType == "AWS::CloudFormation::Stack" && e.logicalResourceId == stackName
     def updateStart(stackName: String)(e: StackEvent): Boolean =
-      isStackEvent(stackName)(e) && (e.getResourceStatus == "UPDATE_IN_PROGRESS" || e.getResourceStatus == "CREATE_IN_PROGRESS")
+      isStackEvent(stackName)(e) && (e.resourceStatus.toString == "UPDATE_IN_PROGRESS" || e.resourceStatus.toString == "CREATE_IN_PROGRESS")
     def updateComplete(stackName: String)(e: StackEvent): Boolean =
-      isStackEvent(stackName)(e) && (e.getResourceStatus == "UPDATE_COMPLETE" || e.getResourceStatus == "CREATE_COMPLETE")
+      isStackEvent(stackName)(e) && (e.resourceStatus.toString == "UPDATE_COMPLETE" || e.resourceStatus.toString == "CREATE_COMPLETE")
 
-    def failed(e: StackEvent): Boolean = e.getResourceStatus.contains("FAILED") || e.getResourceStatus.contains("ROLLBACK")
+    def failed(e: StackEvent): Boolean = e.resourceStatus.toString.contains("FAILED") || e.resourceStatus.toString.contains("ROLLBACK")
 
     def fail(reporter: DeployReporter, e: StackEvent): Unit = reporter.fail(
-      s"""${e.getLogicalResourceId}(${e.getResourceType}}: ${e.getResourceStatus}
-            |${e.getResourceStatusReason}""".stripMargin)
+      s"""${e.logicalResourceId}(${e.resourceType}}: ${e.resourceStatus}
+            |${e.resourceStatusReason}""".stripMargin)
   }
 
   def description = s"Checking events on update for stack $stackLookupStrategy"

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -69,21 +69,14 @@ case class S3Upload(
         case _ =>
       }
       retryOnException(S3.clientConfiguration) {
-//        val getObjectRequest = GetObjectRequest.builder().bucket(req.source.bucket).key(req.source.key).build()
-//        val inputStream = artifactClient.getObjectAsBytes(getObjectRequest).asByteArray()
-//        val putRequest: PutObjectRequest = req.toAwsRequest
         val copyObjectRequest = CopyObjectRequest.builder()
           .copySource(s"${req.source.bucket}/${req.source.key}")
           .bucket(req.target.bucket)
           .key(req.target.key)
           .build()
-        try {
-//          val result = client.putObject(putRequest, AWSRequestBody.fromBytes(inputStream))
-          val result = client.copyObject(copyObjectRequest)
-          logger.debug(s"Copy object ${req.source.key} to ${req.target.key}")
-          result
-        } finally {
-        }
+        val result = client.copyObject(copyObjectRequest)
+        logger.debug(s"Copy object ${req.source.key} to ${req.target.key}")
+        result
       }
     }
     reporter.verbose(s"Finished transfer of ${fileString(objectMappings.size)}")

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -61,7 +61,7 @@ case class S3Upload(
     val client = clientFactory(keyRing, region, S3.clientConfigurationNoRetry)
 
     reporter.verbose(s"Starting transfer of ${fileString(objectMappings.size)} ($totalSize bytes)")
-    requests.zipWithIndex.foreach { case (req, index) =>
+    requests.zipWithIndex.par.foreach { case (req, index) =>
       logger.debug(s"Transferring ${requestToString(req.source, req)}")
       index match {
         case x if x < 10 => reporter.verbose(s"Transferring ${requestToString(req.source, req)}")

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -1,21 +1,18 @@
 package magenta
 package tasks
 
-import java.io.InputStream
-import java.nio.ByteBuffer
+import java.io.File
 
-import com.amazonaws.ClientConfiguration
-import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.internal.Mimetypes
-import com.amazonaws.services.s3.model.CannedAccessControlList._
-import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest}
-import com.amazonaws.util.IOUtils
 import com.gu.management.Loggable
 import magenta.artifact._
 import magenta.deployment_type.param_reads.PatternValue
 import okhttp3._
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
+import software.amazon.awssdk.core.internal.util.Mimetype
+import software.amazon.awssdk.core.sync.{RequestBody => AWSRequestBody}
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.{GetObjectRequest, ObjectCannedACL, PutObjectRequest}
 
-import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
 case class S3Upload(
@@ -26,16 +23,16 @@ case class S3Upload(
   extensionToMimeType: Map[String,String] = Map.empty,
   publicReadAcl: Boolean = false,
   detailedLoggingThreshold: Int = 10
-)(implicit val keyRing: KeyRing, artifactClient: AmazonS3,
-  clientFactory: (KeyRing, Region, ClientConfiguration) => AmazonS3 = S3.makeS3client) extends Task with Loggable {
+)(implicit val keyRing: KeyRing, artifactClient: S3Client,
+  clientFactory: (KeyRing, Region, ClientOverrideConfiguration) => S3Client = S3.makeS3client) extends Task with Loggable {
 
-  lazy val objectMappings = paths flatMap {
+  lazy val objectMappings: Seq[(S3Object, S3Path)] = paths flatMap {
     case (file, targetKey) => resolveMappings(file, targetKey, bucket)
   }
 
-  lazy val totalSize = objectMappings.map{ case (source, target) => source.size}.sum
+  lazy val totalSize: Long = objectMappings.map{ case (source, _) => source.size }.sum
 
-  lazy val requests = objectMappings.map { case (source, target) =>
+  lazy val requests: Seq[PutReq] = objectMappings.map { case (source, target) =>
     PutReq(source, target, cacheControlLookup(target.key), contentTypeLookup(target.key), publicReadAcl)
   }
 
@@ -54,17 +51,17 @@ case class S3Upload(
   // execute this task (should throw on failure)
   override def execute(reporter: DeployReporter, stopFlag: => Boolean) {
     if (totalSize == 0) {
-      val locationDescription = (paths.map {
+      val locationDescription = paths.map {
         case (path: S3Path, _) => path.show()
-        case (location, _) => location.toString()
-      }).mkString("\n")
+        case (location, _) => location.toString
+      }.mkString("\n")
       reporter.fail(s"No files found to upload in $locationDescription")
     }
 
     val client = clientFactory(keyRing, region, S3.clientConfigurationNoRetry)
 
     reporter.verbose(s"Starting transfer of ${fileString(objectMappings.size)} ($totalSize bytes)")
-    requests.zipWithIndex.par foreach { case (req, index) =>
+    requests.zipWithIndex.foreach { case (req, index) =>
       logger.debug(s"Transferring ${requestToString(req.source, req)}")
       index match {
         case x if x < 10 => reporter.verbose(s"Transferring ${requestToString(req.source, req)}")
@@ -72,11 +69,12 @@ case class S3Upload(
         case _ =>
       }
       retryOnException(S3.clientConfiguration) {
-        val inputStream = artifactClient.getObject(req.source.bucket, req.source.key).getObjectContent
-        val putRequest = req.toAwsRequest(inputStream)
+        val getObjectRequest = GetObjectRequest.builder().bucket(req.source.bucket).key(req.source.key).build()
+        val inputStream = artifactClient.getObject(getObjectRequest)
+        val putRequest: PutObjectRequest = req.toAwsRequest
         try {
-          val result = client.putObject(putRequest)
-          logger.debug(s"Put object ${putRequest.getKey}: MD5: ${result.getContentMd5} Metadata: ${result.getMetadata.getRawMetadata.asScala}")
+          val result = client.putObject(putRequest, AWSRequestBody.fromInputStream(inputStream, putRequest.contentLength()))
+          logger.debug(s"Put object ${putRequest.key}")
           result
         } finally {
           inputStream.close()
@@ -105,9 +103,9 @@ case class S3Upload(
 }
 
 object S3Upload {
-  private val mimeTypes = Mimetypes.getInstance()
+  private val mimeTypes = Mimetype.getInstance()
 
-  def awsMimeTypeLookup(fileName: String): String = mimeTypes.getMimetype(fileName)
+  def awsMimeTypeLookup(fileName: String): String = mimeTypes.getMimetype(new File(fileName))
 
   def prefixGenerator(stack:Option[Stack] = None, stage:Option[Stage] = None, packageName:Option[String] = None): String = {
     (stack.map(_.name) :: stage.map(_.name) :: packageName :: Nil).flatten.mkString("/")
@@ -117,13 +115,14 @@ object S3Upload {
 }
 
 case class PutReq(source: S3Object, target: S3Path, cacheControl: Option[String], contentType: Option[String], publicReadAcl: Boolean) {
-  def toAwsRequest(inputStream: InputStream): PutObjectRequest = {
-    val metaData = new ObjectMetadata
-    cacheControl foreach metaData.setCacheControl
-    metaData.setContentType(contentType.getOrElse(S3Upload.awsMimeTypeLookup(target.key)))
-    metaData.setContentLength(source.size)
-    val req = new PutObjectRequest(target.bucket, target.key, inputStream, metaData)
-    if (publicReadAcl) req.withCannedAcl(PublicRead) else req
+  def toAwsRequest: PutObjectRequest = {
+    val req = PutObjectRequest.builder()
+      .bucket(target.bucket)
+      .key(target.key)
+      .contentType(contentType.getOrElse(S3Upload.awsMimeTypeLookup(target.key)))
+      .contentLength(source.size)
+    val reqWithCacheControl = if (cacheControl.isDefined) req.cacheControl(cacheControl.get) else req
+    if (publicReadAcl) reqWithCacheControl.acl(ObjectCannedACL.PUBLIC_READ).build() else reqWithCacheControl.build()
   }
 }
 
@@ -141,11 +140,11 @@ trait PollingCheck {
           val remainingTime = expiry - System.currentTimeMillis()
           if (remainingTime > 0) {
             val sleepyTime = calculateSleepTime(currentAttempt)
-            reporter.verbose("Check failed on attempt #%d (Will wait for a further %.1f seconds, retrying again after %.1fs)" format (currentAttempt, (remainingTime.toFloat/1000), (sleepyTime.toFloat/1000)))
+            reporter.verbose(f"Check failed on attempt #$currentAttempt (Will wait for a further ${remainingTime.toFloat / 1000} seconds, retrying again after ${sleepyTime.toFloat / 1000}s)")
             Thread.sleep(sleepyTime)
             checkAttempt(currentAttempt + 1)
           } else {
-            reporter.fail("Check failed to pass within %d milliseconds (tried %d times) - aborting" format (duration,currentAttempt))
+            reporter.fail(s"Check failed to pass within $duration milliseconds (tried $currentAttempt times) - aborting")
           }
         }
       }
@@ -175,16 +174,16 @@ case class SayHello(host: Host)(implicit val keyRing: KeyRing) extends Task {
     reporter.info("Hello to " + host.name + "!")
   }
 
-  def description = "to " + host.name
-  def verbose = fullDescription
+  def description: String = "to " + host.name
+  def verbose: String = fullDescription
 }
 
 case class ChangeSwitch(host: Host, protocol:String, port: Int, path: String, switchName: String, desiredState: Boolean)(implicit val keyRing: KeyRing) extends Task {
-  val desiredStateName = if (desiredState) "ON" else "OFF"
+  val desiredStateName: String = if (desiredState) "ON" else "OFF"
   val switchboardUrl = s"$protocol://${host.name}:$port$path"
 
   // execute this task (should throw on failure)
-  override def execute(reporter: DeployReporter, stopFlag: => Boolean) = {
+  override def execute(reporter: DeployReporter, stopFlag: => Boolean): Unit = {
     reporter.verbose(s"Changing $switchName to $desiredStateName using $switchboardUrl")
 
     val request = new Request.Builder()
@@ -204,9 +203,8 @@ case class ChangeSwitch(host: Host, protocol:String, port: Int, path: String, sw
       }
       result.body().close()
     } catch {
-      case NonFatal(t) => {
+      case NonFatal(t) =>
         reporter.fail(s"Couldn't set $switchName to $desiredState", t)
-      }
     }
   }
 
@@ -220,7 +218,7 @@ object ChangeSwitch {
 
 case class UpdateS3Lambda(functionName: String, s3Bucket: String, s3Key: String, region: Region)(implicit val keyRing: KeyRing) extends Task {
   def description = s"Updating $functionName Lambda using S3 $s3Bucket:$s3Key"
-  def verbose = description
+  def verbose: String = description
 
   override def execute(reporter: DeployReporter, stopFlag: => Boolean) {
     val client = Lambda.makeLambdaClient(keyRing, region)

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -11,7 +11,7 @@ import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
 import software.amazon.awssdk.core.internal.util.Mimetype
 import software.amazon.awssdk.core.sync.{RequestBody => AWSRequestBody}
 import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.{GetObjectRequest, ObjectCannedACL, PutObjectRequest}
+import software.amazon.awssdk.services.s3.model.{CopyObjectRequest, GetObjectRequest, ObjectCannedACL, PutObjectRequest}
 
 import scala.util.control.NonFatal
 
@@ -69,12 +69,18 @@ case class S3Upload(
         case _ =>
       }
       retryOnException(S3.clientConfiguration) {
-        val getObjectRequest = GetObjectRequest.builder().bucket(req.source.bucket).key(req.source.key).build()
-        val inputStream = artifactClient.getObjectAsBytes(getObjectRequest).asByteArray()
-        val putRequest: PutObjectRequest = req.toAwsRequest
+//        val getObjectRequest = GetObjectRequest.builder().bucket(req.source.bucket).key(req.source.key).build()
+//        val inputStream = artifactClient.getObjectAsBytes(getObjectRequest).asByteArray()
+//        val putRequest: PutObjectRequest = req.toAwsRequest
+        val copyObjectRequest = CopyObjectRequest.builder()
+          .copySource(s"${req.source.bucket}/${req.source.key}")
+          .bucket(req.target.bucket)
+          .key(req.target.key)
+          .build()
         try {
-          val result = client.putObject(putRequest, AWSRequestBody.fromBytes(inputStream))
-          logger.debug(s"Put object ${putRequest.key}")
+//          val result = client.putObject(putRequest, AWSRequestBody.fromBytes(inputStream))
+          val result = client.copyObject(copyObjectRequest)
+          logger.debug(s"Copy object ${req.source.key} to ${req.target.key}")
           result
         } finally {
         }

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -70,14 +70,13 @@ case class S3Upload(
       }
       retryOnException(S3.clientConfiguration) {
         val getObjectRequest = GetObjectRequest.builder().bucket(req.source.bucket).key(req.source.key).build()
-        val inputStream = artifactClient.getObject(getObjectRequest)
+        val inputStream = artifactClient.getObjectAsBytes(getObjectRequest).asByteArray()
         val putRequest: PutObjectRequest = req.toAwsRequest
         try {
-          val result = client.putObject(putRequest, AWSRequestBody.fromInputStream(inputStream, putRequest.contentLength()))
+          val result = client.putObject(putRequest, AWSRequestBody.fromBytes(inputStream))
           logger.debug(s"Put object ${putRequest.key}")
           result
         } finally {
-          inputStream.close()
         }
       }
     }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -2,21 +2,20 @@ package magenta
 
 import java.util.UUID
 
-import com.amazonaws.regions.RegionUtils
-import com.amazonaws.services.s3.AmazonS3
 import magenta.artifact.S3Path
-import magenta.deployment_type.{AutoScaling, DeploymentType}
+import magenta.deployment_type.AutoScaling
 import magenta.fixtures._
 import magenta.tasks._
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.{JsNumber, JsString, JsValue}
+import software.amazon.awssdk.services.s3.S3Client
 
 class AutoScalingTest extends FlatSpec with Matchers {
-  implicit val fakeKeyRing = KeyRing()
-  implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
-  implicit val artifactClient: AmazonS3 = null
+  implicit val fakeKeyRing: KeyRing = KeyRing()
+  implicit val reporter: DeployReporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val artifactClient: S3Client = null
   val region = Region("eu-west-1")
-  val deploymentTypes = Seq(AutoScaling)
+  val deploymentTypes: Seq[AutoScaling.type] = Seq(AutoScaling)
 
   "auto-scaling with ELB package type" should "have a deploy action" in {
     val data: Map[String, JsValue] = Map(

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -2,8 +2,6 @@ package magenta.deployment_type
 
 import java.util.UUID
 
-import com.amazonaws.services.cloudformation.model.{Change, ChangeSetType, Parameter}
-import com.amazonaws.services.s3.AmazonS3
 import magenta._
 import magenta.artifact.S3Path
 import magenta.fixtures._
@@ -12,13 +10,15 @@ import magenta.tasks.UpdateCloudFormationTask._
 import magenta.tasks._
 import org.scalatest.{FlatSpec, Inside, Matchers}
 import play.api.libs.json.{JsBoolean, JsString, JsValue, Json}
+import software.amazon.awssdk.services.cloudformation.model.{Change, ChangeSetType, Parameter}
+import software.amazon.awssdk.services.s3.S3Client
 
 class CloudFormationTest extends FlatSpec with Matchers with Inside {
-  implicit val fakeKeyRing = KeyRing()
-  implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
-  implicit val artifactClient: AmazonS3 = null
+  implicit val fakeKeyRing: KeyRing = KeyRing()
+  implicit val reporter: DeployReporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val artifactClient: S3Client = null
   val region = Region("eu-west-1")
-  val deploymentTypes = Seq(CloudFormation)
+  val deploymentTypes: Seq[CloudFormation.type] = Seq(CloudFormation)
   val app = App("app")
   val testStack = Stack("cfn")
   val cfnStackName = s"cfn-app-PROD"
@@ -106,7 +106,7 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
 
   "CloudFormationParameters" should "substitute stack and stage parameters" in {
     val templateParameters =
-      Seq(TemplateParameter("param1", false), TemplateParameter("Stack", false), TemplateParameter("Stage", false))
+      Seq(TemplateParameter("param1", default = false), TemplateParameter("Stack", default = false), TemplateParameter("Stage", default = false))
     val combined = combineParameters(Stack("cfn"), PROD, templateParameters, Map("param1" -> "value1"))
 
     combined should be(Map(
@@ -118,7 +118,7 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
 
   it should "default required parameters to use existing parameters" in {
     val templateParameters =
-      Seq(TemplateParameter("param1", true), TemplateParameter("param3", false), TemplateParameter("Stage", false))
+      Seq(TemplateParameter("param1", default = true), TemplateParameter("param3", default = false), TemplateParameter("Stage", default = false))
     val combined = combineParameters(Stack("cfn"), PROD, templateParameters, Map("param1" -> "value1"))
 
     combined should be(Map(
@@ -132,12 +132,12 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
 
   it should "convert specified parameter" in {
     convertParameters(Map("key" -> SpecifiedValue("value")), ChangeSetType.UPDATE, reporter) should
-      contain only new Parameter().withParameterKey("key").withParameterValue("value")
+      contain only Parameter.builder().parameterKey("key").parameterValue("value").build()
   }
 
   it should "use existing value" in {
     convertParameters(Map("key" -> UseExistingValue), ChangeSetType.UPDATE, reporter) should
-      contain only new Parameter().withParameterKey("key").withUsePreviousValue(true)
+      contain only Parameter.builder().parameterKey("key").usePreviousValue(true).build()
   }
 
   it should "fail if using existing value on stack creation" in {
@@ -219,7 +219,7 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
     val _ :: (check: CheckChangeSetCreatedTask) :: _ = generateTasks()
 
     intercept[FailException] {
-      check.shouldStopWaiting("FAILED", "", List(new Change()), reporter)
+      check.shouldStopWaiting("FAILED", "", List(Change.builder().build()), reporter)
     }
   }
 

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -2,22 +2,21 @@ package magenta.deployment_type
 
 import java.util.UUID
 
-import com.amazonaws.services.s3.AmazonS3
 import magenta._
 import magenta.artifact.S3Path
 import magenta.deployment_type.param_reads.PatternValue
 import magenta.fixtures._
 import magenta.tasks._
-import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpec, Inside, Matchers}
 import play.api.libs.json.{JsBoolean, JsString, JsValue, Json}
+import software.amazon.awssdk.services.s3.S3Client
 
 class DeploymentTypeTest extends FlatSpec with Matchers with Inside with MockitoSugar {
   implicit val fakeKeyRing = KeyRing()
   implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
-  implicit val artifactClient: AmazonS3 = null
+  implicit val artifactClient: S3Client = null
   val region = Region("eu-west-1")
   val deploymentTypes = Seq(S3, Lambda)
 

--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
@@ -2,21 +2,21 @@ package magenta.deployment_type
 
 import java.util.UUID
 
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
 import magenta.artifact.S3Path
 import magenta.fixtures._
 import magenta.tasks.{S3Upload, UpdateS3Lambda}
-import magenta.{App, DeployReporter, DeployTarget, DeploymentPackage, DeploymentResources, KeyRing, Stack, Region, fixtures}
+import magenta.{App, DeployReporter, DeployTarget, DeploymentPackage, DeploymentResources, KeyRing, Region, Stack, fixtures}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.{JsBoolean, JsString, JsValue, Json}
+import software.amazon.awssdk.services.s3.S3Client
 
 class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
-  implicit val fakeKeyRing = KeyRing()
-  implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
-  implicit val artifactClient: AmazonS3 = mock[AmazonS3Client]
+  implicit val fakeKeyRing: KeyRing = KeyRing()
+  implicit val reporter: DeployReporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val artifactClient: S3Client = mock[S3Client]
   val region = Region("eu-west-1")
-  val deploymentTypes = Seq(Lambda)
+  val deploymentTypes: Seq[Lambda.type] = Seq(Lambda)
 
   behavior of "Lambda deployment action uploadLambda"
 

--- a/magenta-lib/src/test/scala/magenta/fixtures/fixtures.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/fixtures.scala
@@ -7,7 +7,7 @@ import magenta.tasks.Task
 case class StubTask(description: String, region: Region, stack: Option[Stack] = None) extends Task {
 
   def execute(reporter: DeployReporter, stopFlag: => Boolean) { }
-  def verbose = "stub(%s)" format description
+  def verbose = s"stub($description)"
   def keyRing = KeyRing()
 }
 

--- a/magenta-lib/src/test/scala/magenta/graph/DeploymentGraphTest.scala
+++ b/magenta-lib/src/test/scala/magenta/graph/DeploymentGraphTest.scala
@@ -1,15 +1,15 @@
 package magenta.graph
 
-import com.amazonaws.services.s3.AmazonS3Client
 import magenta.{Host, KeyRing, Region}
 import magenta.tasks.{ChangeSwitch, S3Upload, SayHello}
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.mockito.MockitoSugar
 import magenta.fixtures._
+import software.amazon.awssdk.services.s3.S3Client
 
 class DeploymentGraphTest extends FlatSpec with Matchers with MockitoSugar {
-  implicit val fakeKeyRing = KeyRing()
-  implicit val artifactClient = mock[AmazonS3Client]
+  implicit val fakeKeyRing: KeyRing = KeyRing()
+  implicit val artifactClient: S3Client = mock[S3Client]
 
   "DeploymentGraph" should "Convert a list of tasks to a graph" in {
     val graph = DeploymentGraph(threeSimpleTasks, "unnamed")

--- a/magenta-lib/src/test/scala/magenta/input/resolver/TaskResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/TaskResolverTest.scala
@@ -3,19 +3,19 @@ package magenta.input.resolver
 import java.util.UUID
 
 import cats.data.{NonEmptyList => NEL}
-import com.amazonaws.services.s3.AmazonS3Client
 import magenta.artifact.S3YamlArtifact
-import magenta.deployment_type.{Action, AutoScaling}
+import magenta.deployment_type.Action
 import magenta.fixtures._
 import magenta.input.Deployment
-import magenta.{Build, DeployParameters, DeployReporter, Deployer, DeploymentResources, Stack, Region, Stage, fixtures}
+import magenta.{Build, DeployParameters, DeployReporter, Deployer, DeploymentResources, Region, Stack, Stage, fixtures}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.JsString
+import software.amazon.awssdk.services.s3.S3Client
 
 class TaskResolverTest extends FlatSpec with Matchers with MockitoSugar with ValidatedValues {
-  implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
-  implicit val artifactClient = mock[AmazonS3Client]
+  implicit val reporter: DeployReporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val artifactClient: S3Client = mock[S3Client]
 
   val deploymentTypes = List(StubDeploymentType(
     actionsMap = Map(

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
@@ -2,49 +2,56 @@ package magenta.tasks
 
 import java.util.UUID
 
-import com.amazonaws.services.autoscaling.AmazonAutoScalingClient
-import com.amazonaws.services.autoscaling.model.{AutoScalingGroup, SetDesiredCapacityRequest}
 import magenta.artifact.S3Path
-import magenta.deployment_type.DeploymentType
 import magenta.fixtures._
 import magenta.{KeyRing, Stage, _}
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}
+import software.amazon.awssdk.services.autoscaling.AutoScalingClient
+import software.amazon.awssdk.services.autoscaling.model.{AutoScalingGroup, SetDesiredCapacityRequest}
 
 class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
-  implicit val fakeKeyRing = KeyRing()
-  val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
-  val deploymentTypes = Seq(stubDeploymentType(name="testDeploymentType", actionNames = Seq("testAction")))
+  implicit val fakeKeyRing: KeyRing = KeyRing()
+  val reporter: DeployReporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
+  val deploymentTypes: Seq[StubDeploymentType] = Seq(stubDeploymentType(name = "testDeploymentType", actionNames = Seq("testAction")))
 
   it should "double the size of the autoscaling group" in {
-    val asg = new AutoScalingGroup().withDesiredCapacity(3).withAutoScalingGroupName("test").withMaxSize(10)
-    val asgClientMock = mock[AmazonAutoScalingClient]
+    val asg = AutoScalingGroup.builder()
+      .desiredCapacity(3)
+      .autoScalingGroupName("test")
+      .maxSize(10)
+      .build()
+    val asgClientMock = mock[AutoScalingClient]
 
     val p = DeploymentPackage("test", App("app"), Map.empty, "testDeploymentType", S3Path("artifact-bucket", "project/123/test"),
       deploymentTypes)
 
-    val task = new DoubleSize(p, Stage("PROD"), stack, Region("eu-west-1"))
+    val task = DoubleSize(p, Stage("PROD"), stack, Region("eu-west-1"))
 
-    task.execute(asg, reporter, false, asgClientMock)
+    task.execute(asg, reporter, stopFlag = false, asgClientMock)
 
     verify(asgClientMock).setDesiredCapacity(
-      new SetDesiredCapacityRequest().withAutoScalingGroupName("test").withDesiredCapacity(6)
+      SetDesiredCapacityRequest.builder().autoScalingGroupName("test").desiredCapacity(6).build()
     )
   }
 
   it should "fail if you do not have the capacity to deploy" in {
-    val asg = new AutoScalingGroup().withAutoScalingGroupName("test")
-      .withMinSize(1).withDesiredCapacity(1).withMaxSize(1)
+    val asg = AutoScalingGroup.builder()
+      .autoScalingGroupName("test")
+      .minSize(1)
+      .desiredCapacity(1)
+      .maxSize(1)
+      .build()
 
-    val asgClientMock = mock[AmazonAutoScalingClient]
+    val asgClientMock = mock[AutoScalingClient]
 
     val p = DeploymentPackage("test", App("app"), Map.empty, "testDeploymentType", S3Path("artifact-bucket", "project/123/test"),
       deploymentTypes)
 
-    val task = new CheckGroupSize(p, Stage("PROD"), stack, Region("eu-west-1"))
+    val task = CheckGroupSize(p, Stage("PROD"), stack, Region("eu-west-1"))
 
-    val thrown = intercept[FailException](task.execute(asg, reporter, false, asgClientMock))
+    val thrown = intercept[FailException](task.execute(asg, reporter, stopFlag = false, asgClientMock))
 
     thrown.getMessage should startWith ("Autoscaling group does not have the capacity")
   }

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -3,52 +3,52 @@ package tasks
 
 import java.io.{ByteArrayInputStream, OutputStreamWriter}
 import java.net.ServerSocket
-import java.util
 import java.util.UUID
 
-import com.amazonaws.ClientConfiguration
-import com.amazonaws.services.s3.model._
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
 import magenta.artifact.{S3Path, S3Object => MagentaS3Object}
 import magenta.deployment_type.param_reads.PatternValue
+import magenta.input.All
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}
-import magenta.Region
-import magenta.input.All
+import software.amazon.awssdk.awscore.DefaultAwsResponseMetadata
+import software.amazon.awssdk.core.ResponseInputStream
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.http.AbortableInputStream
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model._
 
 import scala.collection.JavaConverters._
 
 
 class TasksTest extends FlatSpec with Matchers with MockitoSugar {
-  implicit val fakeKeyRing = KeyRing()
-  implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
+  implicit val fakeKeyRing: KeyRing = KeyRing()
+  implicit val reporter: DeployReporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
 
   "PutRec" should "create an upload request with correct permissions" in {
     val putRec = PutReq(
-      MagentaS3Object("artifact-bucket", "foo/bar/foo-bar.jar", 31),
-      S3Path("artifact-bucket", "foo/bar/the-jar.jar"),
-      None, None,
+      source = MagentaS3Object("artifact-bucket", "foo/bar/foo-bar.jar", 31),
+      target = S3Path("artifact-bucket", "foo/bar/the-jar.jar"),
+      cacheControl = None, contentType = None,
       publicReadAcl = false
     )
 
-    val stream = new ByteArrayInputStream("bob".getBytes("UTF-8"))
-    val awsRequest = putRec.toAwsRequest(stream)
+    val awsRequest = putRec.toAwsRequest
 
-    awsRequest.getBucketName should be ("artifact-bucket")
-    awsRequest.getCannedAcl should be (null)
-    awsRequest.getKey should be ("foo/bar/the-jar.jar")
-    awsRequest.getInputStream should be (stream)
-    Option(awsRequest.getMetadata.getCacheControl) should be (None)
-    awsRequest.getMetadata.getContentType should be ("application/octet-stream")
+    awsRequest.bucket should be ("artifact-bucket")
+    awsRequest.acl should be (null)
+    awsRequest.key should be ("foo/bar/the-jar.jar")
+    Option(awsRequest.cacheControl) should be (None)
+    awsRequest.contentType should be ("application/java-archive")
 
     val reqWithoutAcl = putRec.copy(publicReadAcl = true)
 
-    val awsRequestWithoutAcl = reqWithoutAcl.toAwsRequest(stream)
+    val awsRequestWithoutAcl = reqWithoutAcl.toAwsRequest
 
-    awsRequestWithoutAcl.getCannedAcl should be (CannedAccessControlList.PublicRead)
+    awsRequestWithoutAcl.acl should be (ObjectCannedACL.PUBLIC_READ)
   }
 
   it should "create an upload request with cache control and content type" in {
@@ -59,15 +59,13 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
       publicReadAcl = false
     )
 
-    val stream = new ByteArrayInputStream("bob".getBytes("UTF-8"))
-    val awsRequest = putRec.toAwsRequest(stream)
+    val awsRequest = putRec.toAwsRequest
 
-    awsRequest.getBucketName should be ("artifact-bucket")
-    awsRequest.getCannedAcl should be (null)
-    awsRequest.getKey should be ("foo/bar/the-jar.jar")
-    awsRequest.getInputStream should be (stream)
-    Option(awsRequest.getMetadata.getCacheControl) should be (Some("no-cache"))
-    Option(awsRequest.getMetadata.getContentType) should be (Some("application/json"))
+    awsRequest.bucket should be ("artifact-bucket")
+    awsRequest.acl should be (null)
+    awsRequest.key should be ("foo/bar/the-jar.jar")
+    Option(awsRequest.cacheControl) should be (Some("no-cache"))
+    Option(awsRequest.contentType) should be (Some("application/json"))
   }
 
   it should "use a default mime type from S3" in {
@@ -79,7 +77,7 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
     )
     val putRecTwo = PutReq(
       MagentaS3Object("artifact-bucket", "foo/bar/foo-bar.xpi", 31),
-      S3Path("artifact-bucket", "foo/bar/the-jar.xpi"),
+      S3Path("artifact-bucket", "foo/bar/the-jar.abc"),
       Some("no-cache"), None,
       publicReadAcl = false
     )
@@ -90,75 +88,79 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
       publicReadAcl = false
     )
 
-    val stream = new ByteArrayInputStream("bob".getBytes("UTF-8"))
-    val awsRequestOne = putRecOne.toAwsRequest(stream)
-    val awsRequestTwo = putRecTwo.toAwsRequest(stream)
-    val awsRequestThree = putRecThree.toAwsRequest(stream)
+    val awsRequestOne = putRecOne.toAwsRequest
+    val awsRequestTwo = putRecTwo.toAwsRequest
+    val awsRequestThree = putRecThree.toAwsRequest
 
-    awsRequestOne.getMetadata.getContentType should be ("text/css")
-    awsRequestTwo.getMetadata.getContentType should be ("application/octet-stream")
-    awsRequestThree.getMetadata.getContentType should be ("application/x-javascript")
+    awsRequestOne.contentType should be ("text/css")
+    awsRequestTwo.contentType should be ("application/octet-stream")
+    awsRequestThree.contentType should be ("application/javascript")
   }
 
   "S3Upload" should "upload a single file to S3" in {
-    val artifactClient = mock[AmazonS3Client]
-    val objectResult = mockListObjects(List(MagentaS3Object("artifact-bucket", "foo/bar/the-jar.jar", 31)))
+    val artifactClient = mock[S3Client]
+    val s3Client = mock[S3Client]
+
+    val sourceBucket = "artifact-bucket"
+    val targetBucket = "destination-bucket"
+    val sourceKey = "foo/bar/the-jar.jar"
+    val targetKey = "keyPrefix/the-jar.jar"
+
+    val objectResult = mockListObjectsResponse(List(MagentaS3Object(sourceBucket, sourceKey, 31)))
     when(artifactClient.listObjectsV2(any[ListObjectsV2Request])).thenReturn(objectResult)
-    when(artifactClient.getObject("artifact-bucket", "foo/bar/the-jar.jar")).thenReturn(mockObject("Some content for this S3 object"))
 
-    val fileToUpload = new S3Path("artifact-bucket", "foo/bar/the-jar.jar")
-    val s3Client = mock[AmazonS3Client]
-    val putObjectResult = {
-      val por = new PutObjectResult
-      por.setContentMd5("testMd5Sum")
-      val metadata = new ObjectMetadata()
-      metadata.setContentLength(300)
-      por.setMetadata(metadata)
-      por
-    }
-    when(s3Client.putObject(any[PutObjectRequest])).thenReturn(putObjectResult)
-    val task = new S3Upload(Region("eu-west-1"), "destination-bucket", Seq(fileToUpload -> "keyPrefix/the-jar.jar"))(fakeKeyRing, artifactClient, clientFactory(s3Client))
+    when(artifactClient.getObject(GetObjectRequest.builder()
+      .bucket(sourceBucket)
+      .key(sourceKey).build())
+    ).thenReturn(mockGetObjectResponse())
 
+    val putObjectResult = PutObjectResponse.builder()
+      .sseCustomerKeyMD5("testMd5Sum")
+      .build()
+    when(s3Client.putObject(any[PutObjectRequest], any[RequestBody])).thenReturn(putObjectResult)
+
+
+    val fileToUpload = new S3Path(sourceBucket, sourceKey)
+    val task = S3Upload(Region("eu-west-1"), targetBucket, Seq(fileToUpload -> targetKey))(fakeKeyRing, artifactClient, clientFactory(s3Client))
     val mappings = task.objectMappings
     mappings.size should be (1)
     val (source, target) = mappings.head
-    source.bucket should be ("artifact-bucket")
-    source.key should be ("foo/bar/the-jar.jar")
+    source.bucket should be (sourceBucket)
+    source.key should be (sourceKey)
     source.size should be (31)
 
-    target.bucket should be ("destination-bucket")
-    target.key should be ("keyPrefix/the-jar.jar")
+    target.bucket should be (targetBucket)
+    target.key should be (targetKey)
 
     task.execute(reporter)
 
-    val request = ArgumentCaptor.forClass(classOf[PutObjectRequest])
-    verify(s3Client).putObject(request.capture())
+    val request: ArgumentCaptor[PutObjectRequest] = ArgumentCaptor.forClass(classOf[PutObjectRequest])
+    verify(s3Client).putObject(request.capture(), any[RequestBody])
     verifyNoMoreInteractions(s3Client)
-    request.getValue.getKey should be ("keyPrefix/the-jar.jar")
-    request.getValue.getBucketName should be ("destination-bucket")
+    request.getValue.key should be ("keyPrefix/the-jar.jar")
+    request.getValue.bucket should be ("destination-bucket")
   }
 
   it should "upload a directory to S3" in {
-    val artifactClient = mock[AmazonS3Client]
+    val artifactClient = mock[S3Client]
+    val s3Client = mock[S3Client]
+
     val fileOne = MagentaS3Object("artifact-bucket", "test/123/package/one.txt", 31)
     val fileTwo = MagentaS3Object("artifact-bucket", "test/123/package/two.txt", 31)
     val fileThree = MagentaS3Object("artifact-bucket", "test/123/package/sub/three.txt", 31)
-    val objectResult = mockListObjects(List(fileOne, fileTwo, fileThree))
+
+    val objectResult = mockListObjectsResponse(List(fileOne, fileTwo, fileThree))
     when(artifactClient.listObjectsV2(any[ListObjectsV2Request])).thenReturn(objectResult)
-    when(artifactClient.getObject(any[String], any[String])).thenReturn(mockObject("Some content for this S3 object"))
+
+    when(artifactClient.getObject(any[GetObjectRequest]))
+      .thenReturn(mockGetObjectResponse())
 
     val packageRoot = new S3Path("artifact-bucket", "test/123/package/")
-    val s3Client = mock[AmazonS3Client]
-    val putObjectResult = {
-      val por = new PutObjectResult
-      por.setContentMd5("testMd5Sum")
-      val metadata = new ObjectMetadata()
-      metadata.setContentLength(300)
-      por.setMetadata(metadata)
-      por
-    }
-    when(s3Client.putObject(any[PutObjectRequest])).thenReturn(putObjectResult)
+
+    val putObjectResult = PutObjectResponse.builder().sseCustomerKeyMD5("testMd5Sum").build()
+    when(s3Client.putObject(any[PutObjectRequest], any[RequestBody])).thenReturn(putObjectResult)
     val task = new S3Upload(Region("eu-west-1"), "bucket", Seq(packageRoot -> "myStack/CODE/myApp"))(fakeKeyRing, artifactClient, clientFactory(s3Client))
+
     task.execute(reporter)
 
     val files = task.objectMappings
@@ -167,32 +169,29 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
     files should contain ((fileTwo, S3Path("bucket", "myStack/CODE/myApp/two.txt")))
     files should contain ((fileThree, S3Path("bucket", "myStack/CODE/myApp/sub/three.txt")))
 
-    verify(s3Client, times(3)).putObject(any(classOf[PutObjectRequest]))
+    verify(s3Client, times(3)).putObject(any[PutObjectRequest], any[RequestBody])
 
     verifyNoMoreInteractions(s3Client)
   }
 
   it should "upload a directory to S3 with no prefix" in {
+    val artifactClient = mock[S3Client]
+    val s3Client = mock[S3Client]
 
-    val artifactClient = mock[AmazonS3Client]
     val fileOne = MagentaS3Object("artifact-bucket", "test/123/package/one.txt", 31)
     val fileTwo = MagentaS3Object("artifact-bucket", "test/123/package/two.txt", 31)
     val fileThree = MagentaS3Object("artifact-bucket", "test/123/package/sub/three.txt", 31)
-    val objectResult = mockListObjects(List(fileOne, fileTwo, fileThree))
+
+    val objectResult = mockListObjectsResponse(List(fileOne, fileTwo, fileThree))
     when(artifactClient.listObjectsV2(any[ListObjectsV2Request])).thenReturn(objectResult)
-    when(artifactClient.getObject(any[String], any[String])).thenReturn(mockObject("Some content for this S3 object"))
+
+    when(artifactClient.getObject(any[GetObjectRequest])).thenReturn(mockGetObjectResponse())
 
     val packageRoot = new S3Path("artifact-bucket", "test/123/package/")
-    val s3Client = mock[AmazonS3Client]
-    val putObjectResult = {
-      val por = new PutObjectResult
-      por.setContentMd5("testMd5Sum")
-      val metadata = new ObjectMetadata()
-      metadata.setContentLength(300)
-      por.setMetadata(metadata)
-      por
-    }
-    when(s3Client.putObject(any[PutObjectRequest])).thenReturn(putObjectResult)
+
+    val putObjectResult = PutObjectResponse.builder().sseCustomerKeyMD5("testMd5Sum").build()
+    when(s3Client.putObject(any[PutObjectRequest], any[RequestBody])).thenReturn(putObjectResult)
+
     val task = new S3Upload(Region("eu-west-1"), "bucket", Seq(packageRoot -> ""))(fakeKeyRing, artifactClient, clientFactory(s3Client))
     task.execute(reporter)
 
@@ -203,17 +202,17 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
     files should contain ((fileTwo, S3Path("bucket", "two.txt")))
     files should contain ((fileThree, S3Path("bucket", "sub/three.txt")))
 
-    verify(s3Client, times(3)).putObject(any(classOf[PutObjectRequest]))
+    verify(s3Client, times(3)).putObject(any[PutObjectRequest], any[RequestBody])
 
     verifyNoMoreInteractions(s3Client)
   }
 
   it should "use different cache control" in {
-    val artifactClient = mock[AmazonS3Client]
+    val artifactClient = mock[S3Client]
     val fileOne = MagentaS3Object("artifact-bucket", "test/123/package/one.txt", 31)
     val fileTwo = MagentaS3Object("artifact-bucket", "test/123/package/two.txt", 31)
     val fileThree = MagentaS3Object("artifact-bucket", "test/123/package/sub/three.txt", 31)
-    val objectResult = mockListObjects(List(fileOne, fileTwo, fileThree))
+    val objectResult = mockListObjectsResponse(List(fileOne, fileTwo, fileThree))
     when(artifactClient.listObjectsV2(any[ListObjectsV2Request])).thenReturn(objectResult)
 
     val patternValues = List(PatternValue("^keyPrefix/sub/", "public; max-age=3600"), PatternValue(".*", "no-cache"))
@@ -226,10 +225,10 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
   }
 
   it should "use overridden mime type" in {
-    val artifactClient = mock[AmazonS3Client]
+    val artifactClient = mock[S3Client]
     val fileOne = MagentaS3Object("artifact-bucket", "test/123/package/one.test.txt", 31)
     val fileTwo = MagentaS3Object("artifact-bucket", "test/123/package/two.test.xpi", 31)
-    val objectResult = mockListObjects(List(fileOne, fileTwo))
+    val objectResult = mockListObjectsResponse(List(fileOne, fileTwo))
     when(artifactClient.listObjectsV2(any[ListObjectsV2Request])).thenReturn(objectResult)
 
     val mimeTypes = Map("xpi" -> "application/x-xpinstall")
@@ -240,28 +239,22 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
     task.requests.find(_.source == fileTwo).get.contentType should be(Some("application/x-xpinstall"))
   }
 
-  def mockListObjects(objs: List[MagentaS3Object]) = {
-    val summaries = objs.map { obj =>
-      val summary = new S3ObjectSummary()
-      summary.setBucketName(obj.bucket)
-      summary.setKey(obj.key)
-      summary.setSize(obj.size)
-      summary
+  def mockListObjectsResponse(objs: List[MagentaS3Object]): ListObjectsV2Response = {
+    val s3Objects = objs.map { obj =>
+      S3Object.builder().key(obj.key).size(obj.size).build()
     }
-    new ListObjectsV2Result() {
-      override def getObjectSummaries: util.List[S3ObjectSummary] = {
-        summaries.asJava
-      }
-    }
+
+    ListObjectsV2Response.builder().contents(s3Objects:_*).build()
   }
 
-  def mockObject(content: String): S3Object = {
-    val mockedObject = new S3Object()
-    mockedObject.setObjectContent(new ByteArrayInputStream(content.getBytes("UTF-8")))
-    mockedObject
+  def mockGetObjectResponse(): ResponseInputStream[GetObjectResponse] = {
+    val stream = new ByteArrayInputStream("Some content for this S3Object.".getBytes("UTF-8"))
+    new ResponseInputStream[GetObjectResponse](
+      GetObjectResponse.builder().contentLength(31L).build(),
+      AbortableInputStream.create(stream))
   }
-  
-  def clientFactory(client: AmazonS3): (KeyRing, Region, ClientConfiguration) => AmazonS3 = { (_, _, _) => client }
+
+  def clientFactory(client: S3Client): (KeyRing, Region, ClientOverrideConfiguration) => S3Client = { (_, _, _) => client }
 
   val parameters = DeployParameters(Deployer("tester"), Build("Project","1"), Stage("CODE"), All)
 }
@@ -273,7 +266,7 @@ class TestServer(port:Int = 9997) {
     val server = new ServerSocket(port)
     val socket = server.accept()
     val osw = new OutputStreamWriter(socket.getOutputStream)
-    osw.write("%s\r\n\r\n" format (response))
+    osw.write("%s\r\n\r\n" format response)
     osw.flush()
     socket.close()
     server.close()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val aws = "1.11.106"
+    val aws = "2.5.14"
     val guardianManagement = "5.41"
     val jackson = "2.9.8"
   }
@@ -15,7 +15,7 @@ object Dependencies {
     "org.typelevel" %% "cats-core" % "1.0.1",
     "com.kailuowang" %% "henkan-convert" % "0.2.10",
     "org.scalatest" %% "scalatest" % "3.0.3" % Test,
-    "org.mockito" % "mockito-core" % "1.10.19" % Test
+    "org.mockito" % "mockito-core" % "2.27.0" % Test
   )
 
   val magentaLibDeps = commonDeps ++ Seq(
@@ -24,15 +24,15 @@ object Dependencies {
     "org.bouncycastle" % "bcpg-jdk15on" % "1.61",
     "com.github.seratch.com.veact" %% "scala-ssh" % "0.8.0-1" exclude ("org.bouncycastle", "bcpkix-jdk15on"),
     "ch.qos.logback" % "logback-classic" % "1.2.0",
-    "com.amazonaws" % "aws-java-sdk-core" % Versions.aws,
-    "com.amazonaws" % "aws-java-sdk-autoscaling" % Versions.aws,
-    "com.amazonaws" % "aws-java-sdk-s3" % Versions.aws,
-    "com.amazonaws" % "aws-java-sdk-ec2" % Versions.aws,
-    "com.amazonaws" % "aws-java-sdk-elasticloadbalancing" % Versions.aws,
-    "com.amazonaws" % "aws-java-sdk-elasticloadbalancingv2" % Versions.aws,
-    "com.amazonaws" % "aws-java-sdk-lambda" % Versions.aws,
-    "com.amazonaws" % "aws-java-sdk-cloudformation" % Versions.aws,
-    "com.amazonaws" % "aws-java-sdk-sts" % Versions.aws,
+    "software.amazon.awssdk" % "core" % Versions.aws,
+    "software.amazon.awssdk" % "autoscaling" % Versions.aws,
+    "software.amazon.awssdk" % "s3" % Versions.aws,
+    "software.amazon.awssdk" % "ec2" % Versions.aws,
+    "software.amazon.awssdk" % "elasticloadbalancing" % Versions.aws,
+    "software.amazon.awssdk" % "elasticloadbalancingv2" % Versions.aws,
+    "software.amazon.awssdk" % "lambda" % Versions.aws,
+    "software.amazon.awssdk" % "cloudformation" % Versions.aws,
+    "software.amazon.awssdk" % "sts" % Versions.aws,
     "com.gu" %% "management" % Versions.guardianManagement,
     "com.gu" %% "fastly-api-client" % "0.2.6",
     "com.ning" % "async-http-client" % "1.9.40", // we need this to solve vulnerabilities from fastly-api-client
@@ -56,7 +56,8 @@ object Dependencies {
     "org.pegdown" % "pegdown" % "1.6.0",
     "com.adrianhurt" %% "play-bootstrap" % "1.2-P26-B3-RC2",
     "com.gu" %% "scanamo" % "1.0.0-M6",
-    "com.amazonaws" % "aws-java-sdk-dynamodb" % Versions.aws,
+    "software.amazon.awssdk" % "dynamodb" % Versions.aws,
+    "software.amazon.awssdk" % "sns" % Versions.aws,
     "org.quartz-scheduler" % "quartz" % "2.3.0",
     "com.gu" %% "anghammarad-client" % "1.1.3",
     "org.webjars" %% "webjars-play" % "2.7.0-1",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,3 +10,6 @@ addSbtPlugin("com.gu" % "sbt-teamcity-test-reporting-plugin" % "1.5")
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.4")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
+addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.9")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,4 +12,3 @@ addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.4")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
-addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.9")

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -60,7 +60,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
       parameterName = config.auth.secretStateSupplierKeyName,
       ssmClient = AWSSimpleSystemsManagementClientBuilder.standard()
         .withRegion(config.auth.secretStateSupplierRegion)
-        .withCredentials(config.credentialsProviderChain(None, None))
+        .withCredentials(config.oldCredentialsProviderChain(None, None))
         .build()
     )
   }

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -60,7 +60,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
       parameterName = config.auth.secretStateSupplierKeyName,
       ssmClient = AWSSimpleSystemsManagementClientBuilder.standard()
         .withRegion(config.auth.secretStateSupplierRegion)
-        .withCredentials(config.oldCredentialsProviderChain(None, None))
+        .withCredentials(config.credentialsProviderChainV1(None, None))
         .build()
     )
   }

--- a/riff-raff/app/controllers/Testing.scala
+++ b/riff-raff/app/controllers/Testing.scala
@@ -120,14 +120,17 @@ class Testing(config: Config,
       testForm.bindFromRequest().fold(
         errors => BadRequest(views.html.test.form(errors)(config, menu)),
         form => {
-          log.info("Form post: %s" format form.toString)
+          log.info(s"Form post: ${form.toString}")
           Redirect(routes.Testing.form)
         }
       )
     }
 
   def testcharset = authAction { implicit request =>
-    Ok("Raw string: %s\nParsed strings: \n%s" format (request.rawQueryString, request.queryString))
+    Ok(
+      s"""Raw string: ${request.rawQueryString}
+         |Parsed strings:
+         |${request.queryString}""".stripMargin)
   }
 
   def uuidList(limit:Int) = authAction { implicit request =>
@@ -176,15 +179,15 @@ class Testing(config: Config,
       form => {
         form.action match {
           case "summarise" =>
-            log.info("Summarising deploy with UUID %s" format form.uuid)
+            log.info(s"Summarising deploy with UUID ${form.uuid}")
             datastore.summariseDeploy(UUID.fromString(form.uuid))
             Redirect(routes.Testing.uuidList())
           case "deleteV2" =>
-            log.info("Deleting deploy in V2 with UUID %s" format form.uuid)
+            log.info(s"Deleting deploy in V2 with UUID ${form.uuid}")
             datastore.deleteDeployLog(UUID.fromString(form.uuid))
             Redirect(routes.Testing.uuidList())
           case "addStringUUID" =>
-            log.info("Adding string UUID for %s" format form.uuid)
+            log.info(s"Adding string UUID for ${form.uuid}")
             datastore.addStringUUID(UUID.fromString(form.uuid))
             Redirect(routes.Testing.uuidList())
         }

--- a/riff-raff/app/controllers/api.scala
+++ b/riff-raff/app/controllers/api.scala
@@ -102,7 +102,7 @@ class Api(config: Config,
       }
 
       jsonpCallback map { callback =>
-        Ok("%s(%s)" format (callback, responseObject.toString)).as("application/javascript")
+        Ok(s"$callback(${responseObject.toString})").as("application/javascript")
       } getOrElse {
         response \ "response" \ "status" match {
           case JsDefined(JsString("ok")) => Ok(responseObject)

--- a/riff-raff/app/deployment/actors/DeployGroupRunner.scala
+++ b/riff-raff/app/deployment/actors/DeployGroupRunner.scala
@@ -6,7 +6,6 @@ import akka.actor.SupervisorStrategy.Stop
 import akka.actor.{Actor, ActorRef, ActorRefFactory, OneForOneStrategy, Terminated}
 import akka.agent.Agent
 import cats.data.Validated.{Invalid, Valid}
-import com.amazonaws.services.s3.AmazonS3
 import conf.Config
 import controllers.Logging
 import deployment.Record
@@ -174,7 +173,7 @@ class DeployGroupRunner(
     DeployReporter.withFailureHandling(rootReporter) { implicit safeReporter =>
       import cats.syntax.either._
 
-      implicit val client: AmazonS3 = config.artifact.aws.client
+      implicit val client = config.artifact.aws.client
       val bucketName = config.artifact.aws.bucketName
 
       safeReporter.info("Reading riff-raff.yaml")

--- a/riff-raff/app/deployment/filter.scala
+++ b/riff-raff/app/deployment/filter.scala
@@ -124,7 +124,7 @@ trait Pagination extends QueryStringBuilder {
   implicit def call2AddQueryParams(call: Call) = new {
     def appendQueryParams(params: String): Call = {
       val sep = if (call.url.contains("?")) "&" else "?"
-      Call(call.method, "%s%s%s" format (call.url, sep, params))
+      Call(call.method, s"${call.url}$sep$params")
     }
   }
 

--- a/riff-raff/app/persistence/SummariseDeploysHousekeeping.scala
+++ b/riff-raff/app/persistence/SummariseDeploysHousekeeping.scala
@@ -11,10 +11,10 @@ class SummariseDeploysHousekeeping(config: Config, datastore: DataStore) extends
   lazy val housekeepingTime = new LocalTime(config.housekeeping.hour, config.housekeeping.minute)
 
   def summariseDeploys(): Int = {
-    log.info("Summarising deploys older than %d days" format maxAgeDays)
+    log.info(s"Summarising deploys older than $maxAgeDays days")
     val maxAgeThreshold = LocalDate.now().minusDays(maxAgeDays)
     val deploys = datastore.getCompleteDeploysOlderThan(maxAgeThreshold.toDateTimeAtStartOfDay)
-    log.info("Found %d deploys to summarise" format deploys.size)
+    log.info(s"Found ${deploys.size} deploys to summarise")
     deploys.foreach(detail => datastore.summariseDeploy(detail.uuid))
     log.info("Finished summarising")
     deploys.size

--- a/riff-raff/app/persistence/datastore.scala
+++ b/riff-raff/app/persistence/datastore.scala
@@ -43,7 +43,7 @@ abstract class DataStore(config: Config) extends DocumentStore with Retriable {
       Right(result)
     } catch {
       case t: Throwable =>
-        val error = "Caught exception%s" format message.map(" whilst %s" format _).getOrElse("")
+        val error = s"Caught exception ${message.map(m => s"whilst $m").getOrElse("")}"
         log.error(error, t)
         Left(t)
     }

--- a/riff-raff/app/utils/ScheduledAgent.scala
+++ b/riff-raff/app/utils/ScheduledAgent.scala
@@ -82,7 +82,7 @@ class ScheduledAgent[T](system: ActorSystem, initialValue: T, updates: Scheduled
 
   def scheduleNext(update: DailyScheduledAgentUpdate[T]): Cancellable = {
     val delay = update.timeToNextExecution
-    log.debug("Scheduling %s to run next in %s" format (update, delay))
+    log.debug(s"Scheduling $update to run next in $delay")
     system.scheduler.scheduleOnce(delay) {
       queueUpdate(update)
       val newCancellable = scheduleNext(update)

--- a/riff-raff/app/utils/VCSInfo.scala
+++ b/riff-raff/app/utils/VCSInfo.scala
@@ -29,9 +29,9 @@ trait VCSInfo {
 
 case class GitHub(ciVcsUrl: String, revision: String, repo: String) extends VCSInfo {
   lazy val name = "GitHub"
-  lazy val baseUrl = new URI("https://github.com/%s" format repo)
-  lazy val commitUrl = new URI("%s/commit/%s" format (baseUrl, revision))
-  lazy val treeUrl = new URI("%s/tree/%s" format (baseUrl, revision))
+  lazy val baseUrl = new URI(s"https://github.com/$repo")
+  lazy val commitUrl = new URI(s"$baseUrl/commit/$revision")
+  lazy val treeUrl = new URI(s"$baseUrl/tree/$revision")
   lazy val headUrl = baseUrl
 }
 

--- a/riff-raff/test/deployment/Fixtures.scala
+++ b/riff-raff/test/deployment/Fixtures.scala
@@ -2,16 +2,16 @@ package deployment
 
 import java.util.UUID
 
-import com.amazonaws.services.s3.AmazonS3Client
 import magenta.graph.{DeploymentGraph, DeploymentTasks, Graph}
-import magenta.{App, Build, DeployContext, Deployer, DeployParameters, DeployReporter, Host, KeyRing, Region, Stage}
 import magenta.tasks._
+import magenta.{App, Build, DeployContext, DeployParameters, DeployReporter, Deployer, Host, KeyRing, Region, Stage}
 import org.joda.time.DateTime
 import org.scalatest.mockito.MockitoSugar
+import software.amazon.awssdk.services.s3.S3Client
 
 object Fixtures extends MockitoSugar {
-  implicit val fakeKeyRing = KeyRing()
-  implicit val artifactClient = mock[AmazonS3Client]
+  implicit val fakeKeyRing: KeyRing = KeyRing()
+  implicit val artifactClient: S3Client = mock[S3Client]
 
   private val host = Host("testHost", App("testApp"), "CODE", "testStack")
 

--- a/riff-raff/test/deployment/preview/PreviewTest.scala
+++ b/riff-raff/test/deployment/preview/PreviewTest.scala
@@ -4,7 +4,6 @@ import java.util.UUID
 
 import cats.data.Validated.{Invalid, Valid}
 import cats.data.{Validated, NonEmptyList => NEL}
-import com.amazonaws.services.s3.AmazonS3Client
 import magenta.artifact.S3YamlArtifact
 import magenta.fixtures.{ValidatedValues, _}
 import magenta.graph.{DeploymentTasks, EndNode, Graph, StartNode, ValueNode}
@@ -12,6 +11,7 @@ import magenta.input.DeploymentKey
 import magenta.{Build, DeployParameters, DeployReporter, Deployer, DeploymentResources, Region, Stage}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}
+import software.amazon.awssdk.services.s3.S3Client
 
 class PreviewTest extends FlatSpec with Matchers with ValidatedValues with MockitoSugar {
   def valid(n: Int): Validated[NEL[String], Int] = Valid(n)
@@ -35,7 +35,7 @@ class PreviewTest extends FlatSpec with Matchers with ValidatedValues with Mocki
   }
 
 
-  implicit val artifactClient = mock[AmazonS3Client]
+  implicit val artifactClient: S3Client = mock[S3Client]
 
   "apply" should "create a preview" in {
     val artifact = S3YamlArtifact("test-bucket", "test-key")

--- a/riff-raff/test/housekeeping/ArtifactHousekeepingTest.scala
+++ b/riff-raff/test/housekeeping/ArtifactHousekeepingTest.scala
@@ -1,17 +1,16 @@
 package housekeeping
 
-import java.util
 import java.util.UUID
 
-import com.amazonaws.services.s3.model.{ListObjectsV2Request, ListObjectsV2Result, S3ObjectSummary, SetObjectTaggingRequest}
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
 import deployment._
 import magenta.{Build, DeployParameters, Deployer, RunState, Stage}
 import org.joda.time.{DateTime, DateTimeZone}
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.{CommonPrefix, ListObjectsV2Request, ListObjectsV2Response, S3Object}
 
 import scala.collection.JavaConverters._
 
@@ -24,20 +23,12 @@ class ArtifactHousekeepingTest extends FlatSpec with Matchers with MockitoSugar 
 
   val housekeepingDate = new DateTime(2018, 6, 28, 0, 0, 0, DateTimeZone.UTC)
 
-  private def mockListObjectsV2Result(objectSummaries: List[ObjectSummary]): ListObjectsV2Result = {
-    val summaries: List[S3ObjectSummary] = objectSummaries.map { obj =>
-      val summary = new S3ObjectSummary()
-      summary.setKey(obj.key)
-      summary.setBucketName(obj.bucketName)
-      summary.setLastModified(obj.lastModified.toDate)
-      summary
+  private def mockListObjectsV2Result(objectSummaries: List[ObjectSummary]): ListObjectsV2Response = {
+    val s3Objects: List[S3Object] = objectSummaries.map { obj =>
+      S3Object.builder().key(obj.key).lastModified(obj.lastModified.toDate.toInstant).build()
     }
 
-    new ListObjectsV2Result() {
-      override def getObjectSummaries: util.List[S3ObjectSummary] = {
-        summaries.asJava
-      }
-    }
+    ListObjectsV2Response.builder().contents(s3Objects:_*).build()
   }
 
   private def fixtureRecord(date: DateTime, stageName: String, buildNumber: String): Record = DeployRecord(
@@ -60,9 +51,13 @@ class ArtifactHousekeepingTest extends FlatSpec with Matchers with MockitoSugar 
 
 
   "getProjectNames" should "make a single listObjectsV2 request and return the project names" in {
-    val artifactClientMock: AmazonS3 = mock[AmazonS3Client]
-    val listObjectsResult: ListObjectsV2Result = new ListObjectsV2Result()
-    listObjectsResult.setCommonPrefixes(List("project-name-1/", "project-name-2/", "project-name-3/").asJava)
+    val artifactClientMock = mock[S3Client]
+    val listObjectsResult: ListObjectsV2Response = ListObjectsV2Response.builder()
+      .commonPrefixes(List(
+        CommonPrefix.builder().prefix("project-name-1/").build(),
+        CommonPrefix.builder().prefix("project-name-2/").build(),
+        CommonPrefix.builder().prefix("project-name-3/").build()).asJava
+      ).build()
 
     when(artifactClientMock.listObjectsV2(any[ListObjectsV2Request])) thenReturn listObjectsResult
 
@@ -72,9 +67,13 @@ class ArtifactHousekeepingTest extends FlatSpec with Matchers with MockitoSugar 
   }
 
   "getBuildIds" should "make a single listObjectsV2 request and return the build IDs" in {
-    val artifactClientMock: AmazonS3 = mock[AmazonS3Client]
-    val listObjectsResult: ListObjectsV2Result = new ListObjectsV2Result()
-    listObjectsResult.setCommonPrefixes(List("project-name/10/", "project-name/11/", "project-name/12/").asJava)
+    val artifactClientMock = mock[S3Client]
+    val listObjectsResult: ListObjectsV2Response = ListObjectsV2Response.builder()
+      .commonPrefixes(List(
+        CommonPrefix.builder().prefix("project-name/10/").build(),
+        CommonPrefix.builder().prefix("project-name/11/").build(),
+        CommonPrefix.builder().prefix("project-name/12/").build()).asJava
+      ).build()
     when(artifactClientMock.listObjectsV2(any[ListObjectsV2Request])) thenReturn listObjectsResult
 
     val result = ArtifactHousekeeping.getBuildIds(artifactClientMock, "bucket-name", "project-name")
@@ -122,7 +121,7 @@ class ArtifactHousekeepingTest extends FlatSpec with Matchers with MockitoSugar 
   }
 
   "getObjectsToTag" should "only return objects that are older than the configured date" in {
-    val artifactClientMock: AmazonS3 = mock[AmazonS3Client]
+    val artifactClientMock = mock[S3Client]
 
     when(artifactClientMock.listObjectsV2(any[ListObjectsV2Request])) thenReturn mockListObjectsV2Result(
       List.tabulate(3)(n => ObjectSummary(s"object-x$n", "project-name", oldDate.plusDays(n))) ++
@@ -131,6 +130,6 @@ class ArtifactHousekeepingTest extends FlatSpec with Matchers with MockitoSugar 
 
     val result = ArtifactHousekeeping.getObjectsToTag(artifactClientMock, "bucket-name", "project-name", "12", housekeepingDate, 40)
     verify(artifactClientMock, times(1)).listObjectsV2(any[ListObjectsV2Request])
-    result.map(_.getKey) shouldEqual List("object-x0", "object-x1", "object-x2")
+    result.map(_.key) shouldEqual List("object-x0", "object-x1", "object-x2")
   }
 }


### PR DESCRIPTION
I got too much into upgrading libraries and this happened...

Most of the changes are syntax related, yay!

It is a bit annoying that some libs use v1 so we have to pass an old client around in a couple of cases, but that will probably go away with time.

I've tested deployment on CODE and seems to be happy.