### PR TITLE
[WIP] Add functionality to fetch db password via RDS IAM.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -74,7 +74,7 @@ object Dependencies {
     "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.8" % "test",
     filters,
     ws,
-    "com.typesafe.akka" %% "akka-testkit" % "2.5.17" % Test,
+    "com.typesafe.akka" %% "akka-testkit" % "2.5.21" % Test,
     "org.gnieh" %% "diffson-play-json" % "2.2.1" % Test,
     "com.amazonaws" % "aws-java-sdk-rds" % Versions.awsRds
   ).map((m: ModuleID) =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -74,7 +74,8 @@ object Dependencies {
     filters,
     ws,
     "com.typesafe.akka" %% "akka-testkit" % "2.5.17" % Test,
-    "org.gnieh" %% "diffson-play-json" % "2.2.1" % Test
+    "org.gnieh" %% "diffson-play-json" % "2.2.1" % Test,
+    "com.amazonaws" % "aws-java-sdk-rds" % Versions.aws
   ).map((m: ModuleID) =>
     // don't even ask why I need to do this
     m.excludeAll(ExclusionRule(organization = "com.google.code.findbugs", name = "jsr305"))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,6 +7,7 @@ object Dependencies {
     val aws = "2.5.14"
     val guardianManagement = "5.41"
     val jackson = "2.9.8"
+    val awsRds = "1.11.563"
   }
 
   val commonDeps = Seq(
@@ -75,7 +76,7 @@ object Dependencies {
     ws,
     "com.typesafe.akka" %% "akka-testkit" % "2.5.17" % Test,
     "org.gnieh" %% "diffson-play-json" % "2.2.1" % Test,
-    "com.amazonaws" % "aws-java-sdk-rds" % Versions.aws
+    "com.amazonaws" % "aws-java-sdk-rds" % Versions.awsRds
   ).map((m: ModuleID) =>
     // don't even ask why I need to do this
     m.excludeAll(ExclusionRule(organization = "com.google.code.findbugs", name = "jsr305"))

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -35,7 +35,7 @@ import utils.{ChangeFreeze, ElkLogging, HstsFilter, ScheduledAgent}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
-class AppComponents(context: Context) extends BuiltInComponentsFromContext(context)
+class AppComponents(context: Context, config: Config) extends BuiltInComponentsFromContext(context)
   with RotatingSecretComponents
   with AhcWSComponents
   with I18nComponents
@@ -46,8 +46,6 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
   with DBComponents
   with HikariCPComponents
   with Logging {
-  
-  val config = new Config(context.initialConfiguration.underlying)
 
   lazy val datastore: DataStore = new PostgresDatastoreOps(config).buildDatastore()
 

--- a/riff-raff/app/AppLoader.scala
+++ b/riff-raff/app/AppLoader.scala
@@ -1,7 +1,7 @@
 import java.io.File
 
 import com.typesafe.config.ConfigFactory
-import conf.Config
+import conf.{Config, RDSIAM}
 import play.api.ApplicationLoader.Context
 import play.api.{Application, ApplicationLoader, Configuration, LoggerConfigurator}
 

--- a/riff-raff/app/AppLoader.scala
+++ b/riff-raff/app/AppLoader.scala
@@ -1,7 +1,7 @@
 import java.io.File
 
 import com.typesafe.config.ConfigFactory
-import conf.{Config, RDSIAM}
+import conf.Config
 import play.api.ApplicationLoader.Context
 import play.api.{Application, ApplicationLoader, Configuration, LoggerConfigurator}
 

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -8,6 +8,7 @@ import com.amazonaws.auth.{AWSCredentials => AWSCredentialsV1, AWSCredentialsPro
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClientBuilder
 import com.amazonaws.services.sns.{AmazonSNSAsyncClientBuilder => AmazonSNSAsyncClientBuilderV1}
 import com.amazonaws.services.rds.auth.{GetIamAuthTokenRequest, RdsIamAuthTokenGenerator}
+import com.amazonaws.util.EC2MetadataUtils
 import com.gu.management._
 import com.gu.management.logback.LogbackLevelPage
 import com.typesafe.config.{Config => TypesafeConfig}

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -8,7 +8,6 @@ import com.amazonaws.auth.{AWSCredentials => AWSCredentialsV1, AWSCredentialsPro
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClientBuilder
 import com.amazonaws.services.sns.{AmazonSNSAsyncClientBuilder => AmazonSNSAsyncClientBuilderV1}
 import com.amazonaws.services.rds.auth.{GetIamAuthTokenRequest, RdsIamAuthTokenGenerator}
-import com.amazonaws.util.EC2MetadataUtils
 import com.gu.management._
 import com.gu.management.logback.LogbackLevelPage
 import com.typesafe.config.{Config => TypesafeConfig}
@@ -177,7 +176,8 @@ class Config(configuration: TypesafeConfig) extends Logging {
 
     def getPassword: String = {
       if (stage == "CODE" || stage =="PROD") {
-        lazy val hostname = getString("db.default.hostname")
+        val hostname = getString("db.default.hostname")
+        logger.info(s"Fetching password for database $hostname, stage=$stage.")
         val generator = RdsIamAuthTokenGenerator.builder().credentials(credentialsProviderChainV1()).region(artifact.aws.regionName).build()
         generator.getAuthToken(GetIamAuthTokenRequest.builder.hostname(hostname).port(5432).userName(user).build())
       } else {

--- a/riff-raff/conf/application.conf
+++ b/riff-raff/conf/application.conf
@@ -42,7 +42,7 @@ auth.clientSecret="5uLmlI8afy5vufKFWXWS2GPw"
 
 play.evolutions.enabled=true
 play.evolutions.autoApply=true
-play.evolutions.autoApplyDowns=true
+play.evolutions.autoApplyDowns=false
 
 db.default {
   driver=org.postgresql.Driver


### PR DESCRIPTION
For great security gains! Essentially AWS RDS allows you to generate a password for a database user via IAM if that user has the rds iam role assigned to it in postgres. This PR includes the changes that need to be made to the app in order for it to fetch this password and use it. There's some complexity because we're using Play to handle our database evolutions, and the only way to configure play evolutions is using properties in the application context config - so having fetched the password from RDS we're having to use it to set the db.default.password property in the ApplicationLoader. 

Before this is merged:

- [ ] Update cloudformation stacks of riffraff and riffraff rds - https://github.com/guardian/deploy-tools-platform/pull/166
- [ ] Update riffraff config in S3