### PR TITLE
Remove forced ning upgrade

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,6 @@ object Dependencies {
     "com.amazonaws" % "aws-java-sdk-sts" % Versions.aws,
     "com.gu" %% "management" % Versions.guardianManagement,
     "com.gu" %% "fastly-api-client" % "0.2.6",
-    "com.ning" % "async-http-client" % "1.9.40", // we need this to solve vulnerabilities from fastly-api-client
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % Versions.jackson,
     "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jackson,
     "com.typesafe.play" %% "play-json" % "2.7.2",


### PR DESCRIPTION
Sadly this forced upgrade broke fastly deploys, so gonna have to remove it for now and bring back the vulnerability.

Hopefully when this is release https://github.com/guardian/fastly-api-client/pull/19 we can import it and the problem will be solved.