### PR TITLE
Bump fastly api client to version 0.2.7.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,7 +34,7 @@ object Dependencies {
     "com.amazonaws" % "aws-java-sdk-cloudformation" % Versions.aws,
     "com.amazonaws" % "aws-java-sdk-sts" % Versions.aws,
     "com.gu" %% "management" % Versions.guardianManagement,
-    "com.gu" %% "fastly-api-client" % "0.2.6",
+    "com.gu" %% "fastly-api-client" % "0.2.7",
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % Versions.jackson,
     "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jackson,
     "com.typesafe.play" %% "play-json" % "2.7.2",


### PR DESCRIPTION
...to pull in [ning http upgrade](https://github.com/guardian/fastly-api-client/pull/19) which patches a vulnerability.