### PR TITLE
Target lambda deployments using tags

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -44,6 +44,10 @@ object Lambda extends DeploymentType  {
   val prefixStackParam = Param[Boolean]("prefixStack",
     "If true then the values in the functionNames param will be prefixed with the name of the stack being deployed").default(true)
 
+  val prefixStackToKeyParam = Param[Boolean]("prefixStackToKey",
+    documentation = "Whether to prefix `package` to the S3 location"
+  ).default(true)
+
   val fileNameParam = Param[String]("fileName", "The name of the archive of the function", deprecatedDefault = true)
     .defaultFromContext((pkg, _) => Right(s"${pkg.name}.zip"))
 
@@ -77,18 +81,21 @@ object Lambda extends DeploymentType  {
     val stage = target.parameters.stage.name
 
     (functionNamesParam.get(pkg), functionsParam.get(pkg), lookupByTags(pkg, target, reporter), prefixStackParam(pkg, target, reporter)) match {
+      // the lambdas are a simple hardcoded list of function names
       case (Some(functionNames), None, false, prefixStack) =>
         val stackNamePrefix = if (prefixStack) target.stack.name else ""
         for {
           name <- functionNames
         } yield UpdateLambdaFunction(LambdaFunctionName(s"$stackNamePrefix$name$stage"), fileNameParam(pkg, target, reporter), target.region, bucket)
 
+      // the list of lambdas are provided in a map from stage to lambda name and filename
       case (None, Some(functionsMap), false, _) =>
         val functionDefinition = functionsMap.getOrElse(stage, reporter.fail(s"Function not defined for stage $stage"))
         val functionName = functionDefinition.getOrElse("name", reporter.fail(s"Function name not defined for stage $stage"))
         val fileName = functionDefinition.getOrElse("filename", "lambda.zip")
         List(UpdateLambdaFunction(LambdaFunctionName(functionName), fileName, target.region, bucket))
 
+      // the lambda to update is discovered from Stack, App and Stage tags
       case (None, None, true, _) =>
         val tags = LambdaFunctionTags(Map(
           "Stack" -> target.stack.name,
@@ -101,8 +108,10 @@ object Lambda extends DeploymentType  {
     }
   }
 
-  def makeS3Key(stack: Stack, params:DeployParameters, pkg:DeploymentPackage, fileName: String): String = {
-    List(stack.name, params.stage.name, pkg.app.name, fileName).mkString("/")
+  def makeS3Key(target: DeployTarget, pkg:DeploymentPackage, fileName: String, reporter: DeployReporter): String = {
+    val prefixStack = prefixStackToKeyParam(pkg, target, reporter)
+    val prefix = if (prefixStack) List(target.stack.name) else Nil
+    (prefix ::: List(target.parameters.stage.name, pkg.app.name, fileName)).mkString("/")
   }
 
   val uploadLambda = Action("uploadLambda",
@@ -112,7 +121,7 @@ object Lambda extends DeploymentType  {
     implicit val keyRing: KeyRing = resources.assembleKeyring(target, pkg)
     implicit val artifactClient: S3Client = resources.artifactClient
     lambdaToProcess(pkg, target, resources.reporter).map { lambda =>
-      val s3Key = makeS3Key(target.stack, target.parameters, pkg, lambda.fileName)
+      val s3Key = makeS3Key(target, pkg, lambda.fileName, resources.reporter)
       S3Upload(
         lambda.region,
         lambda.s3Bucket,
@@ -139,7 +148,7 @@ object Lambda extends DeploymentType  {
     implicit val keyRing: KeyRing = resources.assembleKeyring(target, pkg)
     implicit val artifactClient: S3Client = resources.artifactClient
     lambdaToProcess(pkg, target, resources.reporter).map { lambda =>
-        val s3Key = makeS3Key(target.stack, target.parameters, pkg, lambda.fileName)
+        val s3Key = makeS3Key(target, pkg, lambda.fileName, resources.reporter)
         UpdateS3Lambda(
           lambda.function,
           lambda.s3Bucket,

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -35,6 +35,12 @@ object Lambda extends DeploymentType  {
     optional = true
   )
 
+  val lookupByTags = Param[Boolean]("lookupByTags",
+    """When true, this will lookup the function to deploy to by using the Stack, Stage and App tags on a function.
+      |The values looked up come from the `stacks` and `app` in the riff-raff.yaml and the stage deployed to.
+    """.stripMargin
+  ).default(false)
+
   val prefixStackParam = Param[Boolean]("prefixStack",
     "If true then the values in the functionNames param will be prefixed with the name of the stack being deployed").default(true)
 
@@ -65,25 +71,33 @@ object Lambda extends DeploymentType  {
     optional = true
   )
 
-  def lambdaToProcess(pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter): List[LambdaFunction] = {
+  def lambdaToProcess(pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter): List[UpdateLambdaFunction] = {
     val bucket = bucketParam(pkg, target, reporter)
 
     val stage = target.parameters.stage.name
 
-    (functionNamesParam.get(pkg), functionsParam.get(pkg), prefixStackParam(pkg, target, reporter)) match {
-      case (Some(functionNames), None, prefixStack) =>
+    (functionNamesParam.get(pkg), functionsParam.get(pkg), lookupByTags(pkg, target, reporter), prefixStackParam(pkg, target, reporter)) match {
+      case (Some(functionNames), None, false, prefixStack) =>
         val stackNamePrefix = if (prefixStack) target.stack.name else ""
         for {
           name <- functionNames
-        } yield LambdaFunction(s"$stackNamePrefix$name$stage", fileNameParam(pkg, target, reporter), target.region, bucket)
-        
-      case (None, Some(functionsMap), _) =>
+        } yield UpdateLambdaFunction(LambdaFunctionName(s"$stackNamePrefix$name$stage"), fileNameParam(pkg, target, reporter), target.region, bucket)
+
+      case (None, Some(functionsMap), false, _) =>
         val functionDefinition = functionsMap.getOrElse(stage, reporter.fail(s"Function not defined for stage $stage"))
         val functionName = functionDefinition.getOrElse("name", reporter.fail(s"Function name not defined for stage $stage"))
         val fileName = functionDefinition.getOrElse("filename", "lambda.zip")
-        List(LambdaFunction(functionName, fileName, target.region, bucket))
+        List(UpdateLambdaFunction(LambdaFunctionName(functionName), fileName, target.region, bucket))
 
-      case _ => reporter.fail("Must specify one of 'functions' or 'functionNames' parameters")
+      case (None, None, true, _) =>
+        val tags = LambdaFunctionTags(Map(
+          "Stack" -> target.stack.name,
+          "App" -> pkg.app.name,
+          "Stage" -> stage
+        ))
+        List(UpdateLambdaFunction(tags, fileNameParam(pkg, target, reporter), target.region, bucket))
+
+      case _ => reporter.fail("Must specify one of 'functions', 'functionNames' or 'lookupByTags' parameters")
     }
   }
 
@@ -127,7 +141,7 @@ object Lambda extends DeploymentType  {
     lambdaToProcess(pkg, target, resources.reporter).map { lambda =>
         val s3Key = makeS3Key(target.stack, target.parameters, pkg, lambda.fileName)
         UpdateS3Lambda(
-          lambda.functionName,
+          lambda.function,
           lambda.s3Bucket,
           s3Key,
           lambda.region
@@ -138,4 +152,7 @@ object Lambda extends DeploymentType  {
   def defaultActions = List(uploadLambda, updateLambda)
 }
 
-case class LambdaFunction(functionName: String, fileName: String, region: Region, s3Bucket: String)
+sealed trait LambdaFunction
+case class LambdaFunctionName(name: String) extends LambdaFunction
+case class LambdaFunctionTags(tags: Map[String, String]) extends LambdaFunction
+case class UpdateLambdaFunction(function: LambdaFunction, fileName: String, region: Region, s3Bucket: String)

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -134,7 +134,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
     val p = DeploymentPackage("myapp", app1, data, "aws-lambda", S3Path("artifact-bucket", "test/123"), deploymentTypes)
 
     Lambda.actionsMap("updateLambda").taskGenerator(p, DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), stack, region)) should be (
-      List(UpdateS3Lambda("myLambda", "artifact-bucket", "test-stack/CODE/the_role/lambda.zip", defaultRegion)
+      List(UpdateS3Lambda(LambdaFunctionName("myLambda"), "artifact-bucket", "test-stack/CODE/the_role/lambda.zip", defaultRegion)
       ))
   }
 
@@ -152,7 +152,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
 
     val thrown = the[FailException] thrownBy {
       Lambda.actionsMap("updateLambda").taskGenerator(p, DeploymentResources(reporter, lookupSingleHost, artifactClient), DeployTarget(parameters(CODE), stack, region)) should be (
-        List(UpdateS3Lambda("myLambda", "artifact-bucket", "test-stack/CODE/the_role/lambda.zip", defaultRegion)
+        List(UpdateS3Lambda(LambdaFunctionName("myLambda"), "artifact-bucket", "test-stack/CODE/the_role/lambda.zip", defaultRegion)
         ))
     }
 


### PR DESCRIPTION
A phoenix of #499.

Making a deployment generic enough to run across several stages or stacks is currently difficult and requires a high level of discipline with the naming of functions. For example it is currently necessary to hardcode the function name in the cloudformation rather than use dynamically generated names.

This PR allows lambdas to be targeted based on the set of tags that they have. This is similar to the way that autoscaling groups are discovered in `autoscaling` deploys.

This allows a more general approach to deployment. https://github.com/guardian/cloudwatch-logs-management is a good example of where this is helpful: a stack that can be deployed to multiple AWS accounts in which the function names are not specified.

The code follows the same pattern used for `cloud-formation` where a stack can be discovered by either name or tags. A trait and case classes are used to express the target function as `LambdaFunctionName` or `LambdaFunctionTags`. The latter is then resolved via the AWS APIs if necessary at execution time.

Note that the following permissions are required to be added to the account's riff-raff user prior to this working (although some have `lambda:*` which already covers it):
```
 - lambda:ListFunctions
 - lambda:ListTags
```

Finally - the code currently fetches all lambdas and then all tags for all lambdas in a given account (we must fetch all to ensure there isn't a second lambda with the same tags to prevent non-deterministic deployments). This means we make a lot of `ListTags` requests (one for each function) that will gradually get worse as more functions are rolled out. In the future a short term cache might be considered to ease the burden on the AWS API.