### PR TITLE
Attempt to fix a race condition that leads to Riff-Raff not deploying

### DIFF
--- a/riff-raff/app/deployment/Deployments.scala
+++ b/riff-raff/app/deployment/Deployments.scala
@@ -66,7 +66,7 @@ class Deployments(deploymentEngine: DeploymentEngine,
     val record = deployRecordFor(uuid, params) ++ hostNameMetadata
     library send { _ + (uuid -> Agent(record)) }
     documentStoreConverter.saveDeploy(record)
-    await(uuid)
+    await(uuid, 30 seconds)
   }
 
   def deployRecordFor(uuid: UUID, parameters: DeployParameters): DeployRecord = {
@@ -169,7 +169,7 @@ class Deployments(deploymentEngine: DeploymentEngine,
       val record: Option[DeployRecord] =
         Await.result(
           allDeploys.get(uuid).traverse(_.future()),
-          10 seconds
+          30 seconds
         )
 
       record match {
@@ -219,7 +219,7 @@ class Deployments(deploymentEngine: DeploymentEngine,
     }
   }
 
-  def await(uuid: UUID): Record = {
-    library()(uuid)()
+  def await(uuid: UUID, atMost: Duration): Record = {
+    Await.result(library.future.flatMap(_(uuid).future), atMost)
   }
 }


### PR DESCRIPTION
This might resolve one race condition that results in Riff-Raff thinking that a deploy has not finished when it has in fact completely failed to start.

In a recent example, both of the phantom deploys were triggered as scheduled deploys but had throw an exception which indicated that it has not yet arrived in the deployments Agent prior to being accessed.

The following exception was being thrown:
```
java.util.NoSuchElementException: key not found: 8d2d899a-875b-4824-87bc-7eb03437ac75
	<snip>
	at deployment.Deployments.await(Deployments.scala:223)
	at deployment.Deployments.create(Deployments.scala:69)
	at deployment.Deployments.$anonfun$deploy$5(Deployments.scala:47)
	<snip>
```

The following code was blowing up on the `create` call. The call was registering the new deploy and then calling the `await` method to retrieve it again to make sure it was there. Unfortunately the `await` method was not in fact awaiting.

```scala
val record = create(params)
deploymentEngine.interruptibleDeploy(record)
```

This change uses `future` calls on the `Agent` and then waits on the future. Hopefully this will eradicate this particular cause of this bug. I've also taken the liberty of bumping the timeout on the cleanup route to be consistent and more patient.