### PR TITLE
Use automatically create distribution buckets (lambda only)

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoDistBucketParameters.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoDistBucketParameters.scala
@@ -1,0 +1,35 @@
+package magenta.deployment_type
+
+import magenta.tasks.S3.{Bucket, BucketByAuto, BucketByName}
+import magenta.{DeployReporter, DeployTarget, DeploymentPackage, Region}
+
+object AutoDistBucket {
+  val BUCKET_PREFIX = "riff-raff-artifact-bucket"
+}
+
+trait AutoDistBucketParameters {
+  this: DeploymentType =>
+
+  val bucketParam = Param[String]("bucket",
+    documentation =
+      """
+        |Name of the S3 bucket where the distribution artifacts should be uploaded.
+      """.stripMargin
+  )
+
+  val autoDistBucketParam = Param[Boolean]("autoDistBucket",
+    """Use an automatically created dist bucket (that is unique per account/region) to upload the
+      |distribution artifacts to. This should be used in conjunction with `autoDistBucketParameter`
+      |on the `cloud-formation` deployment type.""".stripMargin
+  ).default(false)
+
+  def resolveBucket(pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter): Bucket = {
+    val useAutoDistBucket = autoDistBucketParam(pkg, target, reporter)
+    val maybeExplicitBucket = bucketParam.get(pkg)
+    (useAutoDistBucket, maybeExplicitBucket) match {
+      case (true, None) => BucketByAuto(AutoDistBucket.BUCKET_PREFIX, target.region)
+      case (false, Some(explicitBucket)) => BucketByName(explicitBucket)
+      case _ => reporter.fail("One and only one of the following must be set: the bucket parameter or autoDistBucket=true")
+    }
+  }
+}

--- a/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
@@ -30,7 +30,7 @@ class CreateChangeSetTask(
     val (stackName, changeSetType) = stackLookup.lookup(reporter, cfnClient)
 
     val template = processTemplate(stackName, templateString, s3Client, stsClient, region, reporter)
-    val parameters = unresolvedParameters.resolve(template, accountNumber, changeSetType, reporter, cfnClient)
+    val parameters = unresolvedParameters.resolve(template, accountNumber, changeSetType, reporter, cfnClient, s3Client, stsClient)
 
     reporter.info("Creating Cloudformation change set")
     reporter.info(s"Stack name: $stackName")

--- a/magenta-lib/src/test/scala/magenta/deployment_type/ParamTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/ParamTest.scala
@@ -5,7 +5,6 @@ import java.util.UUID
 import magenta.artifact.S3Path
 import magenta._
 import magenta.fixtures._
-import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}


### PR DESCRIPTION
This is an implementation of an idea that @philmcmahon and I were throwing around to solve the scenario in which you want to deploy a stack to multiple accounts easily. There are two main approaches:
 - put the artifact into a shared bucket and point multiple instances/lambdas across the multiple accounts to the same shared bucket 
 - have one artifact bucket per account and point each instance/lambda at the local bucket

The second of these is preferable for a few reasons but it is not possible to create two buckets with the same name in different accounts. One alternative is to use the `bucketResource` attribute (currently only supported on `aws-s3`) but another option is to automatically create a local bucket in each account/region for uploading artifacts to.

There are a few parts to this:
 - code to create unique buckets in each account
 - a way of communicating this bucket name into a cloudformation template
 - a way of using this bucket in lambda and autoscaling deploys

It turns out that we already have some code to create per account buckets from the CloudFormation work and so this can be reused to create a workable solution. Initially we'll only support this in Lambda and see whether it is useful.

I've added a `autoDistBucketParameter` to the `cloud-formation` deployment type. Similar to `amiParameter` this specifies the CFN template parameter that should be injected with the name of the automatically created bucket. This is guaranteed to be account local and will look something like `riff-raff-artifact-bucket-123456789-eu-west-1`.

In addition I've added an `autoDistBucket` parameter to the `aws-lambda` deployment type as an alternative to the `bucket` parameter. When true it uses the same bucket name creation logic as described above to upload the artifact to and when calling `UpdateFunctionCode`.