### PR TITLE
Fix large cloudformation deploys

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -9,7 +9,7 @@ import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient
 import software.amazon.awssdk.services.cloudformation.model.{ChangeSetType, CloudFormationException, Parameter, StackEvent}
 import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.{GetObjectRequest, PutObjectRequest}
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.sts.StsClient
 
 import scala.collection.JavaConverters._
@@ -185,8 +185,9 @@ object UpdateCloudFormationTask {
         .key(keyName)
         .build()
       s3Client.putObject(request, RequestBody.fromString(templateBody))
-      val url = s3Client.getObject(GetObjectRequest.builder().bucket(bucketName).key(keyName).build())
-      TemplateUrl(url.toString)
+      val url: String = s"https://$bucketName.s3-${region.name}.amazonaws.com/$keyName"
+      logger.info(s"Using template url $url to update the stack")
+      TemplateUrl(url)
     } else {
       TemplateBody(templateBody)
     }


### PR DESCRIPTION
Clouformation deploys involving a large template are currently broken due to the recent [upgrade of the AWS sdk](https://github.com/guardian/riff-raff/pull/545) in riffraff. This fixes the problem. I couldn't find a method in the new sdk for generating a url given a bucket and key so I've manually constructed it here.

Example failed deploy: https://riffraff.code.dev-gutools.co.uk/deployment/view/84fe9dd4-3182-4d38-9226-edf97512c9f5