### PR TITLE
Add option to lookup bucket from an SSM key in the target account

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/BucketParameters.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/BucketParameters.scala
@@ -1,0 +1,36 @@
+package magenta.deployment_type
+
+import magenta.tasks.S3.{Bucket, BucketByName, BucketBySsmKey}
+import magenta.{DeployReporter, DeployTarget, DeploymentPackage}
+
+trait BucketParameters {
+  this: DeploymentType =>
+
+  val bucketParam = Param[String]("bucket",
+    documentation =
+      """
+        |Name of the S3 bucket where the distribution artifacts should be uploaded.
+      """.stripMargin,
+    optional = true
+  )
+
+  val bucketSsmLookupParam = Param[Boolean]("bucketSsmLookup",
+    """Lookup the bucket for uploading distribution artifacts from SSM in the target account and region. This is
+      |designed to be used in conjunction with a matching `AWS::SSM::Parameter::Value<String>` CFN parameter
+      |on any related CloudFormation template.""".stripMargin
+  ).default(false)
+
+  val bucketSsmKeyParam = Param[String]("bucketSsmKey",
+    """The SSM key used to lookup the bucket name for uploading distribution artifacts.""".stripMargin
+  ).default("/account/services/artifact.bucket")
+
+  def resolveBucket(pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter): Bucket = {
+    val bucketSsmLookup = bucketSsmLookupParam(pkg, target, reporter)
+    val maybeExplicitBucket = bucketParam.get(pkg)
+    (bucketSsmLookup, maybeExplicitBucket) match {
+      case (true, None) => BucketBySsmKey(bucketSsmKeyParam(pkg, target, reporter))
+      case (false, Some(explicitBucket)) => BucketByName(explicitBucket)
+      case _ => reporter.fail("One and only one of the following must be set: the bucket parameter or bucketSsmLookup=true")
+    }
+  }
+}

--- a/magenta-lib/src/main/scala/magenta/deployment_type/BucketParameters.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/BucketParameters.scala
@@ -24,12 +24,12 @@ trait BucketParameters {
     """The SSM key used to lookup the bucket name for uploading distribution artifacts.""".stripMargin
   ).default("/account/services/artifact.bucket")
 
-  def resolveBucket(pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter): Bucket = {
+  def getTargetBucketFromConfig(pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter): Bucket = {
     val bucketSsmLookup = bucketSsmLookupParam(pkg, target, reporter)
     val maybeExplicitBucket = bucketParam.get(pkg)
+
     val bucket = (bucketSsmLookup, maybeExplicitBucket) match {
-      case (true, None) =>
-        BucketBySsmKey(bucketSsmKeyParam(pkg, target, reporter))
+      case (true, None) => BucketBySsmKey(bucketSsmKeyParam(pkg, target, reporter))
       case (false, Some(explicitBucket)) => BucketByName(explicitBucket)
       case _ => reporter.fail("One and only one of the following must be set: the bucket parameter or bucketSsmLookup=true")
     }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/BucketParameters.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/BucketParameters.scala
@@ -27,10 +27,13 @@ trait BucketParameters {
   def resolveBucket(pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter): Bucket = {
     val bucketSsmLookup = bucketSsmLookupParam(pkg, target, reporter)
     val maybeExplicitBucket = bucketParam.get(pkg)
-    (bucketSsmLookup, maybeExplicitBucket) match {
-      case (true, None) => BucketBySsmKey(bucketSsmKeyParam(pkg, target, reporter))
+    val bucket = (bucketSsmLookup, maybeExplicitBucket) match {
+      case (true, None) =>
+        BucketBySsmKey(bucketSsmKeyParam(pkg, target, reporter))
       case (false, Some(explicitBucket)) => BucketByName(explicitBucket)
       case _ => reporter.fail("One and only one of the following must be set: the bucket parameter or bucketSsmLookup=true")
     }
+    reporter.verbose(s"Resolved artifact bucket as $bucket")
+    bucket
   }
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -1,11 +1,14 @@
 package magenta.deployment_type
 
 import magenta.artifact.S3Path
-import magenta.tasks.{S3Upload, UpdateS3Lambda}
+import magenta.tasks.{S3Upload, SSM, STS, UpdateS3Lambda, S3 => S3Tasks}
 import magenta.{DeployParameters, DeployReporter, DeployTarget, DeploymentPackage, KeyRing, Region, Stack}
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.ssm.SsmClient
 
-object Lambda extends DeploymentType  {
+object Lambda extends Lambda
+
+trait Lambda extends DeploymentType with BucketParameters {
   val name = "aws-lambda"
   val documentation =
     """
@@ -20,14 +23,6 @@ object Lambda extends DeploymentType  {
       |
       |
       """.stripMargin
-
-  val bucketParam = Param[String]("bucket",
-    documentation =
-      """
-        |Name of the S3 bucket where the lambda archive should be uploaded - if this is not specified then the zip file
-        |will be uploaded in the Lambda Update Function Code request
-      """.stripMargin
-  )
 
   val functionNamesParam = Param[List[String]]("functionNames",
     """One or more function names to update with the code from fileNameParam.
@@ -76,7 +71,7 @@ object Lambda extends DeploymentType  {
   )
 
   def lambdaToProcess(pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter): List[UpdateLambdaFunction] = {
-    val bucket = bucketParam(pkg, target, reporter)
+    val bucket = resolveBucket(pkg, target, reporter)
 
     val stage = target.parameters.stage.name
 
@@ -114,6 +109,8 @@ object Lambda extends DeploymentType  {
     (prefix ::: List(target.parameters.stage.name, pkg.app.name, fileName)).mkString("/")
   }
 
+  def makeSsm(keyRing: KeyRing, region: Region): SsmClient = SSM.makeSsmClient(keyRing, region)
+
   val uploadLambda = Action("uploadLambda",
     """
       |Uploads the lambda code to S3.
@@ -121,10 +118,15 @@ object Lambda extends DeploymentType  {
     implicit val keyRing: KeyRing = resources.assembleKeyring(target, pkg)
     implicit val artifactClient: S3Client = resources.artifactClient
     lambdaToProcess(pkg, target, resources.reporter).map { lambda =>
+      val s3Bucket = S3Tasks.resolveBucket(
+        lambda.s3Bucket,
+        makeSsm(keyRing, target.region),
+        resources.reporter
+      )
       val s3Key = makeS3Key(target, pkg, lambda.fileName, resources.reporter)
       S3Upload(
         lambda.region,
-        lambda.s3Bucket,
+        s3Bucket,
         Seq(S3Path(pkg.s3Package, lambda.fileName) -> s3Key)
       )
     }.distinct
@@ -148,10 +150,15 @@ object Lambda extends DeploymentType  {
     implicit val keyRing: KeyRing = resources.assembleKeyring(target, pkg)
     implicit val artifactClient: S3Client = resources.artifactClient
     lambdaToProcess(pkg, target, resources.reporter).map { lambda =>
+        val s3Bucket = S3Tasks.resolveBucket(
+          lambda.s3Bucket,
+          makeSsm(keyRing, target.region),
+          resources.reporter
+        )
         val s3Key = makeS3Key(target, pkg, lambda.fileName, resources.reporter)
         UpdateS3Lambda(
           lambda.function,
-          lambda.s3Bucket,
+          s3Bucket,
           s3Key,
           lambda.region
         )
@@ -164,4 +171,4 @@ object Lambda extends DeploymentType  {
 sealed trait LambdaFunction
 case class LambdaFunctionName(name: String) extends LambdaFunction
 case class LambdaFunctionTags(tags: Map[String, String]) extends LambdaFunction
-case class UpdateLambdaFunction(function: LambdaFunction, fileName: String, region: Region, s3Bucket: String)
+case class UpdateLambdaFunction(function: LambdaFunction, fileName: String, region: Region, s3Bucket: S3Tasks.Bucket)

--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
@@ -150,7 +150,7 @@ class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
       GetParameterResponse.builder.parameter(Parameter.builder.value("bobbins").build).build
     )
     object LambdaTest extends Lambda {
-      override def makeSsm(keyRing: KeyRing, region: Region): SsmClient = ssmClient
+      override def withSsm[T](keyRing: KeyRing, region: Region): (SsmClient => T) => T = _(ssmClient)
     }
 
     val tasks = LambdaTest.actionsMap("updateLambda")

--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
@@ -5,11 +5,15 @@ import java.util.UUID
 import magenta.artifact.S3Path
 import magenta.fixtures._
 import magenta.tasks.{S3Upload, UpdateS3Lambda}
-import magenta.{App, DeployReporter, DeployTarget, DeploymentPackage, DeploymentResources, KeyRing, Region, Stack, fixtures}
+import magenta.{App, DeployReporter, DeployTarget, DeploymentPackage, DeploymentResources, FailException, KeyRing, Region, Stack, fixtures}
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.{JsBoolean, JsString, JsValue, Json}
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.ssm.SsmClient
+import software.amazon.awssdk.services.ssm.model.{GetParameterRequest, GetParameterResponse, Parameter}
 
 class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing: KeyRing = KeyRing()
@@ -95,6 +99,74 @@ class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
         region = defaultRegion
       )
     ))
+  }
+
+  it should "refuse to work if a bucket name is provided and bucketSsmLookup is true" in {
+    val dataWithoutStackOverride: Map[String, JsValue] = Map(
+      "bucket" -> JsString("lambda-bucket"),
+      "bucketSsmLookup" -> JsBoolean(true),
+      "functionNames" -> Json.arr("MyFunction-")
+    )
+    val app = App("lambda")
+    val pkg = DeploymentPackage("lambda", app, dataWithoutStackOverride, "aws-lambda",
+      S3Path("artifact-bucket", "test/123/lambda"), deploymentTypes)
+
+    val e = the [FailException] thrownBy {
+      Lambda.actionsMap(
+        "updateLambda").taskGenerator(pkg, DeploymentResources(reporter, lookupEmpty, artifactClient),
+        DeployTarget(parameters(PROD), Stack("some-stack"), region))
+    }
+    e.message shouldBe "One and only one of the following must be set: the bucket parameter or bucketSsmLookup=true"
+  }
+
+  it should "refuse to work if bucket name is not provided and bucketSsmLookup is false" in {
+    val dataWithoutStackOverride: Map[String, JsValue] = Map(
+      "functionNames" -> Json.arr("MyFunction-")
+    )
+    val app = App("lambda")
+    val pkg = DeploymentPackage("lambda", app, dataWithoutStackOverride, "aws-lambda",
+      S3Path("artifact-bucket", "test/123/lambda"), deploymentTypes)
+
+    val e = the [FailException] thrownBy {
+      Lambda.actionsMap(
+        "updateLambda").taskGenerator(pkg, DeploymentResources(reporter, lookupEmpty, artifactClient),
+        DeployTarget(parameters(PROD), Stack("some-stack"), region))
+    }
+    e.message shouldBe "One and only one of the following must be set: the bucket parameter or bucketSsmLookup=true"
+  }
+
+  it should "lookup bucket from SSM when bucketSsmLookup is true" in {
+    val dataWithoutStackOverride: Map[String, JsValue] = Map(
+      "bucketSsmLookup" -> JsBoolean(true),
+      "functionNames" -> Json.arr("MyFunction-")
+    )
+    val app = App("lambda")
+    val pkg = DeploymentPackage("lambda", app, dataWithoutStackOverride, "aws-lambda",
+      S3Path("artifact-bucket", "test/123/lambda"), deploymentTypes)
+
+    val ssmClient = mock[SsmClient]
+
+    when(ssmClient.getParameter(ArgumentMatchers.any(classOf[GetParameterRequest]))).thenReturn(
+      GetParameterResponse.builder.parameter(Parameter.builder.value("bobbins").build).build
+    )
+    object LambdaTest extends Lambda {
+      override def makeSsm(keyRing: KeyRing, region: Region): SsmClient = ssmClient
+    }
+
+    val tasks = LambdaTest.actionsMap("updateLambda")
+      .taskGenerator(pkg, DeploymentResources(reporter, lookupEmpty, artifactClient),
+        DeployTarget(parameters(PROD), Stack("some-stack"), region)
+      )
+
+    tasks shouldBe List(
+      UpdateS3Lambda(
+        function = LambdaFunctionName("some-stackMyFunction-PROD"),
+        s3Bucket = s"bobbins",
+        s3Key = "some-stack/PROD/lambda/lambda.zip",
+        region = defaultRegion
+      )
+    )
+
   }
 
   it should "omit prefix when prefixStackToKeyParam is set to false" in {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,6 +34,7 @@ object Dependencies {
     "software.amazon.awssdk" % "lambda" % Versions.aws,
     "software.amazon.awssdk" % "cloudformation" % Versions.aws,
     "software.amazon.awssdk" % "sts" % Versions.aws,
+    "software.amazon.awssdk" % "ssm" % Versions.aws,
     "com.gu" %% "management" % Versions.guardianManagement,
     "com.gu" %% "fastly-api-client" % "0.4.0",
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % Versions.jackson,


### PR DESCRIPTION
NOTE: this is built on top of #547 and should be merged _after_ that

An alternative approach to #549 which avoids creating buckets automatically and is more aligned to existing behaviour.

This is an implementation of an idea that @philmcmahon and I were throwing around to solve the scenario in which you want to deploy a stack to multiple accounts easily. There are two main approaches:
 - put the artifact into a shared bucket and point multiple instances/lambdas across the multiple accounts to the same shared bucket 
 - have one artifact bucket per account and point each instance/lambda at the local bucket

The second of these is preferable for a few reasons (avoidance of cross account permissions primarily) but it is not possible to create two buckets with the same name in different accounts. That means buckets will be differently named in each account. We could create unique buckets automatically or allow a bucket to be configured. In the latter case we could configure it in riff-raff or in the target account.

SSM is a good fit to this as there is already functionality in CloudFormation templates for doing lookups. We just need to add lookup capabilities to the deployment tasks in riff-raff.

This adds `bucketSsmLookup` and `bucketSsmKey` parameters to the Lambda type. When `bucketSsmLookup` is set to true then an SSM `getParameter` API call will be made with the value of `bucketSsmKey` (default is `/account/service/artifact.bucket`). The retrieved value will be used as the bucket to upload artifacts to and to update functions from.

It would make sense to roll this functionality out to the `autoscaling` deployment type in the future.