### PR TITLE
Attempt to set postgres connection pool to a fixed size.

### DIFF
--- a/riff-raff/app/persistence/postgresdb.scala
+++ b/riff-raff/app/persistence/postgresdb.scala
@@ -253,7 +253,10 @@ class PostgresDatastore(config: Config) extends DataStore(config) with Logging {
 class PostgresDatastoreOps(config: Config) {
   def buildDatastore() = {
     Class.forName("org.postgresql.Driver")
-    ConnectionPool.singleton(config.postgres.url, config.postgres.user, config.postgres.password)
+
+    // initalSize and maxSize need to be the same so that all connections remain open. If connections are closed and then
+    // reopned the authentication will fail as the IAM token we use will have expired
+    ConnectionPool.singleton(config.postgres.url, config.postgres.user, config.postgres.password, settings = ConnectionPoolSettings(initialSize = 8, maxSize = 8))
 
     new PostgresDatastore(config)
   }


### PR DESCRIPTION
Currently we are getting authentication errors as a result of riffraff trying to authenticate with RDS using an expires IAM token as connections are dropped/re opened. this is a stopgap fix to attempt to solve the issue before we can do something more thorough. The theory is that if we have initialSize and maxSize of the connection poolthe same then the app will maintain a consistent number of open connections. @alexduf  pointed out that this won't solve a case where a connection is dropped due to network issues, so we need a more permanent solution eventually