### PR TITLE
Provide a way to create connections with a dynamic password.

### DIFF
--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -35,7 +35,7 @@ import utils.{ChangeFreeze, ElkLogging, HstsFilter, ScheduledAgent}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
-class AppComponents(context: Context, config: Config) extends BuiltInComponentsFromContext(context)
+class AppComponents(context: Context, config: Config, passwordProvider: PasswordProvider) extends BuiltInComponentsFromContext(context)
   with RotatingSecretComponents
   with AhcWSComponents
   with I18nComponents
@@ -47,7 +47,7 @@ class AppComponents(context: Context, config: Config) extends BuiltInComponentsF
   with HikariCPComponents
   with Logging {
 
-  lazy val datastore: DataStore = new PostgresDatastoreOps(config).buildDatastore()
+  lazy val datastore: DataStore = new PostgresDatastoreOps(config, passwordProvider).buildDatastore()
 
   val secretStateSupplier: SnapshotProvider = {
     new ParameterStore.SecretSupplier(

--- a/riff-raff/app/AppLoader.scala
+++ b/riff-raff/app/AppLoader.scala
@@ -1,7 +1,9 @@
 import java.io.File
+import java.time.Duration
 
 import com.typesafe.config.ConfigFactory
 import conf.Config
+import persistence.{CachingPasswordProvider, IAMPasswordProvider}
 import play.api.ApplicationLoader.Context
 import play.api.{Application, ApplicationLoader, Configuration, LoggerConfigurator}
 
@@ -19,11 +21,14 @@ class AppLoader extends ApplicationLoader {
     // create config object (including call to RDS to get an IAM auth token for the database)
     val appConfig = new Config(combinedConfig.underlying)
 
+    // get JDBC passwords from IAM and cache them for 12 minutes. They are normally valid for 15 minutes
+    val passwordProvider = new CachingPasswordProvider(new IAMPasswordProvider(appConfig), Duration.ofMinutes(12))
+
     // add password from RDS IAM auth to be used by play evolutions (which relies on db.default.password property)
-    val configWithNewPassword = combinedConfig ++ Configuration.from(Map("db.default.password" -> appConfig.postgres.password))
+    val configWithNewPassword = combinedConfig ++ Configuration.from(Map("db.default.password" -> passwordProvider.providePassword()))
 
     val contextWithUpdatedConfig = context.copy(initialConfiguration = configWithNewPassword)
-    val components = new AppComponents(contextWithUpdatedConfig, appConfig)
+    val components = new AppComponents(contextWithUpdatedConfig, appConfig, passwordProvider)
 
     components.application
   }

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -172,18 +172,8 @@ class Config(configuration: TypesafeConfig) extends Logging {
   object postgres {
     lazy val url = getString("db.default.url")
     lazy val user =  getString("db.default.user")
-    lazy val password = getPassword
-
-    def getPassword: String = {
-      if (stage == "CODE" || stage =="PROD") {
-        val hostname = getString("db.default.hostname")
-        logger.info(s"Fetching password for database $hostname, stage=$stage.")
-        val generator = RdsIamAuthTokenGenerator.builder().credentials(credentialsProviderChainV1()).region(artifact.aws.regionName).build()
-        generator.getAuthToken(GetIamAuthTokenRequest.builder.hostname(hostname).port(5432).userName(user).build())
-      } else {
-        getString("db.default.password")
-      }
-    }
+    lazy val hostname = getString("db.default.hostname")
+    lazy val defaultPassword = getString("db.default.password")
   }
 
   object stages {

--- a/riff-raff/app/persistence/DynamicPasswordDataSourceConnectionPool.scala
+++ b/riff-raff/app/persistence/DynamicPasswordDataSourceConnectionPool.scala
@@ -1,0 +1,47 @@
+package persistence
+
+import java.sql.{Connection, DriverManager}
+
+import javax.sql.DataSource
+import org.apache.commons.dbcp2.{ConnectionFactory, PoolableConnectionFactory, PoolingDataSource}
+import org.apache.commons.pool2.impl.GenericObjectPool
+import scalikejdbc.{ConnectionPool, ConnectionPoolSettings, DataSourceCloser, DataSourceConnectionPool, DataSourceConnectionPoolSettings, DefaultDataSourceCloser}
+
+
+trait PasswordProvider {
+  def providePassword(): String
+}
+
+class DynamicPasswordDataSourceConnectionPool private (
+  dataSource: DataSource,
+  settings: DataSourceConnectionPoolSettings = DataSourceConnectionPoolSettings(),
+  closer: DataSourceCloser = DefaultDataSourceCloser
+) extends DataSourceConnectionPool(
+  dataSource = dataSource,
+  settings = settings,
+  closer = closer
+)
+
+object DynamicPasswordDataSourceConnectionPool {
+  def apply(
+    url: String,
+    user: String,
+    passwordProvider: PasswordProvider,
+    settings: DataSourceConnectionPoolSettings = DataSourceConnectionPoolSettings(),
+    closer: DataSourceCloser = DefaultDataSourceCloser
+  ): DynamicPasswordDataSourceConnectionPool = {
+    val connectionFactory = new ConnectionFactory {
+      override def createConnection(): Connection = {
+        // This is where the trick is, every time the pool try to create a new connection (via the connection factory)
+        // we go and fetch a new IAM password
+        DriverManager.getConnection(url, user, passwordProvider.providePassword())
+      }
+    }
+
+    val poolableConnectionFactory = new PoolableConnectionFactory(connectionFactory, null)
+    val connectionPool = new GenericObjectPool(poolableConnectionFactory)
+    poolableConnectionFactory.setPool(connectionPool)
+    val dataSource = new PoolingDataSource(connectionPool)
+    new DynamicPasswordDataSourceConnectionPool(dataSource, settings, closer)
+  }
+}

--- a/riff-raff/app/persistence/IAMPasswordProvider.scala
+++ b/riff-raff/app/persistence/IAMPasswordProvider.scala
@@ -1,0 +1,34 @@
+package persistence
+
+import java.time.{Duration, Instant}
+
+import com.amazonaws.services.rds.auth.{GetIamAuthTokenRequest, RdsIamAuthTokenGenerator}
+import conf.Config
+import magenta.`package`.logger
+
+
+class IAMPasswordProvider(conf: Config) extends PasswordProvider {
+  override def providePassword(): String = {
+    if (conf.stage == "CODE" || conf.stage =="PROD") {
+      logger.info(s"Fetching password for database ${conf.postgres.hostname}, stage=${conf.stage}.")
+      val generator = RdsIamAuthTokenGenerator.builder().credentials(conf.credentialsProviderChainV1()).region(conf.artifact.aws.regionName).build()
+      generator.getAuthToken(GetIamAuthTokenRequest.builder.hostname(conf.postgres.hostname).port(5432).userName(conf.postgres.user).build())
+    } else {
+      conf.postgres.defaultPassword
+    }
+  }
+}
+
+class CachingPasswordProvider(passwordProvider: PasswordProvider, duration: Duration) extends PasswordProvider {
+
+  case class CachingState(lastPassword: String, timestamp: Instant)
+  var state: Option[CachingState] = None
+
+  override def providePassword(): String = {
+    if (state.exists(_.timestamp.plus(duration).isAfter(Instant.now()))) {
+    } else {
+      state = Some(CachingState(passwordProvider.providePassword(), Instant.now()))
+    }
+    state.get.lastPassword
+  }
+}

--- a/riff-raff/test/postgres/PostgresHelpers.scala
+++ b/riff-raff/test/postgres/PostgresHelpers.scala
@@ -1,7 +1,7 @@
 package postgres
 
 import conf.Config
-import persistence.PostgresDatastoreOps
+import persistence.{PasswordProvider, PostgresDatastoreOps}
 import play.api.db.Databases
 import play.api.db.evolutions.Evolutions
 import play.api.Configuration
@@ -13,8 +13,12 @@ trait PostgresHelpers {
     "db.default.url" -> "jdbc:postgresql://localhost:44444/riffraff")
   ).underlying)
 
+  val passwordProvider = new PasswordProvider {
+    override def providePassword(): String = "riffraff"
+  }
+
   lazy val datastore = {
-    val db = new PostgresDatastoreOps(config).buildDatastore()
+    val db = new PostgresDatastoreOps(config, passwordProvider).buildDatastore()
     applyEvolutions
     db
   }
@@ -26,7 +30,7 @@ trait PostgresHelpers {
       name = "default",
       config = Map(
         "username" -> config.postgres.user,
-        "password" -> config.postgres.password
+        "password" -> passwordProvider.providePassword()
       )
     )
     Evolutions.applyEvolutions(db)


### PR DESCRIPTION
# What I'm trying to solve

We currently provide a fixed pool to access our database. IAM provide passwords that are valid for 15 minutes, which means any connection dropped after that mark can't and won't be replaced.
We shouldn't rely on the network being reliable, this mean if some connection gets dropped, the number of active connection to the DB will slowly decrease until it's depleted.

# How is this helping

I'm providing a connection pool, with a special `ConnectionFactory`. The connection factory is invoked every time a fresh connection is attempted. This gives us an opportunity window to go to IAM and request a new password.

# Limits

- The call to IAM is blocking, this will impact the application performance, but it should work. This is alleviated by adding a 12 minute cache on the validity of the password.
- The cache doesn't attempt to be synchronous. It's perfectly possible to have two threads accessing the password and triggering two password refresh. I deemed it acceptable.

# TODO

- [x] Test on CODE