### PR TITLE
make project field exact match on deploy screen PLUS pop-out link on same mini history table

### DIFF
--- a/riff-raff/app/assets/javascripts/form-autocomplete.coffee
+++ b/riff-raff/app/assets/javascripts/form-autocomplete.coffee
@@ -5,12 +5,14 @@ updateBuildInfo = (buildNumber) ->
   $('#build-info').load(jsRoutes.controllers.DeployController.buildInfo(selectedProject, buildNumber).url)
 
 updateDeployInfo = () ->
-  selectedProject =$('#projectInput').val()
+  elemProjectInput = $('#projectInput')
+  isExactMatch = elemProjectInput.hasClass("project-exact-match")
+  selectedProject = elemProjectInput.val()
   selectedStage = $('#stage').val()
   url = if selectedStage == ''
-          jsRoutes.controllers.DeployController.deployHistory(selectedProject).url
+          jsRoutes.controllers.DeployController.deployHistory(selectedProject, undefined, isExactMatch).url
         else
-          jsRoutes.controllers.DeployController.deployHistory(selectedProject, selectedStage).url
+          jsRoutes.controllers.DeployController.deployHistory(selectedProject, selectedStage, isExactMatch).url
   $('#deploy-info').load(
     url,
     ->

--- a/riff-raff/app/controllers/DeployController.scala
+++ b/riff-raff/app/controllers/DeployController.scala
@@ -133,14 +133,14 @@ class DeployController(config: Config,
     Ok(Json.toJson(possibleProjects))
   }
 
-  def deployHistory(project: String, maybeStage: Option[String]) = AuthAction { request =>
+  def deployHistory(project: String, maybeStage: Option[String], isExactMatchProjectName: Option[Boolean]) = AuthAction { request =>
     if (project.trim.isEmpty) {
       Ok("")
     } else {
       val restrictions = maybeStage.toSeq.flatMap { stage =>
         RestrictionChecker.configsThatPreventDeployment(restrictionConfigDynamoRepository, project, stage, UserRequestSource(request.user))
       }
-      val filter = DeployFilter(projectName = Some(project), stage = maybeStage)
+      val filter = DeployFilter(projectName = Some(project), stage = maybeStage, isExactMatchProjectName = isExactMatchProjectName)
       val records = deployments.getDeploys(Some(filter), PaginationView(pageSize = Some(5)), fetchLogs = false).logAndSquashException(Nil).reverse
       Ok(views.html.deploy.deployHistory(project, maybeStage, records, restrictions))
     }

--- a/riff-raff/app/deployment/filter.scala
+++ b/riff-raff/app/deployment/filter.scala
@@ -18,6 +18,7 @@ trait QueryStringBuilder {
 
 case class DeployFilter(
   projectName: Option[String] = None,
+  isExactMatchProjectName: Option[Boolean] = None,
   stage: Option[String] = None,
   deployer: Option[String] = None,
   status: Option[RunState] = None,
@@ -27,6 +28,7 @@ case class DeployFilter(
   lazy val queryStringParams: List[(String, String)] = {
     Nil ++
       projectName.map("projectName" -> _.toString) ++
+      isExactMatchProjectName.map("isExactMatchProjectName" -> _.toString) ++
       stage.map("stage" -> _.toString) ++
       deployer.map("deployer" -> _.toString) ++
       status.map("status" -> _.toString) ++
@@ -36,7 +38,10 @@ case class DeployFilter(
 
   lazy val sqlParams: List[SQLSyntax] = List(
     projectName.map { pn =>
-      val likeString = s"%$pn%"
+      val likeString = isExactMatchProjectName match {
+        case Some(true) => pn
+        case _ => s"%$pn%"
+      }
       sqls"content->'parameters'->>'projectName' ilike $likeString"
     },
     stage.map(s => sqls"content->'parameters'->>'stage' = $s"),

--- a/riff-raff/app/views/deploy/deployHistory.scala.html
+++ b/riff-raff/app/views/deploy/deployHistory.scala.html
@@ -14,7 +14,7 @@
 }
 @if(records.nonEmpty) {
     <h4>Last deploys of <em>@projectName</em> @maybeStage.map{ stage => to @stage }</h4>
-    @snippets.recordTable(records, None, allColumns = false)
+    @snippets.recordTable(records, None, allColumns = false, popOutLink = true)
 } else {
     <div class="alert alert-danger" role="alert">
         <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>

--- a/riff-raff/app/views/deploy/form.scala.html
+++ b/riff-raff/app/views/deploy/form.scala.html
@@ -8,12 +8,22 @@
 
     <div class="clearfix"><p>&nbsp;</p></div>
 
+    <style type="text/css">
+        #projectInput_field > label::after {
+            content: '(exact match)';
+            display: inline-block;
+            font-style: italic;
+            font-weight: normal;
+            margin-left: 5px;
+        }
+    </style>
+
     <div class="col-md-6">
     @b3.form(routes.DeployController.processForm, 'class -> "well") {
         @CSRF.formField
         <fieldset>
             <legend>What would you like to deploy?</legend>
-            @b3.text(deployForm("project"), '_label -> "project", 'id -> "projectInput", Symbol("data-url") -> "/deployment/request/autoComplete/project", 'class -> "form-control input-md")
+            @b3.text(deployForm("project"), '_label -> "project", 'id -> "projectInput", Symbol("data-url") -> "/deployment/request/autoComplete/project", 'class -> "form-control input-md project-exact-match")
             @b3.text(deployForm("build"),  '_label -> "build", 'id -> "buildInput", Symbol("data-url") -> "/deployment/request/autoComplete/build", 'class -> "form-control input-md")
             @b3.select(
                 deployForm("stage"),

--- a/riff-raff/app/views/snippets/recordTable.scala.html
+++ b/riff-raff/app/views/snippets/recordTable.scala.html
@@ -1,4 +1,4 @@
-@(records: List[deployment.Record], maybeFilter: Option[deployment.DeployFilterPagination] = None, allColumns: Boolean = true, lastColumnContent: Option[(String, Record => Html)] = None)
+@(records: List[deployment.Record], maybeFilter: Option[deployment.DeployFilterPagination] = None, allColumns: Boolean = true, lastColumnContent: Option[(String, Record => Html)] = None, popOutLink: Boolean = false)
 @import deployment._
 @import html.helper.magenta.htmlTooltip
 
@@ -35,7 +35,7 @@
             <td><time class="makeRelativeDate" withinhours="24" datetime="@record.time">@utils.DateFormats.Medium.print(record.time)</time></td>
             <td><span class="label label-default">@record.deployerName</span></td>
             @if(allColumns) {
-                <td><a href="@routes.DeployController.viewUUID(record.uuid.toString)" class="rowlink">@record.buildName</a></td>
+                <td>@record.buildName</td>
             }
             <td>@record.stage.name</td>
             <td>@record.buildId</td>
@@ -71,21 +71,23 @@
             </td>
 
             <td>
-                @htmlTooltip(placement="left"){
-                    @record.metaData.get(deployment.Record.RIFFRAFF_HOSTNAME).getOrElse(Html(""))
-                }{
-                @defining(record.state) { state =>
-                @state match {
-                case RunState.Completed => { <span class="label label-success">Completed in @Record.prettyPrintDuration(record.timeTaken)</span> }
-                case RunState.Failed => { <span class="label label-danger">Failed@if(Record.prettyPrintDuration(record.timeTaken).nonEmpty){ after @Record.prettyPrintDuration(record.timeTaken)}</span> }
-                case RunState.NotRunning => { <span class="label label-default">Waiting</span> }
-                case _ => {
-                    <span class="label label-info">Running for @Record.prettyPrintDuration(record.timeTaken) (@record.completedPercentage%)</span>
-                }
-                }
-                }
-                    @if(record.hasWarnings) { <br/><span class="label label-reporter-warning">Warnings encountered</span> }
-                }
+                <a href="@routes.DeployController.viewUUID(record.uuid.toString)" @if(popOutLink){ target="_blank" } class="rowlink">
+                    @htmlTooltip(placement="left"){
+                        @record.metaData.get(deployment.Record.RIFFRAFF_HOSTNAME).getOrElse(Html(""))
+                    }{
+                    @defining(record.state) { state =>
+                    @state match {
+                    case RunState.Completed => { <span class="label label-success">Completed in @Record.prettyPrintDuration(record.timeTaken)</span> }
+                    case RunState.Failed => { <span class="label label-danger">Failed@if(Record.prettyPrintDuration(record.timeTaken).nonEmpty){ after @Record.prettyPrintDuration(record.timeTaken)}</span> }
+                    case RunState.NotRunning => { <span class="label label-default">Waiting</span> }
+                    case _ => {
+                        <span class="label label-info">Running for @Record.prettyPrintDuration(record.timeTaken) (@record.completedPercentage%)</span>
+                    }
+                    }
+                    }
+                        @if(record.hasWarnings) { <br/><span class="label label-reporter-warning">Warnings encountered</span> }
+                    }
+                </a>
             </td>
             @if(allColumns) {
                 <td class="rowlink-skip">

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -39,7 +39,7 @@ GET         /deployment/updates/:uuid                       controllers.DeployCo
 
 GET         /deployment/request/autoComplete/project        controllers.DeployController.autoCompleteProject(term:String)
 GET         /deployment/request/autoComplete/build          controllers.DeployController.autoCompleteBuild(project:String,term:String)
-GET         /deployment/request/history                     controllers.DeployController.deployHistory(project:String, stage:Option[String])
+GET         /deployment/request/history                     controllers.DeployController.deployHistory(project:String, stage:Option[String], isExactMatchProjectName:Option[Boolean])
 GET         /deployment/request/buildInfo                   controllers.DeployController.buildInfo(project: String, build: String)
 
 


### PR DESCRIPTION
On the deploy screen, the small deploy history table on the right doesn't display the project name and yet the project name filter WAS a wildcard search `like  %$pn%` which meant clicking on projects like `identity` would produce a very confusing/alarming list containing builds from multiple projects (often with very different build numbers).

NOW its an exact match search on the deploy screen...
![image](https://user-images.githubusercontent.com/19289579/61629781-c6572480-ac7d-11e9-9500-25998a8a0ef5.png)
... feature co-authored with @TBonnin 

PLUS @philmcmahon suggested adding some sort of link to those historical deploys (from that small history table on the deploy screen), so made sense to do it at the same time...
![image](https://user-images.githubusercontent.com/19289579/61707944-8195c100-ad43-11e9-8c35-e2c0c2e2ac2f.png)
... the entire row is clickable but opens in a new tab when on the deploy screen.