### PR TITLE
add 'sbt-web' 'digest' plugin and switched to Assets.versioned

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val lib = project.in(file("magenta-lib"))
 
 lazy val riffraff = project.in(file("riff-raff"))
   .dependsOn(lib % "compile->compile;test->test")
-  .enablePlugins(PlayScala, BuildInfoPlugin, RiffRaffArtifact)
+  .enablePlugins(PlayScala, SbtWeb, BuildInfoPlugin, RiffRaffArtifact)
   .settings(commonSettings)
   .settings(Seq(
     name := "riff-raff",
@@ -86,5 +86,7 @@ lazy val riffraff = project.in(file("riff-raff"))
 
     fork in Test := false,
     
-    includeFilter in (Assets, LessKeys.less) := "*.less"
+    includeFilter in (Assets, LessKeys.less) := "*.less",
+
+    pipelineStages in Assets := Seq(digest)
   ))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,6 +5,7 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 
 addSbtPlugin("com.gu" % "sbt-teamcity-test-reporting-plugin" % "1.5")
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.4")

--- a/riff-raff/app/views/deploy/dashboard.scala.html
+++ b/riff-raff/app/views/deploy/dashboard.scala.html
@@ -6,6 +6,6 @@
     <hr/>
 
     <div class="content" data-ajax-refresh="@{routes.DeployController.dashboardContent(projects, search)}" data-ajax-interval="60000">
-        <p><img height="15" width="21" src="@routes.Assets.at("images/parrot-small.gif")"/> Analysing history...</p>
+        <p><img height="15" width="21" src="@routes.Assets.versioned("images/parrot-small.gif")"/> Analysing history...</p>
     </div>
 }(config, menu)

--- a/riff-raff/app/views/deploy/history.scala.html
+++ b/riff-raff/app/views/deploy/history.scala.html
@@ -3,10 +3,10 @@
 @import deployment.DeployFilterPagination
 
 @main("Deployment history", request, List("auto-refresh", "history-dropdown", "autorefresh-rowlink", "graph", "relative-time", "form-autocomplete")) {
-    <link href="@routes.Assets.at("stylesheets/rickshaw.css")" rel="stylesheet">
-    <link href='@routes.Assets.at("stylesheets/graph.css")' rel="stylesheet">
-    <script src='@routes.Assets.at("javascripts/d3.v2.min.js")'></script>
-    <script src='@routes.Assets.at("javascripts/rickshaw.js")'></script>
+    <link href="@routes.Assets.versioned("stylesheets/rickshaw.css")" rel="stylesheet">
+    <link href='@routes.Assets.versioned("stylesheets/graph.css")' rel="stylesheet">
+    <script src='@routes.Assets.versioned("javascripts/d3.v2.min.js")'></script>
+    <script src='@routes.Assets.versioned("javascripts/rickshaw.js")'></script>
     <script>
             $(function () { graph({
                 "container_id": 'deploy-chart',

--- a/riff-raff/app/views/page.scala.html
+++ b/riff-raff/app/views/page.scala.html
@@ -17,21 +17,21 @@
             padding: 9px 0;
         }
     </style>
-    <link href='@routes.Assets.at("lib/bootstrap/css/bootstrap.css")' rel="stylesheet">
-    <link href='@routes.Assets.at("lib/jasny-bootstrap/css/jasny-bootstrap.min.css")' rel="stylesheet">
-    <link href='@routes.Assets.at("stylesheets/magenta.css")' rel="stylesheet">
-    <link href='@routes.Assets.at("lib/jquery-ui/jquery-ui.min.css")' rel="stylesheet">
+    <link href='@routes.Assets.versioned("lib/bootstrap/css/bootstrap.css")' rel="stylesheet">
+    <link href='@routes.Assets.versioned("lib/jasny-bootstrap/css/jasny-bootstrap.min.css")' rel="stylesheet">
+    <link href='@routes.Assets.versioned("stylesheets/magenta.css")' rel="stylesheet">
+    <link href='@routes.Assets.versioned("lib/jquery-ui/jquery-ui.min.css")' rel="stylesheet">
 
-    <link rel="shortcut icon" type="image/png" href='@routes.Assets.at("images/favicon.png")'>
-    <script src='@routes.Assets.at("lib/jquery/jquery.min.js")'></script>
-    <script src='@routes.Assets.at("lib/jquery-ui/jquery-ui.min.js")'></script>
-    <script src='@routes.Assets.at("lib/momentjs/min/moment.min.js")'></script>
+    <link rel="shortcut icon" type="image/png" href='@routes.Assets.versioned("images/favicon.png")'>
+    <script src='@routes.Assets.versioned("lib/jquery/jquery.min.js")'></script>
+    <script src='@routes.Assets.versioned("lib/jquery-ui/jquery-ui.min.js")'></script>
+    <script src='@routes.Assets.versioned("lib/momentjs/min/moment.min.js")'></script>
     <!-- routes used in AJAX functions -->
     <script src='@routes.Application.javascriptRoutes'></script>
-    <script src='@routes.Assets.at("javascripts/tooltips.js")'></script>
+    <script src='@routes.Assets.versioned("javascripts/tooltips.js")'></script>
     <!-- page specific scripts -->
     @for(script <- scripts) {
-        <script src='@routes.Assets.at(s"javascripts/$script.js")'></script>
+        <script src='@routes.Assets.versioned(s"javascripts/$script.js")'></script>
     }
 </head>
 <body>
@@ -58,8 +58,8 @@
 <!-- Le javascript
 ================================================== -->
 <!-- Placed at the end of the document so the pages load faster -->
-<script src='@routes.Assets.at("lib/bootstrap/js/bootstrap.min.js")'></script>
-<script src='@routes.Assets.at("lib/jasny-bootstrap/js/jasny-bootstrap.min.js")'></script>
+<script src='@routes.Assets.versioned("lib/bootstrap/js/bootstrap.min.js")'></script>
+<script src='@routes.Assets.versioned("lib/jasny-bootstrap/js/jasny-bootstrap.min.js")'></script>
 
 </body>
 </html>

--- a/riff-raff/app/views/preview/yaml/loading.scala.html
+++ b/riff-raff/app/views/preview/yaml/loading.scala.html
@@ -1,6 +1,6 @@
 @(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], elapsed: Long)
 
-<p><img height="15" width="21" src="@routes.Assets.at("images/parrot-small.gif")"/>
+<p><img height="15" width="21" src="@routes.Assets.versioned("images/parrot-small.gif")"/>
     @elapsed match {
        case time if time < 10 => {
            Resolving tasks from your riff-raff.yaml file...

--- a/riff-raff/app/views/snippets/changeFreezeDialog.scala.html
+++ b/riff-raff/app/views/snippets/changeFreezeDialog.scala.html
@@ -2,7 +2,7 @@
 @(changeFreeze: ChangeFreeze)
 
 @if(changeFreeze.frozen){
-  <script src='@routes.Assets.at("javascripts/modal-confirm.js")'></script>
+  <script src='@routes.Assets.versioned("javascripts/modal-confirm.js")'></script>
   <div id="freezeModal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="freezeModalLabel" aria-hidden="true" data-stages="@changeFreeze.stages.mkString(",")">
       <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -125,4 +125,4 @@ GET         /builds                                         controllers.DeployCo
 GET         /assets/javascripts/routes                      controllers.Application.javascriptRoutes
 
 # Map static resources from the /public folder to the /assets URL path
-GET         /assets/*file                                   controllers.Assets.at(path="/public", file)
+GET         /assets/*file                                   controllers.Assets.versioned(path="/public", file: Asset)


### PR DESCRIPTION
when testing https://github.com/guardian/riff-raff/pull/556 in CODE, it required busting the browser-cache to see the changes fully take effect (old javascript was being loaded).

This PR implements [`Assets.versioned`](https://www.playframework.com/documentation/2.7.x/AssetsOverview#Reverse-routing-and-fingerprinting-for-public-assets) via [sbt-digest](https://github.com/sbt/sbt-digest#sbt-digest). So now assets are prefixed with a hash to ensure changes get reloaded properly...
![image](https://user-images.githubusercontent.com/19289579/61701079-7b004d00-ad35-11e9-8bea-50cbcce0f3e8.png)
