### PR TITLE
Bump fastly api client to version 0.3.0 to fix large Fastly VCL deploys.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
     "software.amazon.awssdk" % "cloudformation" % Versions.aws,
     "software.amazon.awssdk" % "sts" % Versions.aws,
     "com.gu" %% "management" % Versions.guardianManagement,
-    "com.gu" %% "fastly-api-client" % "0.2.7",
+    "com.gu" %% "fastly-api-client" % "0.3.0",
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % Versions.jackson,
     "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jackson,
     "com.typesafe.play" %% "play-json" % "2.7.2",


### PR DESCRIPTION
Currently when we try to deploy Fastly deploy configurations that have VCL files beyond a certain length (I tested with 100,000 characters) the deploy fails. The latest version of fastly api client should resolve this issue, by posting data to the fastly api in a more sensible way - here's the PR https://github.com/guardian/fastly-api-client


VCL deploys are broken on CODE so I've tested this as much as possible (I ran an autoscaling deploy on CODE)