### PR TITLE
Bump fastly client to 0.4.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
     "software.amazon.awssdk" % "cloudformation" % Versions.aws,
     "software.amazon.awssdk" % "sts" % Versions.aws,
     "com.gu" %% "management" % Versions.guardianManagement,
-    "com.gu" %% "fastly-api-client" % "0.3.0",
+    "com.gu" %% "fastly-api-client" % "0.4.0",
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % Versions.jackson,
     "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jackson,
     "com.typesafe.play" %% "play-json" % "2.7.2",


### PR DESCRIPTION
Following from https://github.com/guardian/fastly-api-client/pull/21 - which modifies the client so that it always url encodes vcl being uploaded - a requirement of the fastly api.