### PR TITLE
Set -Xmx property when starting riffraff.

### DIFF
--- a/riff-raff/bootstrap.sh
+++ b/riff-raff/bootstrap.sh
@@ -84,7 +84,7 @@ Description=${APP}
 
 [Service]
 WorkingDirectory=${HOME}
-ExecStart=${HOME}/${APP}/bin/${APP}
+ExecStart=${HOME}/${APP}/bin/${APP} -J -J -Xmx3072m
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 SuccessExitStatus=143


### PR DESCRIPTION
So as to help avoid out of memory errors. The default MaxHeapSize on the boxes we're using is around 512MB.