### PR TITLE
Ensure AWS S3 Client gets closed after use

### DIFF
--- a/magenta-lib/src/main/scala/magenta/package.scala
+++ b/magenta-lib/src/main/scala/magenta/package.scala
@@ -1,7 +1,5 @@
 package magenta
 
-import java.io.Closeable
-
 import com.gu.management.Loggable
 import software.amazon.awssdk.awscore.exception.AwsServiceException
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
@@ -37,7 +35,7 @@ object `package` extends Loggable {
     }
   }
 
-  def withResource[C <: Closeable, T](resource: C)(f: C => T): T = {
+  def withResource[C <: AutoCloseable, T](resource: C)(f: C => T): T = {
     try {
       f(resource)
     } finally {

--- a/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
@@ -19,7 +19,6 @@ class CreateChangeSetTask(
 
   override def execute(reporter: DeployReporter, stopFlag: => Boolean) = if (!stopFlag) {
     val cfnClient = CloudFormation.makeCfnClient(keyRing, region)
-    val s3Client = S3.makeS3client(keyRing, region)
     val stsClient = STS.makeSTSclient(keyRing, region)
     val accountNumber = STS.getAccountNumber(stsClient)
 
@@ -29,7 +28,7 @@ class CreateChangeSetTask(
 
     val (stackName, changeSetType) = stackLookup.lookup(reporter, cfnClient)
 
-    val template = processTemplate(stackName, templateString, s3Client, stsClient, region, reporter)
+    val template = S3.withS3Client(keyRing, region)(client => processTemplate(stackName, templateString, client, stsClient, region, reporter))
     val parameters = unresolvedParameters.resolve(template, accountNumber, changeSetType, reporter, cfnClient)
 
     reporter.info("Creating Cloudformation change set")

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -115,7 +115,7 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
     when(s3Client.putObject(any[PutObjectRequest], any[RequestBody])).thenReturn(putObjectResult)
 
     val fileToUpload = new S3Path(sourceBucket, sourceKey)
-    val task = S3Upload(Region("eu-west-1"), targetBucket, Seq(fileToUpload -> targetKey))(fakeKeyRing, artifactClient, clientFactory(s3Client))
+    val task = S3Upload(Region("eu-west-1"), targetBucket, Seq(fileToUpload -> targetKey))(fakeKeyRing, artifactClient)
     val mappings = task.objectMappings
     mappings.size should be (1)
     val (source, target) = mappings.head
@@ -153,7 +153,7 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
 
     val packageRoot = new S3Path("artifact-bucket", "test/123/package/")
 
-    val task = new S3Upload(Region("eu-west-1"), "bucket", Seq(packageRoot -> "myStack/CODE/myApp"))(fakeKeyRing, artifactClient, clientFactory(s3Client))
+    val task = new S3Upload(Region("eu-west-1"), "bucket", Seq(packageRoot -> "myStack/CODE/myApp"))(fakeKeyRing, artifactClient)
 
     task.execute(reporter)
 
@@ -186,7 +186,7 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
 
     val packageRoot = new S3Path("artifact-bucket", "test/123/package/")
 
-    val task = new S3Upload(Region("eu-west-1"), "bucket", Seq(packageRoot -> ""))(fakeKeyRing, artifactClient, clientFactory(s3Client))
+    val task = new S3Upload(Region("eu-west-1"), "bucket", Seq(packageRoot -> ""))(fakeKeyRing, artifactClient)
     task.execute(reporter)
 
     val files = task.objectMappings

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -115,7 +115,7 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
     when(s3Client.putObject(any[PutObjectRequest], any[RequestBody])).thenReturn(putObjectResult)
 
     val fileToUpload = new S3Path(sourceBucket, sourceKey)
-    val task = S3Upload(Region("eu-west-1"), targetBucket, Seq(fileToUpload -> targetKey))(fakeKeyRing, artifactClient)
+    val task = S3Upload(Region("eu-west-1"), targetBucket, Seq(fileToUpload -> targetKey))(fakeKeyRing, artifactClient, Some(s3Client))
     val mappings = task.objectMappings
     mappings.size should be (1)
     val (source, target) = mappings.head
@@ -153,7 +153,7 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
 
     val packageRoot = new S3Path("artifact-bucket", "test/123/package/")
 
-    val task = new S3Upload(Region("eu-west-1"), "bucket", Seq(packageRoot -> "myStack/CODE/myApp"))(fakeKeyRing, artifactClient)
+    val task = new S3Upload(Region("eu-west-1"), "bucket", Seq(packageRoot -> "myStack/CODE/myApp"))(fakeKeyRing, artifactClient, Some(s3Client))
 
     task.execute(reporter)
 
@@ -186,7 +186,7 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
 
     val packageRoot = new S3Path("artifact-bucket", "test/123/package/")
 
-    val task = new S3Upload(Region("eu-west-1"), "bucket", Seq(packageRoot -> ""))(fakeKeyRing, artifactClient)
+    val task = new S3Upload(Region("eu-west-1"), "bucket", Seq(packageRoot -> ""))(fakeKeyRing, artifactClient, Some(s3Client))
     task.execute(reporter)
 
     val files = task.objectMappings
@@ -247,8 +247,6 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
       GetObjectResponse.builder().contentLength(31L).build(),
       stream)
   }
-
-  def clientFactory(client: S3Client): (KeyRing, Region, ClientOverrideConfiguration) => S3Client = { (_, _, _) => client }
 
   val parameters = DeployParameters(Deployer("tester"), Build("Project","1"), Stage("CODE"), All)
 }


### PR DESCRIPTION
There's an issue with riffraff at the moment where the aws sdk is opening loads of connections that never get closed, ultimately resulting in an out of memory error. This is step one in an attempt to fix it - using the `withResource` function to ensure that any uses of an s3 client are closed after use.

Next step is to do the same thing for all the other AWS SDK clients in this project, but in the interests of small changes (and confirming that this actually works) this is step one.