### PR TITLE
Ensure that AWS SDK objects are closed after use

### DIFF
--- a/magenta-lib/src/main/scala/magenta/package.scala
+++ b/magenta-lib/src/main/scala/magenta/package.scala
@@ -37,7 +37,7 @@ object `package` extends Loggable {
     }
   }
 
-  def withResource[C <: Closeable, T](resource: C)(f: C => T): T = {
+  def withResource[C <: AutoCloseable, T](resource: C)(f: C => T): T = {
     try {
       f(resource)
     } finally {

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -31,6 +31,7 @@ import software.amazon.awssdk.services.sts.model.GetCallerIdentityRequest
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.util.Try
+import magenta.withResource
 
 object S3 extends AWS {
   def withS3client[T](keyRing: KeyRing, region: Region, config: ClientOverrideConfiguration = clientConfiguration)(block: S3Client => T): T =
@@ -464,14 +465,6 @@ object STS extends AWS {
 }
 
 trait AWS extends Loggable {
-  def withResource[C <: AutoCloseable, T](resource: C)(f: C => T): T = {
-    try {
-      f(resource)
-    } finally {
-      resource.close()
-    }
-  }
-
   lazy val accessKey: String = Option(System.getenv.get("aws_access_key")).getOrElse{
     sys.error("Cannot authenticate, 'aws_access_key' must be set as a system property")
   }

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -30,14 +30,15 @@ import software.amazon.awssdk.services.sts.model.GetCallerIdentityRequest
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
+import scala.util.Try
 
 object S3 extends AWS {
-  def makeS3client(keyRing: KeyRing, region: Region, config: ClientOverrideConfiguration = clientConfiguration): S3Client =
-    S3Client.builder()
+  def withS3client[T](keyRing: KeyRing, region: Region, config: ClientOverrideConfiguration = clientConfiguration)(block: S3Client => T): T =
+    withResource(S3Client.builder()
       .region(region.awsRegion)
       .credentialsProvider(provider(keyRing))
       .overrideConfiguration(config)
-      .build()
+      .build())(block)
 
   /**
     * Check (and if necessary create) that an S3 bucket exists for the account and region. Note that it is assumed that
@@ -84,12 +85,12 @@ object S3 extends AWS {
 }
 
 object Lambda extends AWS {
-  def makeLambdaClient(keyRing: KeyRing, region: Region): LambdaClient =
-    LambdaClient.builder()
+  def withLambdaClient[T](keyRing: KeyRing, region: Region)(block: LambdaClient => T): T =
+    withResource(LambdaClient.builder()
     .credentialsProvider(provider(keyRing))
     .overrideConfiguration(clientConfiguration)
     .region(region.awsRegion)
-    .build()
+    .build())(block)
 
   def lambdaUpdateFunctionCodeRequest(functionName: String, buffer: ByteBuffer): UpdateFunctionCodeRequest =
     UpdateFunctionCodeRequest.builder().functionName(functionName).zipFile(SdkBytes.fromByteBuffer(buffer)).build()
@@ -125,12 +126,12 @@ object Lambda extends AWS {
 }
 
 object ASG extends AWS {
-  def makeAsgClient(keyRing: KeyRing, region: Region): AutoScalingClient =
-    AutoScalingClient.builder()
+  def withAsgClient[T](keyRing: KeyRing, region: Region)(block: AutoScalingClient => T): T =
+    withResource(AutoScalingClient.builder()
       .credentialsProvider(provider(keyRing))
       .overrideConfiguration(clientConfiguration)
       .region(region.awsRegion)
-      .build()
+      .build())(block)
 
   def desiredCapacity(name: String, capacity: Int, client: AutoScalingClient) =
     client.setDesiredCapacity(
@@ -253,19 +254,25 @@ object ASG extends AWS {
 
 object ELB extends AWS {
 
-  case class Client(classic: ClassicELB, application: ApplicationELB)
+  case class Client(classic: ClassicELB, application: ApplicationELB) extends AutoCloseable {
+    def close(): Unit = {
+      val classicClose = Try(classic.close())
+      val applicationClose = Try(application.close())
+      classicClose.flatMap(_ => applicationClose).get
+    }
+  }
 
-  def client(keyRing: KeyRing, region: Region): Client =
-    Client(classicClient(keyRing, region), applicationClient(keyRing, region))
+  def withClient[T](keyRing: KeyRing, region: Region)(block: Client => T): T =
+    withResource(Client(classicClient(keyRing, region), applicationClient(keyRing, region)))(block)
 
-  def classicClient(keyRing: KeyRing, region: Region): ClassicELB =
+  private def classicClient(keyRing: KeyRing, region: Region): ClassicELB =
     ClassicELB.builder()
       .credentialsProvider(provider(keyRing))
       .overrideConfiguration(clientConfiguration)
       .region(region.awsRegion)
       .build()
 
-  def applicationClient(keyRing: KeyRing, region: Region): ApplicationELB =
+  private def applicationClient(keyRing: KeyRing, region: Region): ApplicationELB =
     ApplicationELB.builder()
       .credentialsProvider(provider(keyRing))
       .overrideConfiguration(clientConfiguration)
@@ -299,12 +306,12 @@ object ELB extends AWS {
 }
 
 object EC2 extends AWS {
-  def makeEc2Client(keyRing: KeyRing, region: Region): Ec2Client = {
-    Ec2Client.builder()
+  def withEc2Client[T](keyRing: KeyRing, region: Region)(block: Ec2Client => T) = {
+    withResource(Ec2Client.builder()
       .credentialsProvider(provider(keyRing))
       .overrideConfiguration(clientConfiguration)
       .region(region.awsRegion)
-      .build()
+      .build())(block)
   }
 
   def setTag(instances: List[ASGInstance], key: String, value: String, client: Ec2Client) {
@@ -338,12 +345,12 @@ object CloudFormation extends AWS {
   case class TemplateBody(body: String) extends Template
   case class TemplateUrl(url: String) extends Template
 
-  def makeCfnClient(keyRing: KeyRing, region: Region): CloudFormationClient = {
-    CloudFormationClient.builder()
+  def withCfnClient[T](keyRing: KeyRing, region: Region)(block: CloudFormationClient => T): T = {
+    withResource(CloudFormationClient.builder()
       .credentialsProvider(provider(keyRing))
       .overrideConfiguration(clientConfiguration)
       .region(region.awsRegion)
-      .build()
+      .build())(block)
   }
 
   def validateTemplate(template: Template, client: CloudFormationClient) = {
@@ -442,12 +449,12 @@ object CloudFormation extends AWS {
 }
 
 object STS extends AWS {
-  def makeSTSclient(keyRing: KeyRing, region: Region): StsClient = {
-    StsClient.builder()
+  def withSTSclient[T](keyRing: KeyRing, region: Region)(block: StsClient => T): T = {
+    withResource(StsClient.builder()
       .credentialsProvider(provider(keyRing))
       .overrideConfiguration(clientConfiguration)
       .region(region.awsRegion)
-      .build()
+      .build())(block)
   }
 
   def getAccountNumber(stsClient: StsClient): String = {
@@ -457,6 +464,14 @@ object STS extends AWS {
 }
 
 trait AWS extends Loggable {
+  def withResource[C <: AutoCloseable, T](resource: C)(f: C => T): T = {
+    try {
+      f(resource)
+    } finally {
+      resource.close()
+    }
+  }
+
   lazy val accessKey: String = Option(System.getenv.get("aws_access_key")).getOrElse{
     sys.error("Cannot authenticate, 'aws_access_key' must be set as a system property")
   }

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -186,7 +186,7 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
 
     val packageRoot = new S3Path("artifact-bucket", "test/123/package/")
 
-    val task = new S3Upload(Region("eu-west-1"), "bucket", Seq(packageRoot -> ""))(fakeKeyRing, artifactClient, clientFactory(s3Client))
+     val task = new S3Upload(Region("eu-west-1"), "bucket", Seq(packageRoot -> ""))(fakeKeyRing, artifactClient, clientFactory(s3Client))
     task.execute(reporter)
 
     val files = task.objectMappings
@@ -248,7 +248,7 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
       stream)
   }
 
-  def clientFactory(client: S3Client): (KeyRing, Region, ClientOverrideConfiguration) => S3Client = { (_, _, _) => client }
+  def clientFactory(client: S3Client): (KeyRing, Region, ClientOverrideConfiguration) => (S3Client => Unit) => Unit = { (_, _, _) => block => block(client) }
 
   val parameters = DeployParameters(Deployer("tester"), Build("Project","1"), Stage("CODE"), All)
 }


### PR DESCRIPTION
An alternative to #561.

Best reviewed with whitespace edits disabled.