### PR TITLE
Helpful things for DevX

### DIFF
--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -174,7 +174,7 @@ class AppComponents(context: Context, config: Config, passwordProvider: Password
   val scheduleController = new ScheduleController(config, menu, authAction, controllerComponents, scheduleRepository, prismLookup, deployScheduler)
   val targetController = new TargetController(config, menu, deployments, targetDynamoRepository, authAction, controllerComponents)
   val loginController = new Login(config, menu, deployments, datastore, controllerComponents, authAction, googleAuthConfig)
-  val testingController = new Testing(config, menu, datastore, prismLookup, documentStoreConverter, authAction, controllerComponents, artifactHousekeeper)
+  val testingController = new Testing(config, menu, datastore, prismLookup, documentStoreConverter, authAction, controllerComponents, artifactHousekeeper, deployments)
 
   override lazy val httpErrorHandler = new DefaultHttpErrorHandler(environment, configuration, sourceMapper, Some(router)) {
     override def onServerError(request: RequestHeader, t: Throwable): Future[Result] = {

--- a/riff-raff/app/AppLoader.scala
+++ b/riff-raff/app/AppLoader.scala
@@ -3,6 +3,7 @@ import java.time.Duration
 
 import com.typesafe.config.ConfigFactory
 import conf.Config
+import org.joda.time.{DateTime, DateTimeZone}
 import persistence.{CachingPasswordProvider, IAMPasswordProvider}
 import play.api.ApplicationLoader.Context
 import play.api.{Application, ApplicationLoader, Configuration, LoggerConfigurator}
@@ -19,7 +20,7 @@ class AppLoader extends ApplicationLoader {
     val combinedConfig =  context.initialConfiguration ++ Configuration(userConf)
 
     // create config object (including call to RDS to get an IAM auth token for the database)
-    val appConfig = new Config(combinedConfig.underlying)
+    val appConfig = new Config(combinedConfig.underlying, DateTime.now(DateTimeZone.forID("Europe/London")))
 
     // get JDBC passwords from IAM and cache them for 12 minutes. They are normally valid for 15 minutes
     val passwordProvider = new CachingPasswordProvider(new IAMPasswordProvider(appConfig), Duration.ofMinutes(12))

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -29,14 +29,14 @@ import software.amazon.awssdk.regions.{Region => AWSRegion}
 import software.amazon.awssdk.services.ec2.Ec2Client
 import software.amazon.awssdk.services.ec2.model.{DescribeTagsRequest, Filter}
 import software.amazon.awssdk.services.s3.S3Client
-import utils.{PeriodicScheduledAgentUpdate, ScheduledAgent, UnnaturalOrdering}
+import utils.{DateFormats, PeriodicScheduledAgentUpdate, ScheduledAgent, UnnaturalOrdering}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.util.{Success, Try}
 
-class Config(configuration: TypesafeConfig) extends Logging {
+class Config(configuration: TypesafeConfig, startTime: DateTime) extends Logging {
 
   private def getString(path: String): String = configuration.getString(path)
   private def getStringOpt(path: String): Option[String] = Try(configuration.getString(path)).toOption
@@ -267,6 +267,7 @@ class Config(configuration: TypesafeConfig) extends Logging {
   }
 
   val version:String = BuildInfo.buildNumber
+  val startTimeString:String = DateFormats.Short.print(startTime)
 
   override def toString: String = configuration.toString
 }

--- a/riff-raff/app/views/menu/menubar.scala.html
+++ b/riff-raff/app/views/menu/menubar.scala.html
@@ -9,7 +9,7 @@
             <span class="glyphicon icon-bar"></span>
             <span class="glyphicon icon-bar"></span>
         </button>
-        <a class="navbar-brand" title="Build @config.version" href="/">Riff Raff</a>
+        <a class="navbar-brand" title="Build @config.version (started at @config.startTimeString)" href="/">Riff Raff</a>
     </div>
     @menuBarItems
 </nav>

--- a/riff-raff/app/views/page.scala.html
+++ b/riff-raff/app/views/page.scala.html
@@ -49,7 +49,7 @@
                 <a href="https://github.com/guardian/deploy">
                     <i>Riff Raff</i>
                 </a> is part of <a href="http://www.grauniad.co.uk">The Grauniad's</a> deployment toolset.
-                <br><small>I would like, if I may, to take you on a strange journey.</small><small class="pull-right">Build @config.version</small>
+                <br><small>I would like, if I may, to take you on a strange journey.</small><small class="pull-right">Build @config.version (started @config.startTimeString)</small>
             </p>
         </footer>
     </div>

--- a/riff-raff/app/views/test/running.scala.html
+++ b/riff-raff/app/views/test/running.scala.html
@@ -1,0 +1,28 @@
+@import conf.Config
+@import deployment.Record
+@import _root_.utils.DateFormats
+@(activeDeploys: Iterable[Record])(config: Config, menu: Menu)(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity])
+
+@main("Running deploys", request) {
+    <h1>Running deploys (deploys that the server thinks are running)</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>Start time</th>
+                <th>UUID</th>
+                <th>Build</th>
+                <th>Target</th>
+            </tr>
+        </thead>
+        <tbody>
+            @activeDeploys.map { deploy =>
+                <tr>
+                    <td>@{DateFormats.Medium.print(deploy.time)}</td>
+                    <td><a href="@routes.Testing.debugLogViewer(deploy.uuid.toString)">@{deploy.uuid}</a></td>
+                    <td>@{deploy.parameters.build.projectName} (@{deploy.parameters.build.id})</td>
+                    <td>@{deploy.parameters.stage}</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}(config, menu)

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -119,6 +119,7 @@ GET         /testing/view/:uuid                             controllers.Testing.
 GET         /testing/addStringUUID                          controllers.Testing.transferAllUUIDs
 GET         /testing/testcharset                            controllers.Testing.testcharset
 GET         /testing/deployinfo                             controllers.Testing.hosts
+GET         /testing/running                                controllers.Testing.runningDeploys
 GET         /builds                                         controllers.DeployController.builds
 
 # Javascript routing

--- a/riff-raff/test/ci/S3BuildTest.scala
+++ b/riff-raff/test/ci/S3BuildTest.scala
@@ -7,7 +7,7 @@ import play.api.Configuration
 
 class S3BuildTest extends FunSuite with Matchers with EitherValues {
 
-  val config = new Config(configuration = Configuration(("test.config", "abc")).underlying)
+  val config = new Config(configuration = Configuration(("test.config", "abc")).underlying, DateTime.now)
 
   test("can parse build.json") {
     val json =

--- a/riff-raff/test/deployment/actors/DeployGroupRunnerTest.scala
+++ b/riff-raff/test/deployment/actors/DeployGroupRunnerTest.scala
@@ -10,6 +10,7 @@ import deployment.{Fixtures, Record}
 import magenta.deployment_type.DeploymentType
 import magenta.graph.{DeploymentTasks, Graph, ValueNode}
 import magenta.tasks.Task
+import org.joda.time.DateTime
 import org.scalatest.{FlatSpecLike, Matchers}
 import play.api.Configuration
 
@@ -124,7 +125,7 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
 
   case class DRImpl(record: Record, deployCoordinatorProbe: TestProbe, deploymentRunnerProbe: TestProbe, ref: ActorRef, stopFlagAgent: Agent[Map[UUID, String]]) extends DR
 
-  val config = new Config(configuration = Configuration(("test.config", "abc")).underlying)
+  val config = new Config(configuration = Configuration(("test.config", "abc")).underlying, DateTime.now)
 
   def createDeployRunner(): DRImpl = {
     val deployCoordinatorProbe = TestProbe()

--- a/riff-raff/test/lookup/PrismLookupTest.scala
+++ b/riff-raff/test/lookup/PrismLookupTest.scala
@@ -21,7 +21,7 @@ import scala.concurrent.duration._
 
 class PrismLookupTest extends FlatSpec with Matchers {
 
-  val config = new Config(configuration = Configuration(("lookup.timeoutSeconds", 10), ("lookup.prismUrl", "")).underlying)
+  val config = new Config(configuration = Configuration(("lookup.timeoutSeconds", 10), ("lookup.prismUrl", "")).underlying, DateTime.now)
 
   def withPrismClient[T](images: List[Image])(block: WSClient => T):(T, Option[Request[AnyContent]]) = {
     var mockRequest: Option[Request[AnyContent]] = None

--- a/riff-raff/test/postgres/PostgresHelpers.scala
+++ b/riff-raff/test/postgres/PostgresHelpers.scala
@@ -1,6 +1,7 @@
 package postgres
 
 import conf.Config
+import org.joda.time.DateTime
 import persistence.{PasswordProvider, PostgresDatastoreOps}
 import play.api.db.Databases
 import play.api.db.evolutions.Evolutions
@@ -11,7 +12,7 @@ trait PostgresHelpers {
     "db.default.user" -> "riffraff",
     "db.default.password" -> "riffraff",
     "db.default.url" -> "jdbc:postgresql://localhost:44444/riffraff")
-  ).underlying)
+  ).underlying, DateTime.now)
 
   val passwordProvider = new PasswordProvider {
     override def providePassword(): String = "riffraff"


### PR DESCRIPTION
Riff-Raff occassionally doesn't restart on deploy which is hard to detect at the moment. This PR adds the start time of the VM to the bottom of the UI so it's trivial to diagnose. It also adds a new `/testing/running` endpoint that lists the deploys that the internal deploy controller believes are still running. Again this might make it easier to diagnose why Riff-Raff failed to shut down.