### PR TITLE
Minor UI improvements

### DIFF
--- a/riff-raff/app/views/preview/yaml/showTasks.scala.html
+++ b/riff-raff/app/views/preview/yaml/showTasks.scala.html
@@ -30,6 +30,24 @@ to make it fit in the Play idea of forms but it's far from trivial. Be warned!
           }
       }
     }
+    <div class="actions">
+        @b3.submit(
+            'name -> "action",
+            'value -> "preview",
+            'class -> "btn btn-default"
+        ){Preview with selections}
+        @b3.submit(
+            'name -> "action",
+            'value -> "deploy",
+            'class -> "btn btn-primary"
+        ){Deploy}
+        <a class="btn btn-danger" href="@routes.PreviewController.preview(
+            form("project").value.get,
+            form("build").value.get,
+            form("stage").value.get,
+            None
+        )">Reset selection</a>
+    </div>
     @for((key, deploymentTasks) <- taskGraph.toList) {
         <div class="deployment-target" id="@DeploymentKey.asString(key)">
             <div class="panel panel-default">
@@ -44,7 +62,7 @@ to make it fit in the Play idea of forms but it's far from trivial. Be warned!
                                 'class -> "task-selection",
                                 'value -> DeploymentKey.asString(key),
                                 'checked -> checkedKeys.contains(key),
-                                '_label -> Html("Run tasks")
+                                '_text -> "Run tasks"
                             )
                         </span>
                     </div>

--- a/riff-raff/app/views/preview/yaml/showTasks.scala.html
+++ b/riff-raff/app/views/preview/yaml/showTasks.scala.html
@@ -48,7 +48,7 @@ to make it fit in the Play idea of forms but it's far from trivial. Be warned!
             None
         )">Reset selection</a>
     </div>
-    @for((key, deploymentTasks) <- taskGraph.toList) {
+    @for(((key, deploymentTasks), i) <- taskGraph.toList.zipWithIndex) {
         <div class="deployment-target" id="@DeploymentKey.asString(key)">
             <div class="panel panel-default">
                 <div class="panel-heading">
@@ -59,6 +59,7 @@ to make it fit in the Play idea of forms but it's far from trivial. Be warned!
                         <span>
                             @b3.checkbox(
                                 form("selectedKeys[]"),
+                                'id -> s"selectedKey_$i",
                                 'class -> "task-selection",
                                 'value -> DeploymentKey.asString(key),
                                 'checked -> checkedKeys.contains(key),


### PR DESCRIPTION
In the preview screen, when you have lots of tasks but only want to kick-off some at the top, it's annoying to have to scroll all the way down.

Also, the "run tasks" label isn't active, i.e. the HTML should be

```html
<input type="checkbox" id="selectedKey_1">
<label for="selectedKey_1">Run tasks</label>
```

so that when you click on the text, it (de)activates the checkbox.

**Before (preview, deploy, reset not at top)**
![image](https://user-images.githubusercontent.com/836140/94249990-8aba8900-ff18-11ea-89cb-8517907613e1.png)

**After (preview, deploy, reset at top and bottom**
![image](https://user-images.githubusercontent.com/836140/94250028-960db480-ff18-11ea-944b-7a630a71c9f7.png)


- [x] Test on CODE