### PR TITLE
provide a better experience for clients that don't support prefers-color-scheme

### DIFF
--- a/riff-raff/app/views/page.scala.html
+++ b/riff-raff/app/views/page.scala.html
@@ -17,7 +17,7 @@
             padding: 9px 0;
         }
     </style>
-    <link href='@routes.Assets.versioned("lib/bootstrap/css/bootstrap.css")' rel="stylesheet" media="(prefers-color-scheme: light), (prefers-color-scheme: no-preference)">
+    <link href='@routes.Assets.versioned("lib/bootstrap/css/bootstrap.css")' rel="stylesheet">
     <link href='@routes.Assets.versioned("lib/jasny-bootstrap/css/jasny-bootstrap.min.css")' rel="stylesheet">
     <link href='@routes.Assets.versioned("stylesheets/bootstrap-slate.min.css")' rel="stylesheet" media="(prefers-color-scheme: dark)">
     <link href='@routes.Assets.versioned("stylesheets/magenta.css")' rel="stylesheet">


### PR DESCRIPTION
provide a better experience for clients that don't support prefers-color-scheme

load usual css always and conditionally load dark mode if `prefers-color-scheme` is supported and you've specified a preference for dark mode