### PR TITLE
add more contrast to history hover

### DIFF
--- a/riff-raff/app/assets/stylesheets/magenta.less
+++ b/riff-raff/app/assets/stylesheets/magenta.less
@@ -22,6 +22,10 @@ tr.rowlink td.nolink {
 }
 .table tbody tr.rowlink:hover td {
   background-color: #cfcfcf;
+
+  @media(prefers-color-scheme: dark) {
+    color: black;
+  }
 }
 a.rowlink {
   color: inherit;


### PR DESCRIPTION
when dark mode, text is black to provide more contrast between text and background

**before**
![image](https://user-images.githubusercontent.com/836140/68689220-ec277280-0567-11ea-9a65-56aee4ca4f1a.png)


**after**
![image](https://user-images.githubusercontent.com/836140/68688954-918e1680-0567-11ea-8df0-a4eccefc94c8.png)
