### PR TITLE
Add AWS account ID as Anghammarad target.

### DIFF
--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -109,7 +109,7 @@ class AppComponents(context: Context, config: Config, passwordProvider: Password
   val continuousDeployment = new ContinuousDeployment(config, changeFreeze, buildPoller, deployments, continuousDeploymentConfigRepository)
   val previewCoordinator = new PreviewCoordinator(config,prismLookup, availableDeploymentTypes)
   val artifactHousekeeper = new ArtifactHousekeeping(config, deployments)
-  val scheduledDeployNotifier = new DeployFailureNotifications(config, availableDeploymentTypes, targetResolver)
+  val scheduledDeployNotifier = new DeployFailureNotifications(config, availableDeploymentTypes, targetResolver, prismLookup)
 
   val authAction = new AuthAction[AnyContent](
     googleAuthConfig, routes.Login.loginAction(), controllerComponents.parsers.default)(executionContext)

--- a/riff-raff/app/notification/DeployFailureNotifications.scala
+++ b/riff-raff/app/notification/DeployFailureNotifications.scala
@@ -51,7 +51,7 @@ class DeployFailureNotifications(config: Config,
     }
   }
 
-  def failedDeployNotification(uuid: UUID, parameters: DeployParameters) = {
+  def failedDeployNotification(uuid: UUID, parameters: DeployParameters): Unit = {
     val deriveAnghammaradTargets = for {
       yaml <- targetResolver.fetchYaml(parameters.build)
       deployGraph <- Resolver.resolveDeploymentGraph(yaml, deploymentTypes, magenta.input.All).toEither
@@ -64,8 +64,8 @@ class DeployFailureNotifications(config: Config,
 
     deriveAnghammaradTargets match {
       case Right(targets) =>
-        log.info(s"Targets to notify: ${targets.toSet}")
-        val failureMessage = s"${parameters.deployer.name} for ${parameters.build.projectName} (build ${parameters.build.id}) to stage ${parameters.stage.name} failed. Targets: $targets"
+        log.info(s"Sending anghammarad notification with targets: ${targets.toSet}")
+        val failureMessage = s"${parameters.deployer.name} for ${parameters.build.projectName} (build ${parameters.build.id}) to stage ${parameters.stage.name} failed."
         Anghammarad.notify(
           subject = s"${parameters.deployer.name} failed",
           message = failureMessage,


### PR DESCRIPTION
Some projects have lots of different stack names so it's easier to identify an owner using the AWS account id. This change adds 'aws account id' to the list of 'targets' that riffraff sends to [anghammarad](https://github.com/guardian/anghammarad) after a deploy failure, so that this value can be used to determine the project owner.