### PR TITLE
Source credentials from SSM

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -1,5 +1,6 @@
 package magenta.tasks
 
+import com.gu.management.Loggable
 import magenta.deployment_type.CloudFormationDeploymentTypeParameters._
 import magenta.tasks.CloudFormation._
 import magenta.tasks.UpdateCloudFormationTask.{CloudFormationStackLookupStrategy, LookupByName, LookupByTags, TemplateParameter}
@@ -144,7 +145,7 @@ object CloudFormationParameters {
   }
 }
 
-object UpdateCloudFormationTask {
+object UpdateCloudFormationTask extends Loggable {
   case class TemplateParameter(key:String, default:Boolean)
 
   sealed trait CloudFormationStackLookupStrategy
@@ -261,7 +262,7 @@ case class UpdateAmiCloudFormationParameterTask(
 class CheckUpdateEventsTask(
   region: Region,
   stackLookupStrategy: CloudFormationStackLookupStrategy
-)(implicit val keyRing: KeyRing) extends Task {
+)(implicit val keyRing: KeyRing) extends Task with Loggable {
 
   import UpdateCloudFormationTask._
 

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -59,7 +59,7 @@ case class S3Upload(
       reporter.fail(s"No files found to upload in $locationDescription")
     }
 
-    val withClient = withClientFactory(keyRing, region, S3.clientConfigurationNoRetry)
+    val withClient = withClientFactory(keyRing, region, AWS.clientConfigurationNoRetry)
     withClient { client =>
 
       reporter.verbose(s"Starting transfer of ${fileString(objectMappings.size)} ($totalSize bytes)")
@@ -70,7 +70,7 @@ case class S3Upload(
           case 10 => reporter.verbose(s"Not logging details for the remaining ${fileString(objectMappings.size - 10)}")
           case _ =>
         }
-        retryOnException(S3.clientConfiguration) {
+        retryOnException(AWS.clientConfiguration) {
           val copyObjectRequest = GetObjectRequest.builder()
             .bucket(req.source.bucket)
             .key(req.source.key)

--- a/riff-raff/app/conf/Secrets.scala
+++ b/riff-raff/app/conf/Secrets.scala
@@ -1,0 +1,52 @@
+package conf
+
+import controllers.Logging
+import magenta.SecretProvider
+import software.amazon.awssdk.services.ssm.SsmClient
+import software.amazon.awssdk.services.ssm.model.GetParametersByPathRequest
+
+import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
+
+case class CredentialKey(service: String, account: String)
+
+class Secrets(config: Config, ssmClient: SsmClient) extends SecretProvider with Logging {
+  var credentials = Map.empty[CredentialKey, String]
+
+  override def lookup(service: String, account: String): Option[String] = {
+    credentials.get(CredentialKey(service, account))
+  }
+
+  def populate(): Unit = {
+    credentials = getCredentialsFromSsm
+    log.info(s"Populated credentials from SSM: ${credentials.keys.toList.sortBy(ck => ck.service -> ck.account)}")
+  }
+
+  def getCredentialsFromSsm: Map[CredentialKey, String] = {
+    val prefix = s"${config.credentials.paramPrefix.stripSuffix("/")}/"
+    val request = GetParametersByPathRequest.builder()
+      .path(prefix)
+      .withDecryption(true)
+      .recursive(true)
+      .build()
+    try {
+      val response = ssmClient.getParametersByPathPaginator(request)
+      response.iterator.asScala.flatMap { response =>
+        response.parameters.asScala
+      }.flatMap { parameter =>
+        val name = parameter.name
+        val value = parameter.value
+        name.stripPrefix(prefix).split("/").toList match {
+          case service :: account :: Nil => Some(CredentialKey(service, account) -> value)
+          case other =>
+            log.warn(s"Unable to ingest credential at $name ($other)")
+            None
+        }
+      }.toMap
+    } catch {
+      case NonFatal(t) =>
+        log.warn(s"Unable to build credentials map from SSM", t)
+        throw t
+    }
+  }
+}

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -112,7 +112,8 @@ class Config(configuration: TypesafeConfig, startTime: DateTime) extends Logging
   }
 
   object credentials {
-    def lookupSecret(service: String, id:String): Option[String] = getStringOpt(s"credentials.$service.$id")
+    lazy val regionName = getStringOpt("credentials.aws.region").getOrElse("eu-west-1")
+    lazy val paramPrefix = getStringOpt("credentials.paramPrefix").getOrElse(s"/$stage/deploy/riff-raff/credentials")
   }
 
   object dynamoDb {

--- a/riff-raff/app/resources/PrismLookup.scala
+++ b/riff-raff/app/resources/PrismLookup.scala
@@ -21,7 +21,7 @@ object Image {
   implicit val formats: OFormat[Image] = Json.format[Image]
 }
 
-class PrismLookup(config: Config, wsClient: WSClient) extends Lookup with Logging {
+class PrismLookup(config: Config, wsClient: WSClient, secretProvider: SecretProvider) extends Lookup with Logging {
 
   def keyRing(stage: Stage, app: App, stack: Stack): KeyRing = {
     val KeyPattern = """credentials:(.*)""".r
@@ -144,11 +144,6 @@ class PrismLookup(config: Config, wsClient: WSClient) extends Lookup with Loggin
   }
 
   def stages: Seq[String] = prism.get("/stages"){ json => (json \ "data" \ "stages").as[Seq[String]] }
-
-  val secretProvider = new SecretProvider {
-    def lookup(service: String, account: String): Option[String] =
-      config.credentials.lookupSecret(service, account)
-  }
 
   private def get(accountNumber: Option[String], region: String, tags: Map[String, String]): Seq[Image] = {
     val params: Seq[(String, String)] =

--- a/riff-raff/test/lookup/PrismLookupTest.scala
+++ b/riff-raff/test/lookup/PrismLookupTest.scala
@@ -14,7 +14,7 @@ import play.api.routing.sird._
 import play.api.test.WsTestClient
 import play.core.server.Server
 import resources.{Image, PrismLookup}
-import com.typesafe.config.{Config => TypesafeConfig}
+import magenta.SecretProvider
 
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
@@ -22,6 +22,9 @@ import scala.concurrent.duration._
 class PrismLookupTest extends FlatSpec with Matchers {
 
   val config = new Config(configuration = Configuration(("lookup.timeoutSeconds", 10), ("lookup.prismUrl", "")).underlying, DateTime.now)
+  val secretProvider = new SecretProvider {
+    override def lookup(service: String, account: String): Option[String] = None
+  }
 
   def withPrismClient[T](images: List[Image])(block: WSClient => T):(T, Option[Request[AnyContent]]) = {
     var mockRequest: Option[Request[AnyContent]] = None
@@ -54,7 +57,7 @@ class PrismLookupTest extends FlatSpec with Matchers {
       Image("test-early-ami", new DateTime(2017,1,2,13,32,0), Map.empty)
     )
     withPrismClient(images) { client =>
-      val lookup = new PrismLookup(config, client)
+      val lookup = new PrismLookup(config, client, secretProvider)
       val result = lookup.getLatestAmi(None, _ => true)("bob")(Map.empty)
       result shouldBe Some("test-later-still-ami")
     }
@@ -62,7 +65,7 @@ class PrismLookupTest extends FlatSpec with Matchers {
 
   it should "narrows ami query by region" in {
     val (result, request) = withPrismClient(Nil) { client =>
-      val lookup = new PrismLookup(config, client)
+      val lookup = new PrismLookup(config, client, secretProvider)
       lookup.getLatestAmi(None, _ => true)("bob")(Map.empty)
     }
     result shouldBe None
@@ -71,7 +74,7 @@ class PrismLookupTest extends FlatSpec with Matchers {
 
   it should "correctly query using the tags" in {
     val (result, request) = withPrismClient(Nil) { client =>
-      val lookup = new PrismLookup(config, client)
+      val lookup = new PrismLookup(config, client, secretProvider)
       lookup.getLatestAmi(None, _ => true)("bob")(Map("tagName" -> "tagValue?", "tagName*" -> "tagValue2"))
     }
     request.map(_.queryString) shouldBe Some(Map(
@@ -90,7 +93,7 @@ class PrismLookupTest extends FlatSpec with Matchers {
       Image("test-early-ami", new DateTime(2017,1,2,13,32,0), Map.empty)
     )
     withPrismClient(images) { client =>
-      val lookup = new PrismLookup(config, client)
+      val lookup = new PrismLookup(config, client, secretProvider)
       val result = lookup.getLatestAmi(None, CloudFormationDeploymentTypeParameters.unencryptedTagFilter)("bob")(Map.empty)
       result shouldBe Some("test-ami")
     }


### PR DESCRIPTION
This changes the way credentials are built to source them from SSM param store instead of a config file in S3. At a later point we might migrate the whole config to SSM param store but this is the most important bit.

I initially wrote this to support both the config file and SSM but that just added compexity for no reason. I also initially wrote this so that keyrings were built from live data in AWS. I switched to fetch credentials at startup to make it more robust. It could be changed to have a refresh endpoint if so desired.

I've imported credentials for CODE and PROD as of 9am on the 13th Feb and the build is currently on CODE and tested as working.

There are currently no credentials for DEV. When there are, they will at least no longer be on a developers machine, although they will be shared by anyone that works on riff-raff.

## TODO
 - [ ] Remove credentials from config file, perhaps leaving a comment for those that follow