### PR TITLE
Make the build ID available as a RiffRaffBuildId parameter

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -15,6 +15,11 @@ object CloudFormation extends DeploymentType with CloudFormationDeploymentTypePa
   def documentation =
     """Update an AWS CloudFormation template by creating and executing a change set.
       |
+      |This type will populate the following parameters in a cloudformation template:
+      |  - Stage (e.g. `CODE` or `PROD`)
+      |  - Stack (e.g. `deploy` or `frontend`)
+      |  - BuildId (i.e. the number of the build such as `543`)
+      |
       |NOTE: It is strongly recommended you do _NOT_ set a desired-capacity on auto-scaling groups, managed
       |with CloudFormation templates deployed in this way, as otherwise any deployment will reset the
       |capacity to this number, even if scaling actions have triggered, changing the capacity, in the
@@ -98,8 +103,8 @@ object CloudFormation extends DeploymentType with CloudFormationDeploymentTypePa
 
     val changeSetName = s"${target.stack.name}-${new DateTime().getMillis}"
 
-    val unresolvedParameters = new CloudFormationParameters(target.stack, target.parameters.stage, target.region,
-      stackTags, userParams, amiParameterMap, amiLookupFn)
+    val unresolvedParameters = new CloudFormationParameters(target.stack, target.parameters.stage,
+      target.parameters.build, target.region, stackTags, userParams, amiParameterMap, amiLookupFn)
 
     val createNewStack = createStackIfAbsent(pkg, target, reporter)
     val stackLookup = new CloudFormationStackMetadata(cloudFormationStackLookupStrategy, changeSetName, createNewStack)

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -104,22 +104,23 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
 
   import CloudFormationParameters.combineParameters
 
-  "CloudFormationParameters" should "substitute stack and stage parameters" in {
+  "CloudFormationParameters" should "substitute stack, stage and build ID parameters" in {
     val templateParameters =
-      Seq(TemplateParameter("param1", default = false), TemplateParameter("Stack", default = false), TemplateParameter("Stage", default = false))
-    val combined = combineParameters(Stack("cfn"), PROD, templateParameters, Map("param1" -> "value1"))
+      Seq(TemplateParameter("param1", default = false), TemplateParameter("Stack", default = false), TemplateParameter("Stage", default = false), TemplateParameter("BuildId", default = false))
+    val combined = combineParameters(Stack("cfn"), PROD, Build("projectX", "543"), templateParameters, Map("param1" -> "value1"))
 
     combined should be(Map(
       "param1" -> SpecifiedValue("value1"),
       "Stack" -> SpecifiedValue("cfn"),
-      "Stage" -> SpecifiedValue("PROD")
+      "Stage" -> SpecifiedValue("PROD"),
+      "BuildId" -> SpecifiedValue("543")
       ))
   }
 
   it should "default required parameters to use existing parameters" in {
     val templateParameters =
       Seq(TemplateParameter("param1", default = true), TemplateParameter("param3", default = false), TemplateParameter("Stage", default = false))
-    val combined = combineParameters(Stack("cfn"), PROD, templateParameters, Map("param1" -> "value1"))
+    val combined = combineParameters(Stack("cfn"), PROD, Build("projectX", "543"), templateParameters, Map("param1" -> "value1"))
 
     combined should be(Map(
       "param1" -> SpecifiedValue("value1"),


### PR DESCRIPTION
It sometimes makes sense that a cloudformation template needs the current build ID when being updated by Riff-Raff. This provides that data when there is a `BuildId` parameter in a CFN template.

I also updated the docs to actually document this feature.

There is a small risk that we'll start to clobber `BuildId` if this is a parameter on a template that is currently deployed by Riff-Raff. I suspect this is unlikely.