### PR TITLE
Fix preview display when the preview value is a failed future

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,4 @@
+-J-Xms2048m
+-J-Xmx2048m
+-J-XX:ReservedCodeCacheSize=256m
+-J-XX:MaxMetaspaceSize=512M

--- a/riff-raff/app/controllers/DeployController.scala
+++ b/riff-raff/app/controllers/DeployController.scala
@@ -237,7 +237,7 @@ class DeployController(config: Config,
       project -> deployments.getLastCompletedDeploys(project)
     }.filterNot(_._2.isEmpty))
     deploys.fold(
-      (t: Throwable) => InternalServerError(views.html.errorContent(t, "Could not fetch deploys")(config)),
+      (t: Throwable) => InternalServerError(views.html.errorContent(t, "Could not fetch deploys")),
       (ds: List[(String,Map[String,deployment.Record])]) => Ok(views.html.deploy.dashboardContent(config)(ds))
     )
   }

--- a/riff-raff/app/controllers/PreviewController.scala
+++ b/riff-raff/app/controllers/PreviewController.scala
@@ -15,6 +15,7 @@ import play.api.libs.ws.WSClient
 import play.api.mvc.{AnyContent, BaseController, ControllerComponents}
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
 
 class PreviewController(config: Config,
                         menu: Menu,
@@ -61,6 +62,8 @@ class PreviewController(config: Config,
               Ok(views.html.preview.yaml.showTasks(taskGraph, form, deploymentKeys))
             case Invalid(errors) => Ok(views.html.validation.validationErrors(config, menu)(request, errors))
           }
+        }.recover {
+          case NonFatal(t) => Ok(views.html.errorContent(t, "Preview failed"))
         }
       case Some(result) =>
         Future.successful(Ok(views.html.preview.yaml.loading(request, result.duration.getStandardSeconds)))

--- a/riff-raff/app/controllers/api.scala
+++ b/riff-raff/app/controllers/api.scala
@@ -165,7 +165,7 @@ class Api(config: Config,
 
   def listKeys = authAction { implicit request =>
     datastore.getApiKeyList.fold(
-      (t: Throwable) => InternalServerError(views.html.errorContent(t, "Could not fetch API keys")(config)),
+      (t: Throwable) => InternalServerError(views.html.errorContent(t, "Could not fetch API keys")),
       (ks: Iterable[ApiKey]) => Ok(views.html.api.list(config, menu)(request, ks))
     )
   }

--- a/riff-raff/app/controllers/authentication.scala
+++ b/riff-raff/app/controllers/authentication.scala
@@ -93,7 +93,7 @@ class Login(config: Config, menu: Menu, deployments: Deployments, datastore: Dat
   def profile = authAction { request =>
     val records = deployments.getDeploys(Some(DeployFilter(deployer=Some(request.user.fullName)))).map(_.reverse)
     records.fold(
-      (t: Throwable) => InternalServerError(views.html.errorContent(t, "Could not fetch list of deploys")(config)),
+      (t: Throwable) => InternalServerError(views.html.errorContent(t, "Could not fetch list of deploys")),
       (as: List[Record]) => Ok(views.html.auth.profile(config, menu)(request, as))
     )
   }
@@ -102,7 +102,7 @@ class Login(config: Config, menu: Menu, deployments: Deployments, datastore: Dat
 
   def authList = authAction { request =>
     datastore.getAuthorisationList.map(_.sortBy(_.email)).fold(
-      (t: Throwable) => InternalServerError(views.html.errorContent(t, "Could not fetch authorisation list")(config)),
+      (t: Throwable) => InternalServerError(views.html.errorContent(t, "Could not fetch authorisation list")),
       (as: Seq[AuthorisationRecord]) => Ok(views.html.auth.list(config, menu)(request, as))
     )
   }

--- a/riff-raff/app/views/errorContent.scala.html
+++ b/riff-raff/app/views/errorContent.scala.html
@@ -1,5 +1,4 @@
-@import conf.Config
-@(error: Throwable, message: String)(config: Config)
+@(error: Throwable, message: String)
 
 <p>@message</p>
 

--- a/riff-raff/app/views/validation/validationErrors.scala.html
+++ b/riff-raff/app/views/validation/validationErrors.scala.html
@@ -2,21 +2,21 @@
 @import conf.Config
 @(config: Config, menu: Menu)(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], errors: ConfigErrors)
 
-@main("Validation errors", request) {
-    <div class="clearfix"><p>&nbsp;</p></div>
-    @for((context, errors) <- errors.errors.toList.groupBy(_.context)) {
-        <div class="panel panel-danger">
-            <div class="panel-heading">
-                <h3 class="panel-title"><span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span><span>Error in @context</span></h3>
-            </div>
-            <div class="panel-body">
-                <ul>
-                @errors.map { error =>
-                  <li>@error.message</li>
-                }
-                </ul>
-            </div>
+
+<div class="clearfix"><p>&nbsp;</p></div>
+@for((context, errors) <- errors.errors.toList.groupBy(_.context)) {
+    <div class="panel panel-danger">
+        <div class="panel-heading">
+            <h3 class="panel-title"><span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span><span>Error in @context</span></h3>
         </div>
-    }
-    <div class="clearfix"></div>
-}(config, menu)
+        <div class="panel-body">
+            <ul>
+            @errors.map { error =>
+              <li>@error.message</li>
+            }
+            </ul>
+        </div>
+    </div>
+}
+<div class="clearfix"></div>
+


### PR DESCRIPTION
Preview can fail in a couple of different ways, one of which is a deployment graph that can't be built because of a validation error and the other is an exception being thrown somewhere during the preview. I've improved both. 

For the validation error case it was doubling the furniture in a weird way so I've removed the `@main` wrapper around the response. 

In the latter case the refresh endpoint was blowing up with a 500 which the autorefresh script was ignoring. I've added a `recover` clause that deals with the future throwing an exception and simply displays that exception.

As a bonus I added an `.sbtopts` file that sets sensible memory values for SBT so it doesn't blow up all the time.