### PR TITLE
When we are creating we are interested in failures with empty change sets

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
@@ -4,7 +4,7 @@ import magenta.artifact.S3Path
 import magenta.tasks.UpdateCloudFormationTask._
 import magenta.{DeployReporter, KeyRing, Region}
 import software.amazon.awssdk.services.cloudformation.model.ChangeSetStatus._
-import software.amazon.awssdk.services.cloudformation.model.{Change, DeleteChangeSetRequest, DescribeChangeSetRequest, ExecuteChangeSetRequest}
+import software.amazon.awssdk.services.cloudformation.model.{Change, ChangeSetType, DeleteChangeSetRequest, DescribeChangeSetRequest, ExecuteChangeSetRequest}
 import software.amazon.awssdk.services.s3.S3Client
 
 import scala.collection.JavaConverters._
@@ -55,21 +55,24 @@ class CheckChangeSetCreatedTask(
   override def execute(reporter: DeployReporter, stopFlag: => Boolean): Unit = {
     check(reporter, stopFlag) {
       CloudFormation.withCfnClient(keyRing, region) { cfnClient =>
-        val (stackName, _) = stackLookup.lookup(reporter, cfnClient)
+        val (stackName, changeSetType) = stackLookup.lookup(reporter, cfnClient)
         val changeSetName = stackLookup.changeSetName
 
         val request = DescribeChangeSetRequest.builder().changeSetName(changeSetName).stackName(stackName).build()
         val response = cfnClient.describeChangeSet(request)
 
-        shouldStopWaiting(response.status.toString, response.statusReason, response.changes.asScala, reporter)
+        shouldStopWaiting(changeSetType, response.status.toString, response.statusReason, response.changes.asScala, reporter)
       }
     }
   }
 
-  def shouldStopWaiting(status: String, statusReason: String, changes: Iterable[Change], reporter: DeployReporter): Boolean = {
+  def shouldStopWaiting(changeSetType: ChangeSetType, status: String, statusReason: String, changes: Iterable[Change], reporter: DeployReporter): Boolean = {
     Try(valueOf(status)) match {
       case Success(CREATE_COMPLETE) => true
-      case Success(FAILED) if changes.isEmpty => true
+      // special case an empty change list when the status reason is no updates
+      case Success(FAILED) if changes.isEmpty && statusReason == "No updates are to be performed." =>
+        reporter.info(s"Couldn't create change set as the stack is already up to date")
+        true
       case Success(FAILED) => reporter.fail(statusReason)
       case Success(CREATE_IN_PROGRESS | CREATE_PENDING) =>
         reporter.verbose(status)

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -208,24 +208,24 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
 
   "CheckChangeSetCreatedTask" should "pass on CREATE_COMPLETE" in {
     val _ :: (check: CheckChangeSetCreatedTask) :: _ = generateTasks()
-    check.shouldStopWaiting("CREATE_COMPLETE", "", List.empty, reporter) should be(true)
+    check.shouldStopWaiting(ChangeSetType.UPDATE, "CREATE_COMPLETE", "", List.empty, reporter) should be(true)
   }
 
   it should "pass on FAILED if there are no changes to execute" in {
     val _ :: (check: CheckChangeSetCreatedTask) :: _ = generateTasks()
-    check.shouldStopWaiting("FAILED", "", List.empty, reporter) should be(true)
+    check.shouldStopWaiting(ChangeSetType.UPDATE, "FAILED", "No updates are to be performed.", List.empty, reporter) should be(true)
   }
 
   it should "fail on FAILED" in {
     val _ :: (check: CheckChangeSetCreatedTask) :: _ = generateTasks()
 
     intercept[FailException] {
-      check.shouldStopWaiting("FAILED", "", List(Change.builder().build()), reporter)
+      check.shouldStopWaiting(ChangeSetType.UPDATE, "FAILED", "", List(Change.builder().build()), reporter)
     }
   }
 
   it should "continue on CREATE_IN_PROGRESS" in {
     val _ :: (check: CheckChangeSetCreatedTask) :: _ = generateTasks()
-    check.shouldStopWaiting("CREATE_IN_PROGRESS", "", List.empty, reporter) should be(false)
+    check.shouldStopWaiting(ChangeSetType.UPDATE, "CREATE_IN_PROGRESS", "", List.empty, reporter) should be(false)
   }
 }


### PR DESCRIPTION
This narrows the guard for the good empty change set condition to only be when there is a status reason indicating there are no updates. Without this bad templates were passing this step and it looked like a cloudformation update had completed.