### PR TITLE
Fail fast when applying garbage template

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
@@ -66,11 +66,16 @@ class CheckChangeSetCreatedTask(
     }
   }
 
+  def isNoOpStatusReason(status: String): Boolean = {
+    status == "The submitted information didn't contain changes. Submit different information to create a change set." ||
+    status == "No updates are to be performed."
+  }
+
   def shouldStopWaiting(changeSetType: ChangeSetType, status: String, statusReason: String, changes: Iterable[Change], reporter: DeployReporter): Boolean = {
     Try(valueOf(status)) match {
       case Success(CREATE_COMPLETE) => true
       // special case an empty change list when the status reason is no updates
-      case Success(FAILED) if changes.isEmpty && statusReason == "No updates are to be performed." =>
+      case Success(FAILED) if changes.isEmpty && isNoOpStatusReason(statusReason) =>
         reporter.info(s"Couldn't create change set as the stack is already up to date")
         true
       case Success(FAILED) => reporter.fail(statusReason)

--- a/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
@@ -4,7 +4,7 @@ import magenta.artifact.S3Path
 import magenta.tasks.UpdateCloudFormationTask._
 import magenta.{DeployReporter, KeyRing, Region}
 import software.amazon.awssdk.services.cloudformation.model.ChangeSetStatus._
-import software.amazon.awssdk.services.cloudformation.model.{Change, DeleteChangeSetRequest, DescribeChangeSetRequest, ExecuteChangeSetRequest}
+import software.amazon.awssdk.services.cloudformation.model.{Change, ChangeSetType, DeleteChangeSetRequest, DescribeChangeSetRequest, ExecuteChangeSetRequest}
 import software.amazon.awssdk.services.s3.S3Client
 
 import scala.collection.JavaConverters._
@@ -55,21 +55,24 @@ class CheckChangeSetCreatedTask(
   override def execute(reporter: DeployReporter, stopFlag: => Boolean): Unit = {
     check(reporter, stopFlag) {
       CloudFormation.withCfnClient(keyRing, region) { cfnClient =>
-        val (stackName, _) = stackLookup.lookup(reporter, cfnClient)
+        val (stackName, changeSetType) = stackLookup.lookup(reporter, cfnClient)
         val changeSetName = stackLookup.changeSetName
 
         val request = DescribeChangeSetRequest.builder().changeSetName(changeSetName).stackName(stackName).build()
         val response = cfnClient.describeChangeSet(request)
 
-        shouldStopWaiting(response.status.toString, response.statusReason, response.changes.asScala, reporter)
+        shouldStopWaiting(changeSetType, response.status.toString, response.statusReason, response.changes.asScala, reporter)
       }
     }
   }
 
-  def shouldStopWaiting(status: String, statusReason: String, changes: Iterable[Change], reporter: DeployReporter): Boolean = {
+  def shouldStopWaiting(changeSetType: ChangeSetType, status: String, statusReason: String, changes: Iterable[Change], reporter: DeployReporter): Boolean = {
     Try(valueOf(status)) match {
       case Success(CREATE_COMPLETE) => true
-      case Success(FAILED) if changes.isEmpty => true
+      // special case an empty change list when the status reason is no updates
+      case Success(FAILED) if changes.isEmpty && statusReason == "No updates are to be performed." =>
+        reporter.info(s"Couldn't create change set as the stack is already up to date")
+        true
       case Success(FAILED) => reporter.fail(statusReason)
       case Success(CREATE_IN_PROGRESS | CREATE_PENDING) =>
         reporter.verbose(status)

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -208,24 +208,24 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
 
   "CheckChangeSetCreatedTask" should "pass on CREATE_COMPLETE" in {
     val _ :: (check: CheckChangeSetCreatedTask) :: _ = generateTasks()
-    check.shouldStopWaiting("CREATE_COMPLETE", "", List.empty, reporter) should be(true)
+    check.shouldStopWaiting(ChangeSetType.UPDATE, "CREATE_COMPLETE", "", List.empty, reporter) should be(true)
   }
 
   it should "pass on FAILED if there are no changes to execute" in {
     val _ :: (check: CheckChangeSetCreatedTask) :: _ = generateTasks()
-    check.shouldStopWaiting("FAILED", "", List.empty, reporter) should be(true)
+    check.shouldStopWaiting(ChangeSetType.UPDATE, "FAILED", "No updates are to be performed.", List.empty, reporter) should be(true)
   }
 
   it should "fail on FAILED" in {
     val _ :: (check: CheckChangeSetCreatedTask) :: _ = generateTasks()
 
     intercept[FailException] {
-      check.shouldStopWaiting("FAILED", "", List(Change.builder().build()), reporter)
+      check.shouldStopWaiting(ChangeSetType.UPDATE, "FAILED", "", List(Change.builder().build()), reporter)
     }
   }
 
   it should "continue on CREATE_IN_PROGRESS" in {
     val _ :: (check: CheckChangeSetCreatedTask) :: _ = generateTasks()
-    check.shouldStopWaiting("CREATE_IN_PROGRESS", "", List.empty, reporter) should be(false)
+    check.shouldStopWaiting(ChangeSetType.UPDATE, "CREATE_IN_PROGRESS", "", List.empty, reporter) should be(false)
   }
 }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -214,6 +214,14 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
   it should "pass on FAILED if there are no changes to execute" in {
     val _ :: (check: CheckChangeSetCreatedTask) :: _ = generateTasks()
     check.shouldStopWaiting(ChangeSetType.UPDATE, "FAILED", "No updates are to be performed.", List.empty, reporter) should be(true)
+    check.shouldStopWaiting(ChangeSetType.UPDATE, "FAILED", "The submitted information didn't contain changes. Submit different information to create a change set.", List.empty, reporter) should be(true)
+  }
+
+  it should "fail on a template error" in {
+    val _ :: (check: CheckChangeSetCreatedTask) :: _ = generateTasks()
+    intercept[FailException] {
+      check.shouldStopWaiting(ChangeSetType.UPDATE, "FAILED", "A different error about your template.", List.empty, reporter) should be(true)
+    }
   }
 
   it should "fail on FAILED" in {


### PR DESCRIPTION
Second attempt at #576 where we distinguish between the conditions of failed empty change sets so that we allow no-op changes to succeed whilst also failing fast for garbage templates.