### PR TITLE
Restructure CloudFormation param logic

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -103,8 +103,7 @@ object CloudFormation extends DeploymentType with CloudFormationDeploymentTypePa
 
     val changeSetName = s"${target.stack.name}-${new DateTime().getMillis}"
 
-    val unresolvedParameters = new CloudFormationParameters(target.stack, target.parameters.stage,
-      target.parameters.build, target.region, stackTags, userParams, amiParameterMap, amiLookupFn)
+    val unresolvedParameters = new CloudFormationParameters(target, stackTags, userParams, amiParameterMap, amiLookupFn)
 
     val createNewStack = createStackIfAbsent(pkg, target, reporter)
     val stackLookup = new CloudFormationStackMetadata(cloudFormationStackLookupStrategy, changeSetName, createNewStack)

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -393,14 +393,14 @@ object CloudFormation {
     )
 
   def createChangeSet(reporter: DeployReporter, name: String, tpe: ChangeSetType, stackName: String, maybeTags: Option[Map[String, String]],
-                      template: Template, parameters: Iterable[Parameter], client: CloudFormationClient): Unit = {
+                      template: Template, parameters: List[Parameter], client: CloudFormationClient): Unit = {
 
     val request = CreateChangeSetRequest.builder()
       .changeSetName(name)
       .changeSetType(tpe)
       .stackName(stackName)
       .capabilities(Capability.CAPABILITY_NAMED_IAM)
-      .parameters(parameters.toSeq.asJava)
+      .parameters(parameters.asJava)
 
     val tags: Iterable[CfnTag] = maybeTags
       .getOrElse(Map.empty)

--- a/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
@@ -38,13 +38,14 @@ class CreateChangeSetTask(
             reporter.fail(_),
             identity
           )
+          val awsParameters = CloudFormationParameters.convertInputParametersToAws(parameters)
 
           reporter.info("Creating Cloudformation change set")
           reporter.info(s"Stack name: $stackName")
           reporter.info(s"Change set name: ${stackLookup.changeSetName}")
-          reporter.info(s"Parameters: $parameters")
+          reporter.info(s"Parameters: $awsParameters")
 
-          CloudFormation.createChangeSet(reporter, stackLookup.changeSetName, changeSetType, stackName, unresolvedParameters.stackTags, template, parameters, cfnClient)
+          CloudFormation.createChangeSet(reporter, stackLookup.changeSetName, changeSetType, stackName, unresolvedParameters.stackTags, template, awsParameters, cfnClient)
         }
       }
     }

--- a/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
@@ -43,7 +43,11 @@ class CreateChangeSetTask(
           reporter.info("Creating Cloudformation change set")
           reporter.info(s"Stack name: $stackName")
           reporter.info(s"Change set name: ${stackLookup.changeSetName}")
-          reporter.info(s"Parameters: $awsParameters")
+          val parametersString = awsParameters.map { param =>
+            val v = if (param.usePreviousValue) "PreviousValue" else s"""Value: "${param.parameterValue}""""
+            s"${param.parameterKey} -> $v"
+          }.mkString("; ")
+          reporter.info(s"Parameters: $parametersString")
 
           CloudFormation.createChangeSet(reporter, stackLookup.changeSetName, changeSetType, stackName, unresolvedParameters.stackTags, template, awsParameters, cfnClient)
         }

--- a/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
@@ -34,7 +34,10 @@ class CreateChangeSetTask(
           val templateParameters = CloudFormation.validateTemplate(template, cfnClient).parameters.asScala.toList
             .map(tp => TemplateParameter(tp.parameterKey, Option(tp.defaultValue).isDefined))
 
-          val parameters = CloudFormationParameters.resolve(unresolvedParameters, accountNumber, changeSetType, reporter, templateParameters)
+          val parameters = CloudFormationParameters.resolve(unresolvedParameters, accountNumber, changeSetType, templateParameters).fold(
+            reporter.fail(_),
+            identity
+          )
 
           reporter.info("Creating Cloudformation change set")
           reporter.info(s"Stack name: $stackName")

--- a/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
@@ -30,7 +30,7 @@ class CreateChangeSetTask(
           val (stackName, changeSetType) = stackLookup.lookup(reporter, cfnClient)
 
           val template = processTemplate(stackName, templateString, s3Client, stsClient, region, reporter)
-          val parameters = unresolvedParameters.resolve(template, accountNumber, changeSetType, reporter, cfnClient)
+          val parameters = CloudFormationParameters.resolve(unresolvedParameters, template, accountNumber, changeSetType, reporter, cfnClient)
 
           reporter.info("Creating Cloudformation change set")
           reporter.info(s"Stack name: $stackName")

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -103,7 +103,7 @@ class CloudFormationParameters(stack: Stack, stage: Stage, build: Build, region:
                                latestImage: String => String => Map[String,String] => Option[String]) {
   import CloudFormationParameters._
 
-  def resolve(template: Template, accountNumber: String, changeSetType: ChangeSetType, reporter: DeployReporter, cfnClient: CloudFormationClient): Iterable[Parameter] = {
+  def resolve(template: Template, accountNumber: String, changeSetType: ChangeSetType, reporter: DeployReporter, cfnClient: CloudFormationClient): List[Parameter] = {
     val templateParameters = CloudFormation.validateTemplate(template, cfnClient).parameters.asScala
       .map(tp => TemplateParameter(tp.parameterKey, Option(tp.defaultValue).isDefined))
 
@@ -117,8 +117,8 @@ class CloudFormationParameters(stack: Stack, stage: Stage, build: Build, region:
 }
 
 object CloudFormationParameters {
-  def convertParameters(parameters: Map[String, ParameterValue], tpe: ChangeSetType, reporter: DeployReporter): Iterable[Parameter] = {
-    parameters map {
+  def convertParameters(parameters: Map[String, ParameterValue], tpe: ChangeSetType, reporter: DeployReporter): List[Parameter] = {
+    parameters.toList map {
       case (k, SpecifiedValue(v)) =>
         Parameter.builder().parameterKey(k).parameterValue(v).build()
 

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -6,7 +6,7 @@ import magenta._
 import magenta.artifact.S3Path
 import magenta.fixtures._
 import magenta.tasks.CloudFormation.{SpecifiedValue, UseExistingValue}
-import magenta.tasks.CloudFormationParameters.TemplateParameter
+import magenta.tasks.CloudFormationParameters.{InputParameter, TemplateParameter}
 import magenta.tasks.UpdateCloudFormationTask._
 import magenta.tasks._
 import org.scalatest.{EitherValues, FlatSpec, Inside, Matchers}
@@ -134,14 +134,14 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside with EitherV
 
   import CloudFormationParameters.convertParameters
 
-  it should "convert specified parameter" in {
+  "CloudFormationParameters convertParameters" should "convert specified parameter" in {
     convertParameters(Map("key" -> SpecifiedValue("value")), ChangeSetType.UPDATE).right.value should
-      contain only Parameter.builder().parameterKey("key").parameterValue("value").build()
+      contain only InputParameter("key", "value")
   }
 
   it should "use existing value" in {
     convertParameters(Map("key" -> UseExistingValue), ChangeSetType.UPDATE).right.value should
-      contain only Parameter.builder().parameterKey("key").usePreviousValue(true).build()
+      contain only InputParameter.usePreviousValue("key")
   }
 
   it should "fail if using existing value on stack creation" in {

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -6,6 +6,7 @@ import magenta._
 import magenta.artifact.S3Path
 import magenta.fixtures._
 import magenta.tasks.CloudFormation.{SpecifiedValue, UseExistingValue}
+import magenta.tasks.CloudFormationParameters.TemplateParameter
 import magenta.tasks.UpdateCloudFormationTask._
 import magenta.tasks._
 import org.scalatest.{FlatSpec, Inside, Matchers}

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -111,7 +111,7 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside with EitherV
     val deployParameters = Map("Stack" -> "cfn", "Stage" -> "PROD", "BuildId" -> "543")
     val combined = combineParameters(deployParameters, templateParameters, Map("param1" -> "value1"))
 
-    combined should be(Map(
+    combined.right.value should be(Map(
       "param1" -> SpecifiedValue("value1"),
       "Stack" -> SpecifiedValue("cfn"),
       "Stage" -> SpecifiedValue("PROD"),
@@ -125,7 +125,7 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside with EitherV
     val deployParameters = Map("Stack" -> "cfn", "Stage" -> "PROD", "BuildId" -> "543")
     val combined = combineParameters(deployParameters, templateParameters, Map("param1" -> "value1"))
 
-    combined should be(Map(
+    combined.right.value should be(Map(
       "param1" -> SpecifiedValue("value1"),
       "param3" -> UseExistingValue,
       "Stage" -> SpecifiedValue(PROD.name)

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -104,10 +104,11 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
 
   import CloudFormationParameters.combineParameters
 
-  "CloudFormationParameters" should "substitute stack, stage and build ID parameters" in {
+  "CloudFormationParameters combineParameters" should "substitute stack, stage and build ID parameters" in {
     val templateParameters =
-      Seq(TemplateParameter("param1", default = false), TemplateParameter("Stack", default = false), TemplateParameter("Stage", default = false), TemplateParameter("BuildId", default = false))
-    val combined = combineParameters(Stack("cfn"), PROD, Build("projectX", "543"), templateParameters, Map("param1" -> "value1"))
+      List(TemplateParameter("param1", default = false), TemplateParameter("Stack", default = false), TemplateParameter("Stage", default = false), TemplateParameter("BuildId", default = false))
+    val deployParameters = Map("Stack" -> "cfn", "Stage" -> "PROD", "BuildId" -> "543")
+    val combined = combineParameters(deployParameters, templateParameters, Map("param1" -> "value1"))
 
     combined should be(Map(
       "param1" -> SpecifiedValue("value1"),
@@ -119,8 +120,9 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside {
 
   it should "default required parameters to use existing parameters" in {
     val templateParameters =
-      Seq(TemplateParameter("param1", default = true), TemplateParameter("param3", default = false), TemplateParameter("Stage", default = false))
-    val combined = combineParameters(Stack("cfn"), PROD, Build("projectX", "543"), templateParameters, Map("param1" -> "value1"))
+      List(TemplateParameter("param1", default = true), TemplateParameter("param3", default = false), TemplateParameter("Stage", default = false))
+    val deployParameters = Map("Stack" -> "cfn", "Stage" -> "PROD", "BuildId" -> "543")
+    val combined = combineParameters(deployParameters, templateParameters, Map("param1" -> "value1"))
 
     combined should be(Map(
       "param1" -> SpecifiedValue("value1"),


### PR DESCRIPTION
This PR lays the groundwork for a logic change to fix a long standing corner case where a default parameter in a CloudFormation template takes priority over a manually set value in a live CloudFormation stack.

There are no intentional functional changes in this PR - it is designed to restructure the code to make it easier to test and reason about ahead of fixing the bug in question. 

Some notable changes:
 - Switch most things from `Seq`/`Iterable` to `List` for consistency
 - Move logic out of a class and into the companion object
 - Move calls to AWS outside the main logic
 - Move the reporter failure call outside main logic so we don't deliberately throw exceptions
 - Pass through the list of existing parameters from the live stack - this is not used but is required to fix this bug so will make the next PR more focussed

I've broken the PR into a number of commits with the aim that each individual change is small enough to reason about and I would highly recommend that you review it using that approach initially.