### PR TITLE
Change param logic to stop default template values overriding live stack values

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
@@ -1,7 +1,7 @@
 package magenta.tasks
 
 import magenta.artifact.S3Path
-import magenta.tasks.CloudFormationParameters.TemplateParameter
+import magenta.tasks.CloudFormationParameters.{ExistingParameter, InputParameter, TemplateParameter}
 import magenta.tasks.UpdateCloudFormationTask._
 import magenta.{DeployReporter, KeyRing, Region}
 import software.amazon.awssdk.services.cloudformation.model.ChangeSetStatus._
@@ -43,15 +43,35 @@ class CreateChangeSetTask(
           reporter.info("Creating Cloudformation change set")
           reporter.info(s"Stack name: $stackName")
           reporter.info(s"Change set name: ${stackLookup.changeSetName}")
+
           val parametersString = awsParameters.map { param =>
             val v = if (param.usePreviousValue) "PreviousValue" else s"""Value: "${param.parameterValue}""""
             s"${param.parameterKey} -> $v"
           }.mkString("; ")
           reporter.info(s"Parameters: $parametersString")
 
+          changedParamValues(existingParameters, parameters).foreach { change =>
+            reporter.info(change)
+          }
+
           CloudFormation.createChangeSet(reporter, stackLookup.changeSetName, changeSetType, stackName, unresolvedParameters.stackTags, template, awsParameters, cfnClient)
         }
       }
+    }
+  }
+
+  def changedParamValues(existingParams: List[ExistingParameter], newParams: List[InputParameter]): List[String] = {
+    val keys = (existingParams.map(_.key) ::: newParams.map(_.key)).sorted.distinct
+    val pairs = keys.map { key =>
+      (key, existingParams.find(_.key == key), newParams.find(_.key == key))
+    }
+    pairs.flatMap {
+      case (key, Some(_), None) => Some(s"Parameter $key has been removed")
+      case (key, None, Some(_)) => Some(s"Parameter $key has been added")
+      case (key, Some(ExistingParameter(_, present, _)), Some(InputParameter(_, Some(future), false)))
+        if future != present && present != "****" =>
+          Some(s"Parameter $key has changed from $present to $future")
+      case _ => None
     }
   }
 

--- a/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
@@ -34,7 +34,7 @@ class CreateChangeSetTask(
           val templateParameters = CloudFormation.validateTemplate(template, cfnClient).parameters.asScala.toList
             .map(tp => TemplateParameter(tp.parameterKey, Option(tp.defaultValue).isDefined))
 
-          val parameters = CloudFormationParameters.resolve(unresolvedParameters, accountNumber, changeSetType, templateParameters, existingParameters).fold(
+          val parameters = CloudFormationParameters.resolve(unresolvedParameters, accountNumber, templateParameters, existingParameters).fold(
             reporter.fail(_),
             identity
           )

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -4,7 +4,7 @@ import com.gu.management.Loggable
 import magenta.deployment_type.CloudFormationDeploymentTypeParameters._
 import magenta.tasks.CloudFormation._
 import magenta.tasks.UpdateCloudFormationTask.{CloudFormationStackLookupStrategy, LookupByName, LookupByTags}
-import magenta.{Build, DeployReporter, DeployTarget, DeploymentPackage, KeyRing, Region, Stack, Stage}
+import magenta.{DeployReporter, DeployTarget, DeploymentPackage, KeyRing, Region, Stack, Stage}
 import org.joda.time.{DateTime, Duration}
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient
@@ -12,10 +12,6 @@ import software.amazon.awssdk.services.cloudformation.model.{ChangeSetType, Clou
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.sts.StsClient
-import cats.instances.either._
-import cats.instances.list._
-import cats.syntax.either._
-import cats.syntax.traverse._
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._


### PR DESCRIPTION
This PR changes the logic that resolves the set of parameters to use when creating a CloudFormation change set. It fixes a long standing bug where a default value for a parameter in the template took priority over a live value in the CloudFormation stack.

Note that this PR cannot be merged until #579 as it builds on restructuring that was introduced there.

This is a relatively risky change so it would be good to have a couple of pairs of eyes on it. 

 - [x] Try this on a handful of CODE stacks using Riff-Raff CODE prior to merging.