### PR TITLE
URL decode the key to download to work with spaces in the project name

### DIFF
--- a/riff-raff/app/controllers/DeployController.scala
+++ b/riff-raff/app/controllers/DeployController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import java.net.URLEncoder
+import java.net.{URLDecoder, URLEncoder}
 import java.util.UUID
 
 import akka.stream.scaladsl.{Source, StreamConverters}
@@ -283,9 +283,9 @@ class DeployController(config: Config,
   def getArtifactFile(key: String) = AuthAction { implicit request =>
     val getObjectRequest = GetObjectRequest.builder()
       .bucket(config.artifact.aws.bucketName)
-      .key(UriEncoding.decodePathSegment(key, "utf-8"))
+      .key(URLDecoder.decode(key, "utf-8"))
       .build()
-    
+
     val stream = config.artifact.aws.client.getObject(getObjectRequest)
     val source: Source[ByteString, _] = StreamConverters.fromInputStream(() => stream)
     Ok.sendEntity(HttpEntity.Streamed(source, None, Some(""))).as(stream.response.contentType)


### PR DESCRIPTION
If the project name contains URL-encoded characters (for example spaces) it returns a `key not found` error when you try to download an artifact.

For example in the artifacts page for a [Editorial Tools::Flexible Content](https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=Editorial+Tools%3A%3AFlexible+Content&id=8712) deploy, the links to the `.deb` files have the space in the project name encoded as `%20`:

```
https://riffraff.gutools.co.uk/deployment/request/artifactFile/Editorial%20Tools::Flexible%20Content/8712/composer-backend/composer-backend.deb
```

but when you follow that link, Riff-Raff throws an error:

```

software.amazon.awssdk.services.s3.model.NoSuchKeyException: The specified key does not exist. (Service: S3, Status Code: 404, Request ID: 4492446BC2D432A4)

software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.handleErrorResponse(HandleResponseStage.java:115)
software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.handleResponse(HandleResponseStage.java:73)
software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.execute(HandleResponseStage.java:58)
software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.execute(HandleResponseStage.java:41)
software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:64)
software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:36)
software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:77)
software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:39)
software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage$RetryExecutor.doExecute(RetryableStage.java:113)
software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage$RetryExecutor.execute(RetryableStage.java:86)
software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:62)
software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:42)
software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:57)
software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:37)
software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.executeWithTimer(ApiCallTimeoutTrackingStage.java:80)
software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:60)
software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:42)
software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:37)
software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:26)
software.amazon.awssdk.core.internal.http.AmazonSyncHttpClient$RequestExecutionBuilderImpl.execute(AmazonSyncHttpClient.java:240)
software.amazon.awssdk.core.client.handler.BaseSyncClientHandler.invoke(BaseSyncClientHandler.java:96)
software.amazon.awssdk.core.client.handler.BaseSyncClientHandler.execute(BaseSyncClientHandler.java:120)
software.amazon.awssdk.core.client.handler.BaseSyncClientHandler.execute(BaseSyncClientHandler.java:61)
software.amazon.awssdk.core.client.handler.SdkSyncClientHandler.execute(SdkSyncClientHandler.java:51)
software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler.execute(AwsSyncClientHandler.java:62)
software.amazon.awssdk.services.s3.DefaultS3Client.getObject(DefaultS3Client.java:1597)
software.amazon.awssdk.services.s3.S3Client.getObject(S3Client.java:2363)
controllers.DeployController.$anonfun$getArtifactFile$1(DeployController.scala:284)
scala.Function1.$anonfun$andThen$1(Function1.scala:57)
scala.util.Either.fold(Either.scala:191)
play.api.mvc.ActionRefiner.$anonfun$invokeBlock$3(Action.scala:522)
scala.concurrent.Future.$anonfun$flatMap$1(Future.scala:307)
scala.concurrent.impl.Promise.$anonfun$transformWith$1(Promise.scala:41)
scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:55)
akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:91)
scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:85)
akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:91)
akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:40)
akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:44)
akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```

whereas the links for a deploy of [investigations::pfi-playground](https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=investigations%3A%3Apfi-giant&id=2828) (no spaces) will download the file.

This happens because Riff-Raff is using the url-encoded path to the artifact directly as the key for the request to S3. This PR changes the route to URL decode the path.

The artifact browsing UI already works. It passes the project name as a query parameter and presumably Play already decodes that for us. The download endpoint uses a splat match in the routes which doesn't seem to decode automatically:

https://github.com/guardian/riff-raff/blob/2aeac787f54e7bd10ee1c541160f8fd750e6c33c/riff-raff/conf/routes#L51

We have had similar problems with this in Giant and have considered using a `Uri` wrapper class with a custom Play `Binder` that does the decoding. It would be great if there was a built-in way of doing this for splats in Play though, perhaps I've missed it.