### PR TITLE
Should be possible to remove existing parameters from a stack

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -165,8 +165,10 @@ object CloudFormationParameters {
 
     // Start with the complete list of keys that must be found or have default values
     val allRequiredParamNames = templateParameters.map(_.key).toSet
-    // use existing value for all values in the existing parameter list
-    val existingParametersMap: Map[String, ParameterValue] = existingParameters.map(ep => ep.key -> UseExistingValue).toMap
+    // use existing value for all template values in the existing parameter list
+    val existingParametersMap: Map[String, ParameterValue] = existingParameters
+      .collect { case ExistingParameter(key, _, _) if allRequiredParamNames.contains(key) => key -> UseExistingValue }
+      .toMap
     // Convert the full list of specified parameters
     val specifiedParametersMap: Map[String, ParameterValue] = specifiedParameters.mapValues(SpecifiedValue.apply)
     // Get the deployment parameters that are present in the template

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -239,6 +239,20 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside with EitherV
     ))
   }
 
+  it should "allow parameters to be removed from the template" in {
+    val deployParameters = Map("Stack" -> "cfn", "Stage" -> "PROD", "BuildId" -> "543")
+    val existingParameter =
+      List(ExistingParameter("param1", "monkey", None), ExistingParameter("param2", "monkey", None), ExistingParameter("param3", "old-param", None))
+    val templateParameters =
+      List(TemplateParameter("param1", default = false), TemplateParameter("param2", default = false))
+    val combined = combineParameters(deployParameters, existingParameter, templateParameters, Map.empty)
+
+    combined.right.value shouldBe Map(
+      "param1" -> UseExistingValue,
+      "param2" -> UseExistingValue,
+    )
+  }
+
   import CloudFormationParameters.convertParameters
 
   "CloudFormationParameters convertParameters" should "convert specified parameter" in {


### PR DESCRIPTION
There was a corner case where it wasn't possible to deploy when a parameter was removed from a template due to the change introduced by #580.

This is a relatively small change that only reapplies existing parameter values when the parameter exists in the template.