### PR TITLE
adjust filter in TargetController

### DIFF
--- a/riff-raff/app/controllers/TargetController.scala
+++ b/riff-raff/app/controllers/TargetController.scala
@@ -41,7 +41,7 @@ class TargetController(config: Config,
     val maybeTargetId = targetDynamoRepository.get(targetKey, projectName)
     maybeTargetId.map { targetId =>
       // find recent deploys of this project / stage
-      val filter = DeployFilter(projectName = Some(s"^${targetId.projectName}$$"), stage = Some(stage))
+      val filter = DeployFilter(projectName = Some(targetId.projectName), stage = Some(stage))
       val records = deployments.getDeploys(Some(filter), PaginationView(pageSize = Some(20))).logAndSquashException(Nil).reverse
       Ok(views.html.deployTarget.selectVersion(config, menu)(targetId, stage, records, request))
     }.getOrElse(NotFound(s"No target found for $targetKey and $projectName"))

--- a/riff-raff/app/controllers/TargetController.scala
+++ b/riff-raff/app/controllers/TargetController.scala
@@ -41,7 +41,7 @@ class TargetController(config: Config,
     val maybeTargetId = targetDynamoRepository.get(targetKey, projectName)
     maybeTargetId.map { targetId =>
       // find recent deploys of this project / stage
-      val filter = DeployFilter(projectName = Some(targetId.projectName), stage = Some(stage))
+      val filter = DeployFilter(projectName = Some(targetId.projectName), stage = Some(stage), isExactMatchProjectName = Some(true))
       val records = deployments.getDeploys(Some(filter), PaginationView(pageSize = Some(20))).logAndSquashException(Nil).reverse
       Ok(views.html.deployTarget.selectVersion(config, menu)(targetId, stage, records, request))
     }.getOrElse(NotFound(s"No target found for $targetKey and $projectName"))


### PR DESCRIPTION
Use the exact projectName when filtering for recent deploys, we've already retrieved an entry from the dynamo repository (in the lines before this) so we can use the exact projectName rather than regex it as we've validated it exists.

# Before
`DeployFilter(Some(^editorial-tools:remote-machines$),None,Some(PROD),None,None,None,None)`

# After
`DeployFilter(Some(editorial-tools:remote-machines),None,Some(PROD),None,None,None,None)`

Related to https://github.com/guardian/amiable/pull/55.