### PR TITLE
add --debug flag to make interactive debugging easier

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,8 +58,8 @@ How do I run Riff-Raff locally if I want to hack on it?
 Assuming you have a reasonably recent version of Java installed, 
 
  * Create a basic configuration file at ~/.gu/riff-raff.conf (S3 and postgres config is probably the minimum)
- * Run `./script/start` from the project root
- * visit http://localhost:9000/
+ * Run `./script/start` from the project root (add `--debug` to attach a remote debugger on port 9999)
+ * Visit http://localhost:9000/
  * Details of how to configure Riff-Raff can then be found at http://localhost:9000/docs/riffraff/properties 
 
 

--- a/sbt-debug
+++ b/sbt-debug
@@ -3,4 +3,4 @@
 
 export SBT_EXTRA_PARAMS="$SBT_EXTRA_PARAMS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=9999"
 
-./sbt
+./sbt "$@"

--- a/script/start
+++ b/script/start
@@ -2,5 +2,18 @@
 
 set -e
 
+for arg in "$@"; do
+  if [ "$arg" == "--debug" ]; then
+    IS_DEBUG=true
+    shift
+  fi
+done
+
 docker-compose up -d
-./sbt "project riffraff" "run"
+
+if [ "$IS_DEBUG" == true ] ; then
+  ./sbt-debug "project riffraff" "run"
+else
+  ./sbt "project riffraff" "run"
+fi
+


### PR DESCRIPTION
Running `./script/start --debug` will allow you to attach a remote debugger on port 9999.

An alternative to this would be to have a `./script/debug` script instead - thoughts welcome!