### PR TITLE
Update multiple lambdas by tag

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -31,7 +31,7 @@ trait Lambda extends DeploymentType with BucketParameters {
   )
 
   val lookupByTags = Param[Boolean]("lookupByTags",
-    """When true, this will lookup the function to deploy to by using the Stack, Stage and App tags on a function.
+    """When true, this will lookup the functions to deploy to by using the Stack, Stage and App tags.
       |The values looked up come from the `stacks` and `app` in the riff-raff.yaml and the stage deployed to.
     """.stripMargin
   ).default(false)

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -118,7 +118,7 @@ object Lambda {
       .s3Key(s3Key)
       .build()
 
-  def findFunctionByTags(tags: Map[String, String], reporter: DeployReporter, client: LambdaClient): Option[FunctionConfiguration] = {
+  def findFunctionsByTags(tags: Map[String, String], reporter: DeployReporter, client: LambdaClient): List[FunctionConfiguration] = {
 
     def tagsMatch(function: FunctionConfiguration): Boolean = {
       val tagResponse = client.listTags(ListTagsRequest.builder().resource(function.functionArn).build())
@@ -127,17 +127,7 @@ object Lambda {
     }
 
     val response = client.listFunctionsPaginator()
-    val matchingConfigurations = response.functions().asScala.filter(tagsMatch).toList
-
-    matchingConfigurations match {
-      case functionConfiguration :: Nil =>
-        reporter.verbose(s"Found function ${functionConfiguration.functionName} (${functionConfiguration.functionArn})")
-        Some(functionConfiguration)
-      case Nil =>
-        None
-      case multiple =>
-        reporter.fail(s"More than one function matched for $tags (matched ${multiple.map(_.functionName).mkString(", ")}). Failing fast since this may be non-deterministic.")
-    }
+    response.functions().asScala.filter(tagsMatch).toList
   }
 }
 


### PR DESCRIPTION
I am building a Step Functions pipeline with multiple lambdas (https://github.com/guardian/investigations-platform/pull/234). Each lambda has a different handler from a single bundle I build using [zeit/ncc](https://github.com/zeit/ncc).

At the moment even though Riff-Raff looks up the lambdas to update using tags it will fail if more than one lambda has the same tag:

```
More than one function matched for Map(Stack -> pfi, App -> pfi-video-pipeline, Stage -> PROD) (matched pfi-video-pipeline-PROD-CheckProgressFunctionAABF1-5GNB10FB5STK, pfi-video-pipeline-PROD-TriggerTranscribeFunctionD-1SET5CFQHJ43A). Failing fast since this may be non-deterministic.
```

(https://riffraff.gutools.co.uk/deployment/view/869b91c2-f0d9-49cf-abc1-d6ac9b6e2117)

For my use case it would be easiest to tag all my functions with the same Stack, App, Stage and have Riff-Raff update them all with my bundle.

The code to look up lambdas by tag is not called anywhere else in Riff-Raff apart from the `aws-lambda` task.

I can't remember why this check was added originally in https://github.com/guardian/riff-raff/pull/547):

> we must fetch all to ensure there isn't a second lambda with the same tags to prevent non-deterministic deployments

Hopefully this PR can be a discussion about it and any pros and cons of this change I have not thought of yet 😃 