### PR TITLE
Fix DeployFilter for housekeeping query

### DIFF
--- a/riff-raff/app/housekeeping/ArtifactHousekeeping.scala
+++ b/riff-raff/app/housekeeping/ArtifactHousekeeping.scala
@@ -53,7 +53,7 @@ object ArtifactHousekeeping {
   def getBuildIdsToKeep(deployments: Deployments, projectName: String, numberToScan: Int, numberToKeep: Int): Either[Throwable, List[String]] = {
     for {
       deployList <- deployments.getDeploys(
-        filter = Some(DeployFilter(projectName = Some(s"^$projectName$$"), status = Some(RunState.Completed))),
+        filter = Some(DeployFilter(projectName = Some(s"$projectName"), isExactMatchProjectName = Some(true), status = Some(RunState.Completed))),
         pagination = PaginationView(pageSize = Some(numberToScan))
       )
     } yield {


### PR DESCRIPTION
## What is the problem?
Riffraff was not deleting old deploys in S3 (see this [issue on the DevX trello board](https://trello.com/c/XVO7tSSt)), so our S3 storage has been gradually climbing. See this chart below:
<img width="1440" alt="Screenshot_2020-06-12_at_12 06 30" src="https://user-images.githubusercontent.com/42121379/85151506-c4119780-b24b-11ea-85ad-a415bc829ff0.png">

## How did we solve it?
We realised that the DeployFunction was doing a fuzzy match on the app name. The SQL looked like this, for example: `'%^Apps::iOS::master-debug$%'` which is invalid for a [`LIKE` fuzzy match](https://www.postgresql.org/docs/8.3/functions-matching.html) as the `^` and `$` aren't supported. Therefore, the function wasn't capturing any deploys to delete.

To do an exact match we needed to remove the `%` characters, which is provided by the `isExactMatchProjectName` property. We changed this so that the SQL became `'Apps::iOS::master-debug'` and we added a parameter to get the exact project name.
