### PR TITLE
Add logging for Grafana annotations

### DIFF
--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -14,7 +14,7 @@ import housekeeping.ArtifactHousekeeping
 import lifecycle.ShutdownWhenInactive
 import magenta.deployment_type._
 import magenta.tasks.AWS
-import notification.{DeployFailureNotifications, HooksClient}
+import notification.{DeployFailureNotifications, GrafanaAnnotationLogger, HooksClient}
 import persistence._
 import play.api.ApplicationLoader.Context
 import play.api.db.evolutions.EvolutionsComponents
@@ -154,6 +154,7 @@ class AppComponents(context: Context, config: Config, passwordProvider: Password
     builds,
     targetResolver,
     DeployMetrics,
+    new GrafanaAnnotationLogger,
     hooksClient,
     new SummariseDeploysHousekeeping(config, datastore),
     continuousDeployment,

--- a/riff-raff/app/notification/GrafanaAnnotationLogger.scala
+++ b/riff-raff/app/notification/GrafanaAnnotationLogger.scala
@@ -1,0 +1,49 @@
+package notification
+
+import controllers.Logging
+import lifecycle.Lifecycle
+import magenta.ContextMessage.{FailContext, FinishContext, StartContext}
+import magenta.{DeployParameters, DeployReporter}
+import magenta.Message.Deploy
+import net.logstash.logback.marker.LogstashMarker
+import net.logstash.logback.marker.Markers.appendEntries
+import play.api.MarkerContext
+import rx.lang.scala.Subscription
+
+import scala.collection.JavaConverters._
+
+trait LogMarker {
+  def toLogMarker: LogstashMarker = appendEntries(markerContents.asJava)
+
+  def markerContents: Map[String, Any]
+}
+
+class GrafanaAnnotationLogger extends Lifecycle with Logging {
+
+  val messageSub: Subscription = DeployReporter.messages.subscribe(message => {
+    message.stack.top match {
+      case StartContext(Deploy(parameters)) =>
+        log.info("Started deploy")(buildMarker(parameters))
+      case FailContext(Deploy(parameters)) =>
+        log.info("Failed deploy")(buildMarker(parameters))
+      case FinishContext(Deploy(parameters)) =>
+        log.info("Finished deploy")(buildMarker(parameters))
+      case _ =>
+    }
+  })
+
+  private def buildMarker(parameters: DeployParameters): MarkerContext = {
+    val params: Map[String, Any] =
+      Map(
+        "projectName" -> parameters.build.projectName,
+        "projectBuild" -> parameters.build.id,
+        "projectStage" -> parameters.stage.name,
+        "projectDeployer" -> parameters.deployer.name
+      )
+    MarkerContext(appendEntries(params.asJava))
+  }
+
+  override def init(): Unit = {}
+
+  override def shutdown() { messageSub.unsubscribe() }
+}


### PR DESCRIPTION
## What does this change?

Grafana has an [annotations](https://grafana.com/docs/grafana/latest/reference/annotations/) feature that allows users to show lines on panels. We would like to add deployment lines to panels so that it is easier for users to correlate deployments with changes in metrics.

This is currently done using a bit of a hacky query (`"Editorial Tools::Integration Tests" AND "Started deploying" AND app:"riff-raff"`) in Grafana, and the log lines do not necessarily dictate the actual start of a deployment.

This PR adds loglines to  

## How can we measure success?

Deploys in Riff-Raff create log entries as shown below, so that Grafana can query them for deployment annotations.

## Images

Before: using the message field in the logs to parse tags
![image](https://user-images.githubusercontent.com/25747336/86120272-ea48fa00-bacb-11ea-85bd-ca7ae5e58cea.png)

New: example loglines (from Riff-Raff CODE deploys)
![image](https://user-images.githubusercontent.com/25747336/86127273-86c4c980-bad7-11ea-8ced-e75042e5cd9e.png)


