### PR TITLE
Ensure that tags are acutally consumed

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -395,9 +395,13 @@ object CloudFormation {
         .build()
     )
 
-  def createChangeSet(reporter: DeployReporter, name: String, tpe: ChangeSetType, stackName: String, maybeTags: Option[Map[String, String]],
-                      template: Template, parameters: List[Parameter], client: CloudFormationClient): Unit = {
-
+  def createChangeSetRequest(name: String,
+                             tpe: ChangeSetType,
+                             stackName: String,
+                             maybeTags: Option[Map[String, String]],
+                             template: Template,
+                             parameters: List[Parameter]
+                            ): CreateChangeSetRequest = {
     val maybeCfnTags: Option[util.List[CfnTag]] = maybeTags.map { tags =>
       tags.map { case (key, value) => CfnTag.builder().key(key).value(value).build() }.toSeq.asJava
     }
@@ -415,7 +419,15 @@ object CloudFormation {
       case TemplateUrl(url) => request.templateURL(url)
     }
 
-    client.createChangeSet(requestWithTemplate.build())
+    requestWithTemplate.build()
+  }
+
+  def createChangeSet(name: String, tpe: ChangeSetType, stackName: String, maybeTags: Option[Map[String, String]],
+                      template: Template, parameters: List[Parameter], client: CloudFormationClient): Unit = {
+
+    val request = createChangeSetRequest(name, tpe, stackName, maybeTags, template, parameters)
+
+    client.createChangeSet(request)
   }
 
   def describeStack(name: String, client: CloudFormationClient) =

--- a/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
@@ -55,7 +55,7 @@ class CreateChangeSetTask(
             resources.reporter.info(change)
           }
 
-          CloudFormation.createChangeSet(resources.reporter, stackLookup.changeSetName, changeSetType, stackName, unresolvedParameters.stackTags, template, awsParameters, cfnClient)
+          CloudFormation.createChangeSet(stackLookup.changeSetName, changeSetType, stackName, unresolvedParameters.stackTags, template, awsParameters, cfnClient)
         }
       }
     }

--- a/magenta-lib/src/test/scala/magenta/tasks/AWSTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/AWSTest.scala
@@ -1,17 +1,22 @@
 package magenta.tasks
 import java.util.UUID
 
+import magenta.tasks.CloudFormation.{TemplateBody, TemplateUrl}
 import magenta.{ApiCredentials, KeyRing, StsDeploymentResources}
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.mockito.MockitoSugar
+import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList
+import software.amazon.awssdk.services.cloudformation.model.{ChangeSetType, CreateChangeSetRequest, Parameter}
 import software.amazon.awssdk.services.sts.StsClient
+
+import scala.collection.JavaConverters._
 
 class AWSTest extends FlatSpec with Matchers with MockitoSugar {
 
   val stsClient = mock[StsClient]
 
   val deploymentResources = StsDeploymentResources(UUID.fromString("1-2-3-4-5"), stsClient)
-  it should "use role provider if available" in {
+  "AWS provider" should "use role provider if available" in {
     val keyring = KeyRing(apiCredentials = Map(
       "aws"-> ApiCredentials("aws-role", "role", "secret", Some("comment")),
       "aws-role"-> ApiCredentials("aws-role", "role", "no secret", Some("comment"))))
@@ -29,6 +34,32 @@ class AWSTest extends FlatSpec with Matchers with MockitoSugar {
   it should "throw an exception otherwise" in {
     val keyring = KeyRing(apiCredentials = Map())
     assertThrows[IllegalArgumentException](AWS.provider(keyring, deploymentResources))
+  }
 
+  "CloudFormation.createChangeSetRequest" should "map all of the values into a request correctly" in {
+    val param1 = Parameter.builder.parameterKey("param1").parameterValue("value1").build()
+    val request: CreateChangeSetRequest = CloudFormation.createChangeSetRequest("test", ChangeSetType.CREATE, "testStack", Some(Map("tag1" -> "value1", "tag2" -> "value2")), TemplateBody("banana!"), List(param1))
+    request.changeSetName shouldBe "test"
+    request.stackName shouldBe "testStack"
+    request.changeSetType shouldBe ChangeSetType.CREATE
+    request.tags should have size 2
+    request.tags.asScala.head.key shouldBe "tag1"
+    request.tags.asScala.head.value shouldBe "value1"
+    request.tags.asScala.last.key shouldBe "tag2"
+    request.tags.asScala.last.value shouldBe "value2"
+    request.templateBody shouldBe "banana!"
+    request.parameters.asScala.head.parameterKey shouldBe "param1"
+    request.parameters.asScala.head.parameterValue shouldBe "value1"
+  }
+
+  it should "use a templateUrl correctly" in {
+    val request: CreateChangeSetRequest = CloudFormation.createChangeSetRequest("test", ChangeSetType.CREATE, "testStack", None, TemplateUrl("banana!"), Nil)
+    request.templateBody shouldBe null
+    request.templateURL shouldBe "banana!"
+  }
+
+  it should "set tags to the default instance instead of empty list" in {
+    val request: CreateChangeSetRequest = CloudFormation.createChangeSetRequest("test", ChangeSetType.CREATE, "testStack", None, TemplateUrl("banana!"), Nil)
+    request.tags shouldBe DefaultSdkAutoConstructList.getInstance
   }
 }


### PR DESCRIPTION
## What does this change?
Tags are currently being added to a request object that is discarded. This fixes the issue and adds some tests to make sure we are constructing a fairly complex object correctly.

## How can we measure success?
This fixes a feature that hasn't worked for a while. Should we notify users or understand the impact of this? It should just mean that a whole load of resources become correctly tagged along with the stacks themselves. However this is likely to change stuff at scale and might have unintended consequences?

