### PR TITLE
Use service role for Cloudformation updates

### DIFF
--- a/magenta-lib/src/main/scala/magenta/Credentials.scala
+++ b/magenta-lib/src/main/scala/magenta/Credentials.scala
@@ -4,6 +4,12 @@ case class KeyRing(apiCredentials: Map[String, ApiCredentials] = Map.empty) {
   override def toString = apiCredentials.values.toList.mkString(", ")
 }
 
-case class ApiCredentials(service: String, id: String, secret: String, comment: Option[String]) {
+trait ApiCredentials {
+  val service: String
+  val id: String
+  val comment: Option[String]
   override def toString = s"$service:$id${comment.map(c => s" ($c)").getOrElse("")}"
 }
+
+case class ApiStaticCredentials(service: String, id: String, secret: String, comment: Option[String]) extends ApiCredentials
+case class ApiRoleCredentials(service: String, id: String, comment: Option[String]) extends ApiCredentials

--- a/magenta-lib/src/main/scala/magenta/tasks/FastlyTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/FastlyTasks.scala
@@ -125,21 +125,11 @@ case class UpdateFastlyConfig(s3Package: S3Path)(implicit val keyRing: KeyRing, 
 }
 
 object FastlyApiClientProvider {
-
-  private var fastlyApiClients = Map[String, FastlyApiClient]()
-
   def get(keyRing: KeyRing): Option[FastlyApiClient] = {
-
-    keyRing.apiCredentials.get("fastly").map { credentials =>
+    keyRing.apiCredentials.get("fastly").collect { case credentials: ApiStaticCredentials =>
         val serviceId = credentials.id
         val apiKey = credentials.secret
-
-        if (fastlyApiClients.get(serviceId).isEmpty) {
-          this.fastlyApiClients += (serviceId -> new FastlyApiClient(apiKey, serviceId))
-        }
-        return fastlyApiClients.get(serviceId)
+        new FastlyApiClient(apiKey, serviceId)
     }
-
-    None
   }
 }

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -300,8 +300,10 @@ case class UpdateAmiCloudFormationParameterTask(
       if (resolvedAmiParameters.nonEmpty) {
         val newParameters = existingParameters ++ resolvedAmiParameters
         resources.reporter.info(s"Updating cloudformation stack params: $newParameters")
+        val maybeExecutionRole = CloudFormation.getExecutionRole(keyRing)
+        maybeExecutionRole.foreach(role => resources.reporter.verbose(s"Using execution role $role"))
         updateWithRetry(resources.reporter, stopFlag) {
-          CloudFormation.updateStackParams(cfStack.stackName, newParameters, cfnClient)
+          CloudFormation.updateStackParams(cfStack.stackName, newParameters, maybeExecutionRole, cfnClient)
         }
       } else {
         resources.reporter.info(s"All AMIs the same as current AMIs. No update to perform.")

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/Gcp.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/Gcp.scala
@@ -14,7 +14,7 @@ import com.google.api.services.deploymentmanager.model._
 import com.google.api.services.deploymentmanager.{DeploymentManager, DeploymentManagerScopes}
 import com.gu.management.Loggable
 import magenta.tasks.gcp.GcpRetryHelper.Result
-import magenta.{DeployReporter, KeyRing}
+import magenta.{ApiStaticCredentials, DeployReporter, KeyRing}
 
 import scala.collection.JavaConverters._
 
@@ -27,7 +27,7 @@ object Gcp {
 
   object credentials {
     def getCredentials(keyring: KeyRing): Option[GoogleCredential] = {
-      keyring.apiCredentials.get("gcp").map { credentials =>
+      keyring.apiCredentials.get("gcp").collect { case credentials: ApiStaticCredentials =>
         val in = new ByteArrayInputStream(credentials.secret.getBytes)
         GoogleCredential
           .fromStream(in)

--- a/magenta-lib/src/test/scala/magenta/tasks/AWSTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/AWSTest.scala
@@ -1,7 +1,7 @@
 package magenta.tasks
 import java.util.UUID
 
-import magenta.{ApiCredentials, KeyRing, StsDeploymentResources}
+import magenta.{ApiStaticCredentials, ApiRoleCredentials, KeyRing, StsDeploymentResources}
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.mockito.MockitoSugar
 import software.amazon.awssdk.services.sts.StsClient
@@ -13,15 +13,15 @@ class AWSTest extends FlatSpec with Matchers with MockitoSugar {
   val deploymentResources = StsDeploymentResources(UUID.fromString("1-2-3-4-5"), stsClient)
   it should "use role provider if available" in {
     val keyring = KeyRing(apiCredentials = Map(
-      "aws"-> ApiCredentials("aws-role", "role", "secret", Some("comment")),
-      "aws-role"-> ApiCredentials("aws-role", "role", "no secret", Some("comment"))))
+      "aws"-> ApiStaticCredentials("aws-role", "role", "secret", Some("comment")),
+      "aws-role"-> ApiRoleCredentials("aws-role", "role", Some("comment"))))
     val provider = AWS.provider(keyring, deploymentResources)
     provider.toString.contains("StsAssumeRoleCredentialsProvider") shouldBe true
 
   }
   it should "use static credentials provider if available otherwise" in {
     val keyring = KeyRing(apiCredentials = Map(
-      "aws"-> ApiCredentials("aws-role", "role", "secret", Some("comment"))))
+      "aws"-> ApiStaticCredentials("aws-role", "role", "secret", Some("comment"))))
     val provider = AWS.provider(keyring, deploymentResources)
     provider.toString.contains("StaticCredentialsProvider") shouldBe true
   }

--- a/riff-raff/app/resources/PrismLookup.scala
+++ b/riff-raff/app/resources/PrismLookup.scala
@@ -28,11 +28,11 @@ class PrismLookup(config: Config, wsClient: WSClient, secretProvider: SecretProv
     val apiCredentials = data.keys flatMap {
       case key@KeyPattern(service) =>
         data.datum(key, app, stage, stack).flatMap { data =>
-          if(service == "aws-role") {
-            Some(service -> ApiCredentials(service, data.value, "no secret", data.comment))
+          if(service.endsWith("role")) {
+            Some(service -> ApiRoleCredentials(service, data.value, data.comment))
           } else {
             secretProvider.lookup(service, data.value).map { secret =>
-              service -> ApiCredentials(service, data.value, secret, data.comment)}
+              service -> ApiStaticCredentials(service, data.value, secret, data.comment)}
           }
         }
       case _ => None

--- a/riff-raff/test/lookup/PrismLookupTest.scala
+++ b/riff-raff/test/lookup/PrismLookupTest.scala
@@ -14,7 +14,7 @@ import play.api.routing.sird._
 import play.api.test.WsTestClient
 import play.core.server.Server
 import resources.{Image, PrismLookup}
-import magenta.{ApiCredentials, App, KeyRing, SecretProvider, Stack, Stage}
+import magenta.{ApiCredentials, ApiRoleCredentials, ApiStaticCredentials, App, KeyRing, SecretProvider, Stack, Stage}
 
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
@@ -91,9 +91,12 @@ class PrismLookupTest extends FlatSpec with Matchers {
     withPrismClient(List()) { client =>
       val lookup = new PrismLookup(config, client, secretProvider)
       val result = lookup.keyRing(stage = Stage("PROD"), app = App("amigo"), stack = Stack("deploy"))
-      result.apiCredentials("aws").id shouldBe "access key"
-      result.apiCredentials("aws-role").id shouldBe "role ARN"
-      result.apiCredentials("aws-role").secret shouldBe "no secret"
+      val awsCreds = result.apiCredentials("aws")
+      awsCreds shouldBe a[ApiStaticCredentials]
+      awsCreds.id shouldBe "access key"
+      val roleCreds = result.apiCredentials("aws-role")
+      roleCreds shouldBe a[ApiRoleCredentials]
+      roleCreds.id shouldBe "role ARN"
     }
   }
 


### PR DESCRIPTION
## What does this change?
Uses a less privileged role for most work but then uses a CFN service role when creating or updating CFN stacks.

This uses roles as defined in https://github.com/guardian/deploy-tools-platform/pull/209 

RiffRaff previously used a pile of static credentials to access other accounts. In #587 is was changed to assume a role to access other accounts but this had to be very powerful due to CFN stacks being created and updated.

This PR goes one step further. Riff-Raff assumes a least privileged role to make changes in another account and then uses a CFN service role to allow wide ranging changes to be made to resources.

## How can we measure success?
Deploys still work and we can delete static credentials.
