### PR TITLE
Update node-riffraff-artifact repo links

### DIFF
--- a/riff-raff/public/docs/howto/configure-a-project.md
+++ b/riff-raff/public/docs/howto/configure-a-project.md
@@ -8,7 +8,7 @@ To make a project deployable with riff-raff it needs:
  - The two files above along with any assets uploaded into riff-raff's S3 artifact buckets
 
 Both the [sbt-riffraff-artifact plugin](https://github.com/guardian/sbt-riffraff-artifact) or
-[node-riffraff-artifact plugin](https://github.com/guardian/node-riffraff-artefact) plugins will create the 
+[node-riffraff-artifact plugin](https://github.com/guardian/node-riffraff-artifact) plugins will create the
 `build.json` for you and help you to upload the files to the S3 buckets correctly.
 
 Using SBT

--- a/riff-raff/public/docs/reference/build.json.md
+++ b/riff-raff/public/docs/reference/build.json.md
@@ -4,8 +4,8 @@ The build.json file
 The type ahead of the project name and build number and also the continuous deployment feature is powered by the
 `build.json` files that are created for each project.
 
-This file is normally created by the [sbt-riffraff-artifact plugin](https://github.com/guardian/sbt-riffraff-artifact) 
-or [node-riffraff-artifact plugin](https://github.com/guardian/node-riffraff-artefact) plugin.
+This file is normally created by the [sbt-riffraff-artifact plugin](https://github.com/guardian/sbt-riffraff-artifact)
+or [node-riffraff-artifact plugin](https://github.com/guardian/node-riffraff-artifact) plugin.
 
 ```json
 {  


### PR DESCRIPTION
## What does this change?

Tiny documentation change: while browsing the docs I noticed that these link to a legacy library, `node-riffraff-artefact` (with an e), instead of `node-riffraff-artifact` (with an i).

## How can we measure success?

Ever-so-minor improvement to DevEx 👩‍💻

## Images
