### PR TITLE
Ensure scheduled deploys are matched exactly.

### DIFF
--- a/riff-raff/app/schedule/DeployJob.scala
+++ b/riff-raff/app/schedule/DeployJob.scala
@@ -62,7 +62,8 @@ object DeployJob extends Logging with LogAndSquashBehaviour {
     } else {
       val filter = DeployFilter(
         projectName = Some(projectName),
-        stage = Some(stage)
+        stage = Some(stage),
+        isExactMatchProjectName = Some(true)
       )
       val pagination = PaginationView().withPageSize(Some(1))
 


### PR DESCRIPTION
## What does this change?
We've had an issue in the mobile team where some of our EC2 image got out of date even though we had a weekly scheduled deployment.
Upon investigating we found out two of our projects (`mobile-n10n:notificationworkerlambda` and `mobile-n10n:notification`) have a name including the other, and riff-raff could pick the wrong one.

@twrichards Quickly pointed out the potential use of the `isExactMatchProjectName` flag.

## How can we measure success?
If we deploy the right project.

## What is the cost of failure?
Riff-raff fails to deploy on a schedule.

## Images
YES
