### PR TITLE
Disable automatic AMI update temporarily.

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -123,9 +123,10 @@ object CloudFormationParameters {
               existingParameters: List[ExistingParameter]
              ): Either[String, List[InputParameter]] = {
 
-    val resolvedAmiParameters: Map[String, String] = cfnParameters.amiParameterMap.flatMap { case (name, tags) =>
-      cfnParameters.latestImage(accountNumber)(cfnParameters.target.region.name)(tags).map(name -> _)
-    }
+//    val resolvedAmiParameters: Map[String, String] = cfnParameters.amiParameterMap.flatMap { case (name, tags) =>
+//      cfnParameters.latestImage(accountNumber)(cfnParameters.target.region.name)(tags).map(name -> _)
+//    }
+    val resolvedAmiParameters: Map[String, String] = Map.empty
 
     val deploymentParameters = Map(
       "Stage" -> cfnParameters.target.parameters.stage.name,
@@ -282,8 +283,8 @@ case class UpdateAmiCloudFormationParameterTask(
         }
 
         val currentAmi = cfStack.parameters.asScala.find(_.parameterKey == parameterName).get.parameterValue
-        val accountNumber = STS.withSTSclient(keyRing, region, resources)(STS.getAccountNumber)
-        val maybeNewAmi = latestImage(accountNumber)(region.name)(amiTags)
+        //val accountNumber = STS.withSTSclient(keyRing, region, resources)(STS.getAccountNumber)
+        val maybeNewAmi: Option[String] = Some(currentAmi) //latestImage(accountNumber)(region.name)(amiTags)
         maybeNewAmi match {
           case Some(sameAmi) if currentAmi == sameAmi =>
             resources.reporter.info(s"Current AMI is the same as the resolved AMI for $parameterName ($sameAmi)")


### PR DESCRIPTION
This is following a department wide incident where deploying the latest AMI prevent the autoscaling group from scaling up.

I'm not sure I have covered all the cases nor am I sure it's the right approach, please provide feedback.

## What does this change?
This temporarily disable automatic AMI upgrades on riff-raff to prevent deploying the latest AMI which stops our servers from booting.

## How to test
Unit tests + deployment on CODE

## How can we measure success?
no down time 🤞 

## Have we considered potential risks?
Could potentially break all deployments. Needs to be carefully tested on CODE
