### PR TITLE
Only pick AMIs before Wednesday morning when updating AMIs

### DIFF
--- a/riff-raff/app/resources/PrismLookup.scala
+++ b/riff-raff/app/resources/PrismLookup.scala
@@ -159,6 +159,11 @@ class PrismLookup(config: Config, wsClient: WSClient, secretProvider: SecretProv
     }
   }
   def getLatestAmi(accountNumber: Option[String], tagFilter: Map[String, String] => Boolean)(region: String)(tags: Map[String, String]): Option[String] =
-    get(accountNumber, region, tags).filter(image => tagFilter(image.tags)).sortBy(-_.creationDate.getMillis).headOption.map(_.imageId)
+    get(accountNumber, region, tags)
+      .filter(image => tagFilter(image.tags))
+      .filter(image => image.creationDate.isBefore(1596013200000L)) // drop anything after Wednesday 29th 9AM UTC
+      .sortBy(-_.creationDate.getMillis)
+      .headOption
+      .map(_.imageId)
 
 }


### PR DESCRIPTION
## What does this change?
This is a temporary workaround while we investigate why newer Xenial AMIs aren't booting.

We're only selecting AMIs backed before Wednesday morning when applying an AMI update to limit the risk of breaking existing deploys while we investigate the ongoing Xenial incident.

## How to test
Unit tests + deploy on CODE

## How can we measure success?
Limit downtime and ASG disruptions

## Have we considered potential risks?
Yes, anyone working specifically on getting a new AMI might be very confused after this is merged.
