### PR TITLE
Revert "Only pick AMIs before Wednesday morning when updating AMIs"

### DIFF
--- a/riff-raff/app/resources/PrismLookup.scala
+++ b/riff-raff/app/resources/PrismLookup.scala
@@ -159,11 +159,6 @@ class PrismLookup(config: Config, wsClient: WSClient, secretProvider: SecretProv
     }
   }
   def getLatestAmi(accountNumber: Option[String], tagFilter: Map[String, String] => Boolean)(region: String)(tags: Map[String, String]): Option[String] =
-    get(accountNumber, region, tags)
-      .filter(image => tagFilter(image.tags))
-      .filter(image => image.creationDate.isBefore(1596013200000L)) // drop anything after Wednesday 29th 9AM UTC
-      .sortBy(-_.creationDate.getMillis)
-      .headOption
-      .map(_.imageId)
+    get(accountNumber, region, tags).filter(image => tagFilter(image.tags)).sortBy(-_.creationDate.getMillis).headOption.map(_.imageId)
 
 }


### PR DESCRIPTION
Reverts guardian/riff-raff#596

This change was introduced to prevent us launching instances with broken AMIs. We've now fixed the broken AMIs and can remove the change to continue to use the latest AMIs available in AMIgo 🎉 .

A few teams have confirmed the new AMIs are good and all the impacted recipes in AMIgo have had a bake triggered. This change should be good to go.