### PR TITLE
improve text contrast on warning rows

### DIFF
--- a/riff-raff/app/assets/stylesheets/magenta.less
+++ b/riff-raff/app/assets/stylesheets/magenta.less
@@ -216,6 +216,7 @@ div.deployment-target:target {
 
 tr.has-warnings {
   background: repeating-linear-gradient( 45deg, #fcd7d7, #fcd7d7 10px, #dddddd 10px, #dddddd 20px );
+  color: black;
 }
 
 .label-reporter-warning {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Increases the contrast between text and background on a row with warnings. This makes it easier to read the text.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Deploy to CODE.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Text is easier to read.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a

## Images
### Light mode
#### Before
![image](https://user-images.githubusercontent.com/836140/91812007-4e9d4c80-ec28-11ea-8806-9af335990601.png)

#### After
![image](https://user-images.githubusercontent.com/836140/91812038-5c52d200-ec28-11ea-874a-2dbbd62a02fc.png)

### Dark mode
#### Before
![image](https://user-images.githubusercontent.com/836140/91811862-13028280-ec28-11ea-9f33-ec70d3b25501.png)

#### After
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![image](https://user-images.githubusercontent.com/836140/91811821-05e59380-ec28-11ea-8e20-e5e2a9f24bac.png)
