### PR TITLE
make "master" branch deploy a info rather than warning

### DIFF
--- a/riff-raff/app/deployment/actors/DeployGroupRunner.scala
+++ b/riff-raff/app/deployment/actors/DeployGroupRunner.scala
@@ -174,7 +174,7 @@ class DeployGroupRunner(
   private def warnDeprecatedBranch(): Unit = {
     val maybeBranch: Option[String] = record.metaData.get("branch")
     if (maybeBranch.contains("master"))
-      rootReporter.warning("branch name 'master' is not inclusive, please rename - see https://docs.google.com/document/d/1nqC5Uk6n3y7S79m1yiG6oqT8NtXWpDcsS-uLI_RK7Mg/edit#")
+      rootReporter.info("branch name 'master' is not inclusive, please rename - see https://docs.google.com/document/d/1nqC5Uk6n3y7S79m1yiG6oqT8NtXWpDcsS-uLI_RK7Mg/edit#")
   }
 
   private def createContext: DeployContext = {


### PR DESCRIPTION
according to #599 I added a warning for deploying "master" as it is not inclusive.

Since we use warnings for problems that might cause unexpected behaviour in some situations, the fact that the majority of deploys have a warning anyway, makes it less likely that we will spot other problems if they arise.  This is because you have to click in to see the actual warning, and people might assume it's just because of the branch name.

With the current approach there is a trade off between us saying clearly "this word is not ok, but we haven't fixed it yet" and being able to spot a minority of problems which would be more obvious as a result.

Of course the best approach is if we implemented different styling (more work) then this would be more clear.  However I don't have time for this at present.

What do people think? - this PR is to check if consensus is overall people prefer to do without the warnings and just make it a normal log message.