### PR TITLE
decorate log line with extra information

### DIFF
--- a/riff-raff/app/deployment/Deployments.scala
+++ b/riff-raff/app/deployment/Deployments.scala
@@ -66,7 +66,12 @@ class Deployments(deploymentEngine: DeploymentEngine,
     val uuid = java.util.UUID.randomUUID()
     val hostNameMetadata = Map(Record.RIFFRAFF_HOSTNAME -> java.net.InetAddress.getLocalHost.getHostName)
     val record = deployRecordFor(uuid, params) ++ hostNameMetadata
-    val mc = MarkerContext(appendEntries(record.metaData.asJava))
+
+    // information for creating a master to main progress dashboard
+    val markers = Map(
+      "branch" -> record.metaData.getOrElse("branch", "unknown")
+    )
+    val mc = MarkerContext(appendEntries(markers.asJava))
     log.info(s"Creating deploy record for $params")(mc)
     library send { _ + (uuid -> Agent(record)) }
     documentStoreConverter.saveDeploy(record)


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Log the branch being deployed as a marker. This is primarily to help understand our progress of moving from `master` to `main`.

Logging this information as a marker means we can create graphs within the Central ELK stack.

A graph of branch name used over time would allow us to track our progress of `master` to `main`; `master` reaching 0 is a proxy for our success on this work.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Deploy to CODE
- Perform a deploy
- Witness log lines have extra markers

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We have visibility of which branch is being deployed within the logs.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

I think this log line occurs pretty close to the start of a deploy. That is, we don't know if the deploy has succeeded or not. I think this is fine as we only really care about deploying intent for this particular use case.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

**Log filter (logs from RIffRaff CODE)**
![image](https://user-images.githubusercontent.com/836140/92512075-286a4480-f206-11ea-9811-83c86a1140df.png)

**Dashboard (logs from RIffRaff CODE)**
![image](https://user-images.githubusercontent.com/836140/92513684-9c0d5100-f208-11ea-9878-8d2b8baff390.png)
