### PR TITLE
Support for GCS deployment type

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
@@ -143,12 +143,10 @@ object GCS extends DeploymentType {
       ))
       List(
         GCSUpload(
-          target.region,
           bucket = bucketName,
           paths = Seq(pkg.s3Package -> prefix),
           cacheControlPatterns = cacheControl(pkg, target, reporter),
-          extensionToMimeType = mimeTypes(pkg, target, reporter),
-          publicReadAcl = publicReadAcl(pkg, target, reporter)
+          publicReadAcl = publicReadAcl(pkg, target, reporter),
         )
       )
     }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
@@ -1,0 +1,150 @@
+package magenta.deployment_type
+
+import magenta.Datum
+import magenta.deployment_type.param_reads.PatternValue
+import magenta.tasks.gcp.GCSUpload
+
+object GCS extends DeploymentType {
+  val name = "gcp-gcs"
+  val documentation = "For uploading files into a GCS bucket."
+
+  val prefixStage = Param("prefixStage",
+    "Prefix the GCS bucket key with the target stage").default(true)
+  val prefixPackage = Param("prefixPackage",
+    "Prefix the GCS bucket key with the package name").default(true)
+  val prefixStack = Param("prefixStack",
+    "Prefix the GCS bucket key with the target stack").default(true)
+  val pathPrefixResource = Param[String]("pathPrefixResource",
+    """Deploy Info resource key to use to look up an additional prefix for the path key. Note that this will override
+       the `prefixStage`, `prefixPackage` and `prefixStack` keys - none of those prefixes will be applied, as you have
+       full control over the path with the resource lookup.
+    """.stripMargin,
+    optional = true
+  )
+
+  //required configuration, you cannot upload without setting these
+  val bucket = Param[String]("bucket", "GCS bucket to upload package files to (see also `bucketResource`)", optional = true)
+  val bucketResource = Param[String]("bucketResource",
+    """Deploy Info resource key to use to look up the GCS bucket to which the package files should be uploaded.
+      |
+      |This parameter is mutually exclusive with `bucket`, which can be used instead if you upload to the same bucket
+      |regardless of the target stage.
+    """.stripMargin,
+    optional = true
+  )
+
+  val publicReadAcl = Param[Boolean]("publicReadAcl",
+    "Whether the uploaded artifacts should be given the PublicRead Canned ACL. (Default is true!)"
+  ).default(true)
+
+  val cacheControl = Param[List[PatternValue]]("cacheControl",
+    """
+      |Set the cache control header for the uploaded files. This can take two forms, but in either case the format of
+      |the cache control value itself must be a valid HTTP `Cache-Control` value such as `public, max-age=315360000`.
+      |
+      |In the first form the cacheControl parameter is set to a JSON string and the value will apply to all files
+      |uploaded to the GCS bucket.
+      |
+      |In the second form the cacheControl parameter is set to an array of JSON objects, each of which have `pattern`
+      |and `value` keys. `pattern` is a Java regular expression whilst `value` must be a valid `Cache-Control` header.
+      |For each file being uploaded, the array of regular expressions is evaluated against the file path and name. The
+      |first regular expression that matches the file is used to determine the cache control value. If there is no match
+      |then no cache control will be set.
+      |
+      |In the example below, if the file path matches either of the first two regular expressions then the cache control
+      |header will be set to ten years (i.e. never expire). If neither of the first two match then the catch all regular
+      |expression of the last object will match, setting the cache control header to one hour.
+      |
+      |    "cacheControl": [
+      |      {
+      |        "pattern": "^js/lib/",
+      |        "value": "max-age=315360000"
+      |      },
+      |      {
+      |        "pattern": "^\d*\.\d*\.\d*/",
+      |        "value": "max-age=315360000"
+      |      },
+      |      {
+      |        "pattern": ".*",
+      |        "value": "max-age=3600"
+      |      }
+      |    ]
+    """.stripMargin
+  )
+
+  val mimeTypes = Param[Map[String,String]]("mimeTypes",
+    """
+      |A map of file extension to MIME type.
+      |
+      |When a file is uploaded with a file extension that is in this map, the Content-Type header will be set to the
+      |MIME type provided.
+      |
+      |The example below adds the MIME type for Firefox plugins so that they install correctly rather than opening in
+      |the browser.
+      |
+      |    "mimeTypes": {
+      |      "xpi": "application/x-xpinstall"
+      |    }
+    """.stripMargin
+  ).default(Map.empty)
+
+  val uploadStaticFiles = Action(
+    name = "uploadStaticFiles",
+    documentation =
+      """
+        |Uploads the deployment files to a GCS bucket. In order for this to work, magenta must have credentials that are
+        |valid to write to the bucket in the specified location.
+        |
+        |Each file path and name is used to generate the key, optionally prefixing the target stage and the package name
+        |to the key. The generated key looks like: `/<bucketName>/<targetStage>/<packageName>/<filePathAndName>`.
+        |
+        |Alternatively, you can specify a pathPrefixResource (eg `s3-path-prefix`) to lookup the path prefix, giving you
+        |greater control. The generated key looks like: `/<pathPrefix>/<filePathAndName>`.
+        """.stripMargin
+  ){ (pkg, resources, target) => {
+    def resourceLookupFor(resource: Param[String]): Option[Datum] = {
+      val maybeResource = resource.get(pkg)
+      maybeResource.flatMap { resourceName =>
+        val dataLookup = resources.lookup.data
+        val datumOpt = dataLookup.datum(resourceName, pkg.app, target.parameters.stage, target.stack)
+        if (datumOpt.isEmpty) {
+          def str(f: Datum => String) = s"[${dataLookup.get(resourceName).map(f).toSet.mkString(", ")}]"
+          resources.reporter.verbose(s"No datum found for resource=$resourceName app=${pkg.app} stage=${target.parameters.stage} stack=${target.stack} - values *are* defined for app=${str(_.app)} stage=${str(_.stage)} stack=${str(_.stack.mkString)}")
+        }
+        datumOpt
+      }
+    }
+
+    implicit val keyRing = resources.assembleKeyring(target, pkg)
+    implicit val artifactClient = resources.artifactClient
+    val reporter = resources.reporter
+
+    assert(bucket.get(pkg).isDefined != bucketResource.get(pkg).isDefined, "One, and only one, of bucket or bucketResource must be specified")
+    val bucketName = bucket.get(pkg) getOrElse {
+      val data = resourceLookupFor(bucketResource)
+      assert(data.isDefined, s"Cannot find resource value for ${bucketResource(pkg, target, reporter)} (${pkg.app} in ${target.parameters.stage.name})")
+      data.get.value
+    }
+
+    val maybeDatum = resourceLookupFor(pathPrefixResource)
+    val maybeString = maybeDatum.map(_.value)
+    val prefix: String = maybeString.getOrElse(GCSUpload.prefixGenerator(
+        stack = if (prefixStack(pkg, target, reporter)) Some(target.stack) else None,
+        stage = if (prefixStage(pkg, target, reporter)) Some(target.parameters.stage) else None,
+        packageName = if (prefixPackage(pkg, target, reporter)) Some(pkg.name) else None
+      ))
+      List(
+        GCSUpload(
+          target.region,
+          bucket = bucketName,
+          paths = Seq(pkg.s3Package -> prefix),
+          cacheControlPatterns = cacheControl(pkg, target, reporter),
+          extensionToMimeType = mimeTypes(pkg, target, reporter),
+          publicReadAcl = publicReadAcl(pkg, target, reporter)
+        )
+      )
+    }
+  }
+
+  def defaultActions = List(uploadStaticFiles)
+}

--- a/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
@@ -78,22 +78,6 @@ object GCS extends DeploymentType {
     """.stripMargin
   )
 
-  val mimeTypes = Param[Map[String,String]]("mimeTypes",
-    """
-      |A map of file extension to MIME type.
-      |
-      |When a file is uploaded with a file extension that is in this map, the Content-Type header will be set to the
-      |MIME type provided.
-      |
-      |The example below adds the MIME type for Firefox plugins so that they install correctly rather than opening in
-      |the browser.
-      |
-      |    "mimeTypes": {
-      |      "xpi": "application/x-xpinstall"
-      |    }
-    """.stripMargin
-  ).default(Map.empty)
-
   val uploadStaticFiles = Action(
     name = "uploadStaticFiles",
     documentation =

--- a/magenta-lib/src/main/scala/magenta/deployment_type/GcpDeploymentManager.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/GcpDeploymentManager.scala
@@ -7,7 +7,7 @@ import cats.syntax.traverse._
 import magenta.artifact.{EmptyS3Location, S3Location, S3Path, UnknownS3Error}
 import magenta.input.RiffRaffYamlReader
 import magenta.tasks.gcp.DeploymentManagerTasks
-import magenta.tasks.gcp.Gcp.DeploymentManagerApi.DeploymentBundle
+import magenta.tasks.gcp.GCP.DeploymentManagerApi.DeploymentBundle
 import magenta.{DeployReporter, KeyRing}
 import software.amazon.awssdk.services.s3.S3Client
 

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/GCP.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/GCP.scala
@@ -13,12 +13,11 @@ import com.google.api.services.deploymentmanager.model.Operation.Error.Errors
 import com.google.api.services.deploymentmanager.model._
 import com.google.api.services.deploymentmanager.{DeploymentManager, DeploymentManagerScopes}
 import com.gu.management.Loggable
-import magenta.tasks.gcp.GcpRetryHelper.Result
-import magenta.{ApiStaticCredentials, DeployReporter, KeyRing}
-
+import magenta.tasks.gcp.GCPRetryHelper.Result
+import magenta.{ApiStaticCredentials, DeployReporter, DeploymentResources, KeyRing}
 import scala.collection.JavaConverters._
 
-object Gcp {
+object GCP {
   lazy val httpTransport: ApacheHttpTransport = GoogleApacheHttpTransport.newTrustedTransport
   lazy val jsonFactory: JacksonFactory = JacksonFactory.getDefaultInstance
   val scopes: Seq[String] = Seq(
@@ -125,8 +124,8 @@ object Gcp {
 
   object api {
     def retryWhen500orGoogleError[T](reporter: DeployReporter, failureMessage: String)(op: => T): Result[T] = {
-      GcpRetryHelper.retryableToResult(
-        GcpRetryHelper.retryExponentially(
+      GCPRetryHelper.retryableToResult(
+        GCPRetryHelper.retryExponentially(
           reporter,
           when500orGoogleError,
           failureMessage

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/GCPRetryHelper.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/GCPRetryHelper.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration._
 /**
   * Borrowed from https://github.com/broadinstitute
   */
-object GcpRetryHelper extends Loggable {
+object GCPRetryHelper extends Loggable {
 
   def log(reporter: DeployReporter, message: String, t: Throwable): Unit = {
     logger.info(message, t)

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
@@ -1,0 +1,130 @@
+package magenta.tasks.gcp
+
+import java.io.File
+import java.math.BigInteger
+import java.net.URLConnection
+import java.util.Arrays
+
+import com.google.api.client.http.InputStreamContent
+import com.google.api.services.storage.Storage
+import com.google.api.services.storage.model.{ObjectAccessControl, StorageObject}
+import com.gu.management.Loggable
+import magenta.{DeploymentResources, KeyRing, Region, Stack, Stage}
+import magenta.artifact.{S3Location, S3Object, S3Path}
+import magenta.deployment_type.param_reads.PatternValue
+import magenta.tasks.Task
+import software.amazon.awssdk.core.internal.util.Mimetype
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+
+case class GCSUpload(
+  region: Region,
+  bucket: String,
+  paths: Seq[(S3Location, String)],
+  cacheControlPatterns: List[PatternValue] = Nil,
+  extensionToMimeType: Map[String,String] = Map.empty,
+  publicReadAcl: Boolean = false,
+  detailedLoggingThreshold: Int = 10,
+)(implicit val keyRing: KeyRing, artifactClient: S3Client,
+  withClientFactory: (KeyRing, DeploymentResources) => (Storage => Unit) => Unit = GCS.withGCSClient[Unit]) extends Task with Loggable {
+
+  private val PublicAcl = Arrays.asList(new ObjectAccessControl().setEntity("allUsers").setRole("READER"))
+
+  lazy val objectMappings: Seq[(S3Object, GCSPath)] = paths flatMap {
+    case (file, targetKey) => resolveMappings(file, targetKey, bucket)
+  }
+
+  lazy val totalSize: Long = objectMappings.map{ case (source, _) => source.size }.sum
+
+  lazy val transfers: Seq[StorageObjectTransfer] = objectMappings.map { case (source, target) =>
+    val storageObject = new StorageObject()
+    storageObject.setBucket(bucket)
+    storageObject.setName(target.key)
+    storageObject.setSize(BigInteger.valueOf(source.size))
+    storageObject.setContentType(URLConnection.guessContentTypeFromName(target.key))
+
+    cacheControlLookup(target.key) match {
+      case Some(cacheControl) => storageObject.setCacheControl(cacheControl)
+      case None               => ()
+    }
+
+    if (publicReadAcl) storageObject.setAcl(PublicAcl)
+
+    StorageObjectTransfer(source, storageObject)
+  }
+
+  def fileString(quantity: Int) = s"$quantity file${if (quantity != 1) "s" else ""}"
+
+  // end-user friendly description of this task
+  def description: String = s"Upload ${fileString(objectMappings.size)} to GCS bucket $bucket using file mapping $paths"
+
+  // execute this task (should throw on failure)
+  override def execute(resources: DeploymentResources, stopFlag: => Boolean) {
+    if (totalSize == 0) {
+      val locationDescription = paths.map {
+        case (path: S3Path, _) => path.show()
+        case (location, _) => location.toString
+      }.mkString("\n")
+      resources.reporter.fail(s"No files found to upload in $locationDescription")
+    }
+
+    val withClient = withClientFactory(keyRing, resources)
+    withClient { client =>
+
+      resources.reporter.verbose(s"Starting transfer of ${fileString(objectMappings.size)} ($totalSize bytes)")
+      transfers.zipWithIndex.par.foreach { case (transfer, index) =>
+        logger.debug(s"Transferring $transfer")
+        index match {
+          case x if x < 10 => resources.reporter.verbose(s"Transferring $transfer")
+          case 10 => resources.reporter.verbose(s"Not logging details for the remaining ${fileString(objectMappings.size - 10)}")
+          case _ =>
+        }
+        GCP.api.retryWhen500orGoogleError(resources.reporter, s"GCS Upload $transfer") {
+          val copyObjectRequest = GetObjectRequest.builder()
+                                                  .bucket(transfer.source.bucket)
+                                                  .key(transfer.source.key)
+                                                  .build()
+          val inputStream = resources.artifactClient.getObjectAsBytes(copyObjectRequest).asInputStream()
+          val contentType = Option(transfer.target.getContentType).getOrElse(URLConnection.guessContentTypeFromStream(inputStream))
+          val result      = client.objects().insert(bucket, transfer.target, new InputStreamContent(contentType, inputStream)).execute()
+          logger.debug(s"Put object ${result.getName}: MD5: ${result.getMd5Hash} Metadata: ${result.getMetadata}")
+          result
+        }
+      }
+    }
+    resources.reporter.verbose(s"Finished transfer of ${fileString(objectMappings.size)}")
+  }
+
+  private def subDirectoryPrefix(key: String, fileName: String): String =
+    if (fileName.isEmpty)
+      key
+    else if (key.isEmpty)
+      fileName
+    else s"$key/$fileName"
+
+  private def resolveMappings(path: S3Location, targetKey: String, targetBucket: String): Seq[(S3Object, GCSPath)] = {
+    path.listAll()(artifactClient).map { obj =>
+      obj -> GCSPath(targetBucket, subDirectoryPrefix(targetKey, obj.relativeTo(path)))
+    }
+  }
+
+  private def cacheControlLookup(fileName:String) = cacheControlPatterns.find(_.regex.findFirstMatchIn(fileName).isDefined).map(_.value)
+}
+
+case class StorageObjectTransfer(source: S3Object, target: StorageObject) {
+  override def toString: String =
+    s"s3://${source.bucket}/${source.key} to gcs://${target.getBucket}/${target.getName} with " +
+      s"CacheControl:${target.getCacheControl} ContentType:${target.getContentType} PublicRead:${target.getAcl}"
+}
+
+object GCSUpload {
+  private val mimeTypes = Mimetype.getInstance()
+
+  def awsMimeTypeLookup(fileName: String): String = mimeTypes.getMimetype(new File(fileName))
+
+  def prefixGenerator(stack:Option[Stack] = None, stage:Option[Stage] = None, packageName:Option[String] = None): String = {
+    (stack.map(_.name) :: stage.map(_.name) :: packageName :: Nil).flatten.mkString("/")
+  }
+  def prefixGenerator(stack: Stack, stage: Stage, packageName: String): String =
+    prefixGenerator(Some(stack), Some(stage), Some(packageName))
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,7 +41,8 @@ object Dependencies {
     "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jackson,
     "com.typesafe.play" %% "play-json" % "2.7.2",
     "com.beachape" %% "enumeratum-play-json" % "1.5.16",
-    "com.google.apis" % "google-api-services-deploymentmanager" % "v2-rev75-1.25.0"
+    "com.google.apis" % "google-api-services-deploymentmanager" % "v2-rev75-1.25.0",
+    "com.google.apis" % "google-api-services-storage" % "v1-rev171-1.25.0"
   ).map((m: ModuleID) =>
     // don't even ask why I need to do this
     m.excludeAll(ExclusionRule(organization = "com.google.code.findbugs", name = "jsr305"))

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -89,7 +89,7 @@ class AppComponents(context: Context, config: Config, passwordProvider: Password
   )
 
   val availableDeploymentTypes = Seq(
-    ElasticSearch, S3, AutoScaling, Fastly, CloudFormation, Lambda, AmiCloudFormationParameter, SelfDeploy, GcpDeploymentManager
+    ElasticSearch, S3, AutoScaling, Fastly, CloudFormation, Lambda, AmiCloudFormationParameter, SelfDeploy, GcpDeploymentManager, GCS
   )
 
   val documentStoreConverter = new DocumentStoreConverter(datastore)


### PR DESCRIPTION
## What does this change?

Adds a task to deploy artifacts to Google Cloud Storage.

## How to test

Use the `gcp-gcs` deployment type in `riff-raff.yml`.

## How can we measure success?

Deployments to GCS succeeds.

## Have we considered potential risks?

None, since the task is new.
