### PR TITLE
Update to more inclusive language.

### DIFF
--- a/riff-raff/public/docs/reference/build.json.md
+++ b/riff-raff/public/docs/reference/build.json.md
@@ -49,7 +49,7 @@ _Required:_ Yes.
 ### branch
 
 The name of the VCS branch. This is displayed in the type ahead and also in the audit trail. Supplying this makes it 
-easy to identify in Riff-Raff whether a build is from master or another un-merged branch. It can also be used as a
+easy to identify in Riff-Raff whether a build is from ~`master`~ `main` or another un-merged branch. It can also be used as a
 condition for triggering continuous deployments.
 
 _Required:_ Yes.

--- a/riff-raff/public/docs/reference/build.json.md
+++ b/riff-raff/public/docs/reference/build.json.md
@@ -49,7 +49,7 @@ _Required:_ Yes.
 ### branch
 
 The name of the VCS branch. This is displayed in the type ahead and also in the audit trail. Supplying this makes it 
-easy to identify in Riff-Raff whether a build is from ~`master`~ `main` or another un-merged branch. It can also be used as a
+easy to identify in Riff-Raff whether a build is from the default branch or not. It can also be used as a
 condition for triggering continuous deployments.
 
 _Required:_ Yes.

--- a/riff-raff/public/docs/riffraff/hooksAndCD.md
+++ b/riff-raff/public/docs/riffraff/hooksAndCD.md
@@ -5,7 +5,7 @@ Continuous Integration and Deployment
 You want to continuously deploy your project into production. A typical pipeline (for feature branch style development)
  might be:
 
- - a developer merges a new feature to ~`master`~ `main`
+ - a developer merges a new feature to the default branch
  - the build server creates a new deployable build
  - Riff-Raff deploys the new build to a development environment
  - a set of automated integration tests run against the development environment
@@ -35,7 +35,7 @@ A continuous deployment configuration is designed to watch for new builds and re
  events. You can currently set up a configuration that reacts to a successful build. When the matching event occurs,
  Riff-Raff will start a deploy automatically to the specified environment.
 
-In either case, the configuration can be set to filter by VCS branch (e.g. only builds of the ~`master`~ `main` branch trigger
+In either case, the configuration can be set to filter by VCS branch (e.g. only builds of the default branch trigger
  a new deploy - allowing work on other branches to be safely ignored).
 
 Deploys triggered by Continuous Deployment will have a deployer name of `Continuous Deployment`, but in any other

--- a/riff-raff/public/docs/riffraff/hooksAndCD.md
+++ b/riff-raff/public/docs/riffraff/hooksAndCD.md
@@ -5,7 +5,7 @@ Continuous Integration and Deployment
 You want to continuously deploy your project into production. A typical pipeline (for feature branch style development)
  might be:
 
- - a developer merges a new feature to master
+ - a developer merges a new feature to ~`master`~ `main`
  - the build server creates a new deployable build
  - Riff-Raff deploys the new build to a development environment
  - a set of automated integration tests run against the development environment
@@ -35,7 +35,7 @@ A continuous deployment configuration is designed to watch for new builds and re
  events. You can currently set up a configuration that reacts to a successful build. When the matching event occurs,
  Riff-Raff will start a deploy automatically to the specified environment.
 
-In either case, the configuration can be set to filter by VCS branch (e.g. only builds of the `master` branch trigger
+In either case, the configuration can be set to filter by VCS branch (e.g. only builds of the ~`master`~ `main` branch trigger
  a new deploy - allowing work on other branches to be safely ignored).
 
 Deploys triggered by Continuous Deployment will have a deployer name of `Continuous Deployment`, but in any other


### PR DESCRIPTION
We've recently updated this repo to use `main` as the default branch instead of `master`.

This PR updates some files in the repo to reflect this. I've stricken through `master` to imply its legacy. These files are documentation, until all our repos have been migrated, the docs should support legacy default branches.

Note, some tests still reference `master`. I'm not sure if it is worth updating those too?
﻿
