### PR TITLE
Add docker install step to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,9 @@ How do I run Riff-Raff locally if I want to hack on it?
 
 Assuming you have a reasonably recent version of Java installed, 
 
- * Create a basic configuration file at ~/.gu/riff-raff.conf (S3 and postgres config is probably the minimum)
+ * Install docker. On OS X [docker desktop](https://www.docker.com/products/docker-desktop) is a good shout
+ * Create a basic configuration file at ~/.gu/riff-raff.conf (S3 and prismUrl config is probably the minimum)
+ * You'll need credentials for the deployTools account 
  * Run `./script/start` from the project root (add `--debug` to attach a remote debugger on port 9999)
  * Visit http://localhost:9000/
  * Details of how to configure Riff-Raff can then be found at http://localhost:9000/docs/riffraff/properties 


### PR DESCRIPTION
Docker is required to run riffraff, let's make that explicit 🐳 