### PR TITLE
Add activeTab parameter from querystring in order to preserve tab on page refresh

### DIFF
--- a/riff-raff/app/views/deploy/deployInfoData.scala.html
+++ b/riff-raff/app/views/deploy/deployInfoData.scala.html
@@ -9,7 +9,7 @@
         @if(data.keys.isEmpty) {
             <div class="alert">No data available in lookup service</div>
         } else {
-            @snippets.tabbable(data.keys.toSeq.sorted, pushParam = "key"){ key =>
+            @snippets.tabbable(data.keys.toSeq.sorted, pushParam = "key", activeTab = request.getQueryString("key")){ key =>
                 <table class="table">
                 <thead><tr>
                     <th>Stack</th>

--- a/riff-raff/app/views/deploy/deployInfoHosts.scala.html
+++ b/riff-raff/app/views/deploy/deployInfoHosts.scala.html
@@ -14,7 +14,7 @@
         }
     } else {
 
-        @snippets.tabbable(lookup.stages.filter(hosts.contains), pushParam="stage"){ stage =>
+        @snippets.tabbable(lookup.stages.filter(hosts.contains), pushParam="stage", activeTab = request.getQueryString("stage")){ stage =>
             <table class="table table-condensed">
                 <thead><tr>
                     <th>Stack</th>


### PR DESCRIPTION
## What does this change?
This PR adds the `activeTab` parameter in the call when using the `tabbable` snippet. This value is taken from the appropriate query parameter. This allows the active tab to be preserved across page refreshes.

## How to test
On PROD navigate to `/deployinfo/hosts` and/or `/deployinfo/data` and select a tab that isn't the first. Refresh the page and you'll see that the first tab becomes active again. 
Repeat on the current branch and you should see that the previously selected tab is shown still.

## How can we measure success?
The selected tab is persisted across page refreshes.


