### PR TITLE
Show loading and error status for auto refreshing components

### DIFF
--- a/riff-raff/app/assets/javascripts/auto-refresh.coffee
+++ b/riff-raff/app/assets/javascripts/auto-refresh.coffee
@@ -34,12 +34,23 @@ enableRefresh = (interval=1000) ->
       $('[data-ajax-refresh]').each ->
         if $(".ajax-refresh-disabled").length == 0
           divBottomWasInView = bottomInView($(this).get(-1))
-          $(this).load(
+          wrapper = $(this)
+          loading = wrapper.find(".loading")
+          err = wrapper.find(".error")
+
+          loading.show()
+
+          $(this).find(".content").load(
             $(this).data("ajax-refresh"),
-            ->
-              callbackList.fire()
-              if divBottomWasInView && $(this).data("ajax-autoscroll") == true
-                scrollToBottom($(this).get(-1))
+            (response, status) ->
+              loading.hide()
+              if status == "success"
+                err.hide()
+                callbackList.fire()
+                if divBottomWasInView && wrapper.data("ajax-autoscroll") == true
+                  scrollToBottom(wrapper.get(-1))
+              else
+                err.show()
           )
 
     intervalId = setInterval reload, interval

--- a/riff-raff/app/views/deploy/dashboard.scala.html
+++ b/riff-raff/app/views/deploy/dashboard.scala.html
@@ -5,7 +5,9 @@
     <h2>Dashboard</h2>
     <hr/>
 
-    <div class="content" data-ajax-refresh="@{routes.DeployController.dashboardContent(projects, search)}" data-ajax-interval="60000">
-        <p><img height="15" width="21" src="@routes.Assets.versioned("images/parrot-small.gif")"/> Analysing history...</p>
+    <div data-ajax-refresh="@{routes.DeployController.dashboardContent(projects, search)}" data-ajax-interval="60000">
+        <p class="loading"><img height="15" width="21" src="@routes.Assets.versioned("images/parrot-small.gif")"/> Analysing history...</p>
+        <div class="alert alert-danger error" style="display:none"><strong>An error occurred whilst fetching the latest dashboard information</strong></div>
+        <div class="content"></div>
     </div>
 }(config, menu)

--- a/riff-raff/app/views/deploy/history.scala.html
+++ b/riff-raff/app/views/deploy/history.scala.html
@@ -30,7 +30,9 @@
         <div class="graph-legend"></div>
     </div>
 
-    <div class="content" data-ajax-refresh="@{routes.DeployController.historyContent()}?@request.rawQueryString" data-ajax-interval="60000">
-        <p>Loading...</p>
+    <div data-ajax-refresh="@{routes.DeployController.historyContent()}?@request.rawQueryString" data-ajax-interval="60000">
+        <p class="loading">Loading...</p>
+        <div class="alert alert-danger error" style="display:none"><strong>An error occurred whilst fetching the most recent deployment history</strong></div>
+        <div class="content"></div>
     </div>
 }(config, menu)

--- a/riff-raff/app/views/deploy/viewDeploy.scala.html
+++ b/riff-raff/app/views/deploy/viewDeploy.scala.html
@@ -96,7 +96,6 @@
     @stopDeployButton(record, stopFlag)
 
     <div data-ajax-refresh="@routes.DeployController.updatesUUID(record.uuid.toString)" data-ajax-interval="1000" data-ajax-autoscroll="@{!record.isDone}">
-        <p class="loading">Loading...</p>
         <div class="alert alert-danger error" style="display:none"><strong>An error occurred whilst fetching the most recent update</strong></div>
         <div class="content"></div>
     </div>

--- a/riff-raff/app/views/deploy/viewDeploy.scala.html
+++ b/riff-raff/app/views/deploy/viewDeploy.scala.html
@@ -95,8 +95,10 @@
 
     @stopDeployButton(record, stopFlag)
 
-    <div class="content" data-ajax-refresh="@routes.DeployController.updatesUUID(record.uuid.toString)" data-ajax-interval="1000" data-ajax-autoscroll="@{!record.isDone}">
-        <p>Loading...</p>
+    <div data-ajax-refresh="@routes.DeployController.updatesUUID(record.uuid.toString)" data-ajax-interval="1000" data-ajax-autoscroll="@{!record.isDone}">
+        <p class="loading">Loading...</p>
+        <div class="alert alert-danger error" style="display:none"><strong>An error occurred whilst fetching the most recent update</strong></div>
+        <div class="content"></div>
     </div>
 
     @stopDeployButton(record, stopFlag)

--- a/riff-raff/app/views/preview/yaml/preview.scala.html
+++ b/riff-raff/app/views/preview/yaml/preview.scala.html
@@ -47,9 +47,10 @@
 
     <div class="clearfix"></div>
 
-    <div class="content"
-      data-ajax-refresh="@routes.PreviewController.showTasks(previewId: String)">
-        @views.html.preview.yaml.loading(request, 0L)
+    <div data-ajax-refresh="@routes.PreviewController.showTasks(previewId: String)">
+@*         Loading is not included here as the api endpoint shows a loader every time it is polled until a final result is returned *@
+        <div class="alert alert-danger error" style="display:none"><strong>An error occurred whilst fetching the preview</strong></div>
+        <div class="content">@views.html.preview.yaml.loading(request, 0L)</div>
     </div>
 
 }(config, menu)


### PR DESCRIPTION
## What does this change?
This PR updates the `auto-refresh` script and the views that make use of it in order that loading and error messages are shown around the auto update process. Those components that auto refresh now contain `loading`, `error` and `content` div tags. While the request is loading, the `loading` div is shown. If the request results in an error, the `error` div is displayed. The current content is left unchanged. If the request is successful then the `error` div is hidden and the `content` div is populate with the result of the request. 

The inspiration for this change was confusing behaviour when an error occurred on the `/deployment/history` page where when an error occurred the loading message continued to be shown with no change.

## How to test
You can test the loading message by navigating to any page that auto refreshes. At the point where a new request is fired, the load message should be shown. To test the error messages, while running locally make a change within the API to ensure an error is returned and you should see the error `div` being displayed with a generic error message.

## How can we measure success?
Loading and error messages are displayed as required.

## Images
<img width="1210" alt="history" src="https://user-images.githubusercontent.com/30179286/96421854-3476f800-11ef-11eb-8cff-950ad0b4f33b.png">

