### PR TITLE
Update DeployGroupRunner.scala

### DIFF
--- a/riff-raff/app/deployment/actors/DeployGroupRunner.scala
+++ b/riff-raff/app/deployment/actors/DeployGroupRunner.scala
@@ -174,7 +174,7 @@ class DeployGroupRunner(
   private def warnDeprecatedBranch(): Unit = {
     val maybeBranch: Option[String] = record.metaData.get("branch")
     if (maybeBranch.contains("master"))
-      rootReporter.warning("branch name 'master' is not inclusive, please rename - see https://docs.google.com/document/d/1nqC5Uk6n3y7S79m1yiG6oqT8NtXWpDcsS-uLI_RK7Mg/edit#")
+      rootReporter.warning("branch name 'master' is not inclusive, please rename - see https://github.com/guardian/master-to-main/blob/main/migrating.md")
   }
 
   private def createContext: DeployContext = {


### PR DESCRIPTION
Link to the `master-to-main` repo which replaces the GDoc and keeping everything in one place. Linking also makes the `master-to-main` tool easier to discover/remember.

Requires https://github.com/guardian/master-to-main/pull/19.
