### PR TITLE
Update the docs for aws-s3 param publicReadAcl

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
@@ -34,7 +34,11 @@ object S3 extends DeploymentType {
   )
 
   val publicReadAcl = Param[Boolean]("publicReadAcl",
-    "Whether the uploaded artifacts should be given the PublicRead Canned ACL. (Default is true!)"
+    """
+      |Whether the uploaded artifacts should be given the PublicRead Canned ACL. (Default is true!) Note that the
+      |AWS default S3 bucket setting is to block all public access, which doesn't play nicely with `publicReadAcl`
+      |when set to true. If public access to the bucket is restricted then you should set `publicReadAcl` to `false`.
+    """.stripMargin
   ).default(true)
 
   val cacheControl = Param[List[PatternValue]]("cacheControl",


### PR DESCRIPTION
## What does this change?

We ran into an issue using the `aws-s3` deployment type where the default value for publicReadAcl (true) doesn't play nicely with the default policy for new buckets, which is to restrict all public access. Update the docs to specify that if your bucket blocks public access then you should set this param to false.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Slightly clearer docs == slightly happier developers 👩‍💻 👨‍💻 

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->