### PR TITLE
Prepare to send notifications if scheduled deploys fail to start

### DIFF
--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -132,7 +132,7 @@ class AppComponents(context: Context, config: Config, passwordProvider: Password
     new HstsFilter()(executionContext)
   ) // TODO (this would require an upgrade of the management-play lib) ++ PlayRequestMetrics.asFilters
 
-  val deployScheduler = new DeployScheduler(config, deployments)
+  val deployScheduler = new DeployScheduler(config, deployments, scheduledDeployNotifier)
   log.info("Starting deployment scheduler")
   deployScheduler.start()
   applicationLifecycle.addStopHook { () =>

--- a/riff-raff/app/schedule/DeployJob.scala
+++ b/riff-raff/app/schedule/DeployJob.scala
@@ -23,7 +23,8 @@ class DeployJob extends Job with Logging {
     val scheduledDeploymentEnabled = getAs[Boolean](JobDataKeys.ScheduledDeploymentEnabled)
 
     DeployJob.getLastDeploy(deployments, projectName, stage) match {
-      case Left(error) => log.warn(error.message)
+      case Left(error) =>
+        log.warn(s"Scheduled deploy failed to start. The last deploy could not be retrieved due to ${error.message}.")
       case Right(record) =>
         val result = for {
           params <- DeployJob.createDeployParameters(record, scheduledDeploymentEnabled)
@@ -34,7 +35,7 @@ class DeployJob extends Job with Logging {
           case Left(error) =>
             val schedulerContext = context.getScheduler.getContext
             val scheduledDeployNotifier: DeployFailureNotifications = schedulerContext.get("scheduledDeployNotifier").asInstanceOf[DeployFailureNotifications]
-            log.info(s"Scheduled deploy failed to start due to $error. Deploy parameters were ${extractDeployParameters(record)}")
+            log.info(s"Scheduled deploy failed to start due to ${error.message}. Deploy parameters were ${extractDeployParameters(record)}")
             // Once we understand some common reasons for failing to start deploys and the actions needed to resolve the problems
             // we can uncomment the next line to enable these notifications
             // scheduledDeployNotifier.failedDeployNotification(None, extractDeployParameters(record))

--- a/riff-raff/app/schedule/DeployJob.scala
+++ b/riff-raff/app/schedule/DeployJob.scala
@@ -34,9 +34,10 @@ class DeployJob extends Job with Logging {
           case Left(error) =>
             val schedulerContext = context.getScheduler.getContext
             val scheduledDeployNotifier: DeployFailureNotifications = schedulerContext.get("scheduledDeployNotifier").asInstanceOf[DeployFailureNotifications]
-
-            log.warn(error.message)
-            scheduledDeployNotifier.failedDeployNotification(None, extractDeployParameters(record))
+            log.info(s"Scheduled deploy failed to start due to $error. Deploy parameters were ${extractDeployParameters(record)}")
+            // Once we understand some common reasons for failing to start deploys and the actions needed to resolve the problems
+            // we can uncomment the next line to enable these notifications
+            // scheduledDeployNotifier.failedDeployNotification(None, extractDeployParameters(record))
           case Right(uuid) => log.info(s"Started scheduled deploy $uuid")
         }
     }

--- a/riff-raff/app/schedule/DeployScheduler.scala
+++ b/riff-raff/app/schedule/DeployScheduler.scala
@@ -5,6 +5,7 @@ import java.util.{TimeZone, UUID}
 import conf.Config
 import controllers.Logging
 import deployment.Deployments
+import notification.DeployFailureNotifications
 import org.quartz.CronScheduleBuilder._
 import org.quartz.JobBuilder._
 import org.quartz.TriggerBuilder._
@@ -12,7 +13,7 @@ import org.quartz.impl.StdSchedulerFactory
 import org.quartz.{JobDataMap, JobKey, TriggerKey}
 import schedule.DeployScheduler.JobDataKeys
 
-class DeployScheduler(config: Config, deployments: Deployments) extends Logging {
+class DeployScheduler(config: Config, deployments: Deployments, scheduledDeployNotifier: DeployFailureNotifications) extends Logging {
 
   private val scheduler = StdSchedulerFactory.getDefaultScheduler
 
@@ -37,6 +38,9 @@ class DeployScheduler(config: Config, deployments: Deployments) extends Logging 
         .withIdentity(jobKey(id))
         .usingJobData(buildJobDataMap(scheduleConfig))
         .build()
+
+      scheduler.getContext.put("scheduledDeployNotifier", scheduledDeployNotifier)
+
       val trigger = newTrigger()
         .withIdentity(triggerKey(id))
         .withSchedule(


### PR DESCRIPTION
## What does this change?

This change refactors the code so that we are able to send failure notifications if scheduled deploys fail to start.

At the moment, we will not actually send notifications. Instead, we will log an event whenever we _would have_ notified a team, so that we can collect data on the common failure scenarios and work out how to resolve them.

Once we've done this, it should be trivial to start sending notifications in these scenarios.

## How to test

Prior to commenting out the line which sends the notifications to Anghammarad, we confirmed that this was working as expected.

We've also tested that deploy failure notifications for other scenarios (e.g. a scheduled deploy which fails after starting due to lack of capacity) still results in a message being sent to Anghammarad.

## How can we measure success?

Existing failure notifications should continue to work as before. The logs should contain information which helps us to decide when to send alerts to teams.

## Have we considered potential risks?

This doesn't impact upon the behaviour of the app, so should be low risk.