### PR TITLE
Enable failure notifications if scheduled deploys fail to start

### DIFF
--- a/riff-raff/app/controllers/Restrictions.scala
+++ b/riff-raff/app/controllers/Restrictions.scala
@@ -66,7 +66,7 @@ class Restrictions(config: Config,
               request.user.email, f.editingLocked, f.whitelist, f.continuousDeployment, f.note)
             restrictionConfigDynamoRepository.setRestriction(newConfig)
             Redirect(routes.Restrictions.list())
-          case Left(Error(reason, _)) =>
+          case Left(Error(reason)) =>
             Forbidden(s"Not possible to update this restriction: $reason")
         }
       }
@@ -92,7 +92,7 @@ class Restrictions(config: Config,
       case Right(_) =>
         restrictionConfigDynamoRepository.deleteRestriction(UUID.fromString(id))
         Redirect(routes.Restrictions.list())
-      case Left(Error(reason, _)) =>
+      case Left(Error(reason)) =>
         Forbidden(s"Not possible to delete this restriction: $reason")
     }
   }

--- a/riff-raff/app/controllers/Restrictions.scala
+++ b/riff-raff/app/controllers/Restrictions.scala
@@ -66,7 +66,7 @@ class Restrictions(config: Config,
               request.user.email, f.editingLocked, f.whitelist, f.continuousDeployment, f.note)
             restrictionConfigDynamoRepository.setRestriction(newConfig)
             Redirect(routes.Restrictions.list())
-          case Left(Error(reason)) =>
+          case Left(Error(reason, _)) =>
             Forbidden(s"Not possible to update this restriction: $reason")
         }
       }
@@ -92,7 +92,7 @@ class Restrictions(config: Config,
       case Right(_) =>
         restrictionConfigDynamoRepository.deleteRestriction(UUID.fromString(id))
         Redirect(routes.Restrictions.list())
-      case Left(Error(reason)) =>
+      case Left(Error(reason, _)) =>
         Forbidden(s"Not possible to delete this restriction: $reason")
     }
   }

--- a/riff-raff/app/deployment/model.scala
+++ b/riff-raff/app/deployment/model.scala
@@ -1,7 +1,6 @@
 package deployment
 
 import java.util.UUID
-
 import com.gu.googleauth.UserIdentity
 import controllers.ApiKey
 import magenta.ContextMessage._
@@ -17,7 +16,12 @@ case object ContinuousDeploymentRequestSource extends RequestSource
 case class ApiRequestSource(key: ApiKey) extends RequestSource
 case object ScheduleRequestSource extends RequestSource
 
-case class Error(message: String) extends AnyVal
+sealed trait ScheduledDeployError
+case object NoDeploysFoundForStage extends ScheduledDeployError
+case object SkippedDueToPreviousFailure extends ScheduledDeployError
+case object SkippedDueToPreviousWaitingDeploy extends ScheduledDeployError
+
+case class Error(message: String, scheduledDeployError: Option[ScheduledDeployError] = None)
 
 object Record {
   val RIFFRAFF_HOSTNAME = "riffraff-hostname"

--- a/riff-raff/app/deployment/model.scala
+++ b/riff-raff/app/deployment/model.scala
@@ -16,12 +16,23 @@ case object ContinuousDeploymentRequestSource extends RequestSource
 case class ApiRequestSource(key: ApiKey) extends RequestSource
 case object ScheduleRequestSource extends RequestSource
 
-sealed trait ScheduledDeployError
-case class NoDeploysFoundForStage(projectName: String, stage: String) extends ScheduledDeployError
-case class SkippedDueToPreviousFailure(failedDeployRecord: Record) extends ScheduledDeployError
-case class SkippedDueToPreviousWaitingDeploy(waitingDeployRecord: Record) extends ScheduledDeployError
+sealed trait RiffRaffError {
+  val message: String
+}
 
-case class Error(message: String, scheduledDeployError: Option[ScheduledDeployError] = None)
+case class Error(message: String) extends RiffRaffError
+
+sealed trait ScheduledDeployNotificationError extends RiffRaffError
+case class NoDeploysFoundForStage(projectName: String, stage: String) extends ScheduledDeployNotificationError {
+  val message = s"A scheduled deploy didn't start because Riff-Raff has never deployed $projectName to $stage before. " +
+    "Please inform the owner of this schedule as it's likely that they have made a configuration error."
+}
+case class SkippedDueToPreviousFailure(failedDeployRecord: Record) extends ScheduledDeployNotificationError {
+  val message = s"Scheduled Deployment for ${failedDeployRecord.parameters.build.projectName} to ${failedDeployRecord.parameters.stage.name} didn't start because the most recent deploy failed."
+}
+case class SkippedDueToPreviousWaitingDeploy(waitingDeployRecord: Record) extends ScheduledDeployNotificationError {
+  val message = s"Scheduled Deployment for ${waitingDeployRecord.parameters.build.projectName} to ${waitingDeployRecord.parameters.stage.name} failed to start as a previous deploy was still waiting to be deployed."
+}
 
 object Record {
   val RIFFRAFF_HOSTNAME = "riffraff-hostname"

--- a/riff-raff/app/deployment/model.scala
+++ b/riff-raff/app/deployment/model.scala
@@ -17,9 +17,9 @@ case class ApiRequestSource(key: ApiKey) extends RequestSource
 case object ScheduleRequestSource extends RequestSource
 
 sealed trait ScheduledDeployError
-case object NoDeploysFoundForStage extends ScheduledDeployError
-case object SkippedDueToPreviousFailure extends ScheduledDeployError
-case object SkippedDueToPreviousWaitingDeploy extends ScheduledDeployError
+case class NoDeploysFoundForStage(projectName: String, stage: String) extends ScheduledDeployError
+case class SkippedDueToPreviousFailure(failedDeployRecord: Record) extends ScheduledDeployError
+case class SkippedDueToPreviousWaitingDeploy(stuckDeployRecord: Record) extends ScheduledDeployError
 
 case class Error(message: String, scheduledDeployError: Option[ScheduledDeployError] = None)
 

--- a/riff-raff/app/deployment/model.scala
+++ b/riff-raff/app/deployment/model.scala
@@ -19,7 +19,7 @@ case object ScheduleRequestSource extends RequestSource
 sealed trait ScheduledDeployError
 case class NoDeploysFoundForStage(projectName: String, stage: String) extends ScheduledDeployError
 case class SkippedDueToPreviousFailure(failedDeployRecord: Record) extends ScheduledDeployError
-case class SkippedDueToPreviousWaitingDeploy(stuckDeployRecord: Record) extends ScheduledDeployError
+case class SkippedDueToPreviousWaitingDeploy(waitingDeployRecord: Record) extends ScheduledDeployError
 
 case class Error(message: String, scheduledDeployError: Option[ScheduledDeployError] = None)
 

--- a/riff-raff/app/notification/DeployFailureNotifications.scala
+++ b/riff-raff/app/notification/DeployFailureNotifications.scala
@@ -6,7 +6,7 @@ import com.gu.anghammarad.Anghammarad
 import com.gu.anghammarad.models._
 import conf.Config
 import controllers.Logging
-import deployment.Error
+import deployment.ScheduledDeployNotificationError
 import lifecycle.Lifecycle
 import magenta.Message.Fail
 import magenta.deployment_type.DeploymentType
@@ -79,13 +79,9 @@ class DeployFailureNotifications(config: Config,
     ).recover { case ex => log.error(s"Failed to send notification (via Anghammarad)", ex) }
   }
 
-  def deployUnstartedNotification(error: Error): Unit = {
-    error.scheduledDeployError.map { failedToStartReason =>
-      val contentsWithTargets = deployUnstartedNotificationContents(failedToStartReason, prefix, getTargets, riffRaffTargets)
-      notifyViaAnghammarad(contentsWithTargets.notificationContents, contentsWithTargets.targets)
-    }.getOrElse {
-      log.warn("Scheduled deploy failed to start but notification was not sent...")
-    }
+  def deployUnstartedNotification(error: ScheduledDeployNotificationError): Unit = {
+    val contentsWithTargets = deployUnstartedNotificationContents(error, prefix, getTargets, riffRaffTargets)
+    notifyViaAnghammarad(contentsWithTargets.notificationContents, contentsWithTargets.targets)
   }
 
   def deployFailedNotification(uuid: UUID, parameters: DeployParameters, targets: List[Target]): Unit = {

--- a/riff-raff/app/notification/DeployFailureNotifications.scala
+++ b/riff-raff/app/notification/DeployFailureNotifications.scala
@@ -57,7 +57,7 @@ class DeployFailureNotifications(config: Config,
     val deployManually = Action("Deploy project manually", "https://riffraff.gutools.co.uk/deployment/request")
     scheduledDeployError match {
       case SkippedDueToPreviousFailure =>
-        val message = s"Your scheduled deploy didn't start because the most recent deploy was in a bad state: $errorMessage}"
+        val message = s"Your scheduled deploy didn't start because the most recent deploy was in a bad state: $errorMessage"
         MessageWithActions(message, List(deployManually))
       case SkippedDueToPreviousWaitingDeploy =>
         val message = s"A scheduled deploy failed to start as a previous deploy was stuck: $errorMessage"

--- a/riff-raff/app/notification/DeployFailureNotifications.scala
+++ b/riff-raff/app/notification/DeployFailureNotifications.scala
@@ -77,13 +77,13 @@ class DeployFailureNotifications(config: Config,
     ).recover { case ex => log.error(s"Failed to send notification (via Anghammarad)", ex) }
   }
 
-  def deployUnstartedNotification(error: ScheduledDeployNotificationError): Unit = {
-    val contentsWithTargets = failureNotificationContents.deployUnstartedNotificationContents(error, getTargets, riffRaffTargets)
+  def scheduledDeployFailureNotification(error: ScheduledDeployNotificationError): Unit = {
+    val contentsWithTargets = failureNotificationContents.scheduledDeployFailureNotificationContents(error, getTargets, riffRaffTargets)
     notifyViaAnghammarad(contentsWithTargets.notificationContents, contentsWithTargets.targets)
   }
 
-  def deployFailedNotification(uuid: UUID, parameters: DeployParameters, targets: List[Target]): Unit = {
-    val notificationContents = failureNotificationContents.deployFailedNotificationContents(uuid, parameters)
+  def midDeployFailureNotification(uuid: UUID, parameters: DeployParameters, targets: List[Target]): Unit = {
+    val notificationContents = failureNotificationContents.midDeployFailureNotificationContents(uuid, parameters)
     notifyViaAnghammarad(notificationContents, targets)
   }
 
@@ -95,7 +95,7 @@ class DeployFailureNotifications(config: Config,
       case Fail(_, _) if scheduledDeploy(message.context.parameters) || continuousDeploy(message.context.parameters) =>
         log.info(s"Attempting to send notification via Anghammarad")
         val targets = getTargets(message.context.deployId, message.context.parameters)
-        deployFailedNotification(message.context.deployId, message.context.parameters, targets)
+        midDeployFailureNotification(message.context.deployId, message.context.parameters, targets)
       case _ =>
     }
   })

--- a/riff-raff/app/notification/DeployFailureNotifications.scala
+++ b/riff-raff/app/notification/DeployFailureNotifications.scala
@@ -7,6 +7,7 @@ import com.gu.anghammarad.Anghammarad
 import com.gu.anghammarad.models._
 import conf.Config
 import controllers.{Logging, routes}
+import deployment.ScheduledDeployError
 import lifecycle.Lifecycle
 import magenta.Message.Fail
 import magenta.deployment_type.DeploymentType
@@ -50,7 +51,7 @@ class DeployFailureNotifications(config: Config,
     }
   }
 
-  def failedDeployNotification(uuid: Option[UUID], parameters: DeployParameters): Unit = {
+  def failedDeployNotification(uuid: Option[UUID], parameters: DeployParameters, scheduledDeployError: Option[ScheduledDeployError] = None): Unit = {
 
     val deriveAnghammaradTargets = for {
       yaml <- targetResolver.fetchYaml(parameters.build)

--- a/riff-raff/app/notification/DeployFailureNotifications.scala
+++ b/riff-raff/app/notification/DeployFailureNotifications.scala
@@ -117,7 +117,7 @@ class DeployFailureNotifications(config: Config,
           message = messageWithActions.message,
           sourceSystem = "riff-raff",
           channel = All,
-          target = targets, // TODO: Make this dynamically set to the most appropriate target based on reason for failure
+          target = targets,
           actions = messageWithActions.actions,
           topicArn = anghammaradTopicARN,
           client = snsClient

--- a/riff-raff/app/notification/DeployFailureNotifications.scala
+++ b/riff-raff/app/notification/DeployFailureNotifications.scala
@@ -13,7 +13,7 @@ import magenta.deployment_type.DeploymentType
 import magenta.input.resolver.Resolver
 import magenta.tasks.STS
 import magenta.{DeployParameters, DeployReporter, Lookup, Region, StsDeploymentResources, App => MagentaApp, Stack => MagentaStack}
-import notification.FailureNotificationContents._
+import notification.FailureNotificationContents.NotificationContents
 import schedule.ScheduledDeployer
 import rx.lang.scala.Subscription
 
@@ -80,12 +80,12 @@ class DeployFailureNotifications(config: Config,
   }
 
   def deployUnstartedNotification(error: ScheduledDeployNotificationError): Unit = {
-    val contentsWithTargets = deployUnstartedNotificationContents(error, prefix, getTargets, riffRaffTargets)
+    val contentsWithTargets = FailureNotificationContents.deployUnstartedNotificationContents(error, prefix, getTargets, riffRaffTargets)
     notifyViaAnghammarad(contentsWithTargets.notificationContents, contentsWithTargets.targets)
   }
 
   def deployFailedNotification(uuid: UUID, parameters: DeployParameters, targets: List[Target]): Unit = {
-    val notificationContents = deployFailedNotificationContents(uuid, parameters, prefix)
+    val notificationContents = FailureNotificationContents.deployFailedNotificationContents(uuid, parameters, prefix)
     notifyViaAnghammarad(notificationContents, targets)
   }
 

--- a/riff-raff/app/notification/FailureNotificationContents.scala
+++ b/riff-raff/app/notification/FailureNotificationContents.scala
@@ -29,7 +29,7 @@ class FailureNotificationContents(prefix: String) {
 
   def viewProblematicDeploy(uuid: UUID, status: String) = Action(s"View $status deploy", problematicDeployUrl(uuid))
 
-  def deployFailedNotificationContents(uuid: UUID, parameters: DeployParameters): NotificationContents = {
+  def midDeployFailureNotificationContents(uuid: UUID, parameters: DeployParameters): NotificationContents = {
     NotificationContents(
       subject = s"${parameters.deployer.name} failed",
       message = s"${parameters.deployer.name} for ${parameters.build.projectName} (build ${parameters.build.id}) to stage ${parameters.stage.name} failed.",
@@ -37,7 +37,7 @@ class FailureNotificationContents(prefix: String) {
     )
   }
 
-  def deployUnstartedNotificationContents(scheduledDeployError: ScheduledDeployNotificationError, teamTargetsSearch: (UUID, DeployParameters) => List[Target], riffRaffTargets: List[Target]): NotificationContentsWithTargets = {
+  def scheduledDeployFailureNotificationContents(scheduledDeployError: ScheduledDeployNotificationError, teamTargetsSearch: (UUID, DeployParameters) => List[Target], riffRaffTargets: List[Target]): NotificationContentsWithTargets = {
     val subject = "Scheduled Deployment failed to start"
     scheduledDeployError match {
       case SkippedDueToPreviousFailure(record) =>

--- a/riff-raff/app/notification/FailureNotificationContents.scala
+++ b/riff-raff/app/notification/FailureNotificationContents.scala
@@ -27,31 +27,32 @@ object FailureNotificationContents {
     prefix + path.url
   }
 
+  def viewProblematicDeploy(uuid: UUID, status: String, urlPrefix: String) = Action(s"View $status deploy", problematicDeployUrl(urlPrefix, uuid))
+
   def deployFailedNotificationContents(uuid: UUID, parameters: DeployParameters, urlPrefix: String): NotificationContents = {
     NotificationContents(
       subject = s"${parameters.deployer.name} failed",
       message = s"${parameters.deployer.name} for ${parameters.build.projectName} (build ${parameters.build.id}) to stage ${parameters.stage.name} failed.",
-      actions = List(Action("View failed deploy", problematicDeployUrl(urlPrefix, uuid)))
+      actions = List(viewProblematicDeploy(uuid, "failed", urlPrefix))
     )
   }
 
   def deployUnstartedNotificationContents(scheduledDeployError: ScheduledDeployError, urlPrefix: String, teamTargetsSearch: (Option[UUID], Option[DeployParameters]) => List[Target], riffRaffTargets: List[Target]): NotificationContentsWithTargets = {
-    val subject = "Scheduled deploy failed to start"
-    def viewProblematicDeploy(uuid: UUID, status: String) = Action(s"View $status deploy", problematicDeployUrl(urlPrefix, uuid))
+    val subject = "Scheduled Deployment failed to start"
     scheduledDeployError match {
       case SkippedDueToPreviousFailure(record) =>
-        val message = s"A scheduled deploy of ${record.parameters.build.projectName} to ${record.parameters.stage} didn't start because the most recent deploy failed."
+        val message = s"Scheduled Deployment for ${record.parameters.build.projectName} to ${record.parameters.stage.name} didn't start because the most recent deploy failed."
         val redeployAction = Action("Redeploy manually", deployAgainUrl(urlPrefix, record.uuid))
-        val contents = NotificationContents(subject, message, List(viewProblematicDeploy(record.uuid, "failed"), redeployAction))
+        val contents = NotificationContents(subject, message, List(viewProblematicDeploy(record.uuid, "failed", urlPrefix), redeployAction))
         NotificationContentsWithTargets(contents, teamTargetsSearch(Some(record.uuid), Some(record.parameters)))
       case SkippedDueToPreviousWaitingDeploy(record) =>
-        val message = s"A scheduled deploy of ${record.parameters.build.projectName} to ${record.parameters.stage} failed to start as a previous deploy was still waiting to be deployed."
-        val contents = NotificationContents(subject, message, List(viewProblematicDeploy(record.uuid, "waiting")))
+        val message = s"Scheduled Deployment for ${record.parameters.build.projectName} to ${record.parameters.stage.name} failed to start as a previous deploy was still waiting to be deployed."
+        val contents = NotificationContents(subject, message, List(viewProblematicDeploy(record.uuid, "waiting", urlPrefix)))
         NotificationContentsWithTargets(contents, riffRaffTargets)
       case NoDeploysFoundForStage(projectName, stage) =>
-        val message = s"A scheduled deploy didn't start because RiffRaff has never deployed $projectName to $stage before. " +
+        val message = s"A scheduled deploy didn't start because Riff-Raff has never deployed $projectName to $stage before. " +
           "Please inform the owner of this schedule as it's likely that they have made a configuration error."
-        val scheduledDeployConfig = Action("View scheduled deploy configuration", scheduledDeployConfigUrl(urlPrefix))
+        val scheduledDeployConfig = Action("View Scheduled Deployment configuration", scheduledDeployConfigUrl(urlPrefix))
         val contents = NotificationContents(subject, message, List(scheduledDeployConfig))
         NotificationContentsWithTargets(contents, riffRaffTargets)
     }

--- a/riff-raff/app/notification/FailureNotificationContents.scala
+++ b/riff-raff/app/notification/FailureNotificationContents.scala
@@ -1,0 +1,60 @@
+package notification
+
+import com.gu.anghammarad.models.{Action, Target}
+import controllers.routes
+import deployment.{NoDeploysFoundForStage, ScheduledDeployError, SkippedDueToPreviousFailure, SkippedDueToPreviousWaitingDeploy}
+import magenta.DeployParameters
+
+import java.util.UUID
+
+object FailureNotificationContents {
+
+  case class NotificationContents(subject: String, message: String, actions: List[Action])
+  case class NotificationContentsWithTargets(notificationContents: NotificationContents, targets: List[Target])
+
+  def problematicDeployUrl(prefix: String, uuid: UUID): String = {
+    val path = routes.DeployController.viewUUID(uuid.toString, verbose = true)
+    prefix + path.url
+  }
+
+  def deployAgainUrl(prefix: String, uuid: UUID): String = {
+    val path = routes.DeployController.deployAgainUuid(uuid.toString)
+    prefix + path.url
+  }
+
+  def scheduledDeployConfigUrl(prefix: String): String = {
+    val path = routes.ScheduleController.list()
+    prefix + path.url
+  }
+
+  def deployFailedNotificationContents(uuid: UUID, parameters: DeployParameters, urlPrefix: String): NotificationContents = {
+    NotificationContents(
+      subject = s"${parameters.deployer.name} failed",
+      message = s"${parameters.deployer.name} for ${parameters.build.projectName} (build ${parameters.build.id}) to stage ${parameters.stage.name} failed.",
+      actions = List(Action("View failed deploy", problematicDeployUrl(urlPrefix, uuid)))
+    )
+  }
+
+  def deployUnstartedNotificationContents(scheduledDeployError: ScheduledDeployError, urlPrefix: String, teamTargetsSearch: (Option[UUID], Option[DeployParameters]) => List[Target], riffRaffTargets: List[Target]): NotificationContentsWithTargets = {
+    val subject = "Scheduled deploy failed to start"
+    def viewProblematicDeploy(uuid: UUID, status: String) = Action(s"View $status deploy", problematicDeployUrl(urlPrefix, uuid))
+    scheduledDeployError match {
+      case SkippedDueToPreviousFailure(record) =>
+        val message = s"A scheduled deploy of ${record.parameters.build.projectName} to ${record.parameters.stage} didn't start because the most recent deploy failed."
+        val redeployAction = Action("Redeploy manually", deployAgainUrl(urlPrefix, record.uuid))
+        val contents = NotificationContents(subject, message, List(viewProblematicDeploy(record.uuid, "failed"), redeployAction))
+        NotificationContentsWithTargets(contents, teamTargetsSearch(Some(record.uuid), Some(record.parameters)))
+      case SkippedDueToPreviousWaitingDeploy(record) =>
+        val message = s"A scheduled deploy of ${record.parameters.build.projectName} to ${record.parameters.stage} failed to start as a previous deploy was still waiting to be deployed."
+        val contents = NotificationContents(subject, message, List(viewProblematicDeploy(record.uuid, "waiting")))
+        NotificationContentsWithTargets(contents, riffRaffTargets)
+      case NoDeploysFoundForStage(projectName, stage) =>
+        val message = s"A scheduled deploy didn't start because RiffRaff has never deployed $projectName to $stage before. " +
+          "Please inform the owner of this schedule as it's likely that they have made a configuration error."
+        val scheduledDeployConfig = Action("View scheduled deploy configuration", scheduledDeployConfigUrl(urlPrefix))
+        val contents = NotificationContents(subject, message, List(scheduledDeployConfig))
+        NotificationContentsWithTargets(contents, riffRaffTargets)
+    }
+  }
+
+}

--- a/riff-raff/app/notification/FailureNotificationContents.scala
+++ b/riff-raff/app/notification/FailureNotificationContents.scala
@@ -37,13 +37,13 @@ object FailureNotificationContents {
     )
   }
 
-  def deployUnstartedNotificationContents(scheduledDeployError: ScheduledDeployNotificationError, urlPrefix: String, teamTargetsSearch: (Option[UUID], Option[DeployParameters]) => List[Target], riffRaffTargets: List[Target]): NotificationContentsWithTargets = {
+  def deployUnstartedNotificationContents(scheduledDeployError: ScheduledDeployNotificationError, urlPrefix: String, teamTargetsSearch: (UUID, DeployParameters) => List[Target], riffRaffTargets: List[Target]): NotificationContentsWithTargets = {
     val subject = "Scheduled Deployment failed to start"
     scheduledDeployError match {
       case SkippedDueToPreviousFailure(record) =>
         val redeployAction = Action("Redeploy manually", deployAgainUrl(urlPrefix, record.uuid))
         val contents = NotificationContents(subject, scheduledDeployError.message, List(viewProblematicDeploy(record.uuid, "failed", urlPrefix), redeployAction))
-        NotificationContentsWithTargets(contents, teamTargetsSearch(Some(record.uuid), Some(record.parameters)))
+        NotificationContentsWithTargets(contents, teamTargetsSearch(record.uuid, record.parameters))
       case SkippedDueToPreviousWaitingDeploy(record) =>
         val contents = NotificationContents(subject, scheduledDeployError.message, List(viewProblematicDeploy(record.uuid, "waiting", urlPrefix)))
         NotificationContentsWithTargets(contents, riffRaffTargets)

--- a/riff-raff/app/notification/FailureNotificationContents.scala
+++ b/riff-raff/app/notification/FailureNotificationContents.scala
@@ -7,48 +7,48 @@ import magenta.DeployParameters
 
 import java.util.UUID
 
-object FailureNotificationContents {
+case class NotificationContents(subject: String, message: String, actions: List[Action])
+case class NotificationContentsWithTargets(notificationContents: NotificationContents, targets: List[Target])
 
-  case class NotificationContents(subject: String, message: String, actions: List[Action])
-  case class NotificationContentsWithTargets(notificationContents: NotificationContents, targets: List[Target])
+class FailureNotificationContents(prefix: String) {
 
-  def problematicDeployUrl(prefix: String, uuid: UUID): String = {
+  def problematicDeployUrl(uuid: UUID): String = {
     val path = routes.DeployController.viewUUID(uuid.toString, verbose = true)
     prefix + path.url
   }
 
-  def deployAgainUrl(prefix: String, uuid: UUID): String = {
+  def deployAgainUrl(uuid: UUID): String = {
     val path = routes.DeployController.deployAgainUuid(uuid.toString)
     prefix + path.url
   }
 
-  def scheduledDeployConfigUrl(prefix: String): String = {
+  val scheduledDeployConfigUrl: String = {
     val path = routes.ScheduleController.list()
     prefix + path.url
   }
 
-  def viewProblematicDeploy(uuid: UUID, status: String, urlPrefix: String) = Action(s"View $status deploy", problematicDeployUrl(urlPrefix, uuid))
+  def viewProblematicDeploy(uuid: UUID, status: String) = Action(s"View $status deploy", problematicDeployUrl(uuid))
 
-  def deployFailedNotificationContents(uuid: UUID, parameters: DeployParameters, urlPrefix: String): NotificationContents = {
+  def deployFailedNotificationContents(uuid: UUID, parameters: DeployParameters): NotificationContents = {
     NotificationContents(
       subject = s"${parameters.deployer.name} failed",
       message = s"${parameters.deployer.name} for ${parameters.build.projectName} (build ${parameters.build.id}) to stage ${parameters.stage.name} failed.",
-      actions = List(viewProblematicDeploy(uuid, "failed", urlPrefix))
+      actions = List(viewProblematicDeploy(uuid, "failed"))
     )
   }
 
-  def deployUnstartedNotificationContents(scheduledDeployError: ScheduledDeployNotificationError, urlPrefix: String, teamTargetsSearch: (UUID, DeployParameters) => List[Target], riffRaffTargets: List[Target]): NotificationContentsWithTargets = {
+  def deployUnstartedNotificationContents(scheduledDeployError: ScheduledDeployNotificationError, teamTargetsSearch: (UUID, DeployParameters) => List[Target], riffRaffTargets: List[Target]): NotificationContentsWithTargets = {
     val subject = "Scheduled Deployment failed to start"
     scheduledDeployError match {
       case SkippedDueToPreviousFailure(record) =>
-        val redeployAction = Action("Redeploy manually", deployAgainUrl(urlPrefix, record.uuid))
-        val contents = NotificationContents(subject, scheduledDeployError.message, List(viewProblematicDeploy(record.uuid, "failed", urlPrefix), redeployAction))
+        val redeployAction = Action("Redeploy manually", deployAgainUrl(record.uuid))
+        val contents = NotificationContents(subject, scheduledDeployError.message, List(viewProblematicDeploy(record.uuid, "failed"), redeployAction))
         NotificationContentsWithTargets(contents, teamTargetsSearch(record.uuid, record.parameters))
       case SkippedDueToPreviousWaitingDeploy(record) =>
-        val contents = NotificationContents(subject, scheduledDeployError.message, List(viewProblematicDeploy(record.uuid, "waiting", urlPrefix)))
+        val contents = NotificationContents(subject, scheduledDeployError.message, List(viewProblematicDeploy(record.uuid, "waiting")))
         NotificationContentsWithTargets(contents, riffRaffTargets)
       case NoDeploysFoundForStage(_, _) =>
-        val scheduledDeployConfig = Action("View Scheduled Deployment configuration", scheduledDeployConfigUrl(urlPrefix))
+        val scheduledDeployConfig = Action("View Scheduled Deployment configuration", scheduledDeployConfigUrl)
         val contents = NotificationContents(subject, scheduledDeployError.message, List(scheduledDeployConfig))
         NotificationContentsWithTargets(contents, riffRaffTargets)
     }

--- a/riff-raff/app/schedule/DeployJob.scala
+++ b/riff-raff/app/schedule/DeployJob.scala
@@ -45,7 +45,6 @@ class DeployJob extends Job with Logging {
 object DeployJob extends Logging with LogAndSquashBehaviour {
 
   def createDeployParameters(lastDeploy: Record, scheduledDeploysEnabled: Boolean): Either[RiffRaffError, DeployParameters] = {
-    def defaultError(state: RunState): Error = Error(s"Skipping scheduled deploy as deploy record ${lastDeploy.uuid} has status $state")
     lastDeploy.state match {
       case RunState.Completed =>
         val params = extractDeployParameters(lastDeploy)
@@ -59,7 +58,7 @@ object DeployJob extends Logging with LogAndSquashBehaviour {
       case RunState.NotRunning =>
         Left(SkippedDueToPreviousWaitingDeploy(lastDeploy))
       case otherState =>
-        Left(defaultError(otherState))
+        Left(Error(s"Skipping scheduled deploy as deploy record ${lastDeploy.uuid} has status $otherState"))
     }
   }
 

--- a/riff-raff/app/schedule/DeployJob.scala
+++ b/riff-raff/app/schedule/DeployJob.scala
@@ -33,7 +33,7 @@ class DeployJob extends Job with Logging {
 
     attemptToStartDeploy match {
       case Left(error: ScheduledDeployNotificationError) =>
-        scheduledDeployNotifier.deployUnstartedNotification(error)
+        scheduledDeployNotifier.scheduledDeployFailureNotification(error)
       case Left(anotherError) =>
         log.warn(s"Scheduled deploy failed to start due to $anotherError. A notification will not be sent...")
       case Right(uuid) =>

--- a/riff-raff/app/schedule/DeployJob.scala
+++ b/riff-raff/app/schedule/DeployJob.scala
@@ -22,9 +22,13 @@ class DeployJob extends Job with Logging {
     val stage = getAs[String](JobDataKeys.Stage)
     val scheduledDeploymentEnabled = getAs[Boolean](JobDataKeys.ScheduledDeploymentEnabled)
 
+    val schedulerContext = context.getScheduler.getContext
+    val scheduledDeployNotifier: DeployFailureNotifications = schedulerContext.get("scheduledDeployNotifier").asInstanceOf[DeployFailureNotifications]
+
     DeployJob.getLastDeploy(deployments, projectName, stage) match {
       case Left(error) =>
         log.warn(s"Scheduled deploy failed to start. The last deploy could not be retrieved due to ${error.message}.")
+        scheduledDeployNotifier.failedDeployNotification(None, None, Some(error))
       case Right(record) =>
         val result = for {
           params <- DeployJob.createDeployParameters(record, scheduledDeploymentEnabled)
@@ -33,12 +37,10 @@ class DeployJob extends Job with Logging {
 
         result match {
           case Left(error) =>
-            val schedulerContext = context.getScheduler.getContext
-            val scheduledDeployNotifier: DeployFailureNotifications = schedulerContext.get("scheduledDeployNotifier").asInstanceOf[DeployFailureNotifications]
             log.info(s"Scheduled deploy failed to start due to ${error.message}. Deploy parameters were ${extractDeployParameters(record)}")
             // Once we understand some common reasons for failing to start deploys and the actions needed to resolve the problems
             // we can uncomment the next line to enable these notifications
-            scheduledDeployNotifier.failedDeployNotification(None, extractDeployParameters(record), Some(error))
+            scheduledDeployNotifier.failedDeployNotification(None, Some(extractDeployParameters(record)), Some(error))
           case Right(uuid) => log.info(s"Started scheduled deploy $uuid")
         }
     }

--- a/riff-raff/app/schedule/DeployJob.scala
+++ b/riff-raff/app/schedule/DeployJob.scala
@@ -38,7 +38,7 @@ class DeployJob extends Job with Logging {
             log.info(s"Scheduled deploy failed to start due to ${error.message}. Deploy parameters were ${extractDeployParameters(record)}")
             // Once we understand some common reasons for failing to start deploys and the actions needed to resolve the problems
             // we can uncomment the next line to enable these notifications
-            scheduledDeployNotifier.failedDeployNotification(None, extractDeployParameters(record))
+            scheduledDeployNotifier.failedDeployNotification(None, extractDeployParameters(record), Some(error))
           case Right(uuid) => log.info(s"Started scheduled deploy $uuid")
         }
     }

--- a/riff-raff/app/schedule/DeployJob.scala
+++ b/riff-raff/app/schedule/DeployJob.scala
@@ -38,8 +38,6 @@ class DeployJob extends Job with Logging {
         result match {
           case Left(error) =>
             log.info(s"Scheduled deploy failed to start due to ${error.message}. Deploy parameters were ${extractDeployParameters(record)}")
-            // Once we understand some common reasons for failing to start deploys and the actions needed to resolve the problems
-            // we can uncomment the next line to enable these notifications
             scheduledDeployNotifier.failedDeployNotification(None, Some(extractDeployParameters(record)), Some(error))
           case Right(uuid) => log.info(s"Started scheduled deploy $uuid")
         }

--- a/riff-raff/test/notification/FailureNotificationContentsTest.scala
+++ b/riff-raff/test/notification/FailureNotificationContentsTest.scala
@@ -19,7 +19,7 @@ class FailureNotificationContentsTest extends FunSuite with Matchers {
       message = "Continuous Deployment for project (build 123) to stage PROD failed.",
       actions = List(Action("View failed deploy", s"http://localhost:9000/deployment/view/$uuid?verbose=true"))
     )
-    val result = failureNotificationContents.deployFailedNotificationContents(uuid, parameters)
+    val result = failureNotificationContents.midDeployFailureNotificationContents(uuid, parameters)
     result shouldBe expected
   }
 
@@ -40,7 +40,7 @@ class FailureNotificationContentsTest extends FunSuite with Matchers {
         Action("Redeploy manually", s"http://localhost:9000/deployment/deployAgain/${record.uuid}")
       ),
     )
-    val result = failureNotificationContents.deployUnstartedNotificationContents(error, fakeGetTargets, List(Stack("deploy")))
+    val result = failureNotificationContents.scheduledDeployFailureNotificationContents(error, fakeGetTargets, List(Stack("deploy")))
     result.notificationContents shouldBe expectedContents
   }
 
@@ -58,7 +58,7 @@ class FailureNotificationContentsTest extends FunSuite with Matchers {
       message = "Scheduled Deployment for testProject to PROD failed to start as a previous deploy was still waiting to be deployed.",
       actions = List(Action("View waiting deploy", s"http://localhost:9000/deployment/view/${record.uuid}?verbose=true")),
     )
-    val result = failureNotificationContents.deployUnstartedNotificationContents(error, fakeGetTargets, List(Stack("deploy")))
+    val result = failureNotificationContents.scheduledDeployFailureNotificationContents(error, fakeGetTargets, List(Stack("deploy")))
     result.notificationContents shouldBe expectedContents
   }
 
@@ -71,7 +71,7 @@ class FailureNotificationContentsTest extends FunSuite with Matchers {
       message = "A scheduled deploy didn't start because Riff-Raff has never deployed testProject to PROD before. Please inform the owner of this schedule as it's likely that they have made a configuration error.",
       actions = List(Action("View Scheduled Deployment configuration", s"http://localhost:9000/deployment/schedule"))
     )
-    val result = failureNotificationContents.deployUnstartedNotificationContents(error, fakeGetTargets, List(Stack("deploy")))
+    val result = failureNotificationContents.scheduledDeployFailureNotificationContents(error, fakeGetTargets, List(Stack("deploy")))
     result.notificationContents shouldBe expectedContents
   }
 
@@ -81,7 +81,7 @@ class FailureNotificationContentsTest extends FunSuite with Matchers {
     def fakeGetTargets(uuid: UUID, parameters: DeployParameters): List[Target] = List(Stack("another-team-stack"))
     val error = SkippedDueToPreviousFailure(record)
     val expectedTargets = List(Stack("another-team-stack"))
-    val result = failureNotificationContents.deployUnstartedNotificationContents(error, fakeGetTargets, List(Stack("deploy")))
+    val result = failureNotificationContents.scheduledDeployFailureNotificationContents(error, fakeGetTargets, List(Stack("deploy")))
     result.targets shouldBe expectedTargets
   }
 
@@ -91,7 +91,7 @@ class FailureNotificationContentsTest extends FunSuite with Matchers {
     def fakeGetTargets(uuid: UUID, parameters: DeployParameters): List[Target] = List(Stack("another-team-stack"))
     val error = SkippedDueToPreviousWaitingDeploy(record)
     val expectedTargets = List(Stack("deploy"))
-    val result = failureNotificationContents.deployUnstartedNotificationContents(error, fakeGetTargets, List(Stack("deploy")))
+    val result = failureNotificationContents.scheduledDeployFailureNotificationContents(error, fakeGetTargets, List(Stack("deploy")))
     result.targets shouldBe expectedTargets
   }
 
@@ -101,7 +101,7 @@ class FailureNotificationContentsTest extends FunSuite with Matchers {
     def fakeGetTargets(uuid: UUID, parameters: DeployParameters): List[Target] = List(Stack("another-team-stack"))
     val error = NoDeploysFoundForStage("project", "PROD")
     val expectedTargets = List(Stack("deploy"))
-    val result = failureNotificationContents.deployUnstartedNotificationContents(error, fakeGetTargets, List(Stack("deploy")))
+    val result = failureNotificationContents.scheduledDeployFailureNotificationContents(error, fakeGetTargets, List(Stack("deploy")))
     result.targets shouldBe expectedTargets
   }
 

--- a/riff-raff/test/notification/FailureNotificationContentsTest.scala
+++ b/riff-raff/test/notification/FailureNotificationContentsTest.scala
@@ -1,0 +1,102 @@
+package notification
+
+import FailureNotificationContents._
+import ci.ContinuousDeployment
+import com.gu.anghammarad.models.{Action, Stack, Target}
+import deployment.{Fixtures, NoDeploysFoundForStage, SkippedDueToPreviousFailure, SkippedDueToPreviousWaitingDeploy}
+import magenta.{Build, DeployParameters, Stage}
+import org.scalatest.{FunSuite, Matchers}
+
+import java.util.UUID
+
+class FailureNotificationContentsTest extends FunSuite with Matchers {
+
+  test("should produce sensible notification contents for a failed Continuous Deployment") {
+    val uuid = UUID.randomUUID()
+    val parameters = DeployParameters(ContinuousDeployment.deployer, Build("project", "123"), Stage("PROD"))
+    val expected = NotificationContents(
+      subject = "Continuous Deployment failed",
+      message = "Continuous Deployment for project (build 123) to stage PROD failed.",
+      actions = List(Action("View failed deploy", s"http://localhost:9000/deployment/view/$uuid?verbose=true"))
+    )
+    val result = deployFailedNotificationContents(uuid, parameters, "http://localhost:9000")
+    result shouldBe expected
+  }
+
+  test("should produce sensible notification contents for a Scheduled Deployment which fails to start due to previous failed deploy") {
+    val record = Fixtures.createRecord(
+      projectName = "testProject",
+      buildId = "123",
+      stage = "PROD"
+    )
+    def fakeGetTargets(uuid: Option[UUID], maybeParameters: Option[DeployParameters]): List[Target] = List(Stack("another-team-stack"))
+    val error = SkippedDueToPreviousFailure(record)
+    val expectedContents = NotificationContents(
+      subject = "Scheduled Deployment failed to start",
+      message = "Scheduled Deployment for testProject to PROD didn't start because the most recent deploy failed.",
+      actions = List(
+        Action("View failed deploy", s"http://localhost:9000/deployment/view/${record.uuid}?verbose=true"),
+        Action("Redeploy manually", s"http://localhost:9000/deployment/deployAgain/${record.uuid}")
+      ),
+    )
+    val result = deployUnstartedNotificationContents(error, "http://localhost:9000", fakeGetTargets, List(Stack("deploy")))
+    result.notificationContents shouldBe expectedContents
+  }
+
+  test("should produce sensible notification contents for a Scheduled Deployment which fails to start due to previous waiting deploy") {
+    val record = Fixtures.createRecord(
+      projectName = "testProject",
+      buildId = "123",
+      stage = "PROD"
+    )
+    def fakeGetTargets(uuid: Option[UUID], maybeParameters: Option[DeployParameters]): List[Target] = List(Stack("another-team-stack"))
+    val error = SkippedDueToPreviousWaitingDeploy(record)
+    val expectedContents = NotificationContents(
+      subject = "Scheduled Deployment failed to start",
+      message = "Scheduled Deployment for testProject to PROD failed to start as a previous deploy was still waiting to be deployed.",
+      actions = List(Action("View waiting deploy", s"http://localhost:9000/deployment/view/${record.uuid}?verbose=true")),
+    )
+    val result = deployUnstartedNotificationContents(error, "http://localhost:9000", fakeGetTargets, List(Stack("deploy")))
+    result.notificationContents shouldBe expectedContents
+  }
+
+  test("should produce sensible notification contents for a Scheduled Deployment which fails to start due to a configuration issue") {
+    def fakeGetTargets(uuid: Option[UUID], maybeParameters: Option[DeployParameters]): List[Target] = List(Stack("another-team-stack"))
+    val error = NoDeploysFoundForStage("testProject", "PROD")
+    val expectedContents = NotificationContents(
+      subject = "Scheduled Deployment failed to start",
+      message = "A scheduled deploy didn't start because Riff-Raff has never deployed testProject to PROD before. Please inform the owner of this schedule as it's likely that they have made a configuration error.",
+      actions = List(Action("View Scheduled Deployment configuration", s"http://localhost:9000/deployment/schedule"))
+    )
+    val result = deployUnstartedNotificationContents(error, "http://localhost:9000", fakeGetTargets, List(Stack("deploy")))
+    result.notificationContents shouldBe expectedContents
+  }
+
+  test("should use team-based targets for a Scheduled Deployment which fails to start due to previous failed deploy") {
+    val record = Fixtures.createRecord()
+    def fakeGetTargets(uuid: Option[UUID], maybeParameters: Option[DeployParameters]): List[Target] = List(Stack("another-team-stack"))
+    val error = SkippedDueToPreviousFailure(record)
+    val expectedTargets = List(Stack("another-team-stack"))
+    val result = deployUnstartedNotificationContents(error, "http://localhost:9000", fakeGetTargets, List(Stack("deploy")))
+    result.targets shouldBe expectedTargets
+  }
+
+  test("should use Riff-Raff maintainer targets for a Scheduled Deployment which fails to start due to previous waiting deploy") {
+    val record = Fixtures.createRecord()
+    def fakeGetTargets(uuid: Option[UUID], maybeParameters: Option[DeployParameters]): List[Target] = List(Stack("another-team-stack"))
+    val error = SkippedDueToPreviousWaitingDeploy(record)
+    val expectedTargets = List(Stack("deploy"))
+    val result = deployUnstartedNotificationContents(error, "http://localhost:9000", fakeGetTargets, List(Stack("deploy")))
+    result.targets shouldBe expectedTargets
+  }
+
+  test("should use Riff-Raff maintainer targets for a Scheduled Deployment which fails to start due to a configuration issue") {
+    val record = Fixtures.createRecord()
+    def fakeGetTargets(uuid: Option[UUID], maybeParameters: Option[DeployParameters]): List[Target] = List(Stack("another-team-stack"))
+    val error = NoDeploysFoundForStage("project", "PROD")
+    val expectedTargets = List(Stack("deploy"))
+    val result = deployUnstartedNotificationContents(error, "http://localhost:9000", fakeGetTargets, List(Stack("deploy")))
+    result.targets shouldBe expectedTargets
+  }
+
+}

--- a/riff-raff/test/notification/FailureNotificationContentsTest.scala
+++ b/riff-raff/test/notification/FailureNotificationContentsTest.scala
@@ -29,7 +29,7 @@ class FailureNotificationContentsTest extends FunSuite with Matchers {
       buildId = "123",
       stage = "PROD"
     )
-    def fakeGetTargets(uuid: Option[UUID], maybeParameters: Option[DeployParameters]): List[Target] = List(Stack("another-team-stack"))
+    def fakeGetTargets(uuid: UUID, parameters: DeployParameters): List[Target] = List(Stack("another-team-stack"))
     val error = SkippedDueToPreviousFailure(record)
     val expectedContents = NotificationContents(
       subject = "Scheduled Deployment failed to start",
@@ -49,7 +49,7 @@ class FailureNotificationContentsTest extends FunSuite with Matchers {
       buildId = "123",
       stage = "PROD"
     )
-    def fakeGetTargets(uuid: Option[UUID], maybeParameters: Option[DeployParameters]): List[Target] = List(Stack("another-team-stack"))
+    def fakeGetTargets(uuid: UUID, parameters: DeployParameters): List[Target] = List(Stack("another-team-stack"))
     val error = SkippedDueToPreviousWaitingDeploy(record)
     val expectedContents = NotificationContents(
       subject = "Scheduled Deployment failed to start",
@@ -61,7 +61,7 @@ class FailureNotificationContentsTest extends FunSuite with Matchers {
   }
 
   test("should produce sensible notification contents for a Scheduled Deployment which fails to start due to a configuration issue") {
-    def fakeGetTargets(uuid: Option[UUID], maybeParameters: Option[DeployParameters]): List[Target] = List(Stack("another-team-stack"))
+    def fakeGetTargets(uuid: UUID, parameters: DeployParameters): List[Target] = List(Stack("another-team-stack"))
     val error = NoDeploysFoundForStage("testProject", "PROD")
     val expectedContents = NotificationContents(
       subject = "Scheduled Deployment failed to start",
@@ -74,7 +74,7 @@ class FailureNotificationContentsTest extends FunSuite with Matchers {
 
   test("should use team-based targets for a Scheduled Deployment which fails to start due to previous failed deploy") {
     val record = Fixtures.createRecord()
-    def fakeGetTargets(uuid: Option[UUID], maybeParameters: Option[DeployParameters]): List[Target] = List(Stack("another-team-stack"))
+    def fakeGetTargets(uuid: UUID, parameters: DeployParameters): List[Target] = List(Stack("another-team-stack"))
     val error = SkippedDueToPreviousFailure(record)
     val expectedTargets = List(Stack("another-team-stack"))
     val result = deployUnstartedNotificationContents(error, "http://localhost:9000", fakeGetTargets, List(Stack("deploy")))
@@ -83,7 +83,7 @@ class FailureNotificationContentsTest extends FunSuite with Matchers {
 
   test("should use Riff-Raff maintainer targets for a Scheduled Deployment which fails to start due to previous waiting deploy") {
     val record = Fixtures.createRecord()
-    def fakeGetTargets(uuid: Option[UUID], maybeParameters: Option[DeployParameters]): List[Target] = List(Stack("another-team-stack"))
+    def fakeGetTargets(uuid: UUID, parameters: DeployParameters): List[Target] = List(Stack("another-team-stack"))
     val error = SkippedDueToPreviousWaitingDeploy(record)
     val expectedTargets = List(Stack("deploy"))
     val result = deployUnstartedNotificationContents(error, "http://localhost:9000", fakeGetTargets, List(Stack("deploy")))
@@ -92,7 +92,7 @@ class FailureNotificationContentsTest extends FunSuite with Matchers {
 
   test("should use Riff-Raff maintainer targets for a Scheduled Deployment which fails to start due to a configuration issue") {
     val record = Fixtures.createRecord()
-    def fakeGetTargets(uuid: Option[UUID], maybeParameters: Option[DeployParameters]): List[Target] = List(Stack("another-team-stack"))
+    def fakeGetTargets(uuid: UUID, parameters: DeployParameters): List[Target] = List(Stack("another-team-stack"))
     val error = NoDeploysFoundForStage("project", "PROD")
     val expectedTargets = List(Stack("deploy"))
     val result = deployUnstartedNotificationContents(error, "http://localhost:9000", fakeGetTargets, List(Stack("deploy")))

--- a/riff-raff/test/notification/FailureNotificationContentsTest.scala
+++ b/riff-raff/test/notification/FailureNotificationContentsTest.scala
@@ -1,6 +1,5 @@
 package notification
 
-import FailureNotificationContents._
 import ci.ContinuousDeployment
 import com.gu.anghammarad.models.{Action, Stack, Target}
 import deployment.{Fixtures, NoDeploysFoundForStage, SkippedDueToPreviousFailure, SkippedDueToPreviousWaitingDeploy}
@@ -12,6 +11,7 @@ import java.util.UUID
 class FailureNotificationContentsTest extends FunSuite with Matchers {
 
   test("should produce sensible notification contents for a failed Continuous Deployment") {
+    val failureNotificationContents = new FailureNotificationContents("http://localhost:9000")
     val uuid = UUID.randomUUID()
     val parameters = DeployParameters(ContinuousDeployment.deployer, Build("project", "123"), Stage("PROD"))
     val expected = NotificationContents(
@@ -19,11 +19,12 @@ class FailureNotificationContentsTest extends FunSuite with Matchers {
       message = "Continuous Deployment for project (build 123) to stage PROD failed.",
       actions = List(Action("View failed deploy", s"http://localhost:9000/deployment/view/$uuid?verbose=true"))
     )
-    val result = deployFailedNotificationContents(uuid, parameters, "http://localhost:9000")
+    val result = failureNotificationContents.deployFailedNotificationContents(uuid, parameters)
     result shouldBe expected
   }
 
   test("should produce sensible notification contents for a Scheduled Deployment which fails to start due to previous failed deploy") {
+    val failureNotificationContents = new FailureNotificationContents("http://localhost:9000")
     val record = Fixtures.createRecord(
       projectName = "testProject",
       buildId = "123",
@@ -39,11 +40,12 @@ class FailureNotificationContentsTest extends FunSuite with Matchers {
         Action("Redeploy manually", s"http://localhost:9000/deployment/deployAgain/${record.uuid}")
       ),
     )
-    val result = deployUnstartedNotificationContents(error, "http://localhost:9000", fakeGetTargets, List(Stack("deploy")))
+    val result = failureNotificationContents.deployUnstartedNotificationContents(error, fakeGetTargets, List(Stack("deploy")))
     result.notificationContents shouldBe expectedContents
   }
 
   test("should produce sensible notification contents for a Scheduled Deployment which fails to start due to previous waiting deploy") {
+    val failureNotificationContents = new FailureNotificationContents("http://localhost:9000")
     val record = Fixtures.createRecord(
       projectName = "testProject",
       buildId = "123",
@@ -56,11 +58,12 @@ class FailureNotificationContentsTest extends FunSuite with Matchers {
       message = "Scheduled Deployment for testProject to PROD failed to start as a previous deploy was still waiting to be deployed.",
       actions = List(Action("View waiting deploy", s"http://localhost:9000/deployment/view/${record.uuid}?verbose=true")),
     )
-    val result = deployUnstartedNotificationContents(error, "http://localhost:9000", fakeGetTargets, List(Stack("deploy")))
+    val result = failureNotificationContents.deployUnstartedNotificationContents(error, fakeGetTargets, List(Stack("deploy")))
     result.notificationContents shouldBe expectedContents
   }
 
   test("should produce sensible notification contents for a Scheduled Deployment which fails to start due to a configuration issue") {
+    val failureNotificationContents = new FailureNotificationContents("http://localhost:9000")
     def fakeGetTargets(uuid: UUID, parameters: DeployParameters): List[Target] = List(Stack("another-team-stack"))
     val error = NoDeploysFoundForStage("testProject", "PROD")
     val expectedContents = NotificationContents(
@@ -68,34 +71,37 @@ class FailureNotificationContentsTest extends FunSuite with Matchers {
       message = "A scheduled deploy didn't start because Riff-Raff has never deployed testProject to PROD before. Please inform the owner of this schedule as it's likely that they have made a configuration error.",
       actions = List(Action("View Scheduled Deployment configuration", s"http://localhost:9000/deployment/schedule"))
     )
-    val result = deployUnstartedNotificationContents(error, "http://localhost:9000", fakeGetTargets, List(Stack("deploy")))
+    val result = failureNotificationContents.deployUnstartedNotificationContents(error, fakeGetTargets, List(Stack("deploy")))
     result.notificationContents shouldBe expectedContents
   }
 
   test("should use team-based targets for a Scheduled Deployment which fails to start due to previous failed deploy") {
+    val failureNotificationContents = new FailureNotificationContents("http://localhost:9000")
     val record = Fixtures.createRecord()
     def fakeGetTargets(uuid: UUID, parameters: DeployParameters): List[Target] = List(Stack("another-team-stack"))
     val error = SkippedDueToPreviousFailure(record)
     val expectedTargets = List(Stack("another-team-stack"))
-    val result = deployUnstartedNotificationContents(error, "http://localhost:9000", fakeGetTargets, List(Stack("deploy")))
+    val result = failureNotificationContents.deployUnstartedNotificationContents(error, fakeGetTargets, List(Stack("deploy")))
     result.targets shouldBe expectedTargets
   }
 
   test("should use Riff-Raff maintainer targets for a Scheduled Deployment which fails to start due to previous waiting deploy") {
+    val failureNotificationContents = new FailureNotificationContents("http://localhost:9000")
     val record = Fixtures.createRecord()
     def fakeGetTargets(uuid: UUID, parameters: DeployParameters): List[Target] = List(Stack("another-team-stack"))
     val error = SkippedDueToPreviousWaitingDeploy(record)
     val expectedTargets = List(Stack("deploy"))
-    val result = deployUnstartedNotificationContents(error, "http://localhost:9000", fakeGetTargets, List(Stack("deploy")))
+    val result = failureNotificationContents.deployUnstartedNotificationContents(error, fakeGetTargets, List(Stack("deploy")))
     result.targets shouldBe expectedTargets
   }
 
   test("should use Riff-Raff maintainer targets for a Scheduled Deployment which fails to start due to a configuration issue") {
+    val failureNotificationContents = new FailureNotificationContents("http://localhost:9000")
     val record = Fixtures.createRecord()
     def fakeGetTargets(uuid: UUID, parameters: DeployParameters): List[Target] = List(Stack("another-team-stack"))
     val error = NoDeploysFoundForStage("project", "PROD")
     val expectedTargets = List(Stack("deploy"))
-    val result = deployUnstartedNotificationContents(error, "http://localhost:9000", fakeGetTargets, List(Stack("deploy")))
+    val result = failureNotificationContents.deployUnstartedNotificationContents(error, fakeGetTargets, List(Stack("deploy")))
     result.targets shouldBe expectedTargets
   }
 

--- a/riff-raff/test/schedule/DeployJobTest.scala
+++ b/riff-raff/test/schedule/DeployJobTest.scala
@@ -26,9 +26,7 @@ class DeployJobTest extends FlatSpec with Matchers with EitherValues {
       DeployParameters(Deployer("Bob"), Build("testProject", "1"), Stage("TEST")),
       recordState = Some(RunState.Failed)
     )
-    val expectedScheduledDeployError = SkippedDueToPreviousFailure(record)
-    DeployJob.createDeployParameters(record, true) shouldBe
-      Left(Error("Skipping scheduled deploy as deploy record 7fa2ee0a-8d90-4f7e-a38b-185f36fbc5aa has status Failed", Some(expectedScheduledDeployError)))
+    DeployJob.createDeployParameters(record, true) shouldBe Left(SkippedDueToPreviousFailure(record))
   }
 
   it should "produce an error if scheduled deploys are disabled" in {

--- a/riff-raff/test/schedule/DeployJobTest.scala
+++ b/riff-raff/test/schedule/DeployJobTest.scala
@@ -1,9 +1,8 @@
 package schedule
 
 import java.util.UUID
-
-import deployment.{DeployRecord, Error}
-import magenta.{Build, Deployer, DeployParameters, RunState, Stage}
+import deployment.{DeployRecord, Error, SkippedDueToPreviousFailure}
+import magenta.{Build, DeployParameters, Deployer, RunState, Stage}
 import org.joda.time.DateTime
 import org.scalatest.{EitherValues, FlatSpec, Matchers}
 
@@ -27,8 +26,9 @@ class DeployJobTest extends FlatSpec with Matchers with EitherValues {
       DeployParameters(Deployer("Bob"), Build("testProject", "1"), Stage("TEST")),
       recordState = Some(RunState.Failed)
     )
+    val expectedScheduledDeployError = SkippedDueToPreviousFailure(record)
     DeployJob.createDeployParameters(record, true) shouldBe
-      Left(Error("Skipping scheduled deploy as deploy record 7fa2ee0a-8d90-4f7e-a38b-185f36fbc5aa has status Failed"))
+      Left(Error("Skipping scheduled deploy as deploy record 7fa2ee0a-8d90-4f7e-a38b-185f36fbc5aa has status Failed", Some(expectedScheduledDeployError)))
   }
 
   it should "produce an error if scheduled deploys are disabled" in {


### PR DESCRIPTION
## What does this change?

This PR continues the work started in https://github.com/guardian/riff-raff/pull/611. We have identified the common reasons for scheduled deploys failing to start and are now ready to start sending notifications in these scenarios. 

Where there is a clearly identifiable owner and set of recovery actions, we will notify teams directly.

However, some alerts will be sent to the maintainers of Riff-Raff, rather than the teams who 'own' the scheduled deployments. There are two reasons for this:

1. In some scenarios teams are not actually empowered to fix the problems for themselves (e.g. 'stuck' deploys). Consequently these alerts will also be sent to Riff-Raff maintainers so that we can try to fix the underlying problem(s).
2. In some scenarios (e.g. configuration issues) we lack information about who to send alerts to. Consequently these alerts will also be sent to Riff-Raff maintainers so that we can try to (manually) identify affected users and help them to resolve their problem.

Both of these scenarios should be pretty rare (once the initial backlog of cases has been cleared), so I don't anticipate it generating too much work for the Developer Experience team.

There are also some scenarios where we have intentionally decided _not to_ notify anyone:

1. [Scheduled deployments are disabled](https://github.com/guardian/riff-raff/blob/main/riff-raff/app/schedule/DeployJob.scala#L57) - we assume that this is an intentional choice, so we do not notify about it.
1. [Deployments are switched off via RiffRaff](https://github.com/guardian/riff-raff/blob/main/riff-raff/app/deployment/Deployments.scala#L40) - again, we assume this would only happen in rare, intended scenarios. I don't think notifications would be helpful here!
1. Scheduled deployments fail to start as they are [in conflict with restrictions](https://github.com/guardian/riff-raff/blob/main/riff-raff/app/deployment/Deployments.scala#L38) - in my opinion this is a [bug](https://trello.com/c/kBjw5ZyR/526-make-restrictions-and-scheduled-deploys-compatible) we should fix, rather than a problem that we should notify teams about.

## How to test

I'll deploy this change to `CODE` and test it via manually creating some failure scenarios.

## How can we measure success?

* Teams should find it easier to keep their AMIs up to date, as they should be alerted when scheduled deploys fail to start.

## Have we considered potential risks?

* There is a risk that we end up sending (or receiving) too many alerts. If this becomes too noisy, we might need to consider reverting this PR, or rethinking the logic slightly.