### PR TITLE
Add logging in cases where notification target search fails

### DIFF
--- a/riff-raff/app/notification/DeployFailureNotifications.scala
+++ b/riff-raff/app/notification/DeployFailureNotifications.scala
@@ -59,7 +59,9 @@ class DeployFailureNotifications(config: Config,
       }
     attemptToDeriveTargets match {
       case Right(targets) => targets
-      case Left(_) => riffRaffTargets
+      case Left(error) =>
+        log.warn(s"Failed to identify notification targets for ${parameters.build.projectName} due to $error")
+        riffRaffTargets
     }
   }
 


### PR DESCRIPTION
I accidentally removed some [useful logging](https://github.com/guardian/riff-raff/pull/614/files#diff-0dceec64b87cbc45ffb3aabb2b6f1fb0abd9b04fcc1e1cde546cd01b49275362L81) in https://github.com/guardian/riff-raff/pull/614. This PR reinstates logging in the failure case so that we can debug problems more easily.