### PR TITLE
Update deployment types documentation

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
@@ -12,33 +12,6 @@ object AmiCloudFormationParameter extends DeploymentType with CloudFormationDepl
       |on the provided CloudFormation stack.
       |
       |You will need to add this as a dependency to your autoscaling deploy in your riff-raff.yaml to guard against race conditions.
-      |
-      |The set of AWS permissions needed to let RiffRaff do an AMI updates are:
-      |
-      |    {
-      |      "Statement": [
-      |        {
-      |          "Action": [
-      |             "cloudformation:DescribeStacks",
-      |             "cloudformation:UpdateStack",
-      |             "cloudformation:DescribeStackEvents",
-      |             "ec2:DescribeSecurityGroups",
-      |             "iam:PassRole",
-      |             "autoscaling:CreateLaunchConfiguration",
-      |             "autoscaling:UpdateAutoScalingGroup",
-      |             "autoscaling:DescribeLaunchConfigurations",
-      |             "autoscaling:DescribeScalingActivities",
-      |             "autoscaling:DeleteLaunchConfiguration"
-      |          ],
-      |          "Effect": "Allow",
-      |          "Resource": [
-      |            "*"
-      |          ]
-      |        }
-      |      ]
-      |    }
-      |
-      |You'll need to add this to the Riff-Raff IAM account used for your project.
     """.stripMargin
 
   val update = Action("update",

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -13,45 +13,6 @@ object AutoScaling  extends DeploymentType {
       |
       | - upload a new application artifact to an S3 bucket (from which new instances download their application)
       | - scale up, wait for the new instances to become healthy and then scale back down
-      |
-      |The set of AWS permissions needed to let RiffRaff do an autoscaling deploy are:
-      |
-      |    {
-      |      "Statement": [
-      |        {
-      |          "Action": [
-      |            "autoscaling:DescribeAutoScalingGroups",
-      |            "autoscaling:DescribeAutoScalingInstances",
-      |            "autoscaling:DescribeTags",
-      |            "autoscaling:SuspendProcesses",
-      |            "autoscaling:ResumeProcesses",
-      |            "autoscaling:SetDesiredCapacity",
-      |            "autoscaling:TerminateInstanceInAutoScalingGroup",
-      |            "ec2:CreateTags",
-      |            "ec2:DescribeInstances",
-      |            "elasticloadbalancing:DescribeInstanceHealth",
-      |            "elasticloadbalancing:DescribeTargetHealth",
-      |            "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
-      |            "elasticloadbalancing:DeregisterTargets"
-      |          ],
-      |          "Effect": "Allow",
-      |          "Resource": [
-      |            "*"
-      |          ]
-      |        },
-      |        {
-      |          "Action": [
-      |            "s3:*"
-      |          ],
-      |          "Effect": "Allow",
-      |          "Resource": [
-      |            "arn:aws:s3:::*"
-      |          ]
-      |        }
-      |      ]
-      |    }
-      |
-      |You'll need to add this to the Riff-Raff IAM account used for your project.
     """.stripMargin
 
   val bucket = Param[String]("bucket",

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -32,18 +32,6 @@ object CloudFormation extends DeploymentType with CloudFormationDeploymentTypePa
       |caller identity. If you don't want this to happen then then you are welcome to create it yourself. Riff-Raff will
       |create it with a lifecycle rule that deletes objects after one day. Templates over 51,200 bytes will be uploaded
       |to this bucket and sent to CloudFormation using the template URL parameter.
-      |
-      |In addition to any permissions required in order to create, modify and delete the resources within the template
-      |itself the Riff-Raff user in your account must have the following permissions to create and execute changes:
-      |
-      |  - `cloudformation:CreateChangeSet`
-      |  - `cloudformation:DescribeStacks`
-      |  - `cloudformation:DescribeStackEvents`
-      |  - `cloudformation:DescribeChangeSet`
-      |  - `cloudformation:ExecuteChangeSet`
-      |  - `cloudformation:DeleteChangeSet`
-      |  - `cloudformation:CreateStack` (if `createStackIfAbsent` has not been manually set to false in riff-raff.yaml)
-      |
     """.stripMargin
 
   val templatePath = Param[String]("templatePath",


### PR DESCRIPTION
## What does this change?

This PR removes some unnecessary information from [Riff-Raff's documentation page](https://riffraff.gutools.co.uk/docs/magenta-lib/types).

Historically, teams managed their own Riff-Raff users. Consequently, they needed to ensure that these users had the correct IAM permissions to support various Riff-Raff deployment types. 

Riff-Raff now assumes [a role](https://github.com/guardian/deploy-tools-platform/blob/main/cloudformation/riffraff/riffraff-roles.yaml) which is maintained by DevX. Consequently, other teams / users don't need to think about the IAM permissions which support various deployment types. Similarly, they no longer need to take any steps to add permissions to IAM users.

For more details on the new approach, see [new docs](https://github.com/guardian/deploy-tools-platform/blob/main/cloudformation/riffraff/riff-raff-roles.md).

## How to test
N/A

## How can we measure success?
The docs are slightly easier to follow / no longer contain outdated instructions.

## Have we considered potential risks?
N/A