### PR TITLE
Switch to ARM64 recipe

### DIFF
--- a/riff-raff/riff-raff.yaml
+++ b/riff-raff/riff-raff.yaml
@@ -12,7 +12,7 @@ deployments:
     app: riff-raff
     parameters:
       amiTags:
-        Recipe: bionic-java8-deploy-infrastructure
+        Recipe: arm64-bionic-java8-deploy-infrastructure
         AmigoStage: PROD
         BuiltBy: amigo
       amiEncrypted: true


### PR DESCRIPTION
## What does this change?
Switches riffraff to using the [arm 64 deploy tools bionic recipe](https://amigo.gutools.co.uk/recipes/arm64-bionic-java8-deploy-infrastructure).


## How to test
Deploy riffraff, wait for a quiet time on CODE/PROD and then terminate th riffraff instance

I've tested this on CODE and was able to perform a deploy succesfully