### PR TITLE
Permit scheduled deploys when restrictions are enabled if CD is enabled

### DIFF
--- a/riff-raff/app/restrictions/RestrictionChecker.scala
+++ b/riff-raff/app/restrictions/RestrictionChecker.scala
@@ -1,7 +1,7 @@
 package restrictions
 
 import com.gu.googleauth.UserIdentity
-import deployment.{ContinuousDeploymentRequestSource, Error, RequestSource, UserRequestSource}
+import deployment.{ContinuousDeploymentRequestSource, Error, RequestSource, ScheduleRequestSource, UserRequestSource}
 
 object RestrictionChecker {
   /** Method that checks whether the supplied config is editable by the supplied source and reports and error reason if
@@ -32,7 +32,7 @@ object RestrictionChecker {
 
   def sourceMatches(config: RestrictionConfig, source: RequestSource): Boolean = {
     source match {
-      case ContinuousDeploymentRequestSource => config.continuousDeployment
+      case ContinuousDeploymentRequestSource | ScheduleRequestSource => config.continuousDeployment
       case UserRequestSource(identity) => config.whitelist.contains(identity.email)
       case _ => false
     }

--- a/riff-raff/app/views/restrictions/form.scala.html
+++ b/riff-raff/app/views/restrictions/form.scala.html
@@ -38,8 +38,8 @@
 
             @b3.checkbox(
                 restrictionForm("continuousDeployment"),
-                '_text -> "Permit continuous deployment",
-                '_help -> "If this is checked then deploys triggered by continuous deployment will be allowed to run"
+                '_text -> "Permit continuous and scheduled deployments",
+                '_help -> "If this is checked then deploys triggered by continuous or scheduled deployment will be allowed to run"
             )
 
             @b3.textarea(

--- a/riff-raff/test/restrictions/RestrictionCheckerTest.scala
+++ b/riff-raff/test/restrictions/RestrictionCheckerTest.scala
@@ -1,10 +1,9 @@
 package restrictions
 
 import java.util.UUID
-
 import com.gu.googleauth.UserIdentity
 import controllers.ApiKey
-import deployment.{ApiRequestSource, ContinuousDeploymentRequestSource, Error, UserRequestSource}
+import deployment.{ApiRequestSource, ContinuousDeploymentRequestSource, Error, ScheduleRequestSource, UserRequestSource}
 import org.joda.time.DateTime
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -124,6 +123,18 @@ class RestrictionCheckerTest extends FlatSpec with Matchers {
   it should "not match when a CD and CD is not permitted" in {
     RestrictionChecker.sourceMatches(
       config.copy(continuousDeployment=false), ContinuousDeploymentRequestSource
+    ) shouldBe false
+  }
+
+  it should "match when a scheduled deploy and CD is permitted" in {
+    RestrictionChecker.sourceMatches(
+      config.copy(continuousDeployment=true), ScheduleRequestSource
+    ) shouldBe true
+  }
+
+  it should "not match when a scheduled deploy and CD is not permitted" in {
+    RestrictionChecker.sourceMatches(
+      config.copy(continuousDeployment=false), ScheduleRequestSource
     ) shouldBe false
   }
 


### PR DESCRIPTION
## What does this change?

Giant has restrictions on who can deploy it which form part of our defence in depth strategy as it can contain sensitive data. There is an issue currently where it stalls processing work after a few days and so we set up a daily scheduled deploy to keep it available for users whilst we investigate the underlying issue.

Unfortunately the scheduled deploy didn't work:

```
Scheduled deploy failed to start due to Error(Unable to queue deploy as restrictions are currently in place: Michael Barton: Sensitive data). A notification will not be sent...
```

We had configured the restriction to allow continuous deployment but scheduled deploys were still not allowed. This PR changes the behaviour to allow both if the checkbox is set and updates the description accordingly.

## How to test

It's fully unit tested but to reproduce manually:

- Set up a restriction on a deploy
- Set up a scheduled deploy

Currently the scheduled deploy is suppressed with the error above. After this PR the deploy proceeds.

## How can we measure success?

The scheduled deploy works

## Have we considered potential risks?

I think this is a clear, well tested change that follows what users would expect the behaviour to be. I haven't renamed the config variable though as I think it's serialised.

