### PR TITLE
s3 - surrogate cache parameter

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
@@ -76,6 +76,12 @@ object S3 extends DeploymentType {
     """.stripMargin
   )
 
+  val surrogateCacheControl = Param[List[PatternValue]]("surrogateCacheControl",
+    """
+      |Same as cacheControl, but for setting the surrogate-cache, which is used by Fastly.
+    """.stripMargin
+  )
+
   val mimeTypes = Param[Map[String,String]]("mimeTypes",
     """
       |A map of file extension to MIME type.
@@ -143,6 +149,7 @@ object S3 extends DeploymentType {
           bucket = bucketName,
           paths = Seq(pkg.s3Package -> prefix),
           cacheControlPatterns = cacheControl(pkg, target, reporter),
+          surrogateCacheControlPatterns = surrogateCacheControl(pkg, target, reporter),
           extensionToMimeType = mimeTypes(pkg, target, reporter),
           publicReadAcl = publicReadAcl(pkg, target, reporter)
         )

--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
@@ -78,7 +78,7 @@ object S3 extends DeploymentType {
 
   val surrogateControl = Param[List[PatternValue]]("surrogateControl",
     """
-      |Same as cacheControl, but for setting the surrogate-cache, which is used by Fastly.
+      |Same as cacheControl, but for setting the surrogate-control cache header, which is used by Fastly.
     """.stripMargin
   ).default(Nil)
 

--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
@@ -80,7 +80,7 @@ object S3 extends DeploymentType {
     """
       |Same as cacheControl, but for setting the surrogate-cache, which is used by Fastly.
     """.stripMargin
-  )
+  ).default(Nil)
 
   val mimeTypes = Param[Map[String,String]]("mimeTypes",
     """

--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
@@ -76,7 +76,7 @@ object S3 extends DeploymentType {
     """.stripMargin
   )
 
-  val surrogateCacheControl = Param[List[PatternValue]]("surrogateCacheControl",
+  val surrogateControl = Param[List[PatternValue]]("surrogateControl",
     """
       |Same as cacheControl, but for setting the surrogate-cache, which is used by Fastly.
     """.stripMargin
@@ -149,7 +149,7 @@ object S3 extends DeploymentType {
           bucket = bucketName,
           paths = Seq(pkg.s3Package -> prefix),
           cacheControlPatterns = cacheControl(pkg, target, reporter),
-          surrogateCacheControlPatterns = surrogateCacheControl(pkg, target, reporter),
+          surrogateControlPatterns = surrogateControl(pkg, target, reporter),
           extensionToMimeType = mimeTypes(pkg, target, reporter),
           publicReadAcl = publicReadAcl(pkg, target, reporter)
         )

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -57,7 +57,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
     val p = DeploymentPackage("app", app, data, "autoscaling", S3Path("artifact-bucket", "test/123/app"), deploymentTypes)
     val resource = DeploymentResources(reporter, lookupEmpty, artifactClient, stsClient)
     AutoScaling.actionsMap("uploadArtifacts").taskGenerator(p, resource, DeployTarget(parameters(), stack, region)) should matchPattern {
-      case List(S3Upload(_,_,_,_,_,false,_)) =>
+      case List(S3Upload(_,_,_,_,_,_,false,_)) =>
     }
   }
 

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -23,8 +23,8 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
   val deploymentTypes = Seq(S3, Lambda)
 
   "Deployment types" should "automatically register params in the params Seq" in {
-    S3.params should have size 9
-    S3.params.map(_.name).toSet should be(Set("prefixStage","prefixPackage","prefixStack", "pathPrefixResource","bucket","publicReadAcl","bucketResource","cacheControl","mimeTypes"))
+    S3.params should have size 10
+    S3.params.map(_.name).toSet should be(Set("prefixStage","prefixPackage","prefixStack", "pathPrefixResource","bucket","publicReadAcl","bucketResource","cacheControl","surrogateControl","mimeTypes"))
   }
 
   private val sourceS3Package = S3Path("artifact-bucket", "test/123/static-files")
@@ -72,7 +72,8 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
 
     val data: Map[String, JsValue] = Map(
       "bucket" -> JsString("bucket-1234"),
-      "cacheControl" -> JsString("no-cache")
+      "cacheControl" -> JsString("no-cache"),
+      "surrogateControl" -> JsString("max-age=3600")
     )
 
     val p = DeploymentPackage("myapp", app1, data, "aws-s3", sourceS3Package, deploymentTypes)
@@ -82,7 +83,8 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
         Region("eu-west-1"),
         "bucket-1234",
         Seq(sourceS3Package -> "test-stack/CODE/myapp"),
-        List(PatternValue(".*", "no-cache")),
+        cacheControlPatterns = List(PatternValue(".*", "no-cache")),
+        surrogateControlPatterns = List(PatternValue(".*", "max-age=3600")),
         publicReadAcl = true
       ))
     )

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -33,7 +33,7 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
     val putRec = PutReq(
       source = MagentaS3Object("artifact-bucket", "foo/bar/foo-bar.jar", 31),
       target = S3Path("artifact-bucket", "foo/bar/the-jar.jar"),
-      cacheControl = None, contentType = None,
+      cacheControl = None, surrogateControl = None, contentType = None,
       publicReadAcl = false
     )
 
@@ -56,7 +56,7 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
     val putRec = PutReq(
       MagentaS3Object("artifact-bucket", "foo/bar/foo-bar.jar", 31),
       S3Path("artifact-bucket", "foo/bar/the-jar.jar"),
-      Some("no-cache"), Some("application/json"),
+      Some("no-cache"), None, Some("application/json"),
       publicReadAcl = false
     )
 
@@ -73,19 +73,19 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
     val putRecOne = PutReq(
       MagentaS3Object("artifact-bucket", "foo/bar/foo-bar.css", 31),
       S3Path("artifact-bucket", "foo/bar/the-jar.css"),
-      Some("no-cache"), None,
+      Some("no-cache"), None, None,
       publicReadAcl = false
     )
     val putRecTwo = PutReq(
       MagentaS3Object("artifact-bucket", "foo/bar/foo-bar.xpi", 31),
       S3Path("artifact-bucket", "foo/bar/the-jar.abc"),
-      Some("no-cache"), None,
+      Some("no-cache"), None, None,
       publicReadAcl = false
     )
     val putRecThree = PutReq(
       MagentaS3Object("artifact-bucket", "foo/bar/foo-bar.js", 31),
       S3Path("artifact-bucket", "foo/bar/the-jar.js"),
-      Some("no-cache"), None,
+      Some("no-cache"), None, None,
       publicReadAcl = false
     )
 


### PR DESCRIPTION
We currently have the ability to set the `cache-control` header on the `aws-s3` task.
I'd also like to be able to set the [surrogate-control](https://docs.fastly.com/en/guides/configuring-caching#surrogate-control) header as well.

![Screen Shot 2021-03-24 at 09 10 21](https://user-images.githubusercontent.com/1513454/112284119-c8f2f400-8c80-11eb-96f8-7e217543550d.png)
