### PR TITLE
Apply stack policies before and after CFN updates

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
@@ -1,0 +1,104 @@
+package magenta.tasks
+import magenta.{DeploymentResources, KeyRing, Region}
+import software.amazon.awssdk.services.cloudformation.model.SetStackPolicyRequest
+
+case class StackPolicy(name: String, body: String)
+
+object StackPolicy {
+
+  val ALLOW_ALL_POLICY: StackPolicy = StackPolicy("AllowAll",
+  """{
+    |  "Statement" : [
+    |    {
+    |      "Effect" : "Allow",
+    |      "Action" : "Update:*",
+    |      "Principal": "*",
+    |      "Resource" : "*"
+    |    }
+    |  ]
+    |}
+    |""".stripMargin
+  )
+
+  // CFN resource types that have state or are likely to exist in
+  // external config such as DNS or application config
+  val sensitiveResourceTypes: List[String] = List(
+    // databases: RDS, DynamoDB, DocumentDB, Elastic
+    "AWS::RDS::DBInstance",
+    "AWS::DynamoDB::Table",
+    "AWS::DocDB::DBInstance",
+    "AWS::DocDB::DBCluster",
+    "AWS::Elasticsearch::Domain",
+    // queues/streams: SNS, SQS, Kinesis streams
+    "AWS::SNS::Topic",
+    "AWS::SQS::Queue",
+    "AWS::Kinesis::Stream",
+    // loadbalancers
+    "AWS::ElasticLoadBalancing::LoadBalancer",
+    "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    // cloudfront
+    "AWS::CloudFront::Distribution",
+    // API gateway
+    "AWS::ApiGateway::RestApi",
+    "AWS::ApiGateway::DomainName",
+    // buckets (although we think they can't be deleted with content)
+    "AWS::S3::Bucket"
+  )
+
+  val DENY_REPLACE_DELETE_POLICY: StackPolicy = StackPolicy("DenyReplaceDelete",
+  s"""{
+        |  "Statement" : [
+        |    {
+        |      "Effect" : "Deny",
+        |      "Action" : ["Update:Replace", "Update:Delete"],
+        |      "Principal": "*",
+        |      "Resource" : "*",
+        |      "Condition" : {
+        |        "StringEquals" : {
+        |          "ResourceType" : [
+        |            ${sensitiveResourceTypes.mkString("\"","\",\n\"", "\"")}
+        |          ]
+        |        }
+        |      }
+        |    },
+        |    {
+        |      "Effect" : "Allow",
+        |      "Action" : "Update:*",
+        |      "Principal": "*",
+        |      "Resource" : "*"
+        |    }
+        |  ]
+        |}
+        |""".stripMargin
+  )
+
+  def toMarkdown(policy: StackPolicy): String = {
+    s"""**${policy.name}**:
+      |
+      |```
+      |${policy.body}
+      |```
+      |""".stripMargin
+  }
+}
+
+class SetStackPolicyTask(
+                          region: Region,
+                          stackLookup: CloudFormationStackMetadata,
+                          val stackPolicy: StackPolicy
+                          )(implicit val keyRing: KeyRing) extends Task {
+  override def execute(resources: DeploymentResources, stopFlag: => Boolean): Unit = {
+    CloudFormation.withCfnClient(keyRing, region, resources) { cfnClient =>
+      val (stackName, _, _) = stackLookup.lookup(resources.reporter, cfnClient)
+      resources.reporter.info(s"Setting update policy for stack $stackName to ${stackPolicy.name}")
+      cfnClient.setStackPolicy(
+        SetStackPolicyRequest.builder
+          .stackName(stackName)
+          .stackPolicyBody(stackPolicy.body)
+          .build()
+      )
+    }
+  }
+
+  override def description: String = s"Set stack update policy to ${stackPolicy.name}"
+}

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -44,6 +44,25 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside with EitherV
     tasks(4) shouldBe a[DeleteChangeSetTask]
   }
 
+  it should "generate stack policy tasks in the correct order when manageStackPolicy is true" in {
+    val data: Map[String, JsValue] = Map(
+      "manageStackPolicy" -> JsBoolean(true),
+    )
+
+    val tasks = generateTasks(data)
+    tasks should have size(7)
+
+    tasks(0) shouldBe a[SetStackPolicyTask]
+    tasks(0).asInstanceOf[SetStackPolicyTask].stackPolicy shouldBe StackPolicy.DENY_REPLACE_DELETE_POLICY
+    tasks(1) shouldBe a[CreateChangeSetTask]
+    tasks(2) shouldBe a[CheckChangeSetCreatedTask]
+    tasks(3) shouldBe a[ExecuteChangeSetTask]
+    tasks(4) shouldBe a[CheckUpdateEventsTask]
+    tasks(5) shouldBe a[DeleteChangeSetTask]
+    tasks(6) shouldBe a[SetStackPolicyTask]
+    tasks(6).asInstanceOf[SetStackPolicyTask].stackPolicy shouldBe StackPolicy.ALLOW_ALL_POLICY
+  }
+
   it should "ignore amiTags when amiParametersToTags and amiTags are provided" in {
     val data: Map[String, JsValue] = Map(
       "amiTags" -> Json.obj("myApp" -> JsString("fakeApp")),


### PR DESCRIPTION
## What does this change?
We'd like to better protect users from accidental resource deletion or changes that will replace a resource. For a sub set of resource types this can be destructive so we no longer allow such updates when Riff-Raff is configured to manage the stack policy. 

Riff-Raff can be configured to manage stack policies either by directly setting the `manageStackPolicies` setting in a `riff-raff.yaml` config file or targetted against multiple projects by configuring the `cloudformation:manage-stack-policy` key in the lookup service (Prism data).

## How to test
This will need a permission change (https://github.com/guardian/deploy-tools-platform/pull/471) and setting `manageStackPolicies` to true in another project to try it out (https://github.com/guardian/prism/compare/sihil/riff-raff-stack-policy-management).

## How can we measure success?
If a CFN update is attempted that would replace a load balancer or another resource type on the list then this will fail.

## Have we considered potential risks?
This change sets the stack policy back to "allow all" after making changes. If a team is actually using stack policies then this will overwrite them. For now this is behind a flag whilst we understand this risk better.