### PR TITLE
Stream the S3 data rather than buffer entirely in memory

### DIFF
--- a/magenta-lib/src/main/scala/magenta/Project.scala
+++ b/magenta-lib/src/main/scala/magenta/Project.scala
@@ -9,6 +9,7 @@ import magenta.input._
 import magenta.tasks.Task
 import software.amazon.awssdk.services.sts.StsClient
 
+import scala.concurrent.ExecutionContext
 import scala.collection.immutable
 import scala.math.Ordering.OptionOrdering
 
@@ -54,7 +55,7 @@ object HostList {
   implicit def hostListAsListOfHosts(hostList: HostList): Seq[Host] = hostList.hosts
 }
 
-case class DeploymentResources(reporter: DeployReporter, lookup: Lookup, artifactClient: S3Client, stsClient: StsClient) {
+case class DeploymentResources(reporter: DeployReporter, lookup: Lookup, artifactClient: S3Client, stsClient: StsClient, ioExecutionContext: ExecutionContext) {
   def assembleKeyring(target: DeployTarget, pkg: DeploymentPackage): KeyRing = {
     val keyring: KeyRing = lookup.keyRing(target.parameters.stage, pkg.app, target.stack)
     reporter.verbose(s"Keyring for ${pkg.name} in ${target.stack.name}/${target.region.name}: $keyring")

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -1,7 +1,6 @@
 package magenta
 
 import java.util.UUID
-
 import magenta.artifact.S3Path
 import magenta.deployment_type.AutoScaling
 import magenta.fixtures._
@@ -10,6 +9,8 @@ import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.{JsNumber, JsString, JsValue}
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sts.StsClient
+
+import scala.concurrent.ExecutionContext.global
 
 class AutoScalingTest extends FlatSpec with Matchers {
   implicit val fakeKeyRing: KeyRing = KeyRing()
@@ -29,7 +30,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
     val p = DeploymentPackage("app", app, data, "autoscaling", S3Path("artifact-bucket", "test/123/app"),
       deploymentTypes)
 
-    AutoScaling.actionsMap("deploy").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient, stsClient), DeployTarget(parameters(), stack, region)) should be (List(
+    AutoScaling.actionsMap("deploy").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient, stsClient, global), DeployTarget(parameters(), stack, region)) should be (List(
       WaitForStabilization(p, PROD, stack, 5 * 60 * 1000, Region("eu-west-1")),
       CheckGroupSize(p, PROD, stack, Region("eu-west-1")),
       SuspendAlarmNotifications(p, PROD, stack, Region("eu-west-1")),
@@ -55,7 +56,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
     val app = App("app")
 
     val p = DeploymentPackage("app", app, data, "autoscaling", S3Path("artifact-bucket", "test/123/app"), deploymentTypes)
-    val resource = DeploymentResources(reporter, lookupEmpty, artifactClient, stsClient)
+    val resource = DeploymentResources(reporter, lookupEmpty, artifactClient, stsClient, global)
     AutoScaling.actionsMap("uploadArtifacts").taskGenerator(p, resource, DeployTarget(parameters(), stack, region)) should matchPattern {
       case List(S3Upload(_,_,_,_,_,_,false,_)) =>
     }
@@ -75,7 +76,7 @@ class AutoScalingTest extends FlatSpec with Matchers {
     val p = DeploymentPackage("app", app, data, "autoscaling", S3Path("artifact-bucket", "test/123/app"),
       deploymentTypes)
 
-    AutoScaling.actionsMap("deploy").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient, stsClient), DeployTarget(parameters(), stack, region)) should be (List(
+    AutoScaling.actionsMap("deploy").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient, stsClient, global), DeployTarget(parameters(), stack, region)) should be (List(
       WaitForStabilization(p, PROD, stack, 5 * 60 * 1000, Region("eu-west-1")),
       CheckGroupSize(p, PROD, stack, Region("eu-west-1")),
       SuspendAlarmNotifications(p, PROD, stack, Region("eu-west-1")),

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -16,6 +16,8 @@ import software.amazon.awssdk.services.cloudformation.model.{Change, ChangeSetTy
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sts.StsClient
 
+import scala.concurrent.ExecutionContext.global
+
 class CloudFormationTest extends FlatSpec with Matchers with Inside with EitherValues {
   implicit val fakeKeyRing: KeyRing = KeyRing()
   implicit val reporter: DeployReporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
@@ -30,7 +32,7 @@ class CloudFormationTest extends FlatSpec with Matchers with Inside with EitherV
     deploymentTypes)
 
   private def generateTasks(data: Map[String, JsValue] = Map("cloudFormationStackByTags" -> JsBoolean(false)), updateStrategy: Strategy = MostlyHarmless) = {
-    val resources = DeploymentResources(reporter, lookupEmpty, artifactClient, stsClient)
+    val resources = DeploymentResources(reporter, lookupEmpty, artifactClient, stsClient, global)
     CloudFormation.actionsMap("updateStack").taskGenerator(p(data), resources, DeployTarget(parameters(updateStrategy = updateStrategy), testStack, region))
   }
 

--- a/magenta-lib/src/test/scala/magenta/input/resolver/TaskResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/TaskResolverTest.scala
@@ -14,6 +14,8 @@ import play.api.libs.json.JsString
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sts.StsClient
 
+import scala.concurrent.ExecutionContext.global
+
 class TaskResolverTest extends FlatSpec with Matchers with MockitoSugar with ValidatedValues {
   implicit val reporter: DeployReporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
   implicit val artifactClient: S3Client = mock[S3Client]
@@ -35,7 +37,7 @@ class TaskResolverTest extends FlatSpec with Matchers with MockitoSugar with Val
     val deploymentTask = TaskResolver.resolve(
       deployment = Deployment("test", "stub-package-type", NEL.of("stack"), NEL.of("region"),
         NEL.of("uploadArtifact", "deploy"), "app", "directory", Nil, Map("bucket" -> JsString("bucketName"))),
-      deploymentResources = DeploymentResources(reporter, stubLookup(), artifactClient, stsClient),
+      deploymentResources = DeploymentResources(reporter, stubLookup(), artifactClient, stsClient, global),
       parameters = DeployParameters(Deployer("Test user"), Build("test-project", "1"), Stage("PROD"), updateStrategy = MostlyHarmless),
       deploymentTypes = deploymentTypes,
       artifact = S3YamlArtifact("artifact-bucket", "/path/to/test-project/1")
@@ -52,7 +54,7 @@ class TaskResolverTest extends FlatSpec with Matchers with MockitoSugar with Val
     val deploymentTask = TaskResolver.resolve(
       deployment = Deployment("test", "stub-package-type", NEL.of("stack"), NEL.of("region-one", "region-two"),
         NEL.of("uploadArtifact", "deploy"), "app", "directory", Nil, Map("bucket" -> JsString("bucketName"))),
-      deploymentResources = DeploymentResources(reporter, stubLookup(), artifactClient, stsClient),
+      deploymentResources = DeploymentResources(reporter, stubLookup(), artifactClient, stsClient, global),
       parameters = DeployParameters(Deployer("Test user"), Build("test-project", "1"), Stage("PROD"), updateStrategy = MostlyHarmless),
       deploymentTypes = deploymentTypes,
       artifact = S3YamlArtifact("artifact-bucket", "/path/to/test-project/1")
@@ -70,7 +72,7 @@ class TaskResolverTest extends FlatSpec with Matchers with MockitoSugar with Val
   "resolve" should "produce an error when the deployment type isn't found" in {
     val deploymentTask = TaskResolver.resolve(
       deployment = Deployment("test", "autoscaling", NEL.of("stack"), NEL.of("region"), NEL.of("uploadArtifact", "deploy"), "app", "directory", Nil, Map("bucket" -> JsString("bucketName"))),
-      deploymentResources = DeploymentResources(reporter, stubLookup(), artifactClient, stsClient),
+      deploymentResources = DeploymentResources(reporter, stubLookup(), artifactClient, stsClient, global),
       parameters = DeployParameters(Deployer("Test user"), Build("test-project", "1"), Stage("PROD"), updateStrategy = MostlyHarmless),
       deploymentTypes = Nil,
       artifact = S3YamlArtifact("artifact-bucket", "/path/to/test-project/1")

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
@@ -1,7 +1,6 @@
 package magenta.tasks
 
 import java.util.UUID
-
 import magenta.artifact.S3Path
 import magenta.fixtures._
 import magenta.{KeyRing, Stage, _}
@@ -12,6 +11,8 @@ import software.amazon.awssdk.services.autoscaling.AutoScalingClient
 import software.amazon.awssdk.services.autoscaling.model.{AutoScalingGroup, SetDesiredCapacityRequest}
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sts.StsClient
+
+import scala.concurrent.ExecutionContext.global
 
 class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing: KeyRing = KeyRing()
@@ -30,7 +31,7 @@ class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
       deploymentTypes)
 
     val task = DoubleSize(p, Stage("PROD"), stack, Region("eu-west-1"))
-    val resources = DeploymentResources(reporter, null, mock[S3Client], mock[StsClient])
+    val resources = DeploymentResources(reporter, null, mock[S3Client], mock[StsClient], global)
     task.execute(asg, resources, stopFlag = false, asgClientMock)
 
     verify(asgClientMock).setDesiredCapacity(
@@ -53,7 +54,7 @@ class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
 
     val task = CheckGroupSize(p, Stage("PROD"), stack, Region("eu-west-1"))
 
-    val resources = DeploymentResources(reporter, null, mock[S3Client], mock[StsClient])
+    val resources = DeploymentResources(reporter, null, mock[S3Client], mock[StsClient], global)
 
     val thrown = intercept[FailException](task.execute(asg, resources, stopFlag = false, asgClientMock))
 

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -228,12 +228,6 @@ class Config(configuration: TypesafeConfig, startTime: DateTime) extends Logging
     }
   }
 
-  object deprecation {
-    def pauseSeconds: Option[Int] = {
-      val days = Days.daysBetween(new DateTime(2017,5,22,0,0,0), new DateTime()).getDays
-      if (days > 0) Some(math.min(60, days)) else None
-    }
-  }
 
   def credentialsProviderChainV1(accessKey: Option[String] = None, secretKey: Option[String] = None): AWSCredentialsProviderChainV1 = {
     new AWSCredentialsProviderChainV1(

--- a/riff-raff/app/deployment/DeploymentEngine.scala
+++ b/riff-raff/app/deployment/DeploymentEngine.scala
@@ -12,8 +12,9 @@ import magenta.deployment_type.DeploymentType
 import resources.PrismLookup
 
 import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext
 
-class DeploymentEngine(config: Config, prismLookup: PrismLookup, deploymentTypes: Seq[DeploymentType]) extends Logging {
+class DeploymentEngine(config: Config, prismLookup: PrismLookup, deploymentTypes: Seq[DeploymentType], ioExecutionContext: ExecutionContext) extends Logging {
 
   private val concurrentDeploys = config.concurrency.maxDeploys
 
@@ -41,7 +42,7 @@ class DeploymentEngine(config: Config, prismLookup: PrismLookup, deploymentTypes
   private lazy val deployRunnerFactory = (context: ActorRefFactory, record: Record, deployCoordinator: ActorRef) =>
     context.actorOf(
       props = Props(
-        new DeployGroupRunner(config, record, deployCoordinator, deploymentRunnerFactory, stopFlagAgent, prismLookup, deploymentTypes, config.deprecation.pauseSeconds)
+        new DeployGroupRunner(config, record, deployCoordinator, deploymentRunnerFactory, stopFlagAgent, prismLookup, deploymentTypes, ioExecutionContext)
       ).withDispatcher("akka.deploy-dispatcher"),
       name = s"deployGroupRunner-${record.uuid.toString}"
     )

--- a/riff-raff/app/deployment/preview/PreviewCoordinator.scala
+++ b/riff-raff/app/deployment/preview/PreviewCoordinator.scala
@@ -14,9 +14,9 @@ import resources.PrismLookup
 import scala.collection.JavaConverters._
 import scala.collection.concurrent.{Map => ConcurrentMap}
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
-class PreviewCoordinator(config: Config, prismLookup: PrismLookup, deploymentTypes: Seq[DeploymentType]) extends Loggable {
+class PreviewCoordinator(config: Config, prismLookup: PrismLookup, deploymentTypes: Seq[DeploymentType], ioExecutionContext: ExecutionContext) extends Loggable {
   private val previews: ConcurrentMap[UUID, PreviewResult] = new ConcurrentHashMap[UUID, PreviewResult]().asScala
 
   def cleanupPreviews() {
@@ -31,7 +31,7 @@ class PreviewCoordinator(config: Config, prismLookup: PrismLookup, deploymentTyp
     val previewId = UUID.randomUUID()
     logger.info(s"Starting preview for $previewId")
     val muteLogger = DeployReporter.rootReporterFor(previewId, parameters, publishMessages = false)
-    val resources = DeploymentResources(muteLogger, prismLookup, config.artifact.aws.client, config.credentials.stsClient)
+    val resources = DeploymentResources(muteLogger, prismLookup, config.artifact.aws.client, config.credentials.stsClient, ioExecutionContext)
     val artifact = S3YamlArtifact.apply(parameters.build, config.artifact.aws.bucketName)
     val maybeConfig = artifact.deployObject.fetchContentAsString()(resources.artifactClient)
 

--- a/riff-raff/conf/application.conf
+++ b/riff-raff/conf/application.conf
@@ -50,3 +50,10 @@ db.default {
   user="riffraff"
   password="riffraff"
 }
+
+io-context {
+  fork-join-executor {
+    parallelism-factor = 20.0
+    parallelism-max = 200
+  }
+}

--- a/riff-raff/test/deployment/actors/DeployGroupRunnerTest.scala
+++ b/riff-raff/test/deployment/actors/DeployGroupRunnerTest.scala
@@ -1,15 +1,12 @@
 package deployment.actors
 
 import java.util.UUID
-
 import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
 import akka.agent.Agent
 import akka.testkit.{TestActorRef, TestKit, TestProbe}
 import conf.Config
 import deployment.{Fixtures, Record}
-import magenta.deployment_type.DeploymentType
 import magenta.graph.{DeploymentTasks, Graph, ValueNode}
-import magenta.tasks.Task
 import org.joda.time.DateTime
 import org.scalatest.{FlatSpecLike, Matchers}
 import play.api.Configuration
@@ -135,7 +132,7 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
     val record = createRecord()
     val ref = system.actorOf(
       Props(new DeployGroupRunner(config, record, deployCoordinatorProbe.ref, deploymentRunnerFactory, stopFlagAgent,
-        prismLookup = null, deploymentTypes, None)),
+        prismLookup = null, deploymentTypes, global)),
       name=s"DeployGroupRunner-${record.uuid.toString}"
     )
     DRImpl(record, deployCoordinatorProbe, deploymentRunnerProbe, ref, stopFlagAgent)
@@ -152,7 +149,7 @@ class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")
     val record = createRecord()
     val ref = TestActorRef(
       new DeployGroupRunner(config, record, deployCoordinatorProbe.ref, deploymentRunnerFactory, stopFlagAgent,
-        prismLookup = null, deploymentTypes, None),
+        prismLookup = null, deploymentTypes, global),
       name=s"DeployGroupRunner-${record.uuid.toString}"
     )
     DRwithUnderlying(record, deployCoordinatorProbe, deploymentRunnerProbe, ref, stopFlagAgent, ref.underlyingActor)

--- a/riff-raff/test/deployment/preview/PreviewTest.scala
+++ b/riff-raff/test/deployment/preview/PreviewTest.scala
@@ -14,6 +14,8 @@ import org.scalatest.{FlatSpec, Matchers}
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sts.StsClient
 
+import scala.concurrent.ExecutionContext.global
+
 class PreviewTest extends FlatSpec with Matchers with ValidatedValues with MockitoSugar {
   def valid(n: Int): Validated[NEL[String], Int] = Valid(n)
   def invalid(error: String): Validated[NEL[String], Int] = Invalid(NEL.of(error))
@@ -51,7 +53,7 @@ class PreviewTest extends FlatSpec with Matchers with ValidatedValues with Mocki
     implicit val stsClient: StsClient = mock[StsClient]
     val parameters = DeployParameters(Deployer("test user"), Build("testProject", "1"), Stage("TEST"), updateStrategy = MostlyHarmless)
     val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), parameters)
-    val resources = DeploymentResources(reporter, stubLookup(), artifactClient, stsClient)
+    val resources = DeploymentResources(reporter, stubLookup(), artifactClient, stsClient, global)
     val preview = Preview(artifact, config, parameters, resources, Seq(stubDeploymentType(Seq("testAction"))))
 
     val deploymentTuple = (


### PR DESCRIPTION
## What does this change?
When migrating from AWS SDK v1 to v2 the S3 Upload was changed to buffer the entire file being uploaded from bucket A to B in memory. This created extra memory pressure (and has caused some deploys to fail when they have particularly large artifacts being copied when there is contention with other deploys) so this change switches back to streaming with a 1Mb buffer.

Due to the way that this is now implemented, the get and put requests must be on different threads. In order to facilitate this we add an isolated execution context for IO which is now passed around so tasks can use that when appropriate.

## How to test
Pretty much any deploy will hit this path and so issues will likely become apparent fairly quickly. This has been tested in CODE to deploy itself. On a very small sample it seems to be around 10-15% slower but this might not be the case with further testing.

## How can we measure success?
Riff-Raff memory pressure is significantly decreased when lots of deploys are running simultaneously.

## Have we considered potential risks?
This is a significant change to a frequent path of code and it's possible that there are performance or memory concerns that we've not flushed out. It'll be hard to do this without deploying it.
