### PR TITLE
Add an update strategy to the deploy form

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
 import Dependencies._
 import Helpers._
+import play.sbt.routes.RoutesKeys
+import sbtbuildinfo.BuildInfoKeys.buildInfoKeys
 
 val commonSettings = Seq(
   organization := "com.gu",
@@ -44,6 +46,8 @@ lazy val riffraff = project.in(file("riff-raff"))
       "views.html.helper.magenta._",
       "com.gu.googleauth.AuthenticatedRequest"
     ),
+
+    RoutesKeys.routesImport += "utils.PathBindables._",
 
     buildInfoKeys := Seq[BuildInfoKey](
       name, version, scalaVersion, sbtVersion,

--- a/magenta-lib/src/test/scala/magenta/ReporterTest.scala
+++ b/magenta-lib/src/test/scala/magenta/ReporterTest.scala
@@ -1,12 +1,13 @@
 package magenta
 
 import org.scalatest.{FlatSpec, Matchers}
-import java.util.UUID
 
+import java.util.UUID
 import magenta.ContextMessage._
 
 import collection.mutable.ListBuffer
 import magenta.Message._
+import magenta.Strategy.MostlyHarmless
 
 class ReporterTest extends FlatSpec with Matchers {
 
@@ -18,7 +19,7 @@ class ReporterTest extends FlatSpec with Matchers {
 
   def getRandomReporter = DeployReporter.rootReporterFor(UUID.randomUUID(), parameters)
 
-  val parameters = DeployParameters(Deployer("Tester"), Build("test-app", "test-build"), Stage("TEST"))
+  val parameters = DeployParameters(Deployer("Tester"), Build("test-app", "test-build"), Stage("TEST"), updateStrategy = MostlyHarmless)
 
   it should "send messagewrappers to message sinks" in {
     val reporter = getRandomReporter

--- a/magenta-lib/src/test/scala/magenta/ReportingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/ReportingTest.scala
@@ -1,11 +1,11 @@
 package magenta
 
 import java.util.UUID
-
 import magenta.ContextMessage._
 import org.joda.time.DateTime
 import org.scalatest.{FlatSpec, Matchers}
 import magenta.Message._
+import magenta.Strategy.MostlyHarmless
 
 class ReportingTest extends FlatSpec with Matchers {
 
@@ -86,7 +86,7 @@ class ReportingTest extends FlatSpec with Matchers {
 
     tree.size should be (4)
 
-    tree.render.mkString(", ") should be (""":Deploy(DeployParameters(Deployer(Test reports),Build(test-project,1),Stage(CODE),All)) [Completed], 1:Info($ echo hello) [Completed], 1.1:CommandOutput(hello) [NotRunning], 1.2:Verbose(return value 0) [NotRunning]""")
+    tree.render.mkString(", ") should be (""":Deploy(DeployParameters(Deployer(Test reports),Build(test-project,1),Stage(CODE),All,MostlyHarmless)) [Completed], 1:Info($ echo hello) [Completed], 1.1:CommandOutput(hello) [NotRunning], 1.2:Verbose(return value 0) [NotRunning]""")
   }
 
   it should "know it has failed" in {
@@ -129,7 +129,7 @@ class ReportingTest extends FlatSpec with Matchers {
     DeployReportTree( MessageState(startMessage, failMessage, testTime, id), trees.toList )
   }
 
-  val parameters = DeployParameters(Deployer("Test reports"),Build("test-project","1"),Stage("CODE"))
+  val parameters = DeployParameters(Deployer("Test reports"),Build("test-project","1"),Stage("CODE"), updateStrategy = MostlyHarmless)
 
   val deploy = Deploy(parameters)
   val startDeploy = StartContext(deploy)

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -1,7 +1,8 @@
 package magenta.deployment_type
 
-import java.util.UUID
+import magenta.Strategy.MostlyHarmless
 
+import java.util.UUID
 import magenta._
 import magenta.artifact.S3Path
 import magenta.deployment_type.param_reads.PatternValue
@@ -163,5 +164,5 @@ class DeploymentTypeTest extends FlatSpec with Matchers with Inside with Mockito
     thrown.getMessage should equal ("Function not defined for stage CODE")
   }
 
-  def parameters(stage: Stage) = DeployParameters(Deployer("tester"), Build("project", "version"), stage)
+  def parameters(stage: Stage) = DeployParameters(Deployer("tester"), Build("project", "version"), stage, updateStrategy = MostlyHarmless)
 }

--- a/magenta-lib/src/test/scala/magenta/fixtures/package.scala
+++ b/magenta-lib/src/test/scala/magenta/fixtures/package.scala
@@ -1,5 +1,6 @@
 package magenta
 
+import magenta.Strategy.MostlyHarmless
 import magenta.deployment_type._
 import org.joda.time.DateTime
 
@@ -41,11 +42,12 @@ package object fixtures {
   def testParams() = DeployParameters(
     Deployer("default deployer"),
     Build("default project", "default version"),
-    Stage("test stage")
+    Stage("test stage"),
+    updateStrategy = MostlyHarmless
   )
 
-  def parameters(stage: Stage = PROD, version: String = "version") =
-    DeployParameters(Deployer("tester"), Build("project", version), stage)
+  def parameters(stage: Stage = PROD, version: String = "version", updateStrategy: Strategy = MostlyHarmless) =
+    DeployParameters(Deployer("tester"), Build("project", version), stage, updateStrategy = updateStrategy)
 
   def stubLookup(hostsSeq: Seq[Host] = Nil, resourceData: Map[String, Seq[Datum]] = Map.empty): Lookup = {
     new Lookup {

--- a/magenta-lib/src/test/scala/magenta/input/resolver/TaskResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/TaskResolverTest.scala
@@ -1,8 +1,8 @@
 package magenta.input.resolver
 
 import java.util.UUID
-
 import cats.data.{NonEmptyList => NEL}
+import magenta.Strategy.MostlyHarmless
 import magenta.artifact.S3YamlArtifact
 import magenta.deployment_type.Action
 import magenta.fixtures._
@@ -36,7 +36,7 @@ class TaskResolverTest extends FlatSpec with Matchers with MockitoSugar with Val
       deployment = Deployment("test", "stub-package-type", NEL.of("stack"), NEL.of("region"),
         NEL.of("uploadArtifact", "deploy"), "app", "directory", Nil, Map("bucket" -> JsString("bucketName"))),
       deploymentResources = DeploymentResources(reporter, stubLookup(), artifactClient, stsClient),
-      parameters = DeployParameters(Deployer("Test user"), Build("test-project", "1"), Stage("PROD")),
+      parameters = DeployParameters(Deployer("Test user"), Build("test-project", "1"), Stage("PROD"), updateStrategy = MostlyHarmless),
       deploymentTypes = deploymentTypes,
       artifact = S3YamlArtifact("artifact-bucket", "/path/to/test-project/1")
     )
@@ -53,7 +53,7 @@ class TaskResolverTest extends FlatSpec with Matchers with MockitoSugar with Val
       deployment = Deployment("test", "stub-package-type", NEL.of("stack"), NEL.of("region-one", "region-two"),
         NEL.of("uploadArtifact", "deploy"), "app", "directory", Nil, Map("bucket" -> JsString("bucketName"))),
       deploymentResources = DeploymentResources(reporter, stubLookup(), artifactClient, stsClient),
-      parameters = DeployParameters(Deployer("Test user"), Build("test-project", "1"), Stage("PROD")),
+      parameters = DeployParameters(Deployer("Test user"), Build("test-project", "1"), Stage("PROD"), updateStrategy = MostlyHarmless),
       deploymentTypes = deploymentTypes,
       artifact = S3YamlArtifact("artifact-bucket", "/path/to/test-project/1")
     )
@@ -71,7 +71,7 @@ class TaskResolverTest extends FlatSpec with Matchers with MockitoSugar with Val
     val deploymentTask = TaskResolver.resolve(
       deployment = Deployment("test", "autoscaling", NEL.of("stack"), NEL.of("region"), NEL.of("uploadArtifact", "deploy"), "app", "directory", Nil, Map("bucket" -> JsString("bucketName"))),
       deploymentResources = DeploymentResources(reporter, stubLookup(), artifactClient, stsClient),
-      parameters = DeployParameters(Deployer("Test user"), Build("test-project", "1"), Stage("PROD")),
+      parameters = DeployParameters(Deployer("Test user"), Build("test-project", "1"), Stage("PROD"), updateStrategy = MostlyHarmless),
       deploymentTypes = Nil,
       artifact = S3YamlArtifact("artifact-bucket", "/path/to/test-project/1")
     )

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -4,10 +4,10 @@ package tasks
 import java.io.OutputStreamWriter
 import java.net.ServerSocket
 import java.util.UUID
-
 import com.google.api.client.http.AbstractInputStreamContent
 import com.google.api.services.storage.Storage
 import com.google.api.services.storage.model.StorageObject
+import magenta.Strategy.MostlyHarmless
 import magenta.artifact.{S3Path, S3Object => MagentaS3Object}
 import magenta.deployment_type.param_reads.PatternValue
 import magenta.input.All
@@ -404,7 +404,7 @@ class TasksTest extends FlatSpec with Matchers with MockitoSugar {
   def clientFactory(client: S3Client): (KeyRing, Region, ClientOverrideConfiguration, DeploymentResources) => (S3Client => Unit) => Unit = { (_, _, _, _) => block => block(client) }
   def storageClientFactory(client: Storage): (KeyRing, DeploymentResources) => (Storage => Unit) => Unit = { (_, _) => block => block(client) }
 
-  val parameters = DeployParameters(Deployer("tester"), Build("Project","1"), Stage("CODE"), All)
+  val parameters = DeployParameters(Deployer("tester"), Build("Project","1"), Stage("CODE"), All, updateStrategy = MostlyHarmless)
 }
 
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,6 +8,7 @@ object Dependencies {
     val guardianManagement = "5.41"
     val jackson = "2.9.8"
     val awsRds = "1.11.563"
+    val enumeratumPlay = "1.5.15"
   }
 
   val commonDeps = Seq(
@@ -40,7 +41,7 @@ object Dependencies {
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % Versions.jackson,
     "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jackson,
     "com.typesafe.play" %% "play-json" % "2.7.2",
-    "com.beachape" %% "enumeratum-play-json" % "1.5.16",
+    "com.beachape" %% "enumeratum-play-json" % Versions.enumeratumPlay,
     "com.google.apis" % "google-api-services-deploymentmanager" % "v2-rev75-1.25.0",
     "com.google.apis" % "google-api-services-storage" % "v1-rev171-1.25.0"
   ).map((m: ModuleID) =>
@@ -74,6 +75,7 @@ object Dependencies {
     "org.slf4j" % "jul-to-slf4j" % "1.7.30",
     "org.scalikejdbc" %% "scalikejdbc" % "3.3.3",
     "org.postgresql" % "postgresql" % "42.2.5",
+    "com.beachape" %% "enumeratum-play" % Versions.enumeratumPlay,
     "com.whisk" %% "docker-testkit-scalatest" % "0.9.8" % "test",
     "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.8" % "test",
     filters,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
 // keep in sync with the play version in Dependencies
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.25")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.0")

--- a/riff-raff/app/assets/javascripts/collapsing.coffee
+++ b/riff-raff/app/assets/javascripts/collapsing.coffee
@@ -13,6 +13,7 @@ setupCallbacks = ->
 
 
 $ ->
+  setupCallbacks()
   if (window.autoRefresh)
     window.autoRefresh.postRefresh ->
       setupCallbacks()

--- a/riff-raff/app/ci/ContinuousDeployment.scala
+++ b/riff-raff/app/ci/ContinuousDeployment.scala
@@ -4,6 +4,7 @@ import conf.Config
 import controllers.Logging
 import deployment.{ContinuousDeploymentRequestSource, Deployments}
 import lifecycle.Lifecycle
+import magenta.Strategy.MostlyHarmless
 import magenta.{DeployParameters, Deployer, Stage}
 import persistence.ContinuousDeploymentConfigRepository
 import rx.lang.scala.{Observable, Subscription}
@@ -83,7 +84,8 @@ object ContinuousDeployment extends Logging with Retriable {
     DeployParameters(
       deployer,
       build.toMagentaBuild,
-      Stage(config.stage)
+      Stage(config.stage),
+      updateStrategy = MostlyHarmless
     )
   }
 }

--- a/riff-raff/app/controllers/DeployController.scala
+++ b/riff-raff/app/controllers/DeployController.scala
@@ -57,7 +57,8 @@ class DeployController(config: Config,
         val parameters = DeployParameters(Deployer(request.user.fullName),
           Build(form.project, form.build.toString),
           Stage(form.stage),
-          selector = form.makeSelector
+          selector = form.makeSelector,
+          updateStrategy = form.updateStrategy
         )
 
         form.action match {
@@ -67,7 +68,7 @@ class DeployController(config: Config,
               case DeploymentKeysSelector(keys) => Some(DeploymentKey.asString(keys))
             }
             Redirect(routes.PreviewController.preview(
-              parameters.build.projectName, parameters.build.id, parameters.stage.name, maybeKeys)
+              parameters.build.projectName, parameters.build.id, parameters.stage.name, maybeKeys, parameters.updateStrategy)
             )
           case "deploy" =>
             val uuid = deployments.deploy(parameters, requestSource = UserRequestSource(request.user)).valueOr{ error =>
@@ -192,7 +193,7 @@ class DeployController(config: Config,
       case All => Nil
     }
 
-    val params = DeployParameterForm(record.buildName, record.buildId, record.stage.name, "deploy", keys, None)
+    val params = DeployParameterForm(record.buildName, record.buildId, record.stage.name, "deploy", keys, None, record.parameters.updateStrategy)
 
     val fields = DeployParameterForm.form.fill(params).data
 

--- a/riff-raff/app/controllers/PreviewController.scala
+++ b/riff-raff/app/controllers/PreviewController.scala
@@ -1,7 +1,6 @@
 package controllers
 
 import java.util.UUID
-
 import cats.data.Validated.{Invalid, Valid}
 import com.gu.googleauth.AuthAction
 import com.gu.management.Loggable
@@ -9,7 +8,7 @@ import conf.Config
 import controllers.forms.DeployParameterForm
 import deployment.preview.PreviewCoordinator
 import magenta.input.{All, DeploymentKey, DeploymentKeysSelector}
-import magenta.{Build, DeployParameters, Deployer, Stage}
+import magenta.{Build, DeployParameters, Deployer, Stage, Strategy}
 import play.api.i18n.I18nSupport
 import play.api.libs.ws.WSClient
 import play.api.mvc.{AnyContent, BaseController, ControllerComponents}
@@ -24,13 +23,13 @@ class PreviewController(config: Config,
                         val controllerComponents: ControllerComponents)(
   implicit val wsClient: WSClient, executionContext: ExecutionContext
 ) extends BaseController with I18nSupport with Loggable {
-  def preview(projectName: String, buildId: String, stage: String, deployments: Option[String]) = authAction { request =>
+  def preview(projectName: String, buildId: String, stage: String, deployments: Option[String], updateStrategy: Strategy) = authAction { request =>
     val build = Build(projectName, buildId)
     val selector = deployments.map(DeploymentKey.fromStringToList) match {
       case Some(head :: tail) => DeploymentKeysSelector(head :: tail)
       case _ => All
     }
-    val parameters = DeployParameters(Deployer(request.user.fullName), build, Stage(stage), selector = selector)
+    val parameters = DeployParameters(Deployer(request.user.fullName), build, Stage(stage), selector = selector, updateStrategy = updateStrategy)
     coordinator.startPreview(parameters) match {
       case Right(id) => Ok(views.html.preview.yaml.preview(config, menu)(request, parameters, id.toString))
       case Left(error) => InternalServerError(error.toString)
@@ -57,7 +56,8 @@ class PreviewController(config: Config,
                   preview.parameters.stage.name,
                   "n/a",
                   deploymentKeys,
-                  totalKeyCount
+                  totalKeyCount,
+                  updateStrategy = preview.parameters.updateStrategy
                 ))
               Ok(views.html.preview.yaml.showTasks(taskGraph, form, deploymentKeys))
             case Invalid(errors) => Ok(views.html.validation.validationErrors(config, menu)(request, errors))

--- a/riff-raff/app/controllers/Testing.scala
+++ b/riff-raff/app/controllers/Testing.scala
@@ -1,13 +1,13 @@
 package controllers
 
 import java.util.UUID
-
 import com.gu.googleauth.AuthAction
 import conf.Config
 import deployment.{DeployFilter, DeployRecord, Deployments, PaginationView, Record}
 import housekeeping.ArtifactHousekeeping
 import magenta.ContextMessage._
 import magenta.Message._
+import magenta.Strategy.MostlyHarmless
 import magenta._
 import magenta.input.All
 import magenta.tasks.Task
@@ -51,7 +51,7 @@ class Testing(config: Config,
 
   def reportTestPartial(take: Int, verbose: Boolean) = Action { implicit request =>
     val logUUID = UUID.randomUUID()
-    val parameters = DeployParameters(Deployer("Simon Hildrew"), Build("tools::deploy", "131"), Stage("DEV"), All)
+    val parameters = DeployParameters(Deployer("Simon Hildrew"), Build("tools::deploy", "131"), Stage("DEV"), All, updateStrategy = MostlyHarmless)
 
     val testTask1 = new Task {
       override def execute(resources: DeploymentResources, stopFlag: => Boolean) {}

--- a/riff-raff/app/controllers/api.scala
+++ b/riff-raff/app/controllers/api.scala
@@ -2,11 +2,11 @@ package controllers
 
 import java.security.SecureRandom
 import java.util.UUID
-
 import cats.data.Validated.{Invalid, Valid}
 import com.gu.googleauth.AuthAction
 import conf.Config
 import deployment.{ApiRequestSource, DeployFilter, Deployments, Record}
+import magenta.Strategy.MostlyHarmless
 import magenta._
 import magenta.deployment_type.DeploymentType
 import magenta.input.All
@@ -280,7 +280,8 @@ class Api(config: Config,
         val params = DeployParameters(
           Deployer(request.fullName),
           Build(project, build),
-          Stage(stage)
+          Stage(stage),
+          updateStrategy = MostlyHarmless
         )
         assert(!changeFreeze.frozen(stage), s"Deployment to $stage is frozen (API disabled, use the web interface if you need to deploy): ${changeFreeze.message}")
 

--- a/riff-raff/app/controllers/forms/DeployParameterForm.scala
+++ b/riff-raff/app/controllers/forms/DeployParameterForm.scala
@@ -1,12 +1,14 @@
 package controllers.forms
 
+import magenta.Strategy
 import magenta.input.{All, DeploymentKey, DeploymentKeysSelector, DeploymentSelector}
 import play.api.data.Form
 import play.api.data.Forms._
+import play.api.data.format.Formatter
 import utils.Forms._
 
 case class DeployParameterForm(project:String, build:String, stage:String, action: String,
-  selectedKeys: List[DeploymentKey], totalKeyCount: Option[Int]) {
+  selectedKeys: List[DeploymentKey], totalKeyCount: Option[Int], updateStrategy: Strategy) {
 
   def makeSelector: DeploymentSelector = {
     val keysList =
@@ -23,6 +25,8 @@ case class DeployParameterForm(project:String, build:String, stage:String, actio
 }
 
 object DeployParameterForm {
+  val strategyFormat: Formatter[Strategy] = enumeratum.Forms.format(Strategy)
+
   val form = Form[DeployParameterForm](
     mapping(
       "project" -> nonEmptyText,
@@ -30,7 +34,8 @@ object DeployParameterForm {
       "stage" -> text,
       "action" -> nonEmptyText,
       "selectedKeys" -> list(deploymentKey),
-      "totalKeyCount" -> optional(number)
+      "totalKeyCount" -> optional(number),
+      "updateStrategy" -> of[Strategy](strategyFormat)
     )(DeployParameterForm.apply)(DeployParameterForm.unapply)
   )
 }

--- a/riff-raff/app/docs/DeployTypeDocs.scala
+++ b/riff-raff/app/docs/DeployTypeDocs.scala
@@ -1,7 +1,8 @@
 package docs
 
+import magenta.Strategy.MostlyHarmless
 import magenta.artifact.S3Path
-import magenta.{App, Build, Deployer, DeploymentPackage, DeployParameters, DeployTarget, Region, Stack, Stage}
+import magenta.{App, Build, DeployParameters, DeployTarget, Deployer, DeploymentPackage, Region, Stack, Stage}
 import magenta.deployment_type.{DeploymentType, Param}
 
 case class ActionDoc(name: String, documentation: String, isDefault: Boolean)
@@ -10,7 +11,10 @@ case class DeployTypeDocs(documentation: String, actions: Seq[ActionDoc], params
 
 object DeployTypeDocs {
   def defaultFromParam(fakePackage: DeploymentPackage, param: Param[_]): Option[String] = {
-    val fakeTarget = DeployTarget(DeployParameters(Deployer("<deployerName>"), Build("<projectName>", "<buildNo>"), Stage("<stage>")), Stack("<stack>"), Region("<region>"))
+    val fakeTarget = DeployTarget(
+      DeployParameters(Deployer("<deployerName>"), Build("<projectName>", "<buildNo>"), Stage("<stage>"), updateStrategy = MostlyHarmless),
+      Stack("<stack>"), Region("<region>")
+    )
     (param.defaultValue, param.defaultValueFromContext.map(_(fakePackage, fakeTarget))) match {
       case (Some(default), _) => Some(default.toString)
       case (None, Some(Right(pkgFunction))) => Some(pkgFunction.toString)

--- a/riff-raff/app/persistence/mapping.scala
+++ b/riff-raff/app/persistence/mapping.scala
@@ -48,7 +48,8 @@ object RecordConverter {
         case All => AllDocument
         case DeploymentKeysSelector(ids) =>
           DeploymentKeysSelectorDocument(ids.map(_.to[DeploymentKeyDocument]()))
-      }
+      },
+      updateStrategy = sourceParams.updateStrategy
     )
     RecordConverter(record.uuid, record.time, params, record.state, record.messages)
   }
@@ -64,7 +65,8 @@ case class DocumentConverter(deploy: DeployRecordDocument, logs: Seq[LogDocument
       case AllDocument => All
       case DeploymentKeysSelectorDocument(keys) =>
         DeploymentKeysSelector(keys.map(_.to[DeploymentKey]()))
-    }
+    },
+    deploy.parameters.updateStrategy
   )
 
   lazy val deployRecord =

--- a/riff-raff/app/persistence/mapping.scala
+++ b/riff-raff/app/persistence/mapping.scala
@@ -1,7 +1,6 @@
 package persistence
 
 import java.util.UUID
-
 import cats.instances.either._
 import cats.instances.list._
 import cats.syntax.traverse._
@@ -9,6 +8,7 @@ import controllers.{Logging, SimpleDeployDetail}
 import deployment.{DeployFilter, DeployRecord, PaginationView}
 import henkan.convert.Syntax._
 import magenta.ContextMessage._
+import magenta.Strategy.MostlyHarmless
 import magenta._
 import magenta.input.{All, DeploymentKey, DeploymentKeysSelector}
 import org.joda.time.DateTime
@@ -49,7 +49,7 @@ object RecordConverter {
         case DeploymentKeysSelector(ids) =>
           DeploymentKeysSelectorDocument(ids.map(_.to[DeploymentKeyDocument]()))
       },
-      updateStrategy = sourceParams.updateStrategy
+      updateStrategy = Some(sourceParams.updateStrategy)
     )
     RecordConverter(record.uuid, record.time, params, record.state, record.messages)
   }
@@ -66,7 +66,7 @@ case class DocumentConverter(deploy: DeployRecordDocument, logs: Seq[LogDocument
       case DeploymentKeysSelectorDocument(keys) =>
         DeploymentKeysSelector(keys.map(_.to[DeploymentKey]()))
     },
-    deploy.parameters.updateStrategy
+    deploy.parameters.updateStrategy.getOrElse(MostlyHarmless)
   )
 
   lazy val deployRecord =

--- a/riff-raff/app/persistence/representation.scala
+++ b/riff-raff/app/persistence/representation.scala
@@ -62,7 +62,8 @@ case class ParametersDocument(
   buildId: String,
   stage: String,
   tags: Map[String,String],
-  selector: DeploymentSelectorDocument
+  selector: DeploymentSelectorDocument,
+  updateStrategy: Strategy
 )
 
 object ParametersDocument {

--- a/riff-raff/app/persistence/representation.scala
+++ b/riff-raff/app/persistence/representation.scala
@@ -63,7 +63,7 @@ case class ParametersDocument(
   stage: String,
   tags: Map[String,String],
   selector: DeploymentSelectorDocument,
-  updateStrategy: Strategy
+  updateStrategy: Option[Strategy]
 )
 
 object ParametersDocument {

--- a/riff-raff/app/schedule/DeployJob.scala
+++ b/riff-raff/app/schedule/DeployJob.scala
@@ -2,6 +2,7 @@ package schedule
 
 import controllers.Logging
 import deployment._
+import magenta.Strategy.MostlyHarmless
 import magenta.{DeployParameters, RunState}
 import notification.DeployFailureNotifications
 import org.quartz.{Job, JobDataMap, JobExecutionContext}
@@ -66,7 +67,8 @@ object DeployJob extends Logging with LogAndSquashBehaviour {
     DeployParameters(
       ScheduledDeployer.deployer,
       lastDeploy.parameters.build,
-      lastDeploy.stage
+      lastDeploy.stage,
+      updateStrategy = MostlyHarmless
     )
   }
 

--- a/riff-raff/app/utils/PathBindables.scala
+++ b/riff-raff/app/utils/PathBindables.scala
@@ -1,0 +1,8 @@
+package utils
+
+import magenta.Strategy
+import play.api.mvc.QueryStringBindable
+
+object PathBindables {
+  implicit val strategyQueryBindable: QueryStringBindable[Strategy] = enumeratum.UrlBinders.queryBinder(Strategy)
+}

--- a/riff-raff/app/views/deploy/form.scala.html
+++ b/riff-raff/app/views/deploy/form.scala.html
@@ -40,8 +40,8 @@
             <div class="form-group">
                 <span class="display-inline" role="button" data-toggle="collapse" href="#advanced" aria-expanded="false" aria-controls="advanced">
                     <span id="advanced-icon" class="glyphicon glyphicon-chevron-right"></span>
+                    <span>Advanced settings</span>
                 </span>
-                <span>Advanced settings</span>
 
                 <div id="advanced" class="collapse collapsing-node">
                     <div class="alert alert-danger">Here be dragons! 🐉 Please ensure you read

--- a/riff-raff/app/views/deploy/form.scala.html
+++ b/riff-raff/app/views/deploy/form.scala.html
@@ -1,5 +1,7 @@
 @import conf.Config
 @import utils.ChangeFreeze
+@import magenta.Strategy
+@import magenta.Strategy.MostlyHarmless
 @(config: Config, menu: Menu)(changeFreeze: ChangeFreeze)(deployForm: Form[controllers.forms.DeployParameterForm], prismLookup: resources.PrismLookup)(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], messages: Messages)
 @import b3.vertical.fieldConstructor
 @import helper.CSRF
@@ -33,6 +35,14 @@
                 '_error -> deployForm.globalError.map(_.withMessage("Please select deployment stage")),
                 'id -> "stage",
                 'class -> "form-control"
+            )
+            @b3.select(
+                deployForm("updateStrategy"),
+                helper.options(Strategy.values.map(v => v.entryName -> v.userDescription):_*),
+                '_label -> Html(s"""update strategy (<a href="${routes.Application.documentation("riffraff/update-strategy.md")}">what's this?</a>)"""),
+                'value -> deployForm("updateStrategy").value.getOrElse(Strategy.MostlyHarmless.entryName),
+                '_error -> deployForm.globalError.map(_.withMessage("Please select an update strategy")),
+                'id -> "updateStrategy"
             )
 
             <div class="actions">

--- a/riff-raff/app/views/deploy/form.scala.html
+++ b/riff-raff/app/views/deploy/form.scala.html
@@ -6,7 +6,7 @@
 @import b3.vertical.fieldConstructor
 @import helper.CSRF
 
-@main("Deploy request", request, List("form-autocomplete")) {
+@main("Deploy request", request, List("form-autocomplete", "collapsing")) {
 
     <div class="clearfix"><p>&nbsp;</p></div>
 
@@ -25,25 +25,39 @@
         @CSRF.formField
         <fieldset>
             <legend>What would you like to deploy?</legend>
-            @b3.text(deployForm("project"), '_label -> "project", 'id -> "projectInput", Symbol("data-url") -> "/deployment/request/autoComplete/project", 'class -> "form-control input-md project-exact-match")
-            @b3.text(deployForm("build"),  '_label -> "build", 'id -> "buildInput", Symbol("data-url") -> "/deployment/request/autoComplete/build", 'class -> "form-control input-md")
+            @b3.text(deployForm("project"), '_label -> "Project", 'id -> "projectInput", Symbol("data-url") -> "/deployment/request/autoComplete/project", 'class -> "form-control input-md project-exact-match")
+            @b3.text(deployForm("build"),  '_label -> "Build", 'id -> "buildInput", Symbol("data-url") -> "/deployment/request/autoComplete/build", 'class -> "form-control input-md")
             @b3.select(
                 deployForm("stage"),
                 helper.options(prismLookup.stages.toList),
                 '_default -> "--- Choose a stage ---",
-                '_label -> "stage",
+                '_label -> "Stage",
                 '_error -> deployForm.globalError.map(_.withMessage("Please select deployment stage")),
                 'id -> "stage",
                 'class -> "form-control"
             )
-            @b3.select(
-                deployForm("updateStrategy"),
-                helper.options(Strategy.values.map(v => v.entryName -> v.userDescription):_*),
-                '_label -> Html(s"""update strategy (<a href="${routes.Application.documentation("riffraff/update-strategy.md")}">what's this?</a>)"""),
-                'value -> deployForm("updateStrategy").value.getOrElse(Strategy.MostlyHarmless.entryName),
-                '_error -> deployForm.globalError.map(_.withMessage("Please select an update strategy")),
-                'id -> "updateStrategy"
-            )
+
+            <div class="form-group">
+                <span class="display-inline" role="button" data-toggle="collapse" href="#advanced" aria-expanded="false" aria-controls="advanced">
+                    <span id="advanced-icon" class="glyphicon glyphicon-chevron-right"></span>
+                </span>
+                <span>Advanced settings</span>
+
+                <div id="advanced" class="collapse collapsing-node">
+                    <div class="alert alert-danger">Here be dragons! 🐉 Please ensure you read
+                        <a href="@routes.Application.documentation("riffraff/advanced-settings.md")">about these settings</a>
+                        or speak to someone in DevX before trying to use them.
+                    </div>
+                    @b3.select(
+                        deployForm("updateStrategy"),
+                        helper.options(Strategy.values.map(v => v.entryName -> v.userDescription):_*),
+                        '_label -> "Update strategy",
+                        'value -> deployForm("updateStrategy").value.getOrElse(Strategy.MostlyHarmless.entryName),
+                        '_error -> deployForm.globalError.map(_.withMessage("Please select an update strategy")),
+                        'id -> "updateStrategy"
+                    )
+                </div>
+            </div>
 
             <div class="actions">
                 <button name="action" type="submit" value="preview" class="btn btn-default">Preview...</button>

--- a/riff-raff/app/views/deploy/viewDeploy.scala.html
+++ b/riff-raff/app/views/deploy/viewDeploy.scala.html
@@ -30,6 +30,8 @@
                 <small>This deploy started at @record.time.toString(DateFormats.Short) on @hostname</small>
             }
 
+            <p>The update strategy for this deploy @if(record.isRunning) {is} else {was} @record.parameters.updateStrategy.entryName</p>
+
             @for(vcs <- record.vcsInfo) {
                 <p>
                     The commit for this deploy @if(record.isRunning) {is} else {was}

--- a/riff-raff/app/views/deploy/viewDeploy.scala.html
+++ b/riff-raff/app/views/deploy/viewDeploy.scala.html
@@ -15,7 +15,7 @@
         }
 </script>
 
-@main(s"Deploy for ${record.buildName}", request, List("auto-refresh", "deploy-verbose", "stop-deploy", "notifications", "report-tree-collapsing")) {
+@main(s"Deploy for ${record.buildName}", request, List("auto-refresh", "deploy-verbose", "stop-deploy", "notifications", "collapsing")) {
     <style>
     .visibility-verbose {
       display:@if(!verbose) {none} else {list-item};

--- a/riff-raff/app/views/preview/yaml/showTasks.scala.html
+++ b/riff-raff/app/views/preview/yaml/showTasks.scala.html
@@ -12,10 +12,10 @@ to make it fit in the Play idea of forms but it's far from trivial. Be warned!
 
 @b3.formCSRF(routes.DeployController.processForm) {
     @b3.hiddens(
-        "project" -> form("project").value.get,
-        "build" -> form("build").value.get,
-        "stage" -> form("stage").value.get,
-        "updateStrategy" -> form("updateStrategy").value.get
+        "project" -> form.value.map(_.project).get,
+        "build" -> form.value.map(_.build).get,
+        "stage" -> form.value.map(_.stage).get,
+        "updateStrategy" -> form.value.map(_.updateStrategy).getOrElse(MostlyHarmless)
     )
     @defining(form("totalKeyCount").value){ maybeCount =>
       @maybeCount match {

--- a/riff-raff/app/views/preview/yaml/showTasks.scala.html
+++ b/riff-raff/app/views/preview/yaml/showTasks.scala.html
@@ -5,6 +5,7 @@
 We use checkedKeys here separately from the form as Play! forms do not deal well with repeated checkboxes. We could try
 to make it fit in the Play idea of forms but it's far from trivial. Be warned!
 *@
+@import magenta.Strategy.MostlyHarmless
 @(taskGraph: magenta.graph.Graph[(magenta.input.DeploymentKey, magenta.graph.DeploymentTasks)],
         form: Form[forms.DeployParameterForm], checkedKeys: List[magenta.input.DeploymentKey])(
  implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], messages: Messages)
@@ -13,7 +14,8 @@ to make it fit in the Play idea of forms but it's far from trivial. Be warned!
     @b3.hiddens(
         "project" -> form("project").value.get,
         "build" -> form("build").value.get,
-        "stage" -> form("stage").value.get
+        "stage" -> form("stage").value.get,
+        "updateStrategy" -> form("updateStrategy").value.get
     )
     @defining(form("totalKeyCount").value){ maybeCount =>
       @maybeCount match {
@@ -21,10 +23,11 @@ to make it fit in the Play idea of forms but it's far from trivial. Be warned!
           case None => {
               <div class="alert alert-info">
                   This preview shows only the subset of deployment tasks that would be executed. To see all tasks, <a href="@routes.PreviewController.preview(
-                      form("project").value.get,
-                      form("build").value.get,
-                      form("stage").value.get,
-                      None
+                      form.value.map(_.project).get,
+                      form.value.map(_.build).get,
+                      form.value.map(_.stage).get,
+                      None,
+                      form.value.map(_.updateStrategy).getOrElse(MostlyHarmless)
                   )">reset your selections</a>.
               </div>
           }
@@ -42,10 +45,11 @@ to make it fit in the Play idea of forms but it's far from trivial. Be warned!
             'class -> "btn btn-primary"
         ){Deploy}
         <a class="btn btn-danger" href="@routes.PreviewController.preview(
-            form("project").value.get,
-            form("build").value.get,
-            form("stage").value.get,
-            None
+            form.value.map(_.project).get,
+            form.value.map(_.build).get,
+            form.value.map(_.stage).get,
+            None,
+            form.value.map(_.updateStrategy).getOrElse(MostlyHarmless)
         )">Reset selection</a>
     </div>
     @for(((key, deploymentTasks), i) <- taskGraph.toList.zipWithIndex) {
@@ -114,10 +118,11 @@ to make it fit in the Play idea of forms but it's far from trivial. Be warned!
             'class -> "btn btn-primary"
         ){Deploy}
         <a class="btn btn-danger" href="@routes.PreviewController.preview(
-            form("project").value.get,
-            form("build").value.get,
-            form("stage").value.get,
-            None
+            form.value.map(_.project).get,
+            form.value.map(_.build).get,
+            form.value.map(_.stage).get,
+            None,
+            form.value.map(_.updateStrategy).getOrElse(MostlyHarmless)
         )">Reset selection</a>
     </div>
 }

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -17,7 +17,7 @@ GET         /configuration/validation                       controllers.Applicat
 POST        /configuration/validation                       controllers.Application.validateConfiguration
 
 # Preview endpoints
-GET         /preview/yaml                                   controllers.PreviewController.preview(project:String,build:String,stage:String,deployments:Option[String])
+GET         /preview/yaml                                   controllers.PreviewController.preview(project:String,build:String,stage:String,deployments:Option[String],updateStrategy:magenta.Strategy)
 GET         /preview/yaml/showTasks                         controllers.PreviewController.showTasks(previewId:String)
 
 # Deployment pages

--- a/riff-raff/public/docs/index.md
+++ b/riff-raff/public/docs/index.md
@@ -17,7 +17,7 @@ Reference
 Using Riff-Raff
 ---------------
 
- - [Update Strategies](riffraff/update-strategy.md) - what is an update strategy and how to choose one
+ - [Advanced deploymeny settings](riffraff/advanced-settings.md) - what is an update strategy and how to choose one
  - [API](riffraff/api.md) - how to use the API and a description of the endpoints available
  - [Continuous Integration and Deployment](riffraff/hooksAndCD.md) - guide to the Riff-Raff hooks available to make continuous
  deployment easy

--- a/riff-raff/public/docs/index.md
+++ b/riff-raff/public/docs/index.md
@@ -7,7 +7,7 @@ How-to
  - [Fix a failed deploy](howto/fix-a-failed-deploy.md) - riff-raff fails fast, here are the basic steps
    for fixing an auto-scaling deploy
  - [Configure a project](howto/configure-a-project.md) - how to set up a project so it can be deployed by Riff-Raff
- 
+
 Reference
 ---------
 
@@ -17,6 +17,7 @@ Reference
 Using Riff-Raff
 ---------------
 
+ - [Update Strategies](riffraff/update-strategy.md) - what is an update strategy and how to choose one
  - [API](riffraff/api.md) - how to use the API and a description of the endpoints available
  - [Continuous Integration and Deployment](riffraff/hooksAndCD.md) - guide to the Riff-Raff hooks available to make continuous
  deployment easy

--- a/riff-raff/public/docs/riffraff/advanced-settings.md
+++ b/riff-raff/public/docs/riffraff/advanced-settings.md
@@ -12,3 +12,5 @@ The update strategy parameter controls the risk appetite of a given deploy. The 
 Specifically, this currently means that when your deploy applies updates to a cloudformation stack, Riff-Raff will apply a stack update policy before executing the update. When you are using the default _MostlyHarmless_ update strategy this policy will prohibit the deletion and replacement of certain resource types. When you are using the _Dangerous_ update strategy this policy will allow any change to take place.
 
 In practice, we expect most deploys to be run using the _MostlyHarmless_ strategy. In the case that this fails with a stack policy error you can review the deployment and then use the _Dangerous_ strategy. It is recommended that you manually check (by looking at the change set) that you really do want the resources in question to be deleted before using the _Dangerous_ strategy to execute destructive actions.
+
+Finally - all continuous or scheduled deploys will be run at MostlyHarmless and this cannot be changed.

--- a/riff-raff/public/docs/riffraff/advanced-settings.md
+++ b/riff-raff/public/docs/riffraff/advanced-settings.md
@@ -1,7 +1,11 @@
-Update Strategy
-===============
+Advanced settings
+=================
 
-The `updateStrategy` parameter controls the risk appetite of a given deploy. The aim is to reduce incidents resulting from unintentional changes such as deleting a stateful resource like a DynamoDB table or a resource like a load balancer that has a DNS entry pointed to it.
+There are some advanced settings that won't normally be required but can be used in specific circumstances. 
+
+## Update Strategy
+
+The update strategy parameter controls the risk appetite of a given deploy. The aim is to reduce incidents resulting from unintentional changes such as deleting a stateful resource like a DynamoDB table or a resource like a load balancer that has a DNS entry pointed to it.
 
 **Note: At the time of writing this is only observed for some deploys under some circumstances.**
 

--- a/riff-raff/public/docs/riffraff/update-strategy.md
+++ b/riff-raff/public/docs/riffraff/update-strategy.md
@@ -1,0 +1,10 @@
+Update Strategy
+===============
+
+The `updateStrategy` parameter controls the risk appetite of a given deploy. The aim is to reduce incidents resulting from unintentional changes such as deleting a stateful resource like a DynamoDB table or a resource like a load balancer that has a DNS entry pointed to it.
+
+**Note: At the time of writing this is only observed for some deploys under some circumstances.**
+
+Specifically, this currently means that when your deploy applies updates to a cloudformation stack, Riff-Raff will apply a stack update policy before executing the update. When you are using the default _MostlyHarmless_ update strategy this policy will prohibit the deletion and replacement of certain resource types. When you are using the _Dangerous_ update strategy this policy will allow any change to take place.
+
+In practice, we expect most deploys to be run using the _MostlyHarmless_ strategy. In the case that this fails with a stack policy error you can review the deployment and then use the _Dangerous_ strategy. It is recommended that you manually check (by looking at the change set) that you really do want the resources in question to be deleted before using the _Dangerous_ strategy to execute destructive actions.

--- a/riff-raff/test/MappingTest.scala
+++ b/riff-raff/test/MappingTest.scala
@@ -18,7 +18,7 @@ class MappingTest extends FlatSpec with Matchers with Utilities with Persistence
         testUUID,
         Some(testUUID.toString),
         testTime,
-        ParametersDocument("Tester", "test-project", "1", "CODE", Map("branch"->"master"), AllDocument, MostlyHarmless),
+        ParametersDocument("Tester", "test-project", "1", "CODE", Map("branch"->"master"), AllDocument, Some(MostlyHarmless)),
         RunState.Completed
       )
     )
@@ -92,7 +92,7 @@ class MappingTest extends FlatSpec with Matchers with Utilities with Persistence
         "TEST",
         Map.empty,
         AllDocument,
-        MostlyHarmless
+        None
       ),
       RunState.Completed
     )
@@ -116,7 +116,7 @@ class MappingTest extends FlatSpec with Matchers with Utilities with Persistence
         "TEST",
         Map.empty,
         AllDocument,
-        MostlyHarmless
+        None
       ),
       RunState.Completed
     )

--- a/riff-raff/test/MappingTest.scala
+++ b/riff-raff/test/MappingTest.scala
@@ -1,9 +1,9 @@
 package test
 
 import java.util.UUID
-
 import controllers.Logging
 import magenta.Message.Info
+import magenta.Strategy.MostlyHarmless
 import magenta._
 import magenta.input.{DeploymentKey, DeploymentKeysSelector}
 import org.scalatest.{FlatSpec, Matchers}
@@ -18,7 +18,7 @@ class MappingTest extends FlatSpec with Matchers with Utilities with Persistence
         testUUID,
         Some(testUUID.toString),
         testTime,
-        ParametersDocument("Tester", "test-project", "1", "CODE", Map("branch"->"master"), AllDocument),
+        ParametersDocument("Tester", "test-project", "1", "CODE", Map("branch"->"master"), AllDocument, MostlyHarmless),
         RunState.Completed
       )
     )
@@ -91,7 +91,8 @@ class MappingTest extends FlatSpec with Matchers with Utilities with Persistence
         "test",
         "TEST",
         Map.empty,
-        AllDocument
+        AllDocument,
+        MostlyHarmless
       ),
       RunState.Completed
     )
@@ -114,7 +115,8 @@ class MappingTest extends FlatSpec with Matchers with Utilities with Persistence
         "test",
         "TEST",
         Map.empty,
-        AllDocument
+        AllDocument,
+        MostlyHarmless
       ),
       RunState.Completed
     )

--- a/riff-raff/test/RepresentationTest.scala
+++ b/riff-raff/test/RepresentationTest.scala
@@ -34,7 +34,7 @@ class RepresentationTest extends FlatSpec with Matchers with Utilities with Pers
         testUUID,
         Some(testUUID.toString),
         testTime,
-        ParametersDocument("Tester", "test-project", "1", "CODE", Map("branch"->"master"), AllDocument, updateStrategy = MostlyHarmless),
+        ParametersDocument("Tester", "test-project", "1", "CODE", Map("branch"->"master"), AllDocument, updateStrategy = Some(MostlyHarmless)),
         RunState.Completed
       )
     )

--- a/riff-raff/test/RepresentationTest.scala
+++ b/riff-raff/test/RepresentationTest.scala
@@ -1,8 +1,8 @@
 package test
 
 import java.util.UUID
-
 import controllers.ApiKey
+import magenta.Strategy.MostlyHarmless
 import magenta._
 import org.joda.time.DateTime
 import org.scalatest.{FlatSpec, Matchers}
@@ -34,7 +34,7 @@ class RepresentationTest extends FlatSpec with Matchers with Utilities with Pers
         testUUID,
         Some(testUUID.toString),
         testTime,
-        ParametersDocument("Tester", "test-project", "1", "CODE", Map("branch"->"master"), AllDocument),
+        ParametersDocument("Tester", "test-project", "1", "CODE", Map("branch"->"master"), AllDocument, updateStrategy = MostlyHarmless),
         RunState.Completed
       )
     )

--- a/riff-raff/test/Utilities.scala
+++ b/riff-raff/test/Utilities.scala
@@ -1,11 +1,11 @@
 package test
 
 import java.util.UUID
-
 import deployment.DeployRecord
 import gnieh.diffson.playJson._
 import magenta.ContextMessage._
 import magenta.Message._
+import magenta.Strategy.MostlyHarmless
 import magenta._
 import magenta.input.All
 import org.joda.time.DateTime
@@ -19,7 +19,7 @@ trait Utilities {
 trait PersistenceTestInstances {
   val testTime = new DateTime()
   lazy val testUUID = UUID.fromString("90013e69-8afc-4ba2-80a8-d7b063183d13")
-  lazy val parameters = DeployParameters(Deployer("Tester"), Build("test-project", "1"), Stage("CODE"), selector = All)
+  lazy val parameters = DeployParameters(Deployer("Tester"), Build("test-project", "1"), Stage("CODE"), selector = All, updateStrategy = MostlyHarmless)
   lazy val testRecord = DeployRecord(testTime, testUUID, parameters, Map("branch"->"master"), messageWrappers)
   lazy val testDocument = RecordConverter(testRecord).deployDocument
 
@@ -27,7 +27,7 @@ trait PersistenceTestInstances {
     val time = new DateTime(2012,11,8,17,20,0)
     val uuid = UUID.fromString("39320f5b-7837-4f47-85f7-bc2d780e19f6")
     val parameters = DeployParameters(
-      Deployer("Tester"), Build("test::project", "1"), Stage("TEST"), selector = All)
+      Deployer("Tester"), Build("test::project", "1"), Stage("TEST"), selector = All, updateStrategy = MostlyHarmless)
     DeployRecord(time, uuid, parameters, Map("branch"->"test"), messageWrappers)
   }
 

--- a/riff-raff/test/ci/ContinuousDeploymentTest.scala
+++ b/riff-raff/test/ci/ContinuousDeploymentTest.scala
@@ -6,8 +6,9 @@ import magenta._
 import magenta.DeployParameters
 import magenta.Deployer
 import magenta.Stage
-import java.util.UUID
+import magenta.Strategy.MostlyHarmless
 
+import java.util.UUID
 import scala.util.{Failure, Success}
 
 class ContinuousDeploymentTest extends FlatSpec with Matchers {
@@ -16,7 +17,7 @@ class ContinuousDeploymentTest extends FlatSpec with Matchers {
     val params = ContinuousDeployment.getMatchesForSuccessfulBuilds(tdB71, contDeployConfigs).map(ContinuousDeployment.getDeployParams(_)).toSet
     params.size should be(1)
     params should be(Set(
-      DeployParameters(Deployer("Continuous Deployment"), Build("tools::deploy", "71"), Stage("PROD"))
+      DeployParameters(Deployer("Continuous Deployment"), Build("tools::deploy", "71"), Stage("PROD"), updateStrategy = MostlyHarmless)
     ))
   }
 
@@ -27,7 +28,7 @@ class ContinuousDeploymentTest extends FlatSpec with Matchers {
 
   it should "take account of branch" in {
     val params = ContinuousDeployment.getMatchesForSuccessfulBuilds(td2B392, contDeployBranchConfigs).map(ContinuousDeployment.getDeployParams(_)).toSet
-    params should be(Set(DeployParameters(Deployer("Continuous Deployment"), Build("tools::deploy2", "392"), Stage("QA"))))
+    params should be(Set(DeployParameters(Deployer("Continuous Deployment"), Build("tools::deploy2", "392"), Stage("QA"), updateStrategy = MostlyHarmless)))
   }
 
   /* Test types */

--- a/riff-raff/test/deployment/Fixtures.scala
+++ b/riff-raff/test/deployment/Fixtures.scala
@@ -1,7 +1,8 @@
 package deployment
 
-import java.util.UUID
+import magenta.Strategy.MostlyHarmless
 
+import java.util.UUID
 import magenta.graph.{DeploymentGraph, DeploymentTasks, Graph}
 import magenta.tasks._
 import magenta.{App, Build, DeployContext, DeployParameters, DeployReporter, Deployer, DeploymentResources, Host, KeyRing, Region, Stage}
@@ -49,7 +50,8 @@ object Fixtures extends MockitoSugar {
     uuid,
     DeployParameters(Deployer(deployer),
       Build(projectName, buildId),
-      Stage(stage)
+      Stage(stage),
+      updateStrategy = MostlyHarmless
     )
   )
 

--- a/riff-raff/test/deployment/preview/PreviewTest.scala
+++ b/riff-raff/test/deployment/preview/PreviewTest.scala
@@ -1,9 +1,9 @@
 package deployment.preview
 
 import java.util.UUID
-
 import cats.data.Validated.{Invalid, Valid}
 import cats.data.{Validated, NonEmptyList => NEL}
+import magenta.Strategy.MostlyHarmless
 import magenta.artifact.S3YamlArtifact
 import magenta.fixtures.{ValidatedValues, _}
 import magenta.graph.{DeploymentTasks, EndNode, Graph, StartNode, ValueNode}
@@ -49,7 +49,7 @@ class PreviewTest extends FlatSpec with Matchers with ValidatedValues with Mocki
         |    type: stub-package-type
       """.stripMargin
     implicit val stsClient: StsClient = mock[StsClient]
-    val parameters = DeployParameters(Deployer("test user"), Build("testProject", "1"), Stage("TEST"))
+    val parameters = DeployParameters(Deployer("test user"), Build("testProject", "1"), Stage("TEST"), updateStrategy = MostlyHarmless)
     val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), parameters)
     val resources = DeploymentResources(reporter, stubLookup(), artifactClient, stsClient)
     val preview = Preview(artifact, config, parameters, resources, Seq(stubDeploymentType(Seq("testAction"))))

--- a/riff-raff/test/housekeeping/ArtifactHousekeepingTest.scala
+++ b/riff-raff/test/housekeeping/ArtifactHousekeepingTest.scala
@@ -1,8 +1,8 @@
 package housekeeping
 
 import java.util.UUID
-
 import deployment._
+import magenta.Strategy.MostlyHarmless
 import magenta.{Build, DeployParameters, Deployer, RunState, Stage}
 import org.joda.time.{DateTime, DateTimeZone}
 import org.mockito.ArgumentMatchers.any
@@ -34,7 +34,7 @@ class ArtifactHousekeepingTest extends FlatSpec with Matchers with MockitoSugar 
   private def fixtureRecord(date: DateTime, stageName: String, buildNumber: String): Record = DeployRecord(
     date,
     UUID.fromString("7fa2ee0a-8d90-4f7e-a38b-185f36fbc5aa"),
-    DeployParameters(Deployer("anon"), Build("testProject", buildNumber), Stage(stageName)),
+    DeployParameters(Deployer("anon"), Build("testProject", buildNumber), Stage(stageName), updateStrategy = MostlyHarmless),
     recordState = Some(RunState.Completed)
   )
 

--- a/riff-raff/test/notification/FailureNotificationContentsTest.scala
+++ b/riff-raff/test/notification/FailureNotificationContentsTest.scala
@@ -3,6 +3,7 @@ package notification
 import ci.ContinuousDeployment
 import com.gu.anghammarad.models.{Action, Stack, Target}
 import deployment.{Fixtures, NoDeploysFoundForStage, SkippedDueToPreviousFailure, SkippedDueToPreviousWaitingDeploy}
+import magenta.Strategy.MostlyHarmless
 import magenta.{Build, DeployParameters, Stage}
 import org.scalatest.{FunSuite, Matchers}
 
@@ -13,7 +14,7 @@ class FailureNotificationContentsTest extends FunSuite with Matchers {
   test("should produce sensible notification contents for a failed Continuous Deployment") {
     val failureNotificationContents = new FailureNotificationContents("http://localhost:9000")
     val uuid = UUID.randomUUID()
-    val parameters = DeployParameters(ContinuousDeployment.deployer, Build("project", "123"), Stage("PROD"))
+    val parameters = DeployParameters(ContinuousDeployment.deployer, Build("project", "123"), Stage("PROD"), updateStrategy = MostlyHarmless)
     val expected = NotificationContents(
       subject = "Continuous Deployment failed",
       message = "Continuous Deployment for project (build 123) to stage PROD failed.",

--- a/riff-raff/test/notification/HookTemplateTest.scala
+++ b/riff-raff/test/notification/HookTemplateTest.scala
@@ -67,7 +67,7 @@ class HookTemplateTest extends FunSuite with Matchers {
     stage = "PROD",
     tags = Map("foo" -> "bar"),
     AllDocument,
-    MostlyHarmless
+    None
   )
   val uuid = UUID.randomUUID()
   val record = DeployRecordDocument(uuid, Some(uuid.toString), DateTime.now(), paramsDoc, RunState.Completed)

--- a/riff-raff/test/notification/HookTemplateTest.scala
+++ b/riff-raff/test/notification/HookTemplateTest.scala
@@ -1,8 +1,8 @@
 package notification
 
 import java.util.UUID
-
 import magenta.RunState
+import magenta.Strategy.MostlyHarmless
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
 import persistence.AllDocument
@@ -66,7 +66,8 @@ class HookTemplateTest extends FunSuite with Matchers {
     buildId = "a123",
     stage = "PROD",
     tags = Map("foo" -> "bar"),
-    AllDocument
+    AllDocument,
+    MostlyHarmless
   )
   val uuid = UUID.randomUUID()
   val record = DeployRecordDocument(uuid, Some(uuid.toString), DateTime.now(), paramsDoc, RunState.Completed)

--- a/riff-raff/test/notification/HooksTest.scala
+++ b/riff-raff/test/notification/HooksTest.scala
@@ -66,7 +66,7 @@ class HooksTest extends FlatSpec with Matchers with BeforeAndAfterAll {
       "TEST",
       Map("vcsRevision" -> "9110598b83a908d7882ac4e3cd4b643d7d8bc54e", "riffraff-domain" -> "10-252-94-200"),
       AllDocument,
-      MostlyHarmless
+      None
     ),
     RunState.Completed
   )

--- a/riff-raff/test/notification/HooksTest.scala
+++ b/riff-raff/test/notification/HooksTest.scala
@@ -1,7 +1,8 @@
 package notification
 
-import java.util.UUID
+import magenta.Strategy.MostlyHarmless
 
+import java.util.UUID
 import magenta._
 import org.joda.time.DateTime
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
@@ -64,7 +65,8 @@ class HooksTest extends FlatSpec with Matchers with BeforeAndAfterAll {
       "23",
       "TEST",
       Map("vcsRevision" -> "9110598b83a908d7882ac4e3cd4b643d7d8bc54e", "riffraff-domain" -> "10-252-94-200"),
-      AllDocument
+      AllDocument,
+      MostlyHarmless
     ),
     RunState.Completed
   )

--- a/riff-raff/test/postgres/TestData.scala
+++ b/riff-raff/test/postgres/TestData.scala
@@ -40,7 +40,7 @@ object TestData {
         stage = "TEST",
         tags = Map.empty,
         selector = AllDocument,
-        updateStrategy = MostlyHarmless
+        updateStrategy = None
       ),
       status = RunState.Completed,
       summarised = Some(true),

--- a/riff-raff/test/postgres/TestData.scala
+++ b/riff-raff/test/postgres/TestData.scala
@@ -1,9 +1,9 @@
 package postgres
 
 import java.util.UUID
-
 import controllers.{ApiKey, AuthorisationRecord}
 import magenta.RunState
+import magenta.Strategy.MostlyHarmless
 import org.joda.time.DateTime
 import persistence.{AllDocument, DeployRecordDocument, LogDocument, MessageDocument, ParametersDocument}
 
@@ -39,7 +39,8 @@ object TestData {
         buildId = s"id-$uuid",
         stage = "TEST",
         tags = Map.empty,
-        selector = AllDocument
+        selector = AllDocument,
+        updateStrategy = MostlyHarmless
       ),
       status = RunState.Completed,
       summarised = Some(true),

--- a/riff-raff/test/schedule/DeployJobTest.scala
+++ b/riff-raff/test/schedule/DeployJobTest.scala
@@ -2,6 +2,7 @@ package schedule
 
 import java.util.UUID
 import deployment.{DeployRecord, Error, SkippedDueToPreviousFailure}
+import magenta.Strategy.MostlyHarmless
 import magenta.{Build, DeployParameters, Deployer, RunState, Stage}
 import org.joda.time.DateTime
 import org.scalatest.{EitherValues, FlatSpec, Matchers}
@@ -12,18 +13,18 @@ class DeployJobTest extends FlatSpec with Matchers with EitherValues {
     val record = new DeployRecord(
       new DateTime(),
       uuid,
-      DeployParameters(Deployer("Bob"), Build("testProject", "1"), Stage("TEST")),
+      DeployParameters(Deployer("Bob"), Build("testProject", "1"), Stage("TEST"), updateStrategy = MostlyHarmless),
       recordState = Some(RunState.Completed)
     )
     DeployJob.createDeployParameters(record, true) shouldBe
-      Right(DeployParameters(Deployer("Scheduled Deployment"), Build("testProject", "1"), Stage("TEST")))
+      Right(DeployParameters(Deployer("Scheduled Deployment"), Build("testProject", "1"), Stage("TEST"), updateStrategy = MostlyHarmless))
   }
 
   it should "produce an error if the last deploy didn't complete" in {
     val record = new DeployRecord(
       new DateTime(),
       uuid,
-      DeployParameters(Deployer("Bob"), Build("testProject", "1"), Stage("TEST")),
+      DeployParameters(Deployer("Bob"), Build("testProject", "1"), Stage("TEST"), updateStrategy = MostlyHarmless),
       recordState = Some(RunState.Failed)
     )
     DeployJob.createDeployParameters(record, true) shouldBe Left(SkippedDueToPreviousFailure(record))
@@ -33,10 +34,10 @@ class DeployJobTest extends FlatSpec with Matchers with EitherValues {
     val record = new DeployRecord(
       new DateTime(),
       uuid,
-      DeployParameters(Deployer("Bob"), Build("testProject", "1"), Stage("TEST")),
+      DeployParameters(Deployer("Bob"), Build("testProject", "1"), Stage("TEST"), updateStrategy = MostlyHarmless),
       recordState = Some(RunState.Completed)
     )
     DeployJob.createDeployParameters(record, false) shouldBe
-      Left(Error("Scheduled deployments disabled. Would have deployed DeployParameters(Deployer(Scheduled Deployment),Build(testProject,1),Stage(TEST),All)"))
+      Left(Error("Scheduled deployments disabled. Would have deployed DeployParameters(Deployer(Scheduled Deployment),Build(testProject,1),Stage(TEST),All,MostlyHarmless)"))
   }
 }


### PR DESCRIPTION
## What does this change?
PR #623 introduced a more cautious approach for applying cloudformation updates. We want to roll this out to everyone but it would be nice to provide a way to execute a destructive change if they really wanted to without having to go around RiffRaff.

This PR introduces the idea of update strategies. We currently support two strategies: `MostlyHarmless` and `Dangerous`. At the moment this will only be used to decide the policy to apply for a cloudformation update when stack policy management is enabled (which should be the default soon).

When set to `MostlyHarmless` we will use a policy that denies updates and replacements. When set to `Dangerous` we will use an allow all policy.

This appears in the deploy dialog as below with a link to docs that describe this in more detail. It's hidden behind an advance settings reveal so that they are not on display until actually required.

<img width="711" alt="image" src="https://user-images.githubusercontent.com/1236466/119113823-67030080-ba1d-11eb-9707-391291a9025a.png">


## How can we measure success?
We can roll out policy management from #623 without concern that users will be unable to deploy certain artifacts if they have an intentionally destructive change.

## Have we considered potential risks?
Users think that we are safer than we really are. In order to mitigate this we provide a page of documentation that is easily discoverable from the deploy screen.