### PR TITLE
Default to managing stack policies

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -66,7 +66,7 @@ object CloudFormation extends DeploymentType with CloudFormationDeploymentTypePa
   val secondsToWaitForChangeSetCreation = Param("secondsToWaitForChangeSetCreation",
     "Number of seconds to wait for the change set to be created").default(15 * 60)
 
-  val manageStackPolicyDefault = false
+  val manageStackPolicyDefault = true
   val manageStackPolicyLookupKey = "cloudformation:manage-stack-policy"
   val manageStackPolicyParam = Param[Boolean]("manageStackPolicy",
     s"""Allow RiffRaff to manage stack update policies on your behalf.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,7 +56,7 @@ object Dependencies {
     "com.gu" %% "management-logback" % Versions.guardianManagement,
     "com.gu" %% "play-googleauth" % "0.7.7",
     "com.gu.play-secret-rotation" %% "aws-parameterstore" % "0.12",
-    "com.typesafe.akka" %% "akka-agent" % "2.5.21",
+    "com.typesafe.akka" %% "akka-agent" % "2.5.26",
     "org.pegdown" % "pegdown" % "1.6.0",
     "com.adrianhurt" %% "play-bootstrap" % "1.2-P26-B3-RC2",
     "com.gu" %% "scanamo" % "1.0.0-M6",

--- a/riff-raff/public/docs/riffraff/advanced-settings.md
+++ b/riff-raff/public/docs/riffraff/advanced-settings.md
@@ -7,10 +7,10 @@ There are some advanced settings that won't normally be required but can be used
 
 The update strategy parameter controls the risk appetite of a given deploy. The aim is to reduce incidents resulting from unintentional changes such as deleting a stateful resource like a DynamoDB table or a resource like a load balancer that has a DNS entry pointed to it.
 
-**Note: At the time of writing this is only observed for some deploys under some circumstances.**
-
 Specifically, this currently means that when your deploy applies updates to a cloudformation stack, Riff-Raff will apply a stack update policy before executing the update. When you are using the default _MostlyHarmless_ update strategy this policy will prohibit the deletion and replacement of certain resource types. When you are using the _Dangerous_ update strategy this policy will allow any change to take place.
 
 In practice, we expect most deploys to be run using the _MostlyHarmless_ strategy. In the case that this fails with a stack policy error you can review the deployment and then use the _Dangerous_ strategy. It is recommended that you manually check (by looking at the change set) that you really do want the resources in question to be deleted before using the _Dangerous_ strategy to execute destructive actions.
+
+**Note: is it possible to opt out of the stack policy being managed, if so the strategy will have no effect.**
 
 Finally - all continuous or scheduled deploys will be run at MostlyHarmless and this cannot be changed.


### PR DESCRIPTION
## What does this change?
#623 and #626 put us in a place that we can enable policy management for CFN stack updates. This will significantly reduce the risk of CFN updates making inadvertently destructive changes.

## How to test
All deploys that update cloudformation

## How can we measure success?
Ultimately this should reduce the number of incident retrospectives caused by accidental destructive cloudformation changes.

## Have we considered potential risks?
If teams are already using CFN stack policies then this will override them and discard what they have. This could leave them in an unexpected state where they do not have protection from their policies. We should confirm this before rolling this out by doing one of the following:
 - Deploying this [Prism PR](https://github.com/guardian/prism/pull/197) that allows us to interrogate all CFN stacks to see if any use policies. This has not yet been rolled out as it needs a stack set change.
 - Emailing everyone and asking

### Update
This has now been evaluated using Prism to inspect the policies. We discovered that a couple of discussion stacks were using policies in this way. However the discussion stack policy targeted S3 buckets and a DynamoDB table which are also targeted by our policy.

However, their policy is in place all the time whilst in this initial phase the policy will only be in place during an update and then later removed.  For the time we will set managePolicy to false for stack `discussion`.

## Comms
<details>
<summary>Draft email</summary>

Hi all,

As part of the DevX experiments with the CDK we are rolling out stack policy support for RiffRaff's Cloudformation deploy type to reduce risk associated with unintentional stack changes. We are trialling this in DevX and wa.

**What are we doing?**
Stack policies are attached to cloudformation stacks and set what changes are allowed by stack update events. We are going to use these to better protect resources that are either stateful (e.g. RDS instances) or are likely to have external dependencies (e.g. a load balancer that has DNS pointing at it or a SQS queue that is consumed by an application external to a given stack). 

The RiffRaff cloudformation deploy type now has the ability to protect these types of resources from destructive updates. This is done by setting a deny policy for update:replace and update:delete changes for a given set of resource types. At present, this restrictive policy is applied ahead of RiffRaff updating a stack. If the update is successful then a permissive policy (effectively the default) is reapplied.

**Why are we doing this?**
DevX recently had an incident retro as a result of some changes which inadvertently replaced a load balancer meaning that DNS for the service had to be updated. Due to the DNS entry having an hour TTL there was further downtime whilst the update propagated. The stack policy approach would have caught this and the deployment would have failed.

**What's next?**
We've been running this for devX tooling for a week or so now but this is not currently the default behaviour. We are hoping to make this the default behaviour for all cloudformation updates in the next week. This will involve adding the ability to override this setting to deal with the need to deliberately replace or delete a sensitive resource.

Thanks,
Simon and Akash
</details>