### PR TITLE
Use mockito-scala and latest version of scalatest

### DIFF
--- a/magenta-lib/src/test/scala/magenta/PackageTest.scala
+++ b/magenta-lib/src/test/scala/magenta/PackageTest.scala
@@ -1,16 +1,16 @@
 package magenta
 
 import java.io.IOException
-
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FlatSpec, Matchers}
+import org.mockito.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.awscore.exception.AwsServiceException
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
 import software.amazon.awssdk.core.retry.RetryPolicy
 import software.amazon.awssdk.core.retry.backoff.BackoffStrategy
 import software.amazon.awssdk.core.retry.conditions.RetryCondition
 
-class PackageTest extends FlatSpec with Matchers with MockitoSugar {
+class PackageTest extends AnyFlatSpec with Matchers with MockitoSugar {
   val clientConfiguration: ClientOverrideConfiguration = ClientOverrideConfiguration.builder().
     retryPolicy(RetryPolicy.builder()
       .retryCondition(RetryCondition.defaultRetryCondition())

--- a/magenta-lib/src/test/scala/magenta/ReporterTest.scala
+++ b/magenta-lib/src/test/scala/magenta/ReporterTest.scala
@@ -1,15 +1,15 @@
 package magenta
 
-import org.scalatest.{FlatSpec, Matchers}
-
 import java.util.UUID
 import magenta.ContextMessage._
 
 import collection.mutable.ListBuffer
 import magenta.Message._
 import magenta.Strategy.MostlyHarmless
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ReporterTest extends FlatSpec with Matchers {
+class ReporterTest extends AnyFlatSpec with Matchers {
 
   def getWrapperBuffer(uuid: UUID): ListBuffer[MessageWrapper] = {
     val wrappers = ListBuffer.empty[MessageWrapper]

--- a/magenta-lib/src/test/scala/magenta/ReportingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/ReportingTest.scala
@@ -3,11 +3,12 @@ package magenta
 import java.util.UUID
 import magenta.ContextMessage._
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import magenta.Message._
 import magenta.Strategy.MostlyHarmless
 
-class ReportingTest extends FlatSpec with Matchers {
+class ReportingTest extends AnyFlatSpec with Matchers {
 
   "Deploy Report" should "build an empty report from an empty list" in {
     val time = new DateTime()

--- a/magenta-lib/src/test/scala/magenta/artifact/S3ArtifactTest.scala
+++ b/magenta-lib/src/test/scala/magenta/artifact/S3ArtifactTest.scala
@@ -1,9 +1,10 @@
 package magenta.artifact
 
 import magenta.Build
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class S3ArtifactTest extends FlatSpec with Matchers {
+class S3ArtifactTest extends AnyFlatSpec with Matchers {
   "S3Artifact" should "create an S3Artifact instance from a build and bucket" in {
     val build = Build("testProject", "123")
     val artifact = S3YamlArtifact(build, "myBucket")

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -5,14 +5,17 @@ import magenta.artifact.S3Path
 import magenta.deployment_type.AutoScaling
 import magenta.fixtures._
 import magenta.tasks._
-import org.scalatest.{FlatSpec, Matchers}
+import org.mockito.ArgumentMatchersSugar
+import org.mockito.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.{JsNumber, JsString, JsValue}
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sts.StsClient
 
 import scala.concurrent.ExecutionContext.global
 
-class AutoScalingTest extends FlatSpec with Matchers {
+class AutoScalingTest extends AnyFlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing: KeyRing = KeyRing()
   implicit val reporter: DeployReporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
   implicit val artifactClient: S3Client = null

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -10,7 +10,9 @@ import magenta.tasks.CloudFormation.{SpecifiedValue, UseExistingValue}
 import magenta.tasks.CloudFormationParameters.{ExistingParameter, InputParameter, TemplateParameter}
 import magenta.tasks.UpdateCloudFormationTask._
 import magenta.tasks._
-import org.scalatest.{EitherValues, FlatSpec, Inside, Matchers}
+import org.scalatest.{EitherValues, Inside}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.{JsBoolean, JsString, JsValue, Json}
 import software.amazon.awssdk.services.cloudformation.model.{Change, ChangeSetType, Parameter}
 import software.amazon.awssdk.services.s3.S3Client
@@ -18,7 +20,7 @@ import software.amazon.awssdk.services.sts.StsClient
 
 import scala.concurrent.ExecutionContext.global
 
-class CloudFormationTest extends FlatSpec with Matchers with Inside with EitherValues {
+class CloudFormationTest extends AnyFlatSpec with Matchers with Inside with EitherValues {
   implicit val fakeKeyRing: KeyRing = KeyRing()
   implicit val reporter: DeployReporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
   implicit val artifactClient: S3Client = null

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -9,15 +9,17 @@ import magenta.deployment_type.param_reads.PatternValue
 import magenta.fixtures._
 import magenta.tasks._
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FlatSpec, Inside, Matchers}
+import org.mockito.MockitoSugar
+import org.scalatest.Inside
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.{JsBoolean, JsString, JsValue, Json}
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sts.StsClient
 
 import scala.concurrent.ExecutionContext.global
 
-class DeploymentTypeTest extends FlatSpec with Matchers with Inside with MockitoSugar {
+class DeploymentTypeTest extends AnyFlatSpec with Matchers with Inside with MockitoSugar {
   implicit val fakeKeyRing = KeyRing()
   implicit val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
   implicit val artifactClient: S3Client = null

--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
@@ -5,10 +5,9 @@ import magenta.artifact.S3Path
 import magenta.fixtures._
 import magenta.tasks.{S3Upload, UpdateS3Lambda}
 import magenta.{App, DeployReporter, DeployTarget, DeploymentPackage, DeploymentResources, FailException, KeyRing, Region, Stack, fixtures}
-import org.mockito.ArgumentMatchers
-import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FlatSpec, Matchers}
+import org.mockito.{ArgumentMatchers, MockitoSugar}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.{JsBoolean, JsString, JsValue, Json}
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.ssm.SsmClient
@@ -17,7 +16,7 @@ import software.amazon.awssdk.services.sts.StsClient
 
 import scala.concurrent.ExecutionContext.global
 
-class LambdaTest extends FlatSpec with Matchers with MockitoSugar {
+class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing: KeyRing = KeyRing()
   implicit val reporter: DeployReporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
   implicit val artifactClient: S3Client = mock[S3Client]

--- a/magenta-lib/src/test/scala/magenta/deployment_type/ParamTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/ParamTest.scala
@@ -5,10 +5,9 @@ import java.util.UUID
 import magenta.artifact.S3Path
 import magenta._
 import magenta.fixtures._
-import org.mockito.Matchers._
-import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.mockito.MockitoSugar
 import play.api.libs.json.JsString
 
 import scala.collection.mutable
@@ -18,7 +17,7 @@ class TestRegister extends ParamRegister {
   def add(param: Param[_]) = paramsList += param.name -> param
 }
 
-class ParamTest extends FlatSpec with Matchers with MockitoSugar {
+class ParamTest extends AnyFlatSpec with Matchers with MockitoSugar {
   val target = DeployTarget(fixtures.parameters(), Stack("testStack"), Region("testRegion"))
   val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), target.parameters)
   val deploymentTypes = Seq(stubDeploymentType(name="testDeploymentType", actionNames = Seq("testAction")))

--- a/magenta-lib/src/test/scala/magenta/deployment_type/param_reads/PatternValueTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/param_reads/PatternValueTest.scala
@@ -1,9 +1,11 @@
 package magenta.deployment_type.param_reads
 
-import org.scalatest.{FlatSpec, Inside, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.Inside
 import play.api.libs.json._
 
-class PatternValueTest extends FlatSpec with Matchers with Inside {
+class PatternValueTest extends AnyFlatSpec with Matchers with Inside {
   "PatternValue" should "parse a JsString to a single item PatternValue list" in {
     val json = JsString("application/json")
     val pv = json.as[List[PatternValue]]

--- a/magenta-lib/src/test/scala/magenta/graph/DeploymentGraphTest.scala
+++ b/magenta-lib/src/test/scala/magenta/graph/DeploymentGraphTest.scala
@@ -1,13 +1,14 @@
 package magenta.graph
 
 import magenta.{DeploymentResources, Host, KeyRing, Region}
-import magenta.tasks.{ChangeSwitch, S3Upload, SayHello}
-import org.scalatest.{FlatSpec, Matchers}
-import org.scalatest.mockito.MockitoSugar
 import magenta.fixtures._
+import magenta.tasks.{ChangeSwitch, S3Upload, SayHello}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.mockito.MockitoSugar
 import software.amazon.awssdk.services.s3.S3Client
 
-class DeploymentGraphTest extends FlatSpec with Matchers with MockitoSugar {
+class DeploymentGraphTest extends AnyFlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing: KeyRing = KeyRing()
   implicit val artifactClient: S3Client = mock[S3Client]
 

--- a/magenta-lib/src/test/scala/magenta/graph/GraphTest.scala
+++ b/magenta-lib/src/test/scala/magenta/graph/GraphTest.scala
@@ -1,8 +1,9 @@
 package magenta.graph
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class GraphTest extends FlatSpec with Matchers {
+class GraphTest extends AnyFlatSpec with Matchers {
 
   val start = StartNode
   val one = ValueNode("one")

--- a/magenta-lib/src/test/scala/magenta/input/DeploymentKeyTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/DeploymentKeyTest.scala
@@ -1,8 +1,9 @@
 package magenta.input
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class DeploymentKeyTest extends FlatSpec with Matchers {
+class DeploymentKeyTest extends AnyFlatSpec with Matchers {
   "DeploymentKey" should "serialise and deserialise a key to and from a string" in {
     val key = DeploymentKey("name", "action", "stack", "region")
     val string = DeploymentKey.asString(key)

--- a/magenta-lib/src/test/scala/magenta/input/RiffRaffYamlReaderTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/RiffRaffYamlReaderTest.scala
@@ -1,10 +1,11 @@
 package magenta.input
 
 import magenta.fixtures.ValidatedValues
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.{JsArray, JsNumber, JsString, Json}
 
-class RiffRaffYamlReaderTest extends FlatSpec with Matchers with ValidatedValues {
+class RiffRaffYamlReaderTest extends AnyFlatSpec with Matchers with ValidatedValues {
   "RiffRaffYamlReader" should "read a minimal file" in {
     val yaml =
       """

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentGraphActionFlatteningTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentGraphActionFlatteningTest.scala
@@ -3,9 +3,10 @@ package magenta.input.resolver
 import cats.data.{NonEmptyList => NEL}
 import magenta.graph.{EndNode, Graph, StartNode, ValueNode}
 import magenta.input.Deployment
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class DeploymentGraphActionFlatteningTest extends FlatSpec with Matchers {
+class DeploymentGraphActionFlatteningTest extends AnyFlatSpec with Matchers {
   "flattenActions" should "flatten out the actions in a deployment graph" in {
     val deployment =
       Deployment("bob", "autoscaling", NEL.of("stackName"), NEL.of("eu-west-1"), NEL.of("action1", "action2"), "bob", "bob", Nil, Map.empty)

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentPrunerTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentPrunerTest.scala
@@ -2,9 +2,10 @@ package magenta.input.resolver
 
 import cats.data.{NonEmptyList => NEL}
 import magenta.input.{Deployment, DeploymentKey}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class DeploymentPrunerTest extends FlatSpec with Matchers {
+class DeploymentPrunerTest extends AnyFlatSpec with Matchers {
   import DeploymentPruner._
   val testDeployment = Deployment("testName", "testType", NEL.of("testStack"), NEL.of("testRegion"),
     NEL.of("testAction"), "testName", "testName", Nil, Map.empty)

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentResolverTest.scala
@@ -3,10 +3,11 @@ package magenta.input.resolver
 import cats.data.{NonEmptyList => NEL}
 import magenta.fixtures.ValidatedValues
 import magenta.input.{ConfigError, Deployment, RiffRaffYamlReader}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.{JsNumber, JsString}
 
-class DeploymentResolverTest extends FlatSpec with Matchers with ValidatedValues {
+class DeploymentResolverTest extends AnyFlatSpec with Matchers with ValidatedValues {
   "DeploymentResolver" should "parse a simple deployment with defaults" in {
     val yamlString =
       """

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTasksGraphBuilderTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTasksGraphBuilderTest.scala
@@ -3,9 +3,10 @@ package magenta.input.resolver
 import cats.data.{NonEmptyList => NEL}
 import magenta.graph.{EndNode, Graph, StartNode, ValueNode}
 import magenta.input.Deployment
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class DeploymentTasksGraphBuilderTest extends FlatSpec with Matchers {
+class DeploymentTasksGraphBuilderTest extends AnyFlatSpec with Matchers {
   val deployment = Deployment("bob", "autoscaling", NEL.of("stackName"), NEL.of("eu-west-1"), NEL.of("deploy"), "bob", "bob", Nil, Map.empty)
 
   "buildGraph" should "build a simple graph for a single deployment" in {

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTypeResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTypeResolverTest.scala
@@ -4,10 +4,11 @@ import cats.data.{NonEmptyList => NEL}
 import magenta.deployment_type.Param
 import magenta.fixtures._
 import magenta.input.{ConfigError, Deployment}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsNumber
 
-class DeploymentTypeResolverTest extends FlatSpec with Matchers with ValidatedValues {
+class DeploymentTypeResolverTest extends AnyFlatSpec with Matchers with ValidatedValues {
   val deployment = PartiallyResolvedDeployment("bob", "stub-package-type", NEL.of("stack"), NEL.of("eu-west-1"), actions=None, "bob", "bob", Nil, Map.empty)
   val deploymentTypes = List(stubDeploymentType(Seq("upload", "deploy")))
 

--- a/magenta-lib/src/test/scala/magenta/input/resolver/TaskResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/TaskResolverTest.scala
@@ -8,15 +8,16 @@ import magenta.deployment_type.Action
 import magenta.fixtures._
 import magenta.input.Deployment
 import magenta.{Build, DeployParameters, DeployReporter, Deployer, DeploymentResources, Region, Stack, Stage, fixtures}
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FlatSpec, Matchers}
+import org.mockito.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsString
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sts.StsClient
 
 import scala.concurrent.ExecutionContext.global
 
-class TaskResolverTest extends FlatSpec with Matchers with MockitoSugar with ValidatedValues {
+class TaskResolverTest extends AnyFlatSpec with Matchers with MockitoSugar with ValidatedValues {
   implicit val reporter: DeployReporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
   implicit val artifactClient: S3Client = mock[S3Client]
   implicit val stsClient: StsClient = mock[StsClient]

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
@@ -4,9 +4,9 @@ import java.util.UUID
 import magenta.artifact.S3Path
 import magenta.fixtures._
 import magenta.{KeyRing, Stage, _}
-import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FlatSpec, Matchers}
+import org.mockito.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.autoscaling.AutoScalingClient
 import software.amazon.awssdk.services.autoscaling.model.{AutoScalingGroup, SetDesiredCapacityRequest}
 import software.amazon.awssdk.services.s3.S3Client
@@ -14,7 +14,7 @@ import software.amazon.awssdk.services.sts.StsClient
 
 import scala.concurrent.ExecutionContext.global
 
-class ASGTasksTest extends FlatSpec with Matchers with MockitoSugar {
+class ASGTasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing: KeyRing = KeyRing()
   val reporter: DeployReporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
   val deploymentTypes: Seq[StubDeploymentType] = Seq(stubDeploymentType(name = "testDeploymentType", actionNames = Seq("testAction")))

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
@@ -5,9 +5,9 @@ import java.util.UUID
 import magenta.artifact.S3Path
 import magenta.{App, KeyRing, Stage, _}
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FlatSpec, Matchers}
+import org.mockito.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.autoscaling.AutoScalingClient
 import software.amazon.awssdk.services.autoscaling.model.{Instance => ASGInstance, _}
 import software.amazon.awssdk.services.elasticloadbalancing.model.{DescribeInstanceHealthRequest, DescribeInstanceHealthResponse, InstanceState}
@@ -17,7 +17,7 @@ import software.amazon.awssdk.services.elasticloadbalancingv2.{ElasticLoadBalanc
 
 import scala.collection.JavaConverters._
 
-class ASGTest extends FlatSpec with Matchers with MockitoSugar {
+class ASGTest extends AnyFlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing: KeyRing = KeyRing()
   val reporter: DeployReporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
   val deploymentTypes: Nil.type = Nil

--- a/magenta-lib/src/test/scala/magenta/tasks/AWSTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/AWSTest.scala
@@ -1,12 +1,13 @@
 package magenta.tasks
 import java.util.UUID
 
-import magenta.{ApiStaticCredentials, ApiRoleCredentials, KeyRing, StsDeploymentResources}
-import org.scalatest.{FlatSpec, Matchers}
-import org.scalatest.mockito.MockitoSugar
+import magenta.{ApiRoleCredentials, ApiStaticCredentials, KeyRing, StsDeploymentResources}
+import org.mockito.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.sts.StsClient
 
-class AWSTest extends FlatSpec with Matchers with MockitoSugar {
+class AWSTest extends AnyFlatSpec with Matchers with MockitoSugar {
 
   val stsClient = mock[StsClient]
 

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -12,14 +12,12 @@ import magenta.artifact.{S3Path, S3Object => MagentaS3Object}
 import magenta.deployment_type.param_reads.PatternValue
 import magenta.input.All
 import magenta.tasks.gcp.{GCSPath, GCSUpload}
-import org.mockito.ArgumentCaptor
+import org.mockito.{ArgumentCaptor, ArgumentMatchers, MockitoSugar}
 import org.mockito.ArgumentMatchers._
-import org.mockito.ArgumentMatchers
-import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.core.ResponseBytes
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
 import software.amazon.awssdk.core.sync.{RequestBody, ResponseTransformer}
@@ -35,7 +33,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.global
 
 
-class TasksTest extends FlatSpec with Matchers with MockitoSugar {
+class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing: KeyRing = KeyRing()
   val reporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,8 +16,8 @@ object Dependencies {
     "org.parboiled" %% "parboiled" % "2.1.5",
     "org.typelevel" %% "cats-core" % "1.0.1",
     "com.kailuowang" %% "henkan-convert" % "0.2.10",
-    "org.scalatest" %% "scalatest" % "3.0.3" % Test,
-    "org.mockito" % "mockito-core" % "2.27.0" % Test
+    "org.scalatest" %% "scalatest" % "3.2.9" % Test,
+    "org.mockito" %% "mockito-scala" % "1.16.37" % Test
   )
 
   val magentaLibDeps = commonDeps ++ Seq(

--- a/riff-raff/test/AuthenticationTest.scala
+++ b/riff-raff/test/AuthenticationTest.scala
@@ -1,12 +1,12 @@
 package test
 
 import com.gu.googleauth.UserIdentity
-import com.gu.googleauth.UserIdentity
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import controllers.{AuthorisationValidator, AuthorisationRecord}
 import org.joda.time.DateTime
 
-class AuthenticationTest extends FlatSpec with Matchers {
+class AuthenticationTest extends AnyFlatSpec with Matchers {
   "AuthorisationValidator" should "allow any domain when not configured" in {
     val validator = new AuthorisationValidator {
       def emailDomainWhitelist = Nil

--- a/riff-raff/test/MappingTest.scala
+++ b/riff-raff/test/MappingTest.scala
@@ -6,12 +6,13 @@ import magenta.Message.Info
 import magenta.Strategy.MostlyHarmless
 import magenta._
 import magenta.input.{DeploymentKey, DeploymentKeysSelector}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import persistence.{AllDocument, DeploymentKeysSelectorDocument}
 import persistence.DeployDocument
 import persistence._
 
-class MappingTest extends FlatSpec with Matchers with Utilities with PersistenceTestInstances with Logging {
+class MappingTest extends AnyFlatSpec with Matchers with Utilities with PersistenceTestInstances with Logging {
   "RecordConverter" should "transform a deploy record into a deploy document" in {
     RecordConverter(testRecord).deployDocument should be(
       DeployRecordDocument(

--- a/riff-raff/test/RepresentationTest.scala
+++ b/riff-raff/test/RepresentationTest.scala
@@ -5,10 +5,11 @@ import controllers.ApiKey
 import magenta.Strategy.MostlyHarmless
 import magenta._
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import persistence._
 
-class RepresentationTest extends FlatSpec with Matchers with Utilities with PersistenceTestInstances {
+class RepresentationTest extends AnyFlatSpec with Matchers with Utilities with PersistenceTestInstances {
 
   "MessageDocument" should "convert from log messages to documents" in {
     deploy.asMessageDocument should be(DeployDocument)

--- a/riff-raff/test/UnnaturalOrderingTest.scala
+++ b/riff-raff/test/UnnaturalOrderingTest.scala
@@ -1,9 +1,10 @@
 package test
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import utils.UnnaturalOrdering
 
-class UnnaturalOrderingTest extends FlatSpec with Matchers {
+class UnnaturalOrderingTest extends AnyFlatSpec with Matchers {
 
   "UnnaturalOrdering" should "order strings in the order that is specified" in {
     val ordering = UnnaturalOrdering(List("test", "alpha", "first"))

--- a/riff-raff/test/ci/BoundedSetTest.scala
+++ b/riff-raff/test/ci/BoundedSetTest.scala
@@ -1,8 +1,9 @@
 package ci
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class BoundedSetTest  extends FunSuite with Matchers {
+class BoundedSetTest  extends AnyFunSuite with Matchers {
   test("bounded set obeys contains") {
     val set = BoundedSet[Int](5) + 1 + 2
     Seq(1,2) map (i => set.contains(i) should be (true))

--- a/riff-raff/test/ci/ContinuousDeploymentTest.scala
+++ b/riff-raff/test/ci/ContinuousDeploymentTest.scala
@@ -1,6 +1,7 @@
 package ci
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.joda.time.DateTime
 import magenta._
 import magenta.DeployParameters
@@ -11,7 +12,7 @@ import magenta.Strategy.MostlyHarmless
 import java.util.UUID
 import scala.util.{Failure, Success}
 
-class ContinuousDeploymentTest extends FlatSpec with Matchers {
+class ContinuousDeploymentTest extends AnyFlatSpec with Matchers {
 
   "Continuous Deployment" should "create deploy parameters for a set of builds" in {
     val params = ContinuousDeployment.getMatchesForSuccessfulBuilds(tdB71, contDeployConfigs).map(ContinuousDeployment.getDeployParams(_)).toSet

--- a/riff-raff/test/ci/GreatestSoFarTest.scala
+++ b/riff-raff/test/ci/GreatestSoFarTest.scala
@@ -1,9 +1,10 @@
 package ci
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 import rx.lang.scala.Observable
 
-class GreatestSoFarTest extends FunSuite with Matchers {
+class GreatestSoFarTest extends AnyFunSuite with Matchers {
 
   test("should return the greatest element seen so far") {
     GreatestSoFar(Observable.just(1, 2, 3, 3, 5, 4)).toBlocking.toList should be (

--- a/riff-raff/test/ci/S3BuildTest.scala
+++ b/riff-raff/test/ci/S3BuildTest.scala
@@ -2,10 +2,12 @@ package ci
 
 import conf.Config
 import org.joda.time.DateTime
-import org.scalatest.{EitherValues, FunSuite, Matchers}
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 import play.api.Configuration
 
-class S3BuildTest extends FunSuite with Matchers with EitherValues {
+class S3BuildTest extends AnyFunSuite with Matchers with EitherValues {
 
   val config = new Config(configuration = Configuration(("test.config", "abc")).underlying, DateTime.now)
 

--- a/riff-raff/test/deployment/Fixtures.scala
+++ b/riff-raff/test/deployment/Fixtures.scala
@@ -7,7 +7,7 @@ import magenta.graph.{DeploymentGraph, DeploymentTasks, Graph}
 import magenta.tasks._
 import magenta.{App, Build, DeployContext, DeployParameters, DeployReporter, Deployer, DeploymentResources, Host, KeyRing, Region, Stage}
 import org.joda.time.DateTime
-import org.scalatest.mockito.MockitoSugar
+import org.mockito.MockitoSugar
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sts.StsClient
 

--- a/riff-raff/test/deployment/actors/DeployCoordinatorTest.scala
+++ b/riff-raff/test/deployment/actors/DeployCoordinatorTest.scala
@@ -7,8 +7,10 @@ import akka.agent.Agent
 import akka.testkit.{TestActorRef, TestKit, TestProbe}
 import com.typesafe.config.ConfigFactory
 import deployment.{Fixtures, Record}
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.mockito.MockitoSugar
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -21,7 +23,7 @@ object DeployCoordinatorTest {
 }
 
 class DeployCoordinatorTest extends TestKit(ActorSystem("DeployCoordinatorTest", DeployCoordinatorTest.testConfig))
-  with FlatSpecLike with Matchers with BeforeAndAfterAll with MockitoSugar {
+  with AnyFlatSpecLike with Matchers with BeforeAndAfterAll with MockitoSugar {
 
   import Fixtures._
 

--- a/riff-raff/test/deployment/actors/DeployGroupRunnerTest.scala
+++ b/riff-raff/test/deployment/actors/DeployGroupRunnerTest.scala
@@ -8,12 +8,13 @@ import conf.Config
 import deployment.{Fixtures, Record}
 import magenta.graph.{DeploymentTasks, Graph, ValueNode}
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpecLike, Matchers}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 import play.api.Configuration
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")) with FlatSpecLike with Matchers {
+class DeployGroupRunnerTest extends TestKit(ActorSystem("DeployGroupRunnerTest")) with AnyFlatSpecLike with Matchers {
   import Fixtures._
   "DeployGroupRunnerTest" should "initalise the state from a set of tasks" in {
     val dr = createDeployRunnerWithUnderlying()

--- a/riff-raff/test/deployment/preview/PreviewTest.scala
+++ b/riff-raff/test/deployment/preview/PreviewTest.scala
@@ -9,14 +9,15 @@ import magenta.fixtures.{ValidatedValues, _}
 import magenta.graph.{DeploymentTasks, EndNode, Graph, StartNode, ValueNode}
 import magenta.input.DeploymentKey
 import magenta.{Build, DeployParameters, DeployReporter, Deployer, DeploymentResources, Region, Stage}
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FlatSpec, Matchers}
+import org.mockito.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sts.StsClient
 
 import scala.concurrent.ExecutionContext.global
 
-class PreviewTest extends FlatSpec with Matchers with ValidatedValues with MockitoSugar {
+class PreviewTest extends AnyFlatSpec with Matchers with ValidatedValues with MockitoSugar {
   def valid(n: Int): Validated[NEL[String], Int] = Valid(n)
   def invalid(error: String): Validated[NEL[String], Int] = Invalid(NEL.of(error))
 

--- a/riff-raff/test/docs/DeployTypeDocsTest.scala
+++ b/riff-raff/test/docs/DeployTypeDocsTest.scala
@@ -1,9 +1,10 @@
 package docs
 
 import magenta.deployment_type._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class DeployTypeDocsTest extends FlatSpec with Matchers {
+class DeployTypeDocsTest extends AnyFlatSpec with Matchers {
   "generateDocs" should "generate documentation for our fake deployment type" in {
     val testDeploymentType = new DeploymentType {
       val action = Action("myAction", "some docs for my action")((_, _, _) => Nil)

--- a/riff-raff/test/housekeeping/ArtifactHousekeepingTest.scala
+++ b/riff-raff/test/housekeeping/ArtifactHousekeepingTest.scala
@@ -6,15 +6,15 @@ import magenta.Strategy.MostlyHarmless
 import magenta.{Build, DeployParameters, Deployer, RunState, Stage}
 import org.joda.time.{DateTime, DateTimeZone}
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FlatSpec, Matchers}
+import org.mockito.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.{CommonPrefix, ListObjectsV2Request, ListObjectsV2Response, S3Object}
 
 import scala.collection.JavaConverters._
 
-class ArtifactHousekeepingTest extends FlatSpec with Matchers with MockitoSugar {
+class ArtifactHousekeepingTest extends AnyFlatSpec with Matchers with MockitoSugar {
 
   case class ObjectSummary(key: String, bucketName: String, lastModified: DateTime)
 

--- a/riff-raff/test/lookup/PrismLookupTest.scala
+++ b/riff-raff/test/lookup/PrismLookupTest.scala
@@ -3,7 +3,8 @@ package lookup
 import conf.Config
 import magenta.deployment_type.CloudFormationDeploymentTypeParameters
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api
 import play.api.libs.json.{JsString, Json}
 import play.api.libs.ws.WSClient
@@ -19,7 +20,7 @@ import magenta.{ApiCredentials, ApiRoleCredentials, ApiStaticCredentials, App, K
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
 
-class PrismLookupTest extends FlatSpec with Matchers {
+class PrismLookupTest extends AnyFlatSpec with Matchers {
 
   val config = new Config(configuration = Configuration(("lookup.timeoutSeconds", 10), ("lookup.prismUrl", "")).underlying, DateTime.now)
   val secretProvider = new SecretProvider {

--- a/riff-raff/test/notification/FailureNotificationContentsTest.scala
+++ b/riff-raff/test/notification/FailureNotificationContentsTest.scala
@@ -5,11 +5,12 @@ import com.gu.anghammarad.models.{Action, Stack, Target}
 import deployment.{Fixtures, NoDeploysFoundForStage, SkippedDueToPreviousFailure, SkippedDueToPreviousWaitingDeploy}
 import magenta.Strategy.MostlyHarmless
 import magenta.{Build, DeployParameters, Stage}
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
 import java.util.UUID
 
-class FailureNotificationContentsTest extends FunSuite with Matchers {
+class FailureNotificationContentsTest extends AnyFunSuite with Matchers {
 
   test("should produce sensible notification contents for a failed Continuous Deployment") {
     val failureNotificationContents = new FailureNotificationContents("http://localhost:9000")

--- a/riff-raff/test/notification/HookTemplateTest.scala
+++ b/riff-raff/test/notification/HookTemplateTest.scala
@@ -4,13 +4,14 @@ import java.util.UUID
 import magenta.RunState
 import magenta.Strategy.MostlyHarmless
 import org.joda.time.DateTime
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 import persistence.AllDocument
 import persistence.{DeployRecordDocument, ParametersDocument}
 
 import scala.util.{Success, Try}
 
-class HookTemplateTest extends FunSuite with Matchers {
+class HookTemplateTest extends AnyFunSuite with Matchers {
   test("HookTemplate should leave unparameterised template as is") {
     val template = new HookTemplate("foo", record)
     val res: Try[String] = template.Template.run()

--- a/riff-raff/test/notification/HooksTest.scala
+++ b/riff-raff/test/notification/HooksTest.scala
@@ -5,13 +5,15 @@ import magenta.Strategy.MostlyHarmless
 import java.util.UUID
 import magenta._
 import org.joda.time.DateTime
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import persistence.AllDocument
 import persistence.{DeployRecordDocument, ParametersDocument}
 import play.api.libs.ws.WSAuthScheme
 import play.api.test.WsTestClient
 
-class HooksTest extends FlatSpec with Matchers with BeforeAndAfterAll {
+class HooksTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 
   it should "create an authenticated request" in {
     WsTestClient.withClient { implicit ws =>

--- a/riff-raff/test/postgres/PostgresDatastoreTest.scala
+++ b/riff-raff/test/postgres/PostgresDatastoreTest.scala
@@ -6,13 +6,14 @@ import deployment.{DeployFilter, PaginationView}
 import magenta.RunState.ChildRunning
 import magenta.{TaskDetail, ThrowableDetail}
 import org.joda.time.DateTime
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import persistence.{DeployDocument, DeployRecordDocument, FailDocument, LogDocument, TaskListDocument}
 import postgres.TestData._
 import scalikejdbc._
 import utils.DockerPostgresService
 
-class PostgresDatastoreTest extends FreeSpec with Matchers with DockerTestKit with DockerPostgresService with PostgresHelpers {
+class PostgresDatastoreTest extends AnyFreeSpec with Matchers with DockerTestKit with DockerPostgresService with PostgresHelpers {
   "ApiKey table" - {
     def withFixture(test: => Any)= {
       try test

--- a/riff-raff/test/restrictions/RestrictionCheckerTest.scala
+++ b/riff-raff/test/restrictions/RestrictionCheckerTest.scala
@@ -5,9 +5,10 @@ import com.gu.googleauth.UserIdentity
 import controllers.ApiKey
 import deployment.{ApiRequestSource, ContinuousDeploymentRequestSource, Error, ScheduleRequestSource, UserRequestSource}
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class RestrictionCheckerTest extends FlatSpec with Matchers {
+class RestrictionCheckerTest extends AnyFlatSpec with Matchers {
 
   val config = makeConfig("", "")
   val configs: Seq[RestrictionConfig] = Seq(

--- a/riff-raff/test/schedule/DeployJobTest.scala
+++ b/riff-raff/test/schedule/DeployJobTest.scala
@@ -5,9 +5,11 @@ import deployment.{DeployRecord, Error, SkippedDueToPreviousFailure}
 import magenta.Strategy.MostlyHarmless
 import magenta.{Build, DeployParameters, Deployer, RunState, Stage}
 import org.joda.time.DateTime
-import org.scalatest.{EitherValues, FlatSpec, Matchers}
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class DeployJobTest extends FlatSpec with Matchers with EitherValues {
+class DeployJobTest extends AnyFlatSpec with Matchers with EitherValues {
   val uuid = UUID.fromString("7fa2ee0a-8d90-4f7e-a38b-185f36fbc5aa")
   "createDeployParameters" should "return params if valid" in {
     val record = new DeployRecord(

--- a/riff-raff/test/utils/GraphTest.scala
+++ b/riff-raff/test/utils/GraphTest.scala
@@ -1,9 +1,10 @@
 package utils
 
-import org.scalatest.{Matchers, FunSuite}
+import org.scalatest.matchers.should.Matchers
 import org.joda.time.LocalDate
+import org.scalatest.funsuite.AnyFunSuite
 
-class GraphTest extends FunSuite with Matchers {
+class GraphTest extends AnyFunSuite with Matchers {
   test("should add zeros for missing days") {
     val statsWithMissingDays = List(
       new LocalDate(2013, 5, 1) -> 4,

--- a/riff-raff/test/utils/MessageHelperTest.scala
+++ b/riff-raff/test/utils/MessageHelperTest.scala
@@ -5,11 +5,12 @@ import java.util.UUID
 import magenta.ContextMessage.StartContext
 import magenta.Message.Verbose
 import magenta.{DeployReportTree, StartMessageState}
-import org.scalatest.{FunSuite, Matchers}
 import org.joda.time.DateTime
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 import views.html.helper.magenta.MessageHelper
 
-class MessageHelperTest extends FunSuite with Matchers {
+class MessageHelperTest extends AnyFunSuite with Matchers {
   test("MessageHelper.messageType should return correct message type") {
     val report = DeployReportTree(messageState = StartMessageState(
       startContext = StartContext(Verbose("verbose")),

--- a/riff-raff/test/utils/VCSInfoTest.scala
+++ b/riff-raff/test/utils/VCSInfoTest.scala
@@ -1,11 +1,11 @@
 package utils
 
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
 import java.net.URI
 
-import org.scalatest.{FunSuite, Matchers}
-
-
-class VCSInfoTest extends FunSuite with Matchers {
+class VCSInfoTest extends AnyFunSuite with Matchers {
   test("extracts details from Github HTTPS URL") {
     val info = VCSInfo("https://github.com/guardian/contributions-frontend", "98a1cffadbe564d570b15c2113c07a28cbe835ee")
     info.get.baseUrl shouldBe new URI("https://github.com/guardian/contributions-frontend")


### PR DESCRIPTION
## What does this change?

* Removes [`mockito-core`](https://github.com/mockito/mockito) and adds [`mockito-scala`](https://github.com/mockito/mockito-scala), as this has better support for Scala projects (I need to make use of [this feature](https://github.com/mockito/mockito-scala#mocking-scala-object) in a subsequent PR, which is the primary motivation for this change).
* Updates `scalatest` for compatibility and to keep things up to date.

Although this PR touches a lot of files as a result of modularisation changes in an [intermediate version of `scalatest`
](https://www.scalatest.org/release_notes/3.1.0) the only thing that's really changing here is import statements. I've raised this in its own PR to avoid adding noise to the refactor that I'm really trying to work on!

## How to test

* All tests should still pass in CI

## How can we measure success?

* Our dependencies are up to date

## Have we considered potential risks?
 
* I don't consider this to be a risky change