### PR TITLE
Add `braze-publish` deployment type (plus hidden `lambda-invoke` deployment type)

### DIFF
--- a/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
+++ b/magenta-lib/src/main/scala/magenta/artifact/S3Location.scala
@@ -88,8 +88,12 @@ object S3Location extends Loggable {
       }
   }
 
-  def fetchContentAsString(location: S3Location)(implicit client: S3Client): Either[S3Error, String] = {
-    fetchContentAsBytes(location).map(bytes => new String(bytes, StandardCharsets.UTF_8))
+  def fetchContentAsString(
+      location: S3Location
+  )(implicit client: S3Client): Either[S3Error, String] = {
+    fetchContentAsBytes(location).map(bytes =>
+      new String(bytes, StandardCharsets.UTF_8)
+    )
   }
 }
 

--- a/magenta-lib/src/main/scala/magenta/deployment_type/BrazePublish.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/BrazePublish.scala
@@ -5,9 +5,10 @@ import play.api.libs.json.{JsArray, JsString, JsBoolean}
 object BrazePublish extends LambdaInvoke {
   val brazePublishLambdaNameMinusStage = s"${LambdaInvoke.lambdaFunctionNamePrefix}braze-version-control-publish-lambda-"
   override val name = "braze-publish"
+  private val summary = s"Invokes Lambda `${brazePublishLambdaNameMinusStage}` (with the STAGE appended). This Lambda publishes content blocks to the target Braze environment (only if there are changes)."
 
   override def documentation: String = s"""
-      |Invokes Lambda `${brazePublishLambdaNameMinusStage}` (with the STAGE appended). This Lambda publishes content blocks to the target Braze environment (only if there are changes).
+      |${summary}
       |
       |The payload sent to the Lambda is constructed from the artifacts associated with this deployment step.
       |The top level key is the name of the deployment step, and the keys of the object within are the file names and the values are the file contents as strings.
@@ -25,7 +26,7 @@ object BrazePublish extends LambdaInvoke {
     """.stripMargin
 
   override def defaultActions: List[Action] = super.defaultActions.map { action =>
-    action.copy(){(pkg, resources, target) =>
+    action.copy(name="brazePublish", documentation=summary){(pkg, resources, target) =>
       action.taskGenerator(
         pkg.copy(pkgSpecificData = pkg.pkgSpecificData ++ Map(
           functionNamesParam.name -> JsArray(Array(JsString(brazePublishLambdaNameMinusStage))),

--- a/magenta-lib/src/main/scala/magenta/deployment_type/BrazePublish.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/BrazePublish.scala
@@ -3,9 +3,11 @@ package magenta.deployment_type
 import play.api.libs.json.{JsArray, JsString, JsBoolean}
 
 object BrazePublish extends LambdaInvoke {
-  val brazePublishLambdaNameMinusStage = s"${LambdaInvoke.lambdaFunctionNamePrefix}braze-version-control-publish-lambda-"
+  val brazePublishLambdaNameMinusStage =
+    s"${LambdaInvoke.lambdaFunctionNamePrefix}braze-version-control-publish-lambda-"
   override val name = "braze-publish"
-  private val summary = s"Invokes Lambda `${brazePublishLambdaNameMinusStage}` (with the STAGE appended). This Lambda publishes content blocks to the target Braze environment (only if there are changes)."
+  private val summary =
+    s"Invokes Lambda `${brazePublishLambdaNameMinusStage}` (with the STAGE appended). This Lambda publishes content blocks to the target Braze environment (only if there are changes)."
 
   override val documentation: String = s"""
       |${summary}
@@ -25,18 +27,27 @@ object BrazePublish extends LambdaInvoke {
       |```
     """.stripMargin
 
-  val brazePublishAction = Action(name="brazePublish", documentation=summary){(pkg, resources, target) =>
-    getInvokeAction.taskGenerator(
-      pkg.copy(pkgSpecificData = pkg.pkgSpecificData.view.filterKeys(key => !super.params.map(_.name).contains(key)).toMap ++ Map(
-        functionNamesParam.name -> JsArray(Array(JsString(brazePublishLambdaNameMinusStage))),
-        prefixStackParam.name -> JsBoolean(false)
-      )),
-      resources,
-      target
-    )
-  }
+  val brazePublishAction =
+    Action(name = "brazePublish", documentation = summary) {
+      (pkg, resources, target) =>
+        getInvokeAction.taskGenerator(
+          pkg.copy(pkgSpecificData =
+            pkg.pkgSpecificData.view
+              .filterKeys(key => !super.params.map(_.name).contains(key))
+              .toMap ++ Map(
+              functionNamesParam.name -> JsArray(
+                Array(JsString(brazePublishLambdaNameMinusStage))
+              ),
+              prefixStackParam.name -> JsBoolean(false)
+            )
+          ),
+          resources,
+          target
+        )
+    }
 
   override def defaultActions: List[Action] = List(brazePublishAction)
 
-  override def paramsToHide: Seq[Param[_]] = super.params // This deployment type takes no parameters, so we hide all the parameters from the parent
+  override def paramsToHide: Seq[Param[_]] =
+    super.params // This deployment type takes no parameters, so we hide all the parameters from the parent
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/BrazePublish.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/BrazePublish.scala
@@ -22,7 +22,7 @@ object BrazePublish extends LambdaInvoke {
       |  }
       |}
       |```
-    """
+    """.stripMargin
 
   override def defaultActions: List[Action] = super.defaultActions.map { action =>
     action.copy(){(pkg, resources, target) =>

--- a/magenta-lib/src/main/scala/magenta/deployment_type/BrazePublish.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/BrazePublish.scala
@@ -1,0 +1,40 @@
+package magenta.deployment_type
+
+import play.api.libs.json.{JsArray, JsString, JsBoolean}
+
+object BrazePublish extends LambdaInvoke {
+  val brazePublishLambdaNameMinusStage = s"${LambdaInvoke.lambdaFunctionNamePrefix}braze-version-control-publish-lambda-"
+  override val name = "braze-publish"
+
+  override def documentation: String = s"""
+      |Invokes Lambda `${brazePublishLambdaNameMinusStage}` (with the STAGE appended). This Lambda publishes content blocks to the target Braze environment (only if there are changes).
+      |
+      |The payload sent to the Lambda is constructed from the artifacts associated with this deployment step.
+      |The top level key is the name of the deployment step, and the keys of the object within are the file names and the values are the file contents as strings.
+      |
+      |For example (given the name of the deployment step is 'hello_world' in the `riff-raff.yaml`), the payload would look something like:
+      |```
+      |{
+      |  "hello_world": {
+      |    "artefact_filenameA.abc" : "file A contents",
+      |    "artefact_filenameB.abc" : "file B contents",
+      |    "artefact_filenameC.abc" : "file C contents"
+      |  }
+      |}
+      |```
+    """
+
+  override def defaultActions: List[Action] = super.defaultActions.map { action =>
+    action.copy(){(pkg, resources, target) =>
+      action.taskGenerator(
+        pkg.copy(pkgSpecificData = pkg.pkgSpecificData ++ Map(
+          functionNamesParam.name -> JsArray(Array(JsString(brazePublishLambdaNameMinusStage))),
+          prefixStackParam.name -> JsBoolean(false)
+          //TODO: Filter out other Lambda params to avoid misuse
+        )),
+        resources,
+        target
+      )
+    }
+  }
+}

--- a/magenta-lib/src/main/scala/magenta/deployment_type/BrazePublish.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/BrazePublish.scala
@@ -25,19 +25,17 @@ object BrazePublish extends LambdaInvoke {
       |```
     """.stripMargin
 
-  override def defaultActions: List[Action] = super.defaultActions.map { action =>
-    Action(name="brazePublish", documentation=summary){(pkg, resources, target) =>
-      action.taskGenerator(
-        pkg.copy(pkgSpecificData = pkg.pkgSpecificData ++ Map(
+  override def defaultActions: List[Action] =
+    List(Action(name="brazePublish", documentation=summary){(pkg, resources, target) =>
+      invokeAction.taskGenerator(
+        pkg.copy(pkgSpecificData = pkg.pkgSpecificData.filterKeys(key => !super.params.map(_.name).contains(key)) ++ Map(
           functionNamesParam.name -> JsArray(Array(JsString(brazePublishLambdaNameMinusStage))),
           prefixStackParam.name -> JsBoolean(false)
-          //TODO: Filter out other Lambda params to avoid misuse
         )),
         resources,
         target
       )
-    }
-  }
+    })
 
-  override def paramsToHide: Seq[Param[_]] = super.params
+  override def paramsToHide: Seq[Param[_]] = super.params // This deployment type takes no parameters, so we hide all the parameters from the parent
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/BrazePublish.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/BrazePublish.scala
@@ -26,7 +26,7 @@ object BrazePublish extends LambdaInvoke {
     """.stripMargin
 
   override def defaultActions: List[Action] = super.defaultActions.map { action =>
-    action.copy(name="brazePublish", documentation=summary){(pkg, resources, target) =>
+    Action(name="brazePublish", documentation=summary){(pkg, resources, target) =>
       action.taskGenerator(
         pkg.copy(pkgSpecificData = pkg.pkgSpecificData ++ Map(
           functionNamesParam.name -> JsArray(Array(JsString(brazePublishLambdaNameMinusStage))),

--- a/magenta-lib/src/main/scala/magenta/deployment_type/BrazePublish.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/BrazePublish.scala
@@ -7,7 +7,7 @@ object BrazePublish extends LambdaInvoke {
   override val name = "braze-publish"
   private val summary = s"Invokes Lambda `${brazePublishLambdaNameMinusStage}` (with the STAGE appended). This Lambda publishes content blocks to the target Braze environment (only if there are changes)."
 
-  override def documentation: String = s"""
+  override val documentation: String = s"""
       |${summary}
       |
       |The payload sent to the Lambda is constructed from the artifacts associated with this deployment step.
@@ -25,17 +25,18 @@ object BrazePublish extends LambdaInvoke {
       |```
     """.stripMargin
 
-  override def defaultActions: List[Action] =
-    List(Action(name="brazePublish", documentation=summary){(pkg, resources, target) =>
-      invokeAction.taskGenerator(
-        pkg.copy(pkgSpecificData = pkg.pkgSpecificData.view.filterKeys(key => !super.params.map(_.name).contains(key)).toMap ++ Map(
-          functionNamesParam.name -> JsArray(Array(JsString(brazePublishLambdaNameMinusStage))),
-          prefixStackParam.name -> JsBoolean(false)
-        )),
-        resources,
-        target
-      )
-    })
+  val brazePublishAction = Action(name="brazePublish", documentation=summary){(pkg, resources, target) =>
+    getInvokeAction.taskGenerator(
+      pkg.copy(pkgSpecificData = pkg.pkgSpecificData.view.filterKeys(key => !super.params.map(_.name).contains(key)).toMap ++ Map(
+        functionNamesParam.name -> JsArray(Array(JsString(brazePublishLambdaNameMinusStage))),
+        prefixStackParam.name -> JsBoolean(false)
+      )),
+      resources,
+      target
+    )
+  }
+
+  override def defaultActions: List[Action] = List(brazePublishAction)
 
   override def paramsToHide: Seq[Param[_]] = super.params // This deployment type takes no parameters, so we hide all the parameters from the parent
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/BrazePublish.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/BrazePublish.scala
@@ -28,7 +28,7 @@ object BrazePublish extends LambdaInvoke {
   override def defaultActions: List[Action] =
     List(Action(name="brazePublish", documentation=summary){(pkg, resources, target) =>
       invokeAction.taskGenerator(
-        pkg.copy(pkgSpecificData = pkg.pkgSpecificData.filterKeys(key => !super.params.map(_.name).contains(key)) ++ Map(
+        pkg.copy(pkgSpecificData = pkg.pkgSpecificData.view.filterKeys(key => !super.params.map(_.name).contains(key)).toMap ++ Map(
           functionNamesParam.name -> JsArray(Array(JsString(brazePublishLambdaNameMinusStage))),
           prefixStackParam.name -> JsBoolean(false)
         )),

--- a/magenta-lib/src/main/scala/magenta/deployment_type/BrazePublish.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/BrazePublish.scala
@@ -38,4 +38,6 @@ object BrazePublish extends LambdaInvoke {
       )
     }
   }
+
+  override def paramsToHide: Seq[Param[_]] = super.params
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
@@ -15,6 +15,7 @@ trait DeploymentType {
     }
   }
   def params = registerParamsList.values.toSeq
+  def paramsToHide = Seq.empty[Param[_]]
 
   private val registerActionsMap = mutable.Map.empty[String, Action]
   implicit val actionsRegister = new ActionRegister {

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaDeploy.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaDeploy.scala
@@ -15,9 +15,9 @@ import magenta.{
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.ssm.SsmClient
 
-object Lambda extends Lambda
+object LambdaDeploy extends LambdaDeploy
 
-trait Lambda extends DeploymentType with BucketParameters {
+trait LambdaDeploy extends DeploymentType with BucketParameters {
   val name = "aws-lambda"
   val documentation =
     """

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaDeploy.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaDeploy.scala
@@ -87,7 +87,7 @@ trait LambdaDeploy extends DeploymentType with BucketParameters {
       """.stripMargin,
     optional = true
   )
-
+  // TODO: Introduce parent trait for LambdaDeploy and LambdaInvoke to inherit from which holds shared behaviour such as this function
   def lambdaToProcess(
       pkg: DeploymentPackage,
       target: DeployTarget,

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaDeploy.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaDeploy.scala
@@ -1,23 +1,17 @@
 package magenta.deployment_type
 
 import magenta.artifact.S3Path
+import magenta.tasks.S3.Bucket
 import magenta.tasks.{S3Upload, SSM, STS, UpdateS3Lambda, S3 => S3Tasks}
-import magenta.{
-  DeployParameters,
-  DeployReporter,
-  DeployTarget,
-  DeploymentPackage,
-  DeploymentResources,
-  KeyRing,
-  Region,
-  Stack
-}
+import magenta.{DeployParameters, DeployReporter, DeployTarget, DeploymentPackage, DeploymentResources, KeyRing, Region, Stack}
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.ssm.SsmClient
 
 object LambdaDeploy extends LambdaDeploy
 
-trait LambdaDeploy extends DeploymentType with BucketParameters {
+case class UpdateLambdaFunction(function: LambdaFunction, fileName: String, region: Region, s3Bucket: S3Tasks.Bucket) extends LambdaTaskPrecursor
+
+trait LambdaDeploy extends LambdaDeploymentType[UpdateLambdaFunction] {
   val name = "aws-lambda"
   val documentation =
     """
@@ -33,157 +27,24 @@ trait LambdaDeploy extends DeploymentType with BucketParameters {
       |
       """.stripMargin
 
-  val functionNamesParam = Param[List[String]](
-    "functionNames",
-    """One or more function names to update with the code from fileNameParam.
-      |Each function name will be suffixed with the stage, e.g. MyFunction- becomes MyFunction-CODE""".stripMargin,
-    optional = true
-  )
-
-  val lookupByTags = Param[Boolean](
-    "lookupByTags",
-    """When true, this will lookup the function to deploy to by using the Stack, Stage and App tags on a function.
-      |The values looked up come from the `stacks` and `app` in the riff-raff.yaml and the stage deployed to.
-    """.stripMargin
-  ).default(false)
-
-  val prefixStackParam = Param[Boolean](
-    "prefixStack",
-    "If true then the values in the functionNames param will be prefixed with the name of the stack being deployed"
-  ).default(true)
-
-  val prefixStackToKeyParam = Param[Boolean](
-    "prefixStackToKey",
-    documentation = "Whether to prefix `package` to the S3 location"
-  ).default(true)
-
-  val fileNameParam = Param[String](
-    "fileName",
-    "The name of the archive of the function",
-    deprecatedDefault = true
-  )
+  val fileNameParam = Param[String]("fileName", "The name of the archive of the function", deprecatedDefault = true)
     .defaultFromContext((pkg, _) => Right(s"${pkg.name}.zip"))
 
-  val functionsParam = Param[Map[String, Map[String, String]]](
-    "functions",
-    documentation = """
-        |In order for this to work, magenta must have credentials that are able to perform `lambda:UpdateFunctionCode`
-        |on the specified resources.
-        |
-        |Map of Stage to Lambda functions. `name` is the Lambda `FunctionName`. The `filename` field is optional and if
-        |not specified defaults to `lambda.zip`
-        |e.g.
-        |
-        |        "functions": {
-        |          "CODE": {
-        |           "name": "myLambda-CODE",
-        |           "filename": "myLambda-CODE.zip",
-        |          },
-        |          "PROD": {
-        |           "name": "myLambda-PROD",
-        |           "filename": "myLambda-PROD.zip",
-        |          }
-        |        }
-      """.stripMargin,
-    optional = true
-  )
-  // TODO: Introduce parent trait for LambdaDeploy and LambdaInvoke to inherit from which holds shared behaviour such as this function
-  def lambdaToProcess(
-      pkg: DeploymentPackage,
-      target: DeployTarget,
-      reporter: DeployReporter
-  ): List[UpdateLambdaFunction] = {
-    val bucket = getTargetBucketFromConfig(pkg, target, reporter)
+  override val functionNamesParamDescriptionSuffix = "update with the code from fileNameParam"
 
-    val stage = target.parameters.stage.name
+  def buildLambdaTaskPrecursor(stackNamePrefix: String, stage: String, name: String, pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter) =
+    UpdateLambdaFunction(LambdaFunctionName(s"$stackNamePrefix$name$stage"), fileNameParam(pkg, target, reporter), target.region, getTargetBucketFromConfig(pkg, target, reporter))
 
-    (
-      functionNamesParam.get(pkg),
-      functionsParam.get(pkg),
-      lookupByTags(pkg, target, reporter),
-      prefixStackParam(pkg, target, reporter)
-    ) match {
-      // the lambdas are a simple hardcoded list of function names
-      case (Some(functionNames), None, false, prefixStack) =>
-        val stackNamePrefix = if (prefixStack) target.stack.name else ""
-        for {
-          name <- functionNames
-        } yield UpdateLambdaFunction(
-          LambdaFunctionName(s"$stackNamePrefix$name$stage"),
-          fileNameParam(pkg, target, reporter),
-          target.region,
-          bucket
-        )
+  def buildLambdaTaskPrecursor(functionName: String, functionDefinition: Map[String, String], pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter) =
+    UpdateLambdaFunction(LambdaFunctionName(functionName), fileName = functionDefinition.getOrElse("filename", "lambda.zip"), target.region, getTargetBucketFromConfig(pkg, target, reporter))
 
-      // the list of lambdas are provided in a map from stage to lambda name and filename
-      case (None, Some(functionsMap), false, _) =>
-        val functionDefinition = functionsMap.getOrElse(
-          stage,
-          reporter.fail(s"Function not defined for stage $stage")
-        )
-        val functionName = functionDefinition.getOrElse(
-          "name",
-          reporter.fail(s"Function name not defined for stage $stage")
-        )
-        val fileName = functionDefinition.getOrElse("filename", "lambda.zip")
-        List(
-          UpdateLambdaFunction(
-            LambdaFunctionName(functionName),
-            fileName,
-            target.region,
-            bucket
-          )
-        )
+  def buildLambdaTaskPrecursor(tags: LambdaFunctionTags, pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter) =
+    UpdateLambdaFunction(tags, fileNameParam(pkg, target, reporter), target.region, getTargetBucketFromConfig(pkg, target, reporter))
 
-      // the lambda to update is discovered from Stack, App and Stage tags
-      case (None, None, true, _) =>
-        val tags = LambdaFunctionTags(
-          Map(
-            "Stack" -> target.stack.name,
-            "App" -> pkg.app.name,
-            "Stage" -> stage
-          )
-        )
-        List(
-          UpdateLambdaFunction(
-            tags,
-            fileNameParam(pkg, target, reporter),
-            target.region,
-            bucket
-          )
-        )
-
-      case _ =>
-        reporter.fail(
-          "Must specify one of 'functions', 'functionNames' or 'lookupByTags' parameters"
-        )
-    }
-  }
-
-  def makeS3Key(
-      target: DeployTarget,
-      pkg: DeploymentPackage,
-      fileName: String,
-      reporter: DeployReporter
-  ): String = {
-    val prefixStack = prefixStackToKeyParam(pkg, target, reporter)
-    val prefix = if (prefixStack) List(target.stack.name) else Nil
-    (prefix ::: List(target.parameters.stage.name, pkg.app.name, fileName))
-      .mkString("/")
-  }
-
-  def withSsm[T](
-      keyRing: KeyRing,
-      region: Region,
-      resources: DeploymentResources
-  ): (SsmClient => T) => T = SSM.withSsmClient[T](keyRing, region, resources)
-
-  val uploadLambda = Action(
-    "uploadLambda",
+  val uploadLambda = Action("uploadLambda",
     """
       |Uploads the lambda code to S3.
-    """.stripMargin
-  ) { (pkg, resources, target) =>
+    """.stripMargin){ (pkg, resources, target) =>
     implicit val keyRing: KeyRing = resources.assembleKeyring(target, pkg)
     implicit val artifactClient: S3Client = resources.artifactClient
     lambdaToProcess(pkg, target, resources.reporter).map { lambda =>
@@ -200,8 +61,7 @@ trait LambdaDeploy extends DeploymentType with BucketParameters {
       )
     }.distinct
   }
-  val updateLambda = Action(
-    "updateLambda",
+  val updateLambda = Action("updateLambda",
     """
       |Updates the lambda to use new code using the UpdateFunctionCode API.
       |
@@ -216,35 +76,24 @@ trait LambdaDeploy extends DeploymentType with BucketParameters {
       |Due to the current limitations in AWS (particularly the lack of configuration mechanisms) there is a more
       |powerful `functions` parameter. This lets you bind a specific file to a specific function for any given stage.
       |As a result you can bundle stage specific configuration into the respective files.
-    """.stripMargin
-  ) { (pkg, resources, target) =>
+    """.stripMargin){ (pkg, resources, target) =>
     implicit val keyRing: KeyRing = resources.assembleKeyring(target, pkg)
     implicit val artifactClient: S3Client = resources.artifactClient
     lambdaToProcess(pkg, target, resources.reporter).map { lambda =>
-      val s3Bucket = S3Tasks.getBucketName(
-        lambda.s3Bucket,
-        withSsm(keyRing, target.region, resources),
-        resources.reporter
-      )
-      val s3Key = makeS3Key(target, pkg, lambda.fileName, resources.reporter)
-      UpdateS3Lambda(
-        lambda.function,
-        s3Bucket,
-        s3Key,
-        lambda.region
-      )
+        val s3Bucket = S3Tasks.getBucketName(
+          lambda.s3Bucket,
+          withSsm(keyRing, target.region, resources),
+          resources.reporter
+        )
+        val s3Key = makeS3Key(target, pkg, lambda.fileName, resources.reporter)
+        UpdateS3Lambda(
+          lambda.function,
+          s3Bucket,
+          s3Key,
+          lambda.region
+        )
     }.distinct
   }
 
   def defaultActions = List(uploadLambda, updateLambda)
 }
-
-sealed trait LambdaFunction
-case class LambdaFunctionName(name: String) extends LambdaFunction
-case class LambdaFunctionTags(tags: Map[String, String]) extends LambdaFunction
-case class UpdateLambdaFunction(
-    function: LambdaFunction,
-    fileName: String,
-    region: Region,
-    s3Bucket: S3Tasks.Bucket
-)

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaDeploy.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaDeploy.scala
@@ -27,6 +27,7 @@ trait LambdaDeploy extends LambdaDeploymentType[UpdateLambdaFunction] with Bucke
       |
       """.stripMargin
 
+  override def lambdaKeyword: String = "deploy"
   val fileNameParam = Param[String]("fileName", "The name of the archive of the function", deprecatedDefault = true)
     .defaultFromContext((pkg, _) => Right(s"${pkg.name}.zip"))
 

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaDeploy.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaDeploy.scala
@@ -11,7 +11,7 @@ object LambdaDeploy extends LambdaDeploy
 
 case class UpdateLambdaFunction(function: LambdaFunction, fileName: String, region: Region, s3Bucket: S3Tasks.Bucket) extends LambdaTaskPrecursor
 
-trait LambdaDeploy extends LambdaDeploymentType[UpdateLambdaFunction] {
+trait LambdaDeploy extends LambdaDeploymentType[UpdateLambdaFunction] with BucketParameters {
   val name = "aws-lambda"
   val documentation =
     """
@@ -30,7 +30,7 @@ trait LambdaDeploy extends LambdaDeploymentType[UpdateLambdaFunction] {
   val fileNameParam = Param[String]("fileName", "The name of the archive of the function", deprecatedDefault = true)
     .defaultFromContext((pkg, _) => Right(s"${pkg.name}.zip"))
 
-  override val functionNamesParamDescriptionSuffix = "update with the code from fileNameParam"
+  override def functionNamesParamDescriptionSuffix = "update with the code from fileNameParam"
 
   def buildLambdaTaskPrecursor(stackNamePrefix: String, stage: String, name: String, pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter) =
     UpdateLambdaFunction(LambdaFunctionName(s"$stackNamePrefix$name$stage"), fileNameParam(pkg, target, reporter), target.region, getTargetBucketFromConfig(pkg, target, reporter))

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaDeploymentType.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaDeploymentType.scala
@@ -4,7 +4,7 @@ import magenta.tasks.SSM
 import magenta.{DeployReporter, DeployTarget, DeploymentPackage, DeploymentResources, KeyRing, Region}
 import software.amazon.awssdk.services.ssm.SsmClient
 
-trait LambdaDeploymentType[LAMBDA_TASK_PRECURSOR <: LambdaTaskPrecursor] extends DeploymentType with BucketParameters  {
+trait LambdaDeploymentType[LAMBDA_TASK_PRECURSOR <: LambdaTaskPrecursor] extends DeploymentType {
   def functionNamesParamDescriptionSuffix: String
   val functionNamesParam = Param[List[String]]("functionNames",
     s"""One or more function names to $functionNamesParamDescriptionSuffix.

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaDeploymentType.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaDeploymentType.scala
@@ -1,0 +1,99 @@
+package magenta.deployment_type
+
+import magenta.tasks.SSM
+import magenta.{DeployReporter, DeployTarget, DeploymentPackage, DeploymentResources, KeyRing, Region}
+import software.amazon.awssdk.services.ssm.SsmClient
+
+trait LambdaDeploymentType[LAMBDA_TASK_PRECURSOR <: LambdaTaskPrecursor] extends DeploymentType with BucketParameters  {
+  def functionNamesParamDescriptionSuffix: String
+  val functionNamesParam = Param[List[String]]("functionNames",
+    s"""One or more function names to $functionNamesParamDescriptionSuffix.
+      |Each function name will be suffixed with the stage, e.g. MyFunction- becomes MyFunction-CODE""".stripMargin,
+    optional = true
+  )
+  // TODO: make 'deploy' an injected value that describes the deployment type x 3
+  val lookupByTags = Param[Boolean]("lookupByTags",
+    """When true, this will lookup the function to deploy to by using the Stack, Stage and App tags on a function.
+      |The values looked up come from the `stacks` and `app` in the riff-raff.yaml and the stage deployed to.
+    """.stripMargin
+  ).default(false)
+
+  val prefixStackParam = Param[Boolean]("prefixStack",
+    "If true then the values in the functionNames param will be prefixed with the name of the stack being deployed").default(true)
+
+  val prefixStackToKeyParam = Param[Boolean]("prefixStackToKey",
+    documentation = "Whether to prefix `package` to the S3 location"
+  ).default(true)
+
+  val functionsParam = Param[Map[String, Map[String, String]]]("functions",
+    documentation =
+      """
+        |In order for this to work, magenta must have credentials that are able to perform `lambda:UpdateFunctionCode`
+        |on the specified resources.
+        |
+        |Map of Stage to Lambda functions. `name` is the Lambda `FunctionName`. The `filename` field is optional and if
+        |not specified defaults to `lambda.zip`
+        |e.g.
+        |
+        |        "functions": {
+        |          "CODE": {
+        |           "name": "myLambda-CODE",
+        |           "filename": "myLambda-CODE.zip",
+        |          },
+        |          "PROD": {
+        |           "name": "myLambda-PROD",
+        |           "filename": "myLambda-PROD.zip",
+        |          }
+        |        }
+      """.stripMargin,
+    optional = true
+  )
+  def withSsm[T](keyRing: KeyRing, region: Region, resources: DeploymentResources): (SsmClient => T) => T = SSM.withSsmClient[T](keyRing, region, resources)
+
+  def makeS3Key(target: DeployTarget, pkg:DeploymentPackage, fileName: String, reporter: DeployReporter): String = {
+    val prefixStack = prefixStackToKeyParam(pkg, target, reporter)
+    val prefix = if (prefixStack) List(target.stack.name) else Nil
+    (prefix ::: List(target.parameters.stage.name, pkg.app.name, fileName)).mkString("/")
+  }
+
+  def buildLambdaTaskPrecursor(stackNamePrefix: String, stage: String, name: String, pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter): LAMBDA_TASK_PRECURSOR
+  def buildLambdaTaskPrecursor(functionName: String, functionDefinition: Map[String, String], pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter): LAMBDA_TASK_PRECURSOR
+  def buildLambdaTaskPrecursor(tags: LambdaFunctionTags, pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter): LAMBDA_TASK_PRECURSOR
+
+  def lambdaToProcess(pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter): List[LAMBDA_TASK_PRECURSOR] = {
+    val stage = target.parameters.stage.name
+
+    (functionNamesParam.get(pkg), functionsParam.get(pkg), lookupByTags(pkg, target, reporter), prefixStackParam(pkg, target, reporter)) match {
+      // the lambdas are a simple hardcoded list of function names
+      case (Some(functionNames), None, false, prefixStack) =>
+        val stackNamePrefix = if (prefixStack) target.stack.name else ""
+        functionNames.map { name =>
+          buildLambdaTaskPrecursor(stackNamePrefix, stage, name, pkg, target, reporter)
+        }
+
+      // the list of lambdas are provided in a map from stage to lambda name and filename
+      case (None, Some(functionsMap), false, _) =>
+        val functionDefinition = functionsMap.getOrElse(stage, reporter.fail(s"Function not defined for stage $stage"))
+        val functionName = functionDefinition.getOrElse("name", reporter.fail(s"Function name not defined for stage $stage"))
+
+        List(buildLambdaTaskPrecursor(functionName, functionDefinition, pkg, target, reporter))
+
+      // the lambda is discovered from Stack, App and Stage tags
+      case (None, None, true, _) =>
+        val tags = LambdaFunctionTags(Map(
+          "Stack" -> target.stack.name,
+          "App" -> pkg.app.name,
+          "Stage" -> stage
+        ))
+        List(buildLambdaTaskPrecursor(tags, pkg, target, reporter))
+
+      case _ => reporter.fail("Must specify one of 'functions', 'functionNames' or 'lookupByTags' parameters")
+    }
+  }
+}
+
+sealed trait LambdaFunction
+case class LambdaFunctionName(name: String) extends LambdaFunction
+case class LambdaFunctionTags(tags: Map[String, String]) extends LambdaFunction
+
+trait LambdaTaskPrecursor

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaDeploymentType.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaDeploymentType.scala
@@ -6,20 +6,21 @@ import software.amazon.awssdk.services.ssm.SsmClient
 
 trait LambdaDeploymentType[LAMBDA_TASK_PRECURSOR <: LambdaTaskPrecursor] extends DeploymentType {
   def functionNamesParamDescriptionSuffix: String
+  def lambdaKeyword: String
+  val lambdaKeywordPastTense = s"$lambdaKeyword${if (lambdaKeyword.endsWith("e")) "d" else "ed"}"
   val functionNamesParam = Param[List[String]]("functionNames",
-    s"""One or more function names to $functionNamesParamDescriptionSuffix.
+    s"""One or more function names to $lambdaKeyword.
       |Each function name will be suffixed with the stage, e.g. MyFunction- becomes MyFunction-CODE""".stripMargin,
     optional = true
   )
-  // TODO: make 'deploy' an injected value that describes the deployment type x 3
   val lookupByTags = Param[Boolean]("lookupByTags",
-    """When true, this will lookup the function to deploy to by using the Stack, Stage and App tags on a function.
-      |The values looked up come from the `stacks` and `app` in the riff-raff.yaml and the stage deployed to.
+    s"""When true, this will lookup the function to ${lambdaKeyword} to by using the Stack, Stage and App tags on a function.
+      |The values looked up come from the `stacks` and `app` in the riff-raff.yaml and the stage ${lambdaKeywordPastTense} to.
     """.stripMargin
   ).default(false)
 
   val prefixStackParam = Param[Boolean]("prefixStack",
-    "If true then the values in the functionNames param will be prefixed with the name of the stack being deployed").default(true)
+    s"If true then the values in the functionNames param will be prefixed with the name of the stack being ${lambdaKeywordPastTense}").default(true)
 
   val prefixStackToKeyParam = Param[Boolean]("prefixStackToKey",
     documentation = "Whether to prefix `package` to the S3 location"

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaDeploymentType.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaDeploymentType.scala
@@ -1,34 +1,48 @@
 package magenta.deployment_type
 
 import magenta.tasks.SSM
-import magenta.{DeployReporter, DeployTarget, DeploymentPackage, DeploymentResources, KeyRing, Region}
+import magenta.{
+  DeployReporter,
+  DeployTarget,
+  DeploymentPackage,
+  DeploymentResources,
+  KeyRing,
+  Region
+}
 import software.amazon.awssdk.services.ssm.SsmClient
 
-trait LambdaDeploymentType[LAMBDA_TASK_PRECURSOR <: LambdaTaskPrecursor] extends DeploymentType {
+trait LambdaDeploymentType[LAMBDA_TASK_PRECURSOR <: LambdaTaskPrecursor]
+    extends DeploymentType {
   def functionNamesParamDescriptionSuffix: String
   def lambdaKeyword: String
-  val lambdaKeywordPastTense = s"$lambdaKeyword${if (lambdaKeyword.endsWith("e")) "d" else "ed"}"
-  val functionNamesParam = Param[List[String]]("functionNames",
+  val lambdaKeywordPastTense =
+    s"$lambdaKeyword${if (lambdaKeyword.endsWith("e")) "d" else "ed"}"
+  val functionNamesParam = Param[List[String]](
+    "functionNames",
     s"""One or more function names to $lambdaKeyword.
       |Each function name will be suffixed with the stage, e.g. MyFunction- becomes MyFunction-CODE""".stripMargin,
     optional = true
   )
-  val lookupByTags = Param[Boolean]("lookupByTags",
+  val lookupByTags = Param[Boolean](
+    "lookupByTags",
     s"""When true, this will lookup the function to ${lambdaKeyword} to by using the Stack, Stage and App tags on a function.
       |The values looked up come from the `stacks` and `app` in the riff-raff.yaml and the stage ${lambdaKeywordPastTense} to.
     """.stripMargin
   ).default(false)
 
-  val prefixStackParam = Param[Boolean]("prefixStack",
-    s"If true then the values in the functionNames param will be prefixed with the name of the stack being ${lambdaKeywordPastTense}").default(true)
+  val prefixStackParam = Param[Boolean](
+    "prefixStack",
+    s"If true then the values in the functionNames param will be prefixed with the name of the stack being ${lambdaKeywordPastTense}"
+  ).default(true)
 
-  val prefixStackToKeyParam = Param[Boolean]("prefixStackToKey",
+  val prefixStackToKeyParam = Param[Boolean](
+    "prefixStackToKey",
     documentation = "Whether to prefix `package` to the S3 location"
   ).default(true)
 
-  val functionsParam = Param[Map[String, Map[String, String]]]("functions",
-    documentation =
-      """
+  val functionsParam = Param[Map[String, Map[String, String]]](
+    "functions",
+    documentation = """
         |In order for this to work, magenta must have credentials that are able to perform `lambda:UpdateFunctionCode`
         |on the specified resources.
         |
@@ -49,46 +63,109 @@ trait LambdaDeploymentType[LAMBDA_TASK_PRECURSOR <: LambdaTaskPrecursor] extends
       """.stripMargin,
     optional = true
   )
-  def withSsm[T](keyRing: KeyRing, region: Region, resources: DeploymentResources): (SsmClient => T) => T = SSM.withSsmClient[T](keyRing, region, resources)
+  def withSsm[T](
+      keyRing: KeyRing,
+      region: Region,
+      resources: DeploymentResources
+  ): (SsmClient => T) => T = SSM.withSsmClient[T](keyRing, region, resources)
 
-  def makeS3Key(target: DeployTarget, pkg:DeploymentPackage, fileName: String, reporter: DeployReporter): String = {
+  def makeS3Key(
+      target: DeployTarget,
+      pkg: DeploymentPackage,
+      fileName: String,
+      reporter: DeployReporter
+  ): String = {
     val prefixStack = prefixStackToKeyParam(pkg, target, reporter)
     val prefix = if (prefixStack) List(target.stack.name) else Nil
-    (prefix ::: List(target.parameters.stage.name, pkg.app.name, fileName)).mkString("/")
+    (prefix ::: List(target.parameters.stage.name, pkg.app.name, fileName))
+      .mkString("/")
   }
 
-  def buildLambdaTaskPrecursor(stackNamePrefix: String, stage: String, name: String, pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter): LAMBDA_TASK_PRECURSOR
-  def buildLambdaTaskPrecursor(functionName: String, functionDefinition: Map[String, String], pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter): LAMBDA_TASK_PRECURSOR
-  def buildLambdaTaskPrecursor(tags: LambdaFunctionTags, pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter): LAMBDA_TASK_PRECURSOR
+  def buildLambdaTaskPrecursor(
+      stackNamePrefix: String,
+      stage: String,
+      name: String,
+      pkg: DeploymentPackage,
+      target: DeployTarget,
+      reporter: DeployReporter
+  ): LAMBDA_TASK_PRECURSOR
+  def buildLambdaTaskPrecursor(
+      functionName: String,
+      functionDefinition: Map[String, String],
+      pkg: DeploymentPackage,
+      target: DeployTarget,
+      reporter: DeployReporter
+  ): LAMBDA_TASK_PRECURSOR
+  def buildLambdaTaskPrecursor(
+      tags: LambdaFunctionTags,
+      pkg: DeploymentPackage,
+      target: DeployTarget,
+      reporter: DeployReporter
+  ): LAMBDA_TASK_PRECURSOR
 
-  def lambdaToProcess(pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter): List[LAMBDA_TASK_PRECURSOR] = {
+  def lambdaToProcess(
+      pkg: DeploymentPackage,
+      target: DeployTarget,
+      reporter: DeployReporter
+  ): List[LAMBDA_TASK_PRECURSOR] = {
     val stage = target.parameters.stage.name
 
-    (functionNamesParam.get(pkg), functionsParam.get(pkg), lookupByTags(pkg, target, reporter), prefixStackParam(pkg, target, reporter)) match {
+    (
+      functionNamesParam.get(pkg),
+      functionsParam.get(pkg),
+      lookupByTags(pkg, target, reporter),
+      prefixStackParam(pkg, target, reporter)
+    ) match {
       // the lambdas are a simple hardcoded list of function names
       case (Some(functionNames), None, false, prefixStack) =>
         val stackNamePrefix = if (prefixStack) target.stack.name else ""
         functionNames.map { name =>
-          buildLambdaTaskPrecursor(stackNamePrefix, stage, name, pkg, target, reporter)
+          buildLambdaTaskPrecursor(
+            stackNamePrefix,
+            stage,
+            name,
+            pkg,
+            target,
+            reporter
+          )
         }
 
       // the list of lambdas are provided in a map from stage to lambda name and filename
       case (None, Some(functionsMap), false, _) =>
-        val functionDefinition = functionsMap.getOrElse(stage, reporter.fail(s"Function not defined for stage $stage"))
-        val functionName = functionDefinition.getOrElse("name", reporter.fail(s"Function name not defined for stage $stage"))
+        val functionDefinition = functionsMap.getOrElse(
+          stage,
+          reporter.fail(s"Function not defined for stage $stage")
+        )
+        val functionName = functionDefinition.getOrElse(
+          "name",
+          reporter.fail(s"Function name not defined for stage $stage")
+        )
 
-        List(buildLambdaTaskPrecursor(functionName, functionDefinition, pkg, target, reporter))
+        List(
+          buildLambdaTaskPrecursor(
+            functionName,
+            functionDefinition,
+            pkg,
+            target,
+            reporter
+          )
+        )
 
       // the lambda is discovered from Stack, App and Stage tags
       case (None, None, true, _) =>
-        val tags = LambdaFunctionTags(Map(
-          "Stack" -> target.stack.name,
-          "App" -> pkg.app.name,
-          "Stage" -> stage
-        ))
+        val tags = LambdaFunctionTags(
+          Map(
+            "Stack" -> target.stack.name,
+            "App" -> pkg.app.name,
+            "Stage" -> stage
+          )
+        )
         List(buildLambdaTaskPrecursor(tags, pkg, target, reporter))
 
-      case _ => reporter.fail("Must specify one of 'functions', 'functionNames' or 'lookupByTags' parameters")
+      case _ =>
+        reporter.fail(
+          "Must specify one of 'functions', 'functionNames' or 'lookupByTags' parameters"
+        )
     }
   }
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaInvoke.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaInvoke.scala
@@ -16,10 +16,11 @@ trait LambdaInvoke extends LambdaDeploymentType[InvokeLambdaFunction] {
   override def functionNamesParamDescriptionSuffix = "invoke"
 
   val name = "aws-invoke-lambda"
+  private val summary = s"Invokes Lambda(s), selected using the parameters below (similar to the way the `${LambdaDeploy.name}` deployment type finds Lambdas)."
 
   override def documentation: String =
     s"""
-      |Invokes Lambda(s), selected using the parameters below (similar to the way the `${LambdaDeploy.name}` deployment type finds Lambdas).
+      |${summary}
       |
       |Lambda function names must begin with `${lambdaFunctionNamePrefix}`.
       |
@@ -47,7 +48,7 @@ trait LambdaInvoke extends LambdaDeploymentType[InvokeLambdaFunction] {
   def buildLambdaTaskPrecursor(tags: LambdaFunctionTags, pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter) =
     InvokeLambdaFunction(tags, target.region)
 
-  override def defaultActions: List[Action] = List(Action("invoke","Do nothing"){
+  override def defaultActions: List[Action] = List(Action(name = "invokeLambda",documentation = summary){
     (pkg, resources, target) => {
       lambdaToProcess(pkg, target, resources.reporter).map { lambda =>
         InvokeLambda(

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaInvoke.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaInvoke.scala
@@ -13,7 +13,8 @@ object LambdaInvoke {
 }
 
 trait LambdaInvoke extends LambdaDeploymentType[InvokeLambdaFunction] {
-  override def functionNamesParamDescriptionSuffix = "invoke"
+  override val lambdaKeyword: String = "invoke"
+  override def functionNamesParamDescriptionSuffix = lambdaKeyword
 
   val name = "aws-invoke-lambda"
   private val summary = s"Invokes Lambda(s), selected using the parameters below (similar to the way the `${LambdaDeploy.name}` deployment type finds Lambdas)."

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaInvoke.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaInvoke.scala
@@ -1,0 +1,19 @@
+package magenta.deployment_type
+
+import magenta.tasks.InvokeLambda
+import magenta.KeyRing
+
+object LambdaInvoke extends LambdaInvoke
+
+trait LambdaInvoke extends DeploymentType with BucketParameters {
+  val name = "aws-invoke-lambda"
+
+  override def documentation: String = "Invokes Lambda"
+
+  override def defaultActions: List[Action] = List(Action("invoke","Do nothing"){
+    (pkg, resources, target) => {
+      List(InvokeLambda()(keyRing = resources.assembleKeyring(target, pkg)))
+    }
+  })
+}
+

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaInvoke.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaInvoke.scala
@@ -4,22 +4,23 @@ import magenta.deployment_type.LambdaInvoke.lambdaFunctionNamePrefix
 import magenta.{DeployReporter, DeployTarget, DeploymentPackage, Region}
 import magenta.tasks.InvokeLambda
 
-//object LambdaInvoke extends LambdaInvoke // TODO: Re-instate once DevX is happy for broad adoption
-
 case class InvokeLambdaFunction(function: LambdaFunction, region: Region) extends LambdaTaskPrecursor
 
-object LambdaInvoke {
+object LambdaInvoke extends LambdaInvoke {
   val lambdaFunctionNamePrefix = "RIFF-RAFF-INVOKABLE-"
+
+  val invokeAction = getInvokeAction
+  override def defaultActions: List[Action] = List(invokeAction)
 }
 
 trait LambdaInvoke extends LambdaDeploymentType[InvokeLambdaFunction] {
-  override val lambdaKeyword: String = "invoke"
+  override def lambdaKeyword: String = "invoke"
   override def functionNamesParamDescriptionSuffix = lambdaKeyword
 
   val name = "aws-invoke-lambda"
   private val summary = s"Invokes Lambda(s), selected using the parameters below (similar to the way the `${LambdaDeploy.name}` deployment type finds Lambdas)."
 
-  override def documentation: String =
+  val documentation: String =
     s"""
       |${summary}
       |
@@ -49,7 +50,7 @@ trait LambdaInvoke extends LambdaDeploymentType[InvokeLambdaFunction] {
   def buildLambdaTaskPrecursor(tags: LambdaFunctionTags, pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter) =
     InvokeLambdaFunction(tags, target.region)
 
-  val invokeAction = Action(name = "invokeLambda",documentation = summary){
+  def getInvokeAction = Action(name = "invokeLambda",documentation = summary){
     (pkg, resources, target) => {
       lambdaToProcess(pkg, target, resources.reporter).map { lambda =>
         InvokeLambda(
@@ -63,5 +64,4 @@ trait LambdaInvoke extends LambdaDeploymentType[InvokeLambdaFunction] {
     }
   }
 
-  override def defaultActions: List[Action] = List(invokeAction)
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaInvoke.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaInvoke.scala
@@ -48,7 +48,7 @@ trait LambdaInvoke extends LambdaDeploymentType[InvokeLambdaFunction] {
   def buildLambdaTaskPrecursor(tags: LambdaFunctionTags, pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter) =
     InvokeLambdaFunction(tags, target.region)
 
-  override def defaultActions: List[Action] = List(Action(name = "invokeLambda",documentation = summary){
+  val invokeAction = Action(name = "invokeLambda",documentation = summary){
     (pkg, resources, target) => {
       lambdaToProcess(pkg, target, resources.reporter).map { lambda =>
         InvokeLambda(
@@ -60,5 +60,7 @@ trait LambdaInvoke extends LambdaDeploymentType[InvokeLambdaFunction] {
         )
       }
     }
-  })
+  }
+
+  override def defaultActions: List[Action] = List(invokeAction)
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaInvoke.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaInvoke.scala
@@ -12,7 +12,7 @@ trait LambdaInvoke extends DeploymentType with BucketParameters {
 
   override def defaultActions: List[Action] = List(Action("invoke","Do nothing"){
     (pkg, resources, target) => {
-      List(InvokeLambda()(keyRing = resources.assembleKeyring(target, pkg)))
+      List(InvokeLambda(artifactsPath = pkg.s3Package)(keyRing = resources.assembleKeyring(target, pkg)))
     }
   })
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaInvoke.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaInvoke.scala
@@ -4,7 +4,8 @@ import magenta.deployment_type.LambdaInvoke.lambdaFunctionNamePrefix
 import magenta.{DeployReporter, DeployTarget, DeploymentPackage, Region}
 import magenta.tasks.InvokeLambda
 
-case class InvokeLambdaFunction(function: LambdaFunction, region: Region) extends LambdaTaskPrecursor
+case class InvokeLambdaFunction(function: LambdaFunction, region: Region)
+    extends LambdaTaskPrecursor
 
 object LambdaInvoke extends LambdaInvoke {
   val lambdaFunctionNamePrefix = "RIFF-RAFF-INVOKABLE-"
@@ -18,7 +19,8 @@ trait LambdaInvoke extends LambdaDeploymentType[InvokeLambdaFunction] {
   override def functionNamesParamDescriptionSuffix = lambdaKeyword
 
   val name = "aws-invoke-lambda"
-  private val summary = s"Invokes Lambda(s), selected using the parameters below (similar to the way the `${LambdaDeploy.name}` deployment type finds Lambdas)."
+  private val summary =
+    s"Invokes Lambda(s), selected using the parameters below (similar to the way the `${LambdaDeploy.name}` deployment type finds Lambdas)."
 
   val documentation: String =
     s"""
@@ -41,27 +43,49 @@ trait LambdaInvoke extends LambdaDeploymentType[InvokeLambdaFunction] {
       |```
     """.stripMargin
 
-  def buildLambdaTaskPrecursor(stackNamePrefix: String, stage: String, name: String, pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter) =
-    InvokeLambdaFunction(LambdaFunctionName(s"$stackNamePrefix$name$stage"), target.region)
+  def buildLambdaTaskPrecursor(
+      stackNamePrefix: String,
+      stage: String,
+      name: String,
+      pkg: DeploymentPackage,
+      target: DeployTarget,
+      reporter: DeployReporter
+  ) =
+    InvokeLambdaFunction(
+      LambdaFunctionName(s"$stackNamePrefix$name$stage"),
+      target.region
+    )
 
-  def buildLambdaTaskPrecursor(functionName: String, functionDefinition: Map[String, String], pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter) =
+  def buildLambdaTaskPrecursor(
+      functionName: String,
+      functionDefinition: Map[String, String],
+      pkg: DeploymentPackage,
+      target: DeployTarget,
+      reporter: DeployReporter
+  ) =
     InvokeLambdaFunction(LambdaFunctionName(functionName), target.region)
 
-  def buildLambdaTaskPrecursor(tags: LambdaFunctionTags, pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter) =
+  def buildLambdaTaskPrecursor(
+      tags: LambdaFunctionTags,
+      pkg: DeploymentPackage,
+      target: DeployTarget,
+      reporter: DeployReporter
+  ) =
     InvokeLambdaFunction(tags, target.region)
 
-  def getInvokeAction = Action(name = "invokeLambda",documentation = summary){
-    (pkg, resources, target) => {
-      lambdaToProcess(pkg, target, resources.reporter).map { lambda =>
-        InvokeLambda(
-          function = lambda.function,
-          artifactsPath = pkg.s3Package,
-          region = lambda.region
-        )(
-          keyRing = resources.assembleKeyring(target, pkg)
-        )
+  def getInvokeAction = Action(name = "invokeLambda", documentation = summary) {
+    (pkg, resources, target) =>
+      {
+        lambdaToProcess(pkg, target, resources.reporter).map { lambda =>
+          InvokeLambda(
+            function = lambda.function,
+            artifactsPath = pkg.s3Package,
+            region = lambda.region
+          )(
+            keyRing = resources.assembleKeyring(target, pkg)
+          )
+        }
       }
-    }
   }
 
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaInvoke.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaInvoke.scala
@@ -1,26 +1,39 @@
 package magenta.deployment_type
 
+import magenta.{DeployReporter, DeployTarget, DeploymentPackage, Region}
 import magenta.tasks.InvokeLambda
 
 object LambdaInvoke extends LambdaInvoke
 
-trait LambdaInvoke extends DeploymentType with BucketParameters {
+case class InvokeLambdaFunction(function: LambdaFunction, region: Region) extends LambdaTaskPrecursor
+
+trait LambdaInvoke extends LambdaDeploymentType[InvokeLambdaFunction] {
+  override val functionNamesParamDescriptionSuffix = "invoke"
+
   val name = "aws-invoke-lambda"
 
   override def documentation: String = "Invokes Lambda"
 
+  def buildLambdaTaskPrecursor(stackNamePrefix: String, stage: String, name: String, pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter) =
+    InvokeLambdaFunction(LambdaFunctionName(s"$stackNamePrefix$name$stage"), target.region)
+
+  def buildLambdaTaskPrecursor(functionName: String, functionDefinition: Map[String, String], pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter) =
+    InvokeLambdaFunction(LambdaFunctionName(functionName), target.region)
+
+  def buildLambdaTaskPrecursor(tags: LambdaFunctionTags, pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter) =
+    InvokeLambdaFunction(tags, target.region)
+
   override def defaultActions: List[Action] = List(Action("invoke","Do nothing"){
     (pkg, resources, target) => {
-      List(
+      lambdaToProcess(pkg, target, resources.reporter).map { lambda =>
         InvokeLambda(
-          function = ???,
+          function = lambda.function,
           artifactsPath = pkg.s3Package,
-          region = ???
+          region = lambda.region
         )(
           keyRing = resources.assembleKeyring(target, pkg)
         )
-      )
+      }
     }
   })
 }
-

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaInvoke.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaInvoke.scala
@@ -1,18 +1,42 @@
 package magenta.deployment_type
 
+import magenta.deployment_type.LambdaInvoke.lambdaFunctionNamePrefix
 import magenta.{DeployReporter, DeployTarget, DeploymentPackage, Region}
 import magenta.tasks.InvokeLambda
 
-object LambdaInvoke extends LambdaInvoke
+//object LambdaInvoke extends LambdaInvoke // TODO: Re-instate once DevX is happy for broad adoption
 
 case class InvokeLambdaFunction(function: LambdaFunction, region: Region) extends LambdaTaskPrecursor
 
+object LambdaInvoke {
+  val lambdaFunctionNamePrefix = "RIFF-RAFF-INVOKABLE-"
+}
+
 trait LambdaInvoke extends LambdaDeploymentType[InvokeLambdaFunction] {
-  override val functionNamesParamDescriptionSuffix = "invoke"
+  override def functionNamesParamDescriptionSuffix = "invoke"
 
   val name = "aws-invoke-lambda"
 
-  override def documentation: String = "Invokes Lambda"
+  override def documentation: String =
+    s"""
+      |Invokes Lambda(s), selected using the parameters below (similar to the way the `${LambdaDeploy.name}` deployment type finds Lambdas).
+      |
+      |Lambda function names must begin with `${lambdaFunctionNamePrefix}`.
+      |
+      |The payload sent to the Lambda is constructed from the artifacts associated with this deployment step.
+      |The top level key is the name of the deployment step, and the keys of the object within are the file names and the values are the file contents as strings.
+      |
+      |For example (given the name of the deployment step is 'hello_world' in the `riff-raff.yaml`), the payload would look something like:
+      |```
+      |{
+      |  "hello_world": {
+      |    "artefact_filenameA.abc" : "file A contents",
+      |    "artefact_filenameB.abc" : "file B contents",
+      |    "artefact_filenameC.abc" : "file C contents"
+      |  }
+      |}
+      |```
+    """.stripMargin
 
   def buildLambdaTaskPrecursor(stackNamePrefix: String, stage: String, name: String, pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter) =
     InvokeLambdaFunction(LambdaFunctionName(s"$stackNamePrefix$name$stage"), target.region)

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaInvoke.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaInvoke.scala
@@ -1,7 +1,6 @@
 package magenta.deployment_type
 
 import magenta.tasks.InvokeLambda
-import magenta.KeyRing
 
 object LambdaInvoke extends LambdaInvoke
 
@@ -12,7 +11,15 @@ trait LambdaInvoke extends DeploymentType with BucketParameters {
 
   override def defaultActions: List[Action] = List(Action("invoke","Do nothing"){
     (pkg, resources, target) => {
-      List(InvokeLambda(artifactsPath = pkg.s3Package)(keyRing = resources.assembleKeyring(target, pkg)))
+      List(
+        InvokeLambda(
+          function = ???,
+          artifactsPath = pkg.s3Package,
+          region = ???
+        )(
+          keyRing = resources.assembleKeyring(target, pkg)
+        )
+      )
     }
   })
 }

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -71,11 +71,7 @@ import software.amazon.awssdk.services.elasticloadbalancingv2.{
   ElasticLoadBalancingV2Client => ApplicationELB
 }
 import software.amazon.awssdk.services.lambda.LambdaClient
-import software.amazon.awssdk.services.lambda.model.{
-  FunctionConfiguration,
-  ListFunctionsRequest,
-  ListTagsRequest,
-  UpdateFunctionCodeRequest
+import software.amazon.awssdk.services.lambda.model.{FunctionConfiguration, InvokeRequest, ListFunctionsRequest, ListTagsRequest, LogType, UpdateFunctionCodeRequest
 }
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model._
@@ -244,6 +240,13 @@ object Lambda {
       .functionName(functionName)
       .s3Bucket(s3Bucket)
       .s3Key(s3Key)
+      .build()
+
+  def lambdaInvokeRequest(functionName: String, payloadBytes: Array[Byte]): InvokeRequest =
+    InvokeRequest.builder()
+      .functionName(functionName)
+      .payload(SdkBytes.fromByteArray(payloadBytes))
+      .logType(LogType.TAIL)
       .build()
 
   def findFunctionByTags(

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -3,7 +3,12 @@ package magenta.tasks
 import java.nio.ByteBuffer
 import cats.implicits._
 import magenta.deployment_type.{
-  LambdaFunction, LambdaFunctionName, LambdaFunctionTags, MigrationTagRequirements, MustBePresent, MustNotBePresent
+  LambdaFunction,
+  LambdaFunctionName,
+  LambdaFunctionTags,
+  MigrationTagRequirements,
+  MustBePresent,
+  MustNotBePresent
 }
 import magenta.{
   ApiRoleCredentials,
@@ -69,7 +74,13 @@ import software.amazon.awssdk.services.elasticloadbalancingv2.{
   ElasticLoadBalancingV2Client => ApplicationELB
 }
 import software.amazon.awssdk.services.lambda.LambdaClient
-import software.amazon.awssdk.services.lambda.model.{FunctionConfiguration, InvokeRequest, ListFunctionsRequest, ListTagsRequest, LogType, UpdateFunctionCodeRequest
+import software.amazon.awssdk.services.lambda.model.{
+  FunctionConfiguration,
+  InvokeRequest,
+  ListFunctionsRequest,
+  ListTagsRequest,
+  LogType,
+  UpdateFunctionCodeRequest
 }
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model._
@@ -240,18 +251,26 @@ object Lambda {
       .s3Key(s3Key)
       .build()
 
-  def lambdaInvokeRequest(functionName: String, payloadBytes: Array[Byte]): InvokeRequest =
-    InvokeRequest.builder()
+  def lambdaInvokeRequest(
+      functionName: String,
+      payloadBytes: Array[Byte]
+  ): InvokeRequest =
+    InvokeRequest
+      .builder()
       .functionName(functionName)
       .payload(SdkBytes.fromByteArray(payloadBytes))
       .logType(LogType.TAIL)
       .build()
 
-  def getFunctionName(client: LambdaClient, function: LambdaFunction, reporter: DeployReporter): String = function match {
+  def getFunctionName(
+      client: LambdaClient,
+      function: LambdaFunction,
+      reporter: DeployReporter
+  ): String = function match {
     case LambdaFunctionName(name) => name
     case LambdaFunctionTags(tags) =>
       val functionConfig = Lambda.findFunctionByTags(tags, reporter, client)
-      functionConfig.map(_.functionName).getOrElse{
+      functionConfig.map(_.functionName).getOrElse {
         reporter.fail(s"Failed to find any function with tags $tags")
       }
   }

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -3,9 +3,7 @@ package magenta.tasks
 import java.nio.ByteBuffer
 import cats.implicits._
 import magenta.deployment_type.{
-  MigrationTagRequirements,
-  MustBePresent,
-  MustNotBePresent
+  LambdaFunction, LambdaFunctionName, LambdaFunctionTags, MigrationTagRequirements, MustBePresent, MustNotBePresent
 }
 import magenta.{
   ApiRoleCredentials,
@@ -248,6 +246,15 @@ object Lambda {
       .payload(SdkBytes.fromByteArray(payloadBytes))
       .logType(LogType.TAIL)
       .build()
+
+  def getFunctionName(client: LambdaClient, function: LambdaFunction, reporter: DeployReporter): String = function match {
+    case LambdaFunctionName(name) => name
+    case LambdaFunctionTags(tags) =>
+      val functionConfig = Lambda.findFunctionByTags(tags, reporter, client)
+      functionConfig.map(_.functionName).getOrElse{
+        reporter.fail(s"Failed to find any function with tags $tags")
+      }
+  }
 
   def findFunctionByTags(
       tags: Map[String, String],

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -409,13 +409,13 @@ case class InvokeLambda(function: LambdaFunction, artifactsPath: S3Path, region:
     implicit val s3client: S3Client = resources.artifactClient
     // TODO: take a parameter to determine whether to read files as bytes or strings
     val artifactFileNameToContentMap = S3Location.listObjects(artifactsPath).map(s3object => {
-      S3Location.fetchContentAsString(s3object).map(_.take(50)).fold(
+      S3Location.fetchContentAsString(s3object).fold(
         error => resources.reporter.fail(error.toString),
         content => s3object.fileName -> content
       )
     }).toMap
 
-    val lambdaPayload = Json.toJson(artifactFileNameToContentMap)
+    val lambdaPayload = Json.toJson(Map(artifactsPath.fileName -> artifactFileNameToContentMap))
     resources.reporter.info(lambdaPayload.toString())
     Lambda.withLambdaClient(keyRing, region, resources) { client =>
 

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -3,7 +3,6 @@ package tasks
 
 import java.io.{File, InputStream, PipedInputStream, PipedOutputStream}
 import java.util.Base64
-import java.nio.charset.StandardCharsets
 import magenta.artifact._
 import magenta.deployment_type.{
   LambdaFunction,
@@ -434,8 +433,8 @@ case class InvokeLambda(function: LambdaFunction, artifactsPath: S3Path, region:
         resources.reporter.verbose(s"Invoking $function Lambda")
         val invokeResponse = client.invoke(Lambda.lambdaInvokeRequest(functionName, payloadBytes = Json.toBytes(lambdaPayload)))
         val logResultByteArray = Base64.getDecoder().decode(invokeResponse.logResult())
-        Source.fromBytes(logResultByteArray).getLines().foreach(resources.reporter.verbose)//TODO: Improve what the Lambda logs
-        resources.reporter.info(invokeResponse.payload().asString(StandardCharsets.UTF_8)) //TODO: Parse as JSON and print per line
+        Source.fromBytes(logResultByteArray).getLines().foreach(resources.reporter.verbose) //TODO: Group and also improve what the Lambda logs
+        Json.parse(invokeResponse.payload().asByteArray()).as[List[String]].foreach(resources.reporter.info)
         resources.reporter.verbose(s"Finished invoking $function Lambda")
       } else {
         resources.reporter.fail(s"Lambda function name '${functionName}' did not begin with '${LambdaInvoke.lambdaFunctionNamePrefix}'.")

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -400,3 +400,12 @@ case class UpdateS3Lambda(
   }
 
 }
+
+case class InvokeLambda()(implicit val keyRing: KeyRing) extends Task {
+  def description = "Task that invokes a lambda."
+
+  override def execute(resources: DeploymentResources, stopFlag: => Boolean){
+    resources.reporter.verbose(s"Doing some verbose stuff")
+    resources.reporter.info(s"Some helpful information")
+  }
+}

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -401,11 +401,10 @@ case class UpdateS3Lambda(
 
 }
 
-case class InvokeLambda()(implicit val keyRing: KeyRing) extends Task {
+case class InvokeLambda(artifactsPath: S3Path)(implicit val keyRing: KeyRing) extends Task {
   def description = "Task that invokes a lambda."
 
   override def execute(resources: DeploymentResources, stopFlag: => Boolean){
-    resources.reporter.verbose(s"Doing some verbose stuff")
-    resources.reporter.info(s"Some helpful information")
+    resources.reporter.info(s"Path is $artifactsPath")
   }
 }

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -417,7 +417,6 @@ case class InvokeLambda(function: LambdaFunction, artifactsPath: S3Path, region:
     }).toMap
 
     val lambdaPayload = Json.toJson(Map(artifactsPath.fileName -> artifactFileNameToContentMap))
-    resources.reporter.verbose(lambdaPayload.toString()) // TODO: Can this be wrapped in some heading/section?
     Lambda.withLambdaClient(keyRing, region, resources) { client =>
 
       // FIXME: Move this into LambdaFunction trait to avoid repetition with UpdateS3Lambda
@@ -433,7 +432,7 @@ case class InvokeLambda(function: LambdaFunction, artifactsPath: S3Path, region:
         resources.reporter.verbose(s"Invoking $function Lambda")
         val invokeResponse = client.invoke(Lambda.lambdaInvokeRequest(functionName, payloadBytes = Json.toBytes(lambdaPayload)))
         val logResultByteArray = Base64.getDecoder().decode(invokeResponse.logResult())
-        Source.fromBytes(logResultByteArray).getLines().foreach(resources.reporter.verbose) //TODO: Group and also improve what the Lambda logs
+        Source.fromBytes(logResultByteArray).getLines().foreach(resources.reporter.verbose)
         Json.parse(invokeResponse.payload().asByteArray()).as[List[String]].foreach(resources.reporter.info)
         resources.reporter.verbose(s"Finished invoking $function Lambda")
       } else {

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -406,5 +406,8 @@ case class InvokeLambda(artifactsPath: S3Path)(implicit val keyRing: KeyRing) ex
 
   override def execute(resources: DeploymentResources, stopFlag: => Boolean){
     resources.reporter.info(s"Path is $artifactsPath")
+    S3Location.listObjects(artifactsPath)(resources.artifactClient).foreach(s3object => resources.reporter.verbose(s3object.toString))
+    // TODO: Read contents of each file`
+    // TODO THEN: build JSON payload (Map of file name to array of bytes)
   }
 }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -30,7 +30,7 @@ class DeploymentTypeTest
   implicit val artifactClient: S3Client = null
   implicit val stsClient: StsClient = null
   val region = Region("eu-west-1")
-  val deploymentTypes = Seq(S3, Lambda)
+  val deploymentTypes = Seq(S3, LambdaDeploy)
 
   "Deployment types" should "automatically register params in the params Seq" in {
     S3.params should have size 11
@@ -299,7 +299,7 @@ class DeploymentTypeTest
       deploymentTypes
     )
 
-    Lambda
+    LambdaDeploy
       .actionsMap("updateLambda")
       .taskGenerator(
         p,
@@ -343,7 +343,7 @@ class DeploymentTypeTest
     )
 
     val thrown = the[FailException] thrownBy {
-      Lambda
+      LambdaDeploy
         .actionsMap("updateLambda")
         .taskGenerator(
           p,

--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaDeployTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaDeployTest.scala
@@ -32,14 +32,15 @@ import software.amazon.awssdk.services.sts.StsClient
 
 import scala.concurrent.ExecutionContext.global
 
-class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
+
+class LambdaDeployTest extends AnyFlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing: KeyRing = KeyRing()
   implicit val reporter: DeployReporter =
     DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
   implicit val artifactClient: S3Client = mock[S3Client]
   implicit val stsClient: StsClient = mock[StsClient]
   val region = Region("eu-west-1")
-  val deploymentTypes: Seq[Lambda.type] = Seq(Lambda)
+  val deploymentTypes: Seq[LambdaDeploy.type] = Seq(LambdaDeploy)
 
   behavior of "Lambda deployment action uploadLambda"
 
@@ -69,7 +70,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
       stsClient,
       global
     )
-    val tasks = Lambda
+    val tasks = LambdaDeploy
       .actionsMap("uploadLambda")
       .taskGenerator(
         pkg,
@@ -93,7 +94,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
   }
 
   it should "produce a lambda update task" in {
-    val tasks = Lambda
+    val tasks = LambdaDeploy
       .actionsMap("updateLambda")
       .taskGenerator(
         pkg,
@@ -134,7 +135,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
       deploymentTypes
     )
 
-    val tasks = Lambda
+    val tasks = LambdaDeploy
       .actionsMap("updateLambda")
       .taskGenerator(
         pkg,
@@ -175,7 +176,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
       deploymentTypes
     )
 
-    val tasks = Lambda
+    val tasks = LambdaDeploy
       .actionsMap("updateLambda")
       .taskGenerator(
         pkg,
@@ -220,7 +221,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
     )
 
     val e = the[FailException] thrownBy {
-      Lambda
+      LambdaDeploy
         .actionsMap("updateLambda")
         .taskGenerator(
           pkg,
@@ -260,7 +261,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
       SsmException.builder.message("Boom!").build()
     )
 
-    object LambdaTest extends Lambda {
+    object LambdaDeployTest extends LambdaDeploy {
       override def withSsm[T](
           keyRing: KeyRing,
           region: Region,
@@ -269,7 +270,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
     }
 
     val e = the[FailException] thrownBy {
-      LambdaTest
+      LambdaDeployTest
         .actionsMap("updateLambda")
         .taskGenerator(
           pkg,
@@ -311,7 +312,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
         .parameter(Parameter.builder.value("bobbins").build)
         .build
     )
-    object LambdaTest extends Lambda {
+    object LambdaDeployTest extends LambdaDeploy {
       override def withSsm[T](
           keyRing: KeyRing,
           region: Region,
@@ -319,7 +320,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
       ): (SsmClient => T) => T = _(ssmClient)
     }
 
-    val tasks = LambdaTest
+    val tasks = LambdaDeployTest
       .actionsMap("updateLambda")
       .taskGenerator(
         pkg,
@@ -368,7 +369,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
         .parameter(Parameter.builder.value("bobbins").build)
         .build
     )
-    object LambdaTest extends Lambda {
+    object LambdaDeployTest extends LambdaDeploy {
       override def withSsm[T](
           keyRing: KeyRing,
           region: Region,
@@ -376,7 +377,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
       ): (SsmClient => T) => T = _(ssmClient)
     }
 
-    val tasks = LambdaTest
+    val tasks = LambdaDeployTest
       .actionsMap("updateLambda")
       .taskGenerator(
         pkg,
@@ -418,7 +419,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
       deploymentTypes
     )
 
-    val tasks = Lambda
+    val tasks = LambdaDeploy
       .actionsMap("updateLambda")
       .taskGenerator(
         pkg,

--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaDeployTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaDeployTest.scala
@@ -32,7 +32,6 @@ import software.amazon.awssdk.services.sts.StsClient
 
 import scala.concurrent.ExecutionContext.global
 
-
 class LambdaDeployTest extends AnyFlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing: KeyRing = KeyRing()
   implicit val reporter: DeployReporter =

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -125,7 +125,7 @@ class AppComponents(
     AutoScaling,
     Fastly,
     new CloudFormation(DefaultBuildTags),
-    Lambda,
+    LambdaDeploy,
     AmiCloudFormationParameter,
     SelfDeploy,
     GcpDeploymentManager,

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -126,6 +126,7 @@ class AppComponents(
     Fastly,
     new CloudFormation(DefaultBuildTags),
     LambdaDeploy,
+    LambdaInvoke,
     AmiCloudFormationParameter,
     SelfDeploy,
     GcpDeploymentManager,

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -124,8 +124,9 @@ class AppComponents(
     S3,
     AutoScaling,
     Fastly,
-    new CloudFormation(DefaultBuildTags),
+   new CloudFormation(DefaultBuildTags),
     LambdaDeploy,
+    // LambdaInvoke, // TODO: Re-instate once DevX is happy for broad adoption
     BrazePublish,
     AmiCloudFormationParameter,
     SelfDeploy,

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -126,7 +126,7 @@ class AppComponents(
     Fastly,
     new CloudFormation(DefaultBuildTags),
     LambdaDeploy,
-    LambdaInvoke,
+    BrazePublish,
     AmiCloudFormationParameter,
     SelfDeploy,
     GcpDeploymentManager,

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -124,7 +124,7 @@ class AppComponents(
     S3,
     AutoScaling,
     Fastly,
-   new CloudFormation(DefaultBuildTags),
+    new CloudFormation(DefaultBuildTags),
     LambdaDeploy,
     // LambdaInvoke, // TODO: Re-instate once DevX is happy for broad adoption
     BrazePublish,

--- a/riff-raff/app/docs/DeployTypeDocs.scala
+++ b/riff-raff/app/docs/DeployTypeDocs.scala
@@ -84,7 +84,7 @@ object DeployTypeDocs {
       )
 
       val paramDocs = dt.params
-        .sortBy(_.name)
+        .diff(dt.paramsToHide).sortBy(_.name)
         .map { param =>
           val defaults = defaultFromParam(deploymentPackage, param)
           ParamDoc(param.name, param.documentation, defaults)

--- a/riff-raff/app/docs/DeployTypeDocs.scala
+++ b/riff-raff/app/docs/DeployTypeDocs.scala
@@ -84,7 +84,8 @@ object DeployTypeDocs {
       )
 
       val paramDocs = dt.params
-        .diff(dt.paramsToHide).sortBy(_.name)
+        .diff(dt.paramsToHide)
+        .sortBy(_.name)
         .map { param =>
           val defaults = defaultFromParam(deploymentPackage, param)
           ParamDoc(param.name, param.documentation, defaults)

--- a/riff-raff/test/docs/DeployTypeDocsTest.scala
+++ b/riff-raff/test/docs/DeployTypeDocsTest.scala
@@ -86,7 +86,7 @@ class DeployTypeDocsTest extends AnyFlatSpec with Matchers {
       AutoScaling,
       Fastly,
       new CloudFormation(EmptyBuildTags),
-      Lambda,
+      LambdaDeploy,
       AmiCloudFormationParameter,
       SelfDeploy,
       GcpDeploymentManager


### PR DESCRIPTION
Co-Authored-By: @twrichards 

The primary motivation for this PR was to facilitate version control and automated deployment of Braze content blocks, making use of [`guardian/braze-version-control-service`](https://github.com/guardian/braze-version-control-service).

## What does this change?
As per the branch name, we initially intended to implement a generic `lambda-invoke` deployment type, but there were concerns around this being used too broadly. Instead, we have kept the `lambda-invoke` deployment type hidden, but extended it in the form of the `braze-publish` deployment type (which adds a more specific description and suppresses user-entered parameters in favour of hard-coded references to the `publish-lambda` - see https://github.com/guardian/braze-version-control-service/pull/3). 

Some example usages of this new `braze-publish` deployment type can be seen in:
- https://github.com/guardian/braze-version-control/blob/main/riff-raff.yaml
- https://github.com/guardian/braze-version-control-TEST/blob/main/riff-raff.yaml

To implement the generic `lambda-invoke` deployment type, we abstracted common behaviour (such as being able to look up lambdas by function name) from `Lambda.scala` into `LambdaDeploymentType.scala` which is extended by both:
- `LambdaDeploy` (existing behaviour but new file name)
- `LambdaInvoke` (new)

The generic `lambda-invoke` deployment type works by taking the artifact files and building the JSON input payload for the lambda from their filenames (keys) and the text content (values) - see the documentation screenshot below for an example. We then invoke the lambda synchronously, which relies on the `lambda:InvokeFunction` IAM permissions added in https://github.com/guardian/deploy-tools-platform/pull/538. The console/log output from the lambda invocation is given to the riff-raff reporter as verbose output, and the lambda response payload as info output. 

When the DevX team are comfortable in opening up the `lambda-invoke` deployment type to the department it should be as simple as uncommenting: https://github.com/guardian/riff-raff/blob/5dd93b0abeb8d1d3bba8162bdab535677b3e656f/riff-raff/app/AppComponents.scala#L89

## How to test
1. Deploy this branch to `riff-raff` CODE.
2. Deploy `braze-version-control-TEST` and observe the deployment detail, e.g. https://riffraff.code.dev-gutools.co.uk/deployment/view/37d754a2-8920-477b-93cd-d84df7b728a0?verbose=1

## How can we measure success?
This allows developers to make changes in Braze with all the confidence of version control, PRs and automated deployments that they are familiar with from all other development at The Guardian.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![image](https://user-images.githubusercontent.com/34686302/158362511-f2a48690-68c6-45fd-a03c-81bff05e5917.png)
