### PR TITLE
Refactor ASG search

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
@@ -37,17 +37,16 @@ object ElasticSearch extends DeploymentType {
   ) { (pkg, resources, target) =>
     implicit val keyRing = resources.assembleKeyring(target, pkg)
     val reporter = resources.reporter
-    val parameters = target.parameters
-    val stack = target.stack
+    val asgName: String = AutoScalingGroupLookup.getTargetAsgName(keyRing, target, resources, pkg)
     List(
-      CheckGroupSize(pkg, parameters.stage, stack, target.region),
-      WaitForElasticSearchClusterGreen(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
-      SuspendAlarmNotifications(pkg, parameters.stage, stack, target.region),
-      TagCurrentInstancesWithTerminationTag(pkg, parameters.stage, stack, target.region),
-      DoubleSize(pkg, parameters.stage, stack, target.region),
-      WaitForElasticSearchClusterGreen(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
-      CullElasticSearchInstancesWithTerminationTag(pkg, parameters.stage, stack, secondsToWait(pkg, target, reporter) * 1000, target.region),
-      ResumeAlarmNotifications(pkg, parameters.stage, stack, target.region)
+      CheckGroupSize(asgName, target.region),
+      WaitForElasticSearchClusterGreen(asgName, secondsToWait(pkg, target, reporter) * 1000, target.region),
+      SuspendAlarmNotifications(asgName, target.region),
+      TagCurrentInstancesWithTerminationTag(asgName, target.region),
+      DoubleSize(asgName, target.region),
+      WaitForElasticSearchClusterGreen(asgName, secondsToWait(pkg, target, reporter) * 1000, target.region),
+      CullElasticSearchInstancesWithTerminationTag(asgName, secondsToWait(pkg, target, reporter) * 1000, target.region),
+      ResumeAlarmNotifications(asgName, target.region)
     )
   }
 

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -230,6 +230,16 @@ object ASG {
       ResumeProcessesRequest.builder().autoScalingGroupName(name).scalingProcesses("AlarmNotification").build()
     )
 
+  def getGroupByName(name: String, client: AutoScalingClient, reporter: DeployReporter): AutoScalingGroup = {
+    val request = DescribeAutoScalingGroupsRequest.builder()
+      .autoScalingGroupNames(name)
+      .maxRecords(1)
+      .build()
+    val autoScalingGroups = client.describeAutoScalingGroups(request).autoScalingGroups().asScala.toList
+    // We've asked for one record and the name must be unique per Region per account
+    autoScalingGroups.headOption.getOrElse(reporter.fail(s"Failed to identify an autoscaling group with name ${name}"))
+  }
+
   def groupForAppAndStage(pkg: DeploymentPackage, stage: Stage, stack: Stack, client: AutoScalingClient, reporter: DeployReporter): AutoScalingGroup = {
     case class ASGMatch(app:App, matches:List[AutoScalingGroup])
 

--- a/magenta-lib/src/main/scala/magenta/tasks/ElasticSearchTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ElasticSearchTasks.scala
@@ -12,7 +12,7 @@ import software.amazon.awssdk.services.ec2.Ec2Client
 
 import scala.collection.JavaConverters._
 
-case class WaitForElasticSearchClusterGreen(pkg: DeploymentPackage, stage: Stage, stack: Stack, duration: Long, region: Region)
+case class WaitForElasticSearchClusterGreen(asgName: String, duration: Long, region: Region)
                                            (implicit val keyRing: KeyRing)
   extends ASGTask with RepeatedPollingCheck {
 
@@ -35,7 +35,7 @@ case class WaitForElasticSearchClusterGreen(pkg: DeploymentPackage, stage: Stage
   }
 }
 
-case class CullElasticSearchInstancesWithTerminationTag(pkg: DeploymentPackage, stage: Stage, stack: Stack, duration: Long, region: Region)
+case class CullElasticSearchInstancesWithTerminationTag(asgName: String, duration: Long, region: Region)
                                                        (implicit val keyRing: KeyRing)
   extends ASGTask with RepeatedPollingCheck{
 

--- a/magenta-lib/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/magenta-lib/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
@@ -30,7 +30,7 @@ class ASGTasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
     val p = DeploymentPackage("test", App("app"), Map.empty, "testDeploymentType", S3Path("artifact-bucket", "project/123/test"),
       deploymentTypes)
 
-    val task = DoubleSize(p, Stage("PROD"), stack, Region("eu-west-1"))
+    val task = DoubleSize("test", Region("eu-west-1"))
     val resources = DeploymentResources(reporter, null, mock[S3Client], mock[StsClient], global)
     task.execute(asg, resources, stopFlag = false, asgClientMock)
 
@@ -52,7 +52,7 @@ class ASGTasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
     val p = DeploymentPackage("test", App("app"), Map.empty, "testDeploymentType", S3Path("artifact-bucket", "project/123/test"),
       deploymentTypes)
 
-    val task = CheckGroupSize(p, Stage("PROD"), stack, Region("eu-west-1"))
+    val task = CheckGroupSize("test", Region("eu-west-1"))
 
     val resources = DeploymentResources(reporter, null, mock[S3Client], mock[StsClient], global)
 


### PR DESCRIPTION
## What does this change?

This PR refactors the way that Riff-Raff identifies which ASG to interact with as part of an `autoscaling` deployment.

Previously, Riff-Raff would search for the relevant ASG (by tags) as part of every individual task (e.g. `WaitForStabilization`) in a deployment action (e.g. `deploy`). Accounts can have many ASGs and the `deploy` action is comprised of many tasks, so this is inefficient. It's also unnecessary, as once we have selected the ASG to deploy to, we should perform all actions against the same ASG.

This PR refactors the code to identify the relevant ASG (still using tags) before starting _any_ tasks. Each individual task can then simply ask for the latest state of the specific ASG it cares about, rather than searching through all ASGs in the account. This allows us to simplify the logic(?) and fail faster if an appropriate ASG cannot be found. It should also make it easier to run multiple `deploy` actions as part of the `autoscaling` deployment type, which we will need in order to support the `cdk` migration.

## How to test

I've deployed this to `CODE` and confirmed that a couple of projects (AMIgo and AMIable) can still be deployed as expected.

## How can we measure success?

* All `autoscaling` deployments should continue working
* It should be easier to add support for deploying to multiple ASGs as part of the same `autoscaling` deploy

## Have we considered potential risks?

Yes, this deployment type is used by many projects in the department, including our highest-profile projects. After merging this we should keep a close eye on the deployment failure rate in case we have introduced any unexpected problems.