### PR TITLE
Add support for dual-ASG deployment (in support of cdk migration)

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/ElasticSearch.scala
@@ -37,7 +37,7 @@ object ElasticSearch extends DeploymentType {
   ) { (pkg, resources, target) =>
     implicit val keyRing = resources.assembleKeyring(target, pkg)
     val reporter = resources.reporter
-    val asgName: String = AutoScalingGroupLookup.getTargetAsgName(keyRing, target, resources, pkg)
+    val asgName: String = AutoScalingGroupLookup.getTargetAsgName(keyRing, target, None, resources, pkg)
     List(
       CheckGroupSize(asgName, target.region),
       WaitForElasticSearchClusterGreen(asgName, secondsToWait(pkg, target, reporter) * 1000, target.region),

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -249,7 +249,7 @@ object ASG {
         tag.key == key && tag.value == value
       }
       def meetsCdkTagRequirements(cdkTagRequirements: Option[CdkTagRequirements]) = {
-        val cdkTagIsPresent: Boolean = asg.tags.asScala.exists { tag => tag.key == "gu:cdk:version" }
+        val cdkTagIsPresent: Boolean = asg.tags.asScala.exists { tag => tag.key == "gu:cdk:pattern-name" }
         cdkTagRequirements match {
           case Some(MustBePresent) => cdkTagIsPresent
           case Some(MustNotBePresent) => !cdkTagIsPresent

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -249,7 +249,7 @@ object ASG {
         tag.key == key && tag.value == value
       }
       def meetsCdkTagRequirements(cdkTagRequirements: Option[CdkTagRequirements]) = {
-        val cdkTagIsPresent: Boolean = asg.tags.asScala.exists { tag => tag.key == "cdk" } //FIXME
+        val cdkTagIsPresent: Boolean = asg.tags.asScala.exists { tag => tag.key == "gu:cdk:version" }
         cdkTagRequirements match {
           case Some(MustBePresent) => cdkTagIsPresent
           case Some(MustNotBePresent) => !cdkTagIsPresent

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -248,6 +248,8 @@ object ASG {
       def hasTag(key: String, value: String): Boolean = asg.tags.asScala.exists { tag =>
         tag.key == key && tag.value == value
       }
+
+      // See https://github.com/guardian/riff-raff/pull/632 for more details
       def meetsCdkTagRequirements(cdkTagRequirements: Option[CdkTagRequirements]) = {
         val cdkTagIsPresent: Boolean = asg.tags.asScala.exists { tag => tag.key == "gu:cdk:pattern-name" }
         cdkTagRequirements match {

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 
 import cats.implicits._
 import com.gu.management.Loggable
-import magenta.deployment_type.{CdkTagRequirements, MustBePresent, MustNotBePresent}
+import magenta.deployment_type.{MigrationTagRequirements, MustBePresent, MustNotBePresent}
 import magenta.{ApiRoleCredentials, ApiStaticCredentials, App, DeployReporter, DeploymentPackage, DeploymentResources, KeyRing, Region, Stack, Stage, StsDeploymentResources, withResource}
 import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, AwsCredentials, AwsCredentialsProvider, AwsCredentialsProviderChain, ProfileCredentialsProvider, StaticCredentialsProvider}
 import software.amazon.awssdk.core.SdkBytes
@@ -241,7 +241,7 @@ object ASG {
     autoScalingGroups.headOption.getOrElse(reporter.fail(s"Failed to identify an autoscaling group with name ${name}"))
   }
 
-  def groupForAppAndStage(pkg: DeploymentPackage, stage: Stage, stack: Stack, cdkTagRequirements: Option[CdkTagRequirements], client: AutoScalingClient, reporter: DeployReporter): AutoScalingGroup = {
+  def groupForAppAndStage(pkg: DeploymentPackage, stage: Stage, stack: Stack, migrationTagRequirements: Option[MigrationTagRequirements], client: AutoScalingClient, reporter: DeployReporter): AutoScalingGroup = {
     case class ASGMatch(app:App, matches:List[AutoScalingGroup])
 
     implicit class RichAutoscalingGroup(asg: AutoScalingGroup) {
@@ -250,16 +250,16 @@ object ASG {
       }
 
       // See https://github.com/guardian/riff-raff/pull/632 for more details
-      def meetsCdkTagRequirements(cdkTagRequirements: Option[CdkTagRequirements]) = {
-        val cdkTagIsPresent: Boolean = asg.tags.asScala.exists { tag => tag.key == "gu:cdk:pattern-name" }
-        cdkTagRequirements match {
-          case Some(MustBePresent) => cdkTagIsPresent
-          case Some(MustNotBePresent) => !cdkTagIsPresent
+      def meetsMigrationTagRequirements(migrationTagRequirements: Option[MigrationTagRequirements]) = {
+        val migrationTagIsPresent: Boolean = asg.tags.asScala.exists { tag => tag.key == "gu:riffraff:new-asg" }
+        migrationTagRequirements match {
+          case Some(MustBePresent) => migrationTagIsPresent
+          case Some(MustNotBePresent) => !migrationTagIsPresent
           case None => true
         }
       }
-      def hasExactTagRequirements(app: App, stack: Stack, cdkTagRequirements: Option[CdkTagRequirements]): Boolean = {
-        hasTag("Stack", stack.name) && hasTag("App", app.name) && meetsCdkTagRequirements(cdkTagRequirements)
+      def hasExactTagRequirements(app: App, stack: Stack, migrationTagRequirements: Option[MigrationTagRequirements]): Boolean = {
+        hasTag("Stack", stack.name) && hasTag("App", app.name) && meetsMigrationTagRequirements(migrationTagRequirements)
       }
     }
 
@@ -277,7 +277,7 @@ object ASG {
     val groups = listAutoScalingGroups()
     val filteredByStage = groups filter { _.hasTag("Stage", stage.name) }
     val appToMatchingGroups = {
-      val matches = filteredByStage.filter(_.hasExactTagRequirements(pkg.app, stack, cdkTagRequirements))
+      val matches = filteredByStage.filter(_.hasExactTagRequirements(pkg.app, stack, migrationTagRequirements))
       if (matches.isEmpty) None else Some(ASGMatch(pkg.app, matches))
     }
 

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -71,6 +71,7 @@ class AutoScalingTest extends AnyFlatSpec with Matchers with MockitoSugar with A
       when(AutoScalingGroupLookup.getTargetAsgName(*, *, *, *, *)).thenReturn("testOldCfnAsg", "testNewCdkAsg")
       val actual = AutoScaling.actionsMap("deploy").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient, stsClient, global), DeployTarget(parameters(), stack, region))
       val expected = List(
+        // All tasks for testOldCfnAsg
         WaitForStabilization("testOldCfnAsg", 5 * 60 * 1000, Region("eu-west-1")),
         CheckGroupSize("testOldCfnAsg", Region("eu-west-1")),
         SuspendAlarmNotifications("testOldCfnAsg", Region("eu-west-1")),
@@ -85,6 +86,7 @@ class AutoScalingTest extends AnyFlatSpec with Matchers with MockitoSugar with A
         TerminationGrace("testOldCfnAsg", Region("eu-west-1"), 10000),
         WaitForStabilization("testOldCfnAsg", 15 * 60 * 1000, Region("eu-west-1")),
         ResumeAlarmNotifications("testOldCfnAsg", Region("eu-west-1")),
+        // All tasks for testNewCdkAsg
         WaitForStabilization("testNewCdkAsg", 5 * 60 * 1000, Region("eu-west-1")),
         CheckGroupSize("testNewCdkAsg", Region("eu-west-1")),
         SuspendAlarmNotifications("testNewCdkAsg", Region("eu-west-1")),

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -56,10 +56,10 @@ class AutoScalingTest extends AnyFlatSpec with Matchers with MockitoSugar with A
     }
   }
 
-  "auto-scaling with cdkMigrationInProgress=true" should "have a deploy action which updates two ASGs" in {
+  "auto-scaling with asgMigrationInProgress=true" should "have a deploy action which updates two ASGs" in {
     val data: Map[String, JsValue] = Map(
       "bucket" -> JsString("asg-bucket"),
-      "cdkMigrationInProgress" -> JsBoolean(true)
+      "asgMigrationInProgress" -> JsBoolean(true)
     )
 
     val app = App("app")

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -34,7 +34,7 @@ class AutoScalingTest extends AnyFlatSpec with Matchers with MockitoSugar with A
       deploymentTypes)
 
     withObjectMocked[AutoScalingGroupLookup.type] {
-      when(AutoScalingGroupLookup.getTargetAsgName(*, *, *, *)) thenAnswer "test"
+      when(AutoScalingGroupLookup.getTargetAsgName(*, *, *, *, *)) thenAnswer "test"
       val actual = AutoScaling.actionsMap("deploy").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient, stsClient, global), DeployTarget(parameters(), stack, region))
       val expected = List(
         WaitForStabilization("test", 5 * 60 * 1000, Region("eu-west-1")),
@@ -85,7 +85,7 @@ class AutoScalingTest extends AnyFlatSpec with Matchers with MockitoSugar with A
       deploymentTypes)
 
     withObjectMocked[AutoScalingGroupLookup.type] {
-      when(AutoScalingGroupLookup.getTargetAsgName(*, *, *, *)) thenAnswer "test"
+      when(AutoScalingGroupLookup.getTargetAsgName(*, *, *, *, *)) thenAnswer "test"
       val actual = AutoScaling.actionsMap("deploy").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient, stsClient, global), DeployTarget(parameters(), stack, region))
       val expected = List(
         WaitForStabilization("test", 5 * 60 * 1000, Region("eu-west-1")),

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
@@ -57,7 +57,7 @@ class ASGTest extends AnyFlatSpec with Matchers with MockitoSugar {
 
     val p = DeploymentPackage("example", App("logcabin"), Map.empty, deploymentType = null,
       S3Path("artifact-bucket", "project/123/example"))
-    ASG.groupForAppAndStage(p, Stage("PROD"), Stack("contentapi"), asgClientMock, reporter) should be (desiredGroup)
+    ASG.groupForAppAndStage(p, Stage("PROD"), Stack("contentapi"), None, asgClientMock, reporter) should be (desiredGroup)
   }
 
   it should "fail if more than one ASG matches the Stack and App tags" in {
@@ -80,7 +80,7 @@ class ASGTest extends AnyFlatSpec with Matchers with MockitoSugar {
       S3Path("artifact-bucket", "project/123/example"))
 
     a [FailException] should be thrownBy {
-      ASG.groupForAppAndStage(p, Stage("PROD"), Stack("contentapi"), asgClientMock, reporter) should be (desiredGroup)
+      ASG.groupForAppAndStage(p, Stage("PROD"), Stack("contentapi"), None, asgClientMock, reporter) should be (desiredGroup)
     }
   }
 
@@ -202,7 +202,7 @@ class ASGTest extends AnyFlatSpec with Matchers with MockitoSugar {
 
     val p = DeploymentPackage("example", App("logcabin"), Map.empty, deploymentType = null,
       S3Path("artifact-bucket", "project/123/example"))
-    ASG.groupForAppAndStage(p, Stage("PROD"), Stack("contentapi"), asgClientMock, reporter) should be (desiredGroup)
+    ASG.groupForAppAndStage(p, Stage("PROD"), Stack("contentapi"), None, asgClientMock, reporter) should be (desiredGroup)
   }
 
   object AutoScalingGroupWithTags {

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
@@ -61,7 +61,7 @@ class ASGTest extends AnyFlatSpec with Matchers with MockitoSugar {
     ASG.groupForAppAndStage(p, Stage("PROD"), Stack("contentapi"), None, asgClientMock, reporter) should be (desiredGroup)
   }
 
-  it should "fail if more than one ASG matches the Stack and App tags (unless cdkTagRequirements are specified)" in {
+  it should "fail if more than one ASG matches the Stack and App tags (unless MigrationTagRequirements are specified)" in {
     val asgClientMock = mock[AutoScalingClient]
 
     val desiredGroup = AutoScalingGroupWithTags("Stack" -> "contentapi", "App" -> "logcabin", "Stage" -> "PROD", "Role" -> "monkey")
@@ -85,15 +85,15 @@ class ASGTest extends AnyFlatSpec with Matchers with MockitoSugar {
     }
   }
 
-  it should "identify a single ASG based on Stack & App tags and MustBePresent cdkTagRequirements" in {
+  it should "identify a single ASG based on Stack & App tags and MustBePresent MigrationTagRequirements" in {
     val asgClientMock = mock[AutoScalingClient]
 
-    val desiredGroup = AutoScalingGroupWithTags("Stack" -> "contentapi", "App" -> "logcabin", "Stage" -> "PROD", "Role" -> "monkey", "gu:cdk:pattern-name" -> "GuPlayApp")
+    val desiredGroup = AutoScalingGroupWithTags("Stack" -> "contentapi", "App" -> "logcabin", "Stage" -> "PROD", "Role" -> "monkey", "gu:riffraff:new-asg" -> "true")
 
     when (asgClientMock.describeAutoScalingGroups(any[DescribeAutoScalingGroupsRequest])) thenReturn
       DescribeAutoScalingGroupsResponse.builder().autoScalingGroups(List(
         desiredGroup,
-        // This should be ignored due to lack of cdk tag
+        // This should be ignored due to lack of migration tag
         AutoScalingGroupWithTags("Stack" -> "contentapi", "App" -> "logcabin", "Stage" -> "PROD", "Role" -> "monkey"),
       ).asJava).build()
 
@@ -102,7 +102,7 @@ class ASGTest extends AnyFlatSpec with Matchers with MockitoSugar {
     ASG.groupForAppAndStage(p, Stage("PROD"), Stack("contentapi"), Some(MustBePresent), asgClientMock, reporter) should be (desiredGroup)
   }
 
-  it should "identify a single ASG based on Stack & App tags and MustNotBePresent cdkTagRequirements" in {
+  it should "identify a single ASG based on Stack & App tags and MustNotBePresent MigrationTagRequirements" in {
     val asgClientMock = mock[AutoScalingClient]
 
     val desiredGroup = AutoScalingGroupWithTags("Stack" -> "contentapi", "App" -> "logcabin", "Stage" -> "PROD", "Role" -> "monkey")
@@ -110,8 +110,8 @@ class ASGTest extends AnyFlatSpec with Matchers with MockitoSugar {
     when (asgClientMock.describeAutoScalingGroups(any[DescribeAutoScalingGroupsRequest])) thenReturn
       DescribeAutoScalingGroupsResponse.builder().autoScalingGroups(List(
         desiredGroup,
-        // This should be ignored due to presence of cdk tag
-        AutoScalingGroupWithTags("Stack" -> "contentapi", "App" -> "logcabin", "Stage" -> "PROD", "Role" -> "monkey", "gu:cdk:pattern-name" -> "GuPlayApp"),
+        // This should be ignored due to presence of migration tag
+        AutoScalingGroupWithTags("Stack" -> "contentapi", "App" -> "logcabin", "Stage" -> "PROD", "Role" -> "monkey", "gu:riffraff:new-asg" -> "true"),
       ).asJava).build()
 
     val p = DeploymentPackage("example", App("logcabin"), Map.empty, deploymentType = null,

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
@@ -88,7 +88,7 @@ class ASGTest extends AnyFlatSpec with Matchers with MockitoSugar {
   it should "identify a single ASG based on Stack & App tags and MustBePresent cdkTagRequirements" in {
     val asgClientMock = mock[AutoScalingClient]
 
-    val desiredGroup = AutoScalingGroupWithTags("Stack" -> "contentapi", "App" -> "logcabin", "Stage" -> "PROD", "Role" -> "monkey", "gu:cdk:version" -> "19.0.0")
+    val desiredGroup = AutoScalingGroupWithTags("Stack" -> "contentapi", "App" -> "logcabin", "Stage" -> "PROD", "Role" -> "monkey", "gu:cdk:pattern-name" -> "GuPlayApp")
 
     when (asgClientMock.describeAutoScalingGroups(any[DescribeAutoScalingGroupsRequest])) thenReturn
       DescribeAutoScalingGroupsResponse.builder().autoScalingGroups(List(
@@ -111,7 +111,7 @@ class ASGTest extends AnyFlatSpec with Matchers with MockitoSugar {
       DescribeAutoScalingGroupsResponse.builder().autoScalingGroups(List(
         desiredGroup,
         // This should be ignored due to presence of cdk tag
-        AutoScalingGroupWithTags("Stack" -> "contentapi", "App" -> "logcabin", "Stage" -> "PROD", "Role" -> "monkey", "gu:cdk:version" -> "19.0.0"),
+        AutoScalingGroupWithTags("Stack" -> "contentapi", "App" -> "logcabin", "Stage" -> "PROD", "Role" -> "monkey", "gu:cdk:pattern-name" -> "GuPlayApp"),
       ).asJava).build()
 
     val p = DeploymentPackage("example", App("logcabin"), Map.empty, deploymentType = null,


### PR DESCRIPTION
## What does this change?

In order to migrate an application from its current (CloudFormation-defined) infrastructure to new (cdk-defined) infrastructure, Riff-Raff must be able to update two Autoscaling Groups (for the same`App`) as part of a single deployment. Prior to this PR it was impossible to do this. 

This PR allows users to instruct Riff-Raff to update both of their Autoscaling Groups by setting a new parameter in their `riff-raff.yaml`. Riff-Raff will check that it's safe to proceed by ensuring that it finds Autoscaling Groups with appropriate tags. If it finds any other AutoScaling groups for the same `App`/`Stack`/`Stage`, it will still refuse to proceed with the deployment.

## How to test

* I have confirmed that deploys which _do not_ set this parameter are unaffected.
* I have confirmed that deploys which set this parameter are able to update two ASGs (given that these ASGs are tagged correctly).

## How can we measure success?

* It is possible to complete a migration to `cdk`, following [this guide](https://docs.google.com/document/d/17M6TK4uVcMiZAHaTFSo-zahIqrA5eGaKNYU-j4BVUB0/edit).
* It is possible to deploy changes via Riff-Raff during a long-running `cdk` migration.

## Have we considered potential risks?

* Deployments which enable this mode will take longer to complete because the Autoscaling Groups are updated in sequence. However, I think this is acceptable as we only expect users to run with this mode enabled for a short period of time (for more details see the [suggested migration process](https://docs.google.com/document/d/17M6TK4uVcMiZAHaTFSo-zahIqrA5eGaKNYU-j4BVUB0/edit)).
* This deployment type is used by many projects in the department, including our highest-profile projects. After merging this we should keep a close eye on the deployment failure rate in case we have introduced any unexpected problems.