### PR TITLE
Improve safety of riff-raff.yaml parsing

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/GcpDeploymentManager.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/GcpDeploymentManager.scala
@@ -140,7 +140,7 @@ object GcpDeploymentManager extends DeploymentType {
     val configFileLocation = S3Path(packageRoot, configFile)
     for {
       yaml <- getFileContent(configFileLocation)
-      json <- Either.catchNonFatal(RiffRaffYamlReader.yamlToJson(yaml)).leftMap(t => UnknownBundleError("Couldn't parse YAML config file", t))
+      json <- RiffRaffYamlReader.yamlToJson(yaml).toEither.leftMap(t => UnknownBundleError("Couldn't parse YAML config file", t))
       dependencies = (json \ "imports" \\ "path").toList.flatMap(_.asOpt[String])
       dependenciesMap <- dependencies.traverse { dependency =>
         val s3Dep = S3Path(packageRoot, dependency)


### PR DESCRIPTION
## What does this change?

Whilst investigating problems with build discovery / CD stopping in a somewhat random fashion I noticed a pattern. The final build discovered before the problems occur seems to have an invalid `riff-raff.yaml` file. 

This problem/exception can be seen when attempting to preview a deployment for the relevant build(s). This PR attempts to improve the situation by wrapping the code which throws an exception in a `Try`.

If I'm wrong, this will still be a slight improvement, as the error page you get when attempting to preview a deployment which suffers from this problem is marginally less ugly and easier to understand 😅 

## How to test

To be completely frank, I don't understand why an exception being thrown in this area of the code would cause _all_ build discovery to break, so I'd like to test my theory with an experiment. I have observed that build discovery breaks simultaneously in `CODE` and `PROD`, so my plan is:

1. Merge this change and ensure it is deployed to `PROD`
1. Leave previous version of `main` (i.e. a build which does not include this potential fix) in `CODE`
1. Create a new build which uploads a 'bad' `riff-raff.yaml`
1. See whether build discovery keeps working in either environment

## How can we measure success?

* Maybe the mysterious problem with build discovery / CD will stop 🤞 🤷‍♂️ 

## Have we considered potential risks?

* This should be pretty safe, we're just improving error handling