### PR TITLE
Render dynamic content for both `types` and `types.md`

### DIFF
--- a/riff-raff/app/controllers/Application.scala
+++ b/riff-raff/app/controllers/Application.scala
@@ -168,7 +168,7 @@ class Application(config: Config,
             }
 
             resource match {
-              case "magenta-lib/types" =>
+              case "magenta-lib/types" | "magenta-lib/types.md" =>
                 val sections = DeployTypeDocs.generateDocs(deploymentTypes).map { case (dt, docs) =>
                   val typeDocumentation = views.html.documentation.deploymentTypeSnippet(docs)
                   (dt.name, typeDocumentation)


### PR DESCRIPTION
## What does this change?

This PR adds an extra condition to the pattern matching which decides whether to render dynamic content for the types doc page or whether to simply render the file contents of the markdown file found. 

This fixes an issue where the link from the `/docs/reference/riff-raff.yaml.md` page, directs you to `/docs/magenta-lib/types.md` which renders the contents of the `public/docs/magenta-lib/types.md` file instead of overriding it with dynamic content. 

**Question: would it be better just to update the link to point to `/docs/magenta-lib/types` instead?**

## How to test

Navigate to both `/docs/magenta-lib/types` and `/docs/magenta-lib/types.md` on production and see that for `/docs/magenta-lib/types.md`, the following string is displayed: 

`This document is dynamically replaced when viewed inside the Riff-Raff web application with information about each of the deployment types that are available.`

Navigate to the same locations with the new code and see the dynamic content is rendered for both.

## How can we measure success?

The correct docs are shown regardless of what link you click to get to the types page / whether you include `.md` on the end of the url or not.


cc @dskamiotis @samanthagottlieb @abeddow91 