### PR TITLE
chore: Follow CI best practice

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 
 addSbtPlugin("com.gu" % "sbt-teamcity-test-reporting-plugin" % "1.5")
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.4")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.12")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
 

--- a/script/ci
+++ b/script/ci
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+sbt clean compile test riffraff/riffRaffNotifyTeamcity


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[Best practice](https://github.com/guardian/recommendations/blob/master/continuous-integration.md#platforms) has been defined as having a `script/ci` file in the repository to get the benefits of VCS.

This change also makes the TeamCity build more accurate. We're currently using the `sbt` runner in TeamCity which always exits 0, even when there are failing tests! This results in artifacts being always uploaded. This is undesirable! As an example, build [1632 failed](https://teamcity.gutools.co.uk/buildConfiguration/Tools_Riffraff/678317) but is available to be deployed and [did](https://riffraff.gutools.co.uk/deployment/history?projectName=tools%3A%3Ariffraff&stage=PROD&pageSize=20&page=1)!

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

This requires a change to the TeamCity configuration and other branches would need to rebase in order to continue building.