### PR TITLE
chore: Add `allowlist` field to DynamoDb

### DIFF
--- a/riff-raff/app/persistence/RestrictionConfigDynamoRepository.scala
+++ b/riff-raff/app/persistence/RestrictionConfigDynamoRepository.scala
@@ -1,13 +1,13 @@
 package persistence
 
 import java.util.UUID
-
 import com.gu.scanamo.Table
 import restrictions.{RestrictionConfig, RestrictionsConfigRepository}
 import cats.syntax.either._
+import com.gu.management.Loggable
 import conf.Config
 
-class RestrictionConfigDynamoRepository(config: Config) extends DynamoRepository(config) with RestrictionsConfigRepository {
+class RestrictionConfigDynamoRepository(config: Config) extends DynamoRepository(config) with RestrictionsConfigRepository with Loggable {
   def tablePrefix = "riffraff-restriction-config"
 
   val table = Table[RestrictionConfig](tableName)
@@ -17,7 +17,24 @@ class RestrictionConfigDynamoRepository(config: Config) extends DynamoRepository
   def setRestriction(config: RestrictionConfig): Unit = exec(table.put(config))
   def getRestriction(id: UUID): Option[RestrictionConfig] = exec(table.get('id -> id)).flatMap(_.toOption)
   def deleteRestriction(id: UUID): Unit = exec(table.delete('id -> id))
-  def getRestrictionList: Iterable[RestrictionConfig] = exec(table.scan()).flatMap(_.toOption)
+  def getRestrictionList: Iterable[RestrictionConfig] = {
+    val restrictions = exec(table.scan()).flatMap(_.toOption)
+
+    /*
+    Renaming whitelist to allowlist is a three step dance:
+      1. Add the new field
+      2. Read the new field
+      3. Remove the old field
+
+     This is step 1.
+     */
+    restrictions.map(restriction => {
+      logger.info(s"adding new allowlist field to restriction ${restriction.id}")
+      exec(table.update('id -> restriction.id, set('allowlist -> restriction.whitelist)))
+    })
+
+    restrictions
+  }
 
   def getRestrictions(projectName: String): Seq[RestrictionConfig] =
     exec(table.index("restriction-config-projectName").query('projectName -> projectName)).flatMap(_.toOption)


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We want to rename "whitelist" to "allowlist" because language matters.

In order to do this safely, we need to perform a three step dance:
  1. Add the new field
  2. Read the new field
  3. Remove the old field

This ensures we can continue to read the data at all times, at the cost of three separate changes.

This is the first step.

It is done in a hacky way by mutating the DynamoDb table in the `GET /deployment/restrictions request`. It's hacky as it makes this route, temporarily, non-idempotent.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Deploy to CODE
- Make a request to `/deployment/restrictions`
- Observe it continuing to work
- Open the DynamoDb table for CODE (riffraff-restriction-config-CODE) and observe the new column

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

The GET request will take a little longer as it's now updating the table. There aren't that many items in DynamoDb (5 in CODE, 62 in PROD) so impact should be minimal.