### PR TITLE
chore: Remove `whitelist` from DynamoDb and config

### DIFF
--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -80,18 +80,8 @@ class Config(configuration: TypesafeConfig, startTime: DateTime) extends Logging
   object auth {
     lazy val domains: List[String] = getStringList("auth.domains")
     object allowList {
-      lazy val useDatabase: Boolean = {
-        // TODO remove reading of legacy config
-        val newConfig = getBooleanOpt("auth.allowlist.useDatabase")
-        val legacyConfig = getBooleanOpt("auth.whitelist.useDatabase").getOrElse(false)
-        newConfig.getOrElse(legacyConfig)
-      }
-      lazy val addresses: List[String] = {
-        // TODO remove reading of legacy config
-        val newConfig = getStringList("auth.allowlist.addresses")
-        val legacyConfig = getStringList("auth.whitelist.addresses")
-        if (newConfig.nonEmpty) newConfig else legacyConfig
-      }
+      lazy val useDatabase: Boolean = getBooleanOpt("auth.whitelist.useDatabase").getOrElse(false)
+      lazy val addresses: List[String] = getStringList("auth.whitelist.addresses")
     }
 
     lazy val clientId: String = getStringOpt("auth.clientId").getOrException("No client ID configured")

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -80,8 +80,8 @@ class Config(configuration: TypesafeConfig, startTime: DateTime) extends Logging
   object auth {
     lazy val domains: List[String] = getStringList("auth.domains")
     object allowList {
-      lazy val useDatabase: Boolean = getBooleanOpt("auth.whitelist.useDatabase").getOrElse(false)
-      lazy val addresses: List[String] = getStringList("auth.whitelist.addresses")
+      lazy val useDatabase: Boolean = getBooleanOpt("auth.allowlist.useDatabase").getOrElse(false)
+      lazy val addresses: List[String] = getStringList("auth.allowlist.addresses")
     }
 
     lazy val clientId: String = getStringOpt("auth.clientId").getOrException("No client ID configured")

--- a/riff-raff/app/persistence/RestrictionConfigDynamoRepository.scala
+++ b/riff-raff/app/persistence/RestrictionConfigDynamoRepository.scala
@@ -1,13 +1,13 @@
 package persistence
 
 import java.util.UUID
-
 import com.gu.scanamo.Table
 import restrictions.{RestrictionConfig, RestrictionsConfigRepository}
 import cats.syntax.either._
+import com.gu.management.Loggable
 import conf.Config
 
-class RestrictionConfigDynamoRepository(config: Config) extends DynamoRepository(config) with RestrictionsConfigRepository {
+class RestrictionConfigDynamoRepository(config: Config) extends DynamoRepository(config) with RestrictionsConfigRepository with Loggable {
   def tablePrefix = "riffraff-restriction-config"
 
   val table = Table[RestrictionConfig](tableName)
@@ -17,7 +17,23 @@ class RestrictionConfigDynamoRepository(config: Config) extends DynamoRepository
   def setRestriction(config: RestrictionConfig): Unit = exec(table.put(config))
   def getRestriction(id: UUID): Option[RestrictionConfig] = exec(table.get('id -> id)).flatMap(_.toOption)
   def deleteRestriction(id: UUID): Unit = exec(table.delete('id -> id))
-  def getRestrictionList: Iterable[RestrictionConfig] = exec(table.scan()).flatMap(_.toOption)
+  def getRestrictionList: Iterable[RestrictionConfig] = {
+    val restrictions = exec(table.scan()).flatMap(_.toOption)
+
+    /*
+    Renaming whitelist to allowlist is a three step dance:
+      1. Add the new field
+      2. Read the new field
+      3. Remove the old field
+     This is step 3.
+     */
+    restrictions.map(restriction => {
+      logger.info(s"removing old whitelist field to restriction ${restriction.id}")
+      exec(table.update('id -> restriction.id, remove('whitelist)))
+    })
+
+    restrictions
+  }
 
   def getRestrictions(projectName: String): Seq[RestrictionConfig] =
     exec(table.index("restriction-config-projectName").query('projectName -> projectName)).flatMap(_.toOption)


### PR DESCRIPTION
Requires #638.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Our language should be more inclusive in 2021. This change removes `whitelist` from the codebase after the migration in #638.

As noted in #637 this is a three step dance:
  1. Add the new field
  2. Read the new field
  3. Remove the old field

This is step 3.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Deploy to CODE, the app should continue to work
- Make a request to `/deployment/restrictions`
- Observe it continuing to work
- Open the DynamoDb table for CODE (riffraff-restriction-config-CODE) and observe the whitelist column being dropped
