### PR TITLE
chore: Remove redundant cleanup logic

### DIFF
--- a/riff-raff/app/persistence/RestrictionConfigDynamoRepository.scala
+++ b/riff-raff/app/persistence/RestrictionConfigDynamoRepository.scala
@@ -1,13 +1,13 @@
 package persistence
 
 import java.util.UUID
+
 import com.gu.scanamo.Table
 import restrictions.{RestrictionConfig, RestrictionsConfigRepository}
 import cats.syntax.either._
-import com.gu.management.Loggable
 import conf.Config
 
-class RestrictionConfigDynamoRepository(config: Config) extends DynamoRepository(config) with RestrictionsConfigRepository with Loggable {
+class RestrictionConfigDynamoRepository(config: Config) extends DynamoRepository(config) with RestrictionsConfigRepository {
   def tablePrefix = "riffraff-restriction-config"
 
   val table = Table[RestrictionConfig](tableName)
@@ -17,23 +17,7 @@ class RestrictionConfigDynamoRepository(config: Config) extends DynamoRepository
   def setRestriction(config: RestrictionConfig): Unit = exec(table.put(config))
   def getRestriction(id: UUID): Option[RestrictionConfig] = exec(table.get('id -> id)).flatMap(_.toOption)
   def deleteRestriction(id: UUID): Unit = exec(table.delete('id -> id))
-  def getRestrictionList: Iterable[RestrictionConfig] = {
-    val restrictions = exec(table.scan()).flatMap(_.toOption)
-
-    /*
-    Renaming whitelist to allowlist is a three step dance:
-      1. Add the new field
-      2. Read the new field
-      3. Remove the old field
-     This is step 3.
-     */
-    restrictions.map(restriction => {
-      logger.info(s"removing old whitelist field to restriction ${restriction.id}")
-      exec(table.update('id -> restriction.id, remove('whitelist)))
-    })
-
-    restrictions
-  }
+  def getRestrictionList: Iterable[RestrictionConfig] = exec(table.scan()).flatMap(_.toOption)
 
   def getRestrictions(projectName: String): Seq[RestrictionConfig] =
     exec(table.index("restriction-config-projectName").query('projectName -> projectName)).flatMap(_.toOption)


### PR DESCRIPTION
Requires #639.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This reverts commit f102394756d5d977c4b46e45a506e81271d899a4 after #639 has been deployed to keep the codebase clean and make the `GET /deployment/restrictions request` route idempotent again.