### PR TITLE
chore: Bump AWS SDK version to 2.17.15

### DIFF
--- a/magenta-lib/src/test/scala/magenta/PackageTest.scala
+++ b/magenta-lib/src/test/scala/magenta/PackageTest.scala
@@ -55,7 +55,14 @@ class PackageTest extends AnyFlatSpec with Matchers with MockitoSugar {
 
     an [AwsServiceException] should be thrownBy retryOnException(clientConfiguration)(block)
 
-    calls should be(3)
+    /*
+    numRetries is set to 3 in `clientConfiguration`
+    1 initial attempt + 3 retries = 4
+
+    Note, when using v2.5.14 of the AWS SDK this was 3.
+    I couldn't work out why it differs in v2.17.15 and the above explanation is an attempt to rationalise it 😅.
+     */
+    calls should be(4)
   }
 
   "retryOnException" should "throw an exception immediately if not retryable" in {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val aws = "2.5.14"
+    val aws = "2.17.15"
     val guardianManagement = "5.41"
     val jackson = "2.9.8"
     val awsRds = "1.11.563"


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We want to start using some classes available in later versions of the AWS SDK, specifically classes that allow us to create/update CFN private types ([this](https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md#aws-cloudformation-14) and [this](https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md#aws-cloudformation-6)).

This change bumps the AWS SDK to the latest available and "fixes" an off by one error in the tests. I've been unable to determine the origin of the off by one error, so have attempted to rationalise it instead.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

CI should pass.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We are able to add new features to Riff-Raff via the new functionality of the AWS SDK.