### PR TITLE
Fix buildinfo commit ID and build number

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,8 +51,8 @@ lazy val riffraff = project.in(file("riff-raff"))
 
     buildInfoKeys := Seq[BuildInfoKey](
       name, version, scalaVersion, sbtVersion,
-      sbtbuildinfo.BuildInfoKey.constant("gitCommitId", System.getProperty("build.vcs.number", "DEV").dequote.trim),
-      sbtbuildinfo.BuildInfoKey.constant("buildNumber", System.getProperty("build.number", "DEV").dequote.trim)
+      BuildInfoKey.constant("gitCommitId", riffRaffBuildInfo.value.revision),
+      BuildInfoKey.constant("buildNumber", riffRaffBuildInfo.value.buildIdentifier)
     ),
     buildInfoOptions += BuildInfoOption.BuildTime,
     buildInfoPackage := "riffraff",


### PR DESCRIPTION
## What does this change?
https://github.com/guardian/riff-raff/pull/635 removed some of the system properties that we rilied on to populate the build info. This gets the information from the riff-raff plugin which means it will always be consistent with the data in the riff-raff manifest.

## How to test
When deployed the data in the bottom right hand corner of Riff-Raff should be accurate.
