### PR TITLE
Make the favourite button more accessible

### DIFF
--- a/riff-raff/app/assets/javascripts/form-autocomplete.coffee
+++ b/riff-raff/app/assets/javascripts/form-autocomplete.coffee
@@ -67,8 +67,8 @@ renderFavourites = () ->
     favourites.forEach (fav) ->
       list.append("
           <div class=\"favourite\">
-            <button class=\"select-favourite-project-button btn btn-default\" value=\"#{fav}\" aria-label=\"Use favourite: #{fav}\">#{fav}</button>
-            <button class=\"delete-favourite-project-button btn btn-xs btn-danger\" value=\"#{fav}\" aria-label=\"Delete favourite: #{fav}\">
+            <button class=\"select-favourite-project-button btn btn-default\" value=\"#{fav}\" aria-label=\"Use favourite: #{fav}\" title=\"Use favourite: #{fav}\">#{fav}</button>
+            <button class=\"delete-favourite-project-button btn btn-xs btn-danger\" value=\"#{fav}\" aria-label=\"Delete favourite: #{fav}\" title=\"Delete favourite: #{fav}\">
               <i class=\"glyphicon glyphicon-trash glyphicon glyphicon-white\"></i>
             </button>
           </div>

--- a/riff-raff/app/assets/javascripts/form-autocomplete.coffee
+++ b/riff-raff/app/assets/javascripts/form-autocomplete.coffee
@@ -67,8 +67,8 @@ renderFavourites = () ->
     favourites.forEach (fav) ->
       list.append("
           <div class=\"favourite\">
-            <button class=\"select-favourite-project-button btn btn-default\" value=\"#{fav}\">#{fav}</button>
-            <button class=\"delete-favourite-project-button btn btn-xs btn-danger\" value=\"#{fav}\">
+            <button class=\"select-favourite-project-button btn btn-default\" value=\"#{fav}\" aria-label=\"Use favourite: #{fav}\">#{fav}</button>
+            <button class=\"delete-favourite-project-button btn btn-xs btn-danger\" value=\"#{fav}\" aria-label=\"Delete favourite: #{fav}\">
               <i class=\"glyphicon glyphicon-trash glyphicon glyphicon-white\"></i>
             </button>
           </div>

--- a/riff-raff/app/views/deploy/form.scala.html
+++ b/riff-raff/app/views/deploy/form.scala.html
@@ -68,7 +68,7 @@
 
             <div class="project-container">
                 @b3.text(deployForm("project"), '_label -> "Project", 'id -> "projectInput", Symbol("data-url") -> "/deployment/request/autoComplete/project", 'class -> "form-control input-md project-exact-match")
-                <button id="add-favourite-project-button"><i class="glyphicon glyphicon-star"></i></button>
+                <button id="add-favourite-project-button" aria-label="Add to favourites"><i class="glyphicon glyphicon-star"></i></button>
             </div>
             @b3.text(deployForm("build"),  '_label -> "Build", 'id -> "buildInput", Symbol("data-url") -> "/deployment/request/autoComplete/build", 'class -> "form-control input-md")
             @b3.select(

--- a/riff-raff/app/views/deploy/form.scala.html
+++ b/riff-raff/app/views/deploy/form.scala.html
@@ -68,7 +68,7 @@
 
             <div class="project-container">
                 @b3.text(deployForm("project"), '_label -> "Project", 'id -> "projectInput", Symbol("data-url") -> "/deployment/request/autoComplete/project", 'class -> "form-control input-md project-exact-match")
-                <button id="add-favourite-project-button" aria-label="Add to favourites"><i class="glyphicon glyphicon-star"></i></button>
+                <button id="add-favourite-project-button" aria-label="Add to favourites" title="Add to favourites"><i class="glyphicon glyphicon-star"></i></button>
             </div>
             @b3.text(deployForm("build"),  '_label -> "Build", 'id -> "buildInput", Symbol("data-url") -> "/deployment/request/autoComplete/build", 'class -> "form-control input-md")
             @b3.select(


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR makes the **Favourite** and **Delete Favourite** buttons more accessible.

It does so by:
- Adding a title attribute (providing a hover tooltip).
- Adding an aria-label attribute (providing a button description for screenreaders).

## How to test
Run [locally](https://github.com/guardian/riff-raff) or test on CODE, adding and removing a favourite deploy.

## Images
![2021-08-17 12 10 47](https://user-images.githubusercontent.com/34686302/129716840-28f3e1a2-0566-40f3-b441-83c94cfd4f57.gif)

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [X] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [X] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [X] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [X] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
