### PR TITLE
When linking, handle https github URLs with .git ext

### DIFF
--- a/riff-raff/app/utils/VCSInfo.scala
+++ b/riff-raff/app/utils/VCSInfo.scala
@@ -47,7 +47,7 @@ object VCSInfo extends Logging {
 
   val GitHubProtocol = """git://github\.com/(.*)\.git""".r
   val GitHubUser = """git@github\.com:(.*)\.git""".r
-  val GitHubWeb = """https://github\.com/(.*)""".r
+  val GitHubWeb = """https://github\.com/(.*?)(?:.git)?$""".r
 
   def apply(ciVcsUrl: String, revision: String): Option[VCSInfo] = {
     log.debug("url:%s revision:%s" format(ciVcsUrl, revision))

--- a/riff-raff/test/utils/VCSInfoTest.scala
+++ b/riff-raff/test/utils/VCSInfoTest.scala
@@ -15,4 +15,9 @@ class VCSInfoTest extends AnyFunSuite with Matchers {
     val info = VCSInfo("git@github.com:guardian/contributions-frontend.git", "98a1cffadbe564d570b15c2113c07a28cbe835ee")
     info.get.baseUrl shouldBe new URI("https://github.com/guardian/contributions-frontend")
   }
+
+  test("extracts details from Github HTTPS URL with .git extension") {
+    val info = VCSInfo("https://github.com/guardian/contributions-frontend.git", "98a1cffadbe564d570b15c2113c07a28cbe835ee")
+    info.get.baseUrl shouldBe new URI("https://github.com/guardian/contributions-frontend")
+  }
 }


### PR DESCRIPTION
## What does this change?

I noticed that the repo URL for frontend is https://github.com/guardian/frontend.git. Afaict this works fine
everywhere except where we build a link to a commit from the `deployment/view` page where the link to the commit is broken due to a superfluous `.git` in the repo path.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
