### PR TITLE
docs: Add documentation for restrictions

### DIFF
--- a/riff-raff/app/views/restrictions/list.scala.html
+++ b/riff-raff/app/views/restrictions/list.scala.html
@@ -13,6 +13,7 @@
         that deploying would be dangerous or potentially degrade the product. In addition they can be used when
         infrastructure security could be compromised by allowing any user to rollback or deploy a branch of their
         choice.</p>
+        <p>Further docs available <a href="/docs/riffraff/restrictions.md">here</a></p>
     </div>
     <p><a class="btn btn-primary" href="@routes.Restrictions.form()"><i class="glyphicon glyphicon-plus glyphicon glyphicon-white"></i> Add new restriction</a></p>
     <div class="content">

--- a/riff-raff/public/docs/index.md
+++ b/riff-raff/public/docs/index.md
@@ -17,7 +17,7 @@ Reference
 Using Riff-Raff
 ---------------
 
- - [Advanced deploymeny settings](riffraff/advanced-settings.md) - what is an update strategy and how to choose one
+ - [Advanced deployment settings](riffraff/advanced-settings.md) - what is an update strategy and how to choose one
  - [API](riffraff/api.md) - how to use the API and a description of the endpoints available
  - [Continuous Integration and Deployment](riffraff/hooksAndCD.md) - guide to the Riff-Raff hooks available to make continuous
  deployment easy

--- a/riff-raff/public/docs/index.md
+++ b/riff-raff/public/docs/index.md
@@ -24,6 +24,7 @@ Using Riff-Raff
  - [External deploy requests](riffraff/externalRequest.md) - how to help a user start a deploy
  - [AWS S3 bucket configuration for uploads](riffraff/s3buckets.md)
  - [Administration](riffraff/administration/) - details on how to configure Riff-Raff
+ - [Restrictions](riffraff/restrictions.md) - how to restrict deployments
 
 Riff-Raff not picking up builds?
 ---------------

--- a/riff-raff/public/docs/riffraff/restrictions.md
+++ b/riff-raff/public/docs/riffraff/restrictions.md
@@ -1,0 +1,22 @@
+# Restricting deployments
+
+## What are restrictions for?
+Restrictions are principally designed to be used when there is a temporary issue with a project or environment, such that deploying would be dangerous or potentially degrade the product.
+
+In addition they can be used when infrastructure security could be compromised by allowing any user to rollback or deploy a branch of their choice.
+
+## Who can deploy a restricted project?
+  - The author
+  - Those in the restriction `allowlist`
+  - Superusers
+
+## Who can edit a restriction?
+  - If the restriction is not locked, it is editable by all users.
+  - If the restriction is locked, it is editable by the user that locked it and superusers. 
+
+## Help! A colleague has left the Guardian and I need to edit their locked restriction!
+Don't panic!
+
+As noted above, superusers have the power to unlock restrictions.
+Therefore, to solve this issue you simply need to ask a superuser to unlock the restriction.
+Once done, you're able to edit the restriction as needed and if appropriate relock it.


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Adds short documentation for restrictions with information on how to resolve issues where a restriction is locked by an ex-colleague.

The doc is linked to from `/docs` and also `/deployment/restrictions`.

It will be useful to expose the list of superusers in the UI to save people from guessing or finding the value from config. I'm initially thinking of denoting superuser status within `/auth/list`. I'll do this in a separate PR - #647.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

![image](https://user-images.githubusercontent.com/836140/132512865-8206a8e9-1961-4227-a195-7cfec9afdf2c.png)