### PR TITLE
Improve rendering of superuser status

### DIFF
--- a/riff-raff/app/views/auth/list.scala.html
+++ b/riff-raff/app/views/auth/list.scala.html
@@ -28,19 +28,12 @@
                         <td>@auth.email</td>
                         <td><span class="label label-default">@auth.approvedBy</span></td>
                         <td>
-                            @(
-                                if(auth.isSuperuser(config)) {
-                                    <span>
-                                        <i class="glyphicon glyphicon-ok"></i>
-                                        Yes
-                                    </span>
-                                } else {
-                                    <span>
-                                        <i class="glyphicon glyphicon-remove"></i>
-                                        No
-                                    </span>
-                                }
-                            )
+                            @(if(auth.isSuperuser(config)) {
+                                <span>
+                                    <i class="glyphicon glyphicon-ok"></i>
+                                    Yes
+                                </span>
+                            })
                         </td>
                         <td>
                         @helper.form(routes.Login.authDelete(), 'class -> "modal-form") {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Following some feedback on #647 (https://github.com/guardian/riff-raff/pull/647#issuecomment-915938924).

By only showing when a user is a superuser, the list is visually easier to process as presence of something in the column means someone is a superuser.
