### PR TITLE
Prevent deletion and replacement of DNS infrastructure

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
@@ -42,7 +42,12 @@ object StackPolicy {
     "AWS::ApiGateway::RestApi",
     "AWS::ApiGateway::DomainName",
     // buckets (although we think they can't be deleted with content)
-    "AWS::S3::Bucket"
+    "AWS::S3::Bucket",
+    // DNS infrastructure
+    "Guardian::DNS::RecordSet",
+    "AWS::Route53::HostedZone",
+    "AWS::Route53::RecordSet",
+    "AWS::Route53::RecordSetGroup"
   )
 
   val DENY_REPLACE_DELETE_POLICY: StackPolicy = StackPolicy("DenyReplaceDelete",


### PR DESCRIPTION
## What does this change?

In https://github.com/guardian/riff-raff/pull/623 we introduced the concept of `sensitiveResourceTypes`. This is essentially a list of infrastructure resources that we don't want Riff-Raff to delete/replace during CloudFormation updates (unless the user has specifically enabled a more dangerous mode of deployment - see https://github.com/guardian/riff-raff/pull/626 and https://github.com/guardian/riff-raff/pull/627).

This PR adds resource types which manage DNS infrastructure to the list of `sensitiveResourceTypes`. 

This change should prevent users from accidentally deleting DNS records, which is particularly important now as we're about to allow/encourage users to manage NS1 DNS infrastructure via CloudFormation.