### PR TITLE
Prevent deletion and replacement of DNS infrastructure

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -4,7 +4,7 @@ import magenta.Strategy.{Dangerous, MostlyHarmless}
 import magenta.artifact.S3Path
 import magenta.deployment_type.CloudFormationDeploymentTypeParameters._
 import magenta.tasks.CloudFormation.withCfnClient
-import magenta.tasks.StackPolicy.{accountPrivateTypes, sensitiveResourceTypes}
+import magenta.tasks.StackPolicy.{accountPrivateTypes, allSensitiveResourceTypes}
 import magenta.tasks.UpdateCloudFormationTask.LookupByTags
 import magenta.tasks._
 import org.joda.time.DateTime

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -158,7 +158,7 @@ object CloudFormation extends DeploymentType with CloudFormationDeploymentTypePa
       )
     )
 
-    val policy = target.parameters.updateStrategy match {
+    val updatePolicy = target.parameters.updateStrategy match {
       case MostlyHarmless => DenyReplaceDeletePolicy
       case Dangerous => AllowAllPolicy
     }
@@ -169,7 +169,7 @@ object CloudFormation extends DeploymentType with CloudFormationDeploymentTypePa
         new SetStackPolicyTask(
           target.region,
           stackLookup,
-          policy
+          updatePolicy
         )
 
       val resetStackPolicy = new SetStackPolicyTask(

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -9,6 +9,8 @@ import magenta.tasks.UpdateCloudFormationTask.LookupByTags
 import magenta.tasks._
 import org.joda.time.DateTime
 
+import scala.collection.mutable.ListBuffer
+
 //noinspection TypeAnnotation
 object CloudFormation extends DeploymentType with CloudFormationDeploymentTypeParameters {
 
@@ -158,15 +160,20 @@ object CloudFormation extends DeploymentType with CloudFormationDeploymentTypePa
 
     // wrap the task list with policy updates if enabled
     if (manageStackPolicy) {
-      new SetStackPolicyTask(
-        target.region,
-        stackLookup,
-        target.parameters.updateStrategy
-      ) :: tasks ::: List(new SetStackPolicyTask(
+      val applyStackPolicy =
+        new SetStackPolicyTask(
+          target.region,
+          stackLookup,
+          target.parameters.updateStrategy
+        )
+
+      val resetStackPolicy = new SetStackPolicyTask(
         target.region,
         stackLookup,
         Dangerous
-      ))
+      )
+
+      applyStackPolicy :: tasks ::: List(resetStackPolicy)
     } else tasks
   }
   }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -4,7 +4,7 @@ import magenta.Strategy.{Dangerous, MostlyHarmless}
 import magenta.artifact.S3Path
 import magenta.deployment_type.CloudFormationDeploymentTypeParameters._
 import magenta.tasks.CloudFormation.withCfnClient
-import magenta.tasks.StackPolicy.{privateResourceTypes, sensitiveResourceTypes}
+import magenta.tasks.StackPolicy.{accountPrivateTypes, sensitiveResourceTypes}
 import magenta.tasks.UpdateCloudFormationTask.LookupByTags
 import magenta.tasks._
 import org.joda.time.DateTime

--- a/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
@@ -1,76 +1,74 @@
 package magenta.tasks
-import magenta.Strategy.{Dangerous, MostlyHarmless}
-import magenta.tasks.CloudFormation.withCfnClient
-import magenta.tasks.StackPolicy.privateSensitiveResourceTypes
-import magenta.{DeploymentResources, KeyRing, Region, Strategy}
+import magenta.tasks.StackPolicy.{privateResourceTypes, sensitiveResourceTypes, toPolicyDoc}
+import magenta.{DeploymentResources, KeyRing, Region}
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient
 import software.amazon.awssdk.services.cloudformation.model.{ChangeSetType, ListTypesRequest, SetStackPolicyRequest, Visibility}
 
-import scala.collection.JavaConverters.asScalaBufferConverter
+import scala.collection.JavaConverters.iterableAsScalaIterableConverter
 
-case class StackPolicy(name: String, body: String)
+sealed trait StackPolicy { def name: String = this.getClass.getSimpleName }
+case object AllowAllPolicy extends StackPolicy
+case object DenyReplaceDeletePolicy extends StackPolicy
 
 object StackPolicy {
 
-  val ALLOW_ALL_POLICY: StackPolicy = StackPolicy("AllowAll",
-  """{
-    |  "Statement" : [
-    |    {
-    |      "Effect" : "Allow",
-    |      "Action" : "Update:*",
-    |      "Principal": "*",
-    |      "Resource" : "*"
-    |    }
-    |  ]
-    |}
-    |""".stripMargin
-  )
+  def toPolicyDoc(policy: StackPolicy, sensitiveResourceTypes: Set[String], accountPrivateTypes: () => Set[String]): String = policy match {
+    case AllowAllPolicy => ALLOW_ALL_POLICY
+    case DenyReplaceDeletePolicy =>
+      val sensitiveResources = sensitiveResourceTypes.filter(t => t.startsWith("AWS") || accountPrivateTypes().contains(t))
+      DENY_REPLACE_DELETE_POLICY(sensitiveResources)
+  }
 
-  def privateSensitiveResourceTypes(client: CloudFormationClient): Set[String] = {
+  def privateResourceTypes(client: CloudFormationClient): Set[String] = {
     val request =  ListTypesRequest.builder().visibility(Visibility.PRIVATE).build()
-    val response = client.listTypes(request)
-    val privateTypes = response.typeSummaries().asScala.map(_.typeName()).toSet
-    privateTypes.intersect(privateSensitiveResourceTypes)
+    val response = client.listTypesPaginator(request)
+    response.typeSummaries().asScala.map(_.typeName()).toSet
   }
 
   // CFN resource types that have state or are likely to exist in
   // external config such as DNS or application config
-  val sensitiveResourceTypes: List[String] = {
-  List(
-    // databases: RDS, DynamoDB, DocumentDB, Elastic
-    "AWS::RDS::DBInstance",
-    "AWS::DynamoDB::Table",
-    "AWS::DocDB::DBInstance",
-    "AWS::DocDB::DBCluster",
-    "AWS::Elasticsearch::Domain",
-    // queues/streams: SNS, SQS, Kinesis streams
-    "AWS::SNS::Topic",
-    "AWS::SQS::Queue",
-    "AWS::Kinesis::Stream",
-    // loadbalancers
-    "AWS::ElasticLoadBalancing::LoadBalancer",
-    "AWS::ElasticLoadBalancingV2::LoadBalancer",
-    // cloudfront
-    "AWS::CloudFront::Distribution",
-    // API gateway
-    "AWS::ApiGateway::RestApi",
-    "AWS::ApiGateway::DomainName",
-    // buckets (although we think they can't be deleted with content)
-    "AWS::S3::Bucket",
-    // DNS infrastructure
-    "AWS::Route53::HostedZone",
-    "AWS::Route53::RecordSet",
-    "AWS::Route53::RecordSetGroup"
-  )
-  }
-
-  val privateSensitiveResourceTypes: Set[String] = {
+  val sensitiveResourceTypes: Set[String] =
     Set(
-      "Guardian::DNS::RecordSet"
+      // databases: RDS, DynamoDB, DocumentDB, Elastic
+      "AWS::RDS::DBInstance",
+      "AWS::DynamoDB::Table",
+      "AWS::DocDB::DBInstance",
+      "AWS::DocDB::DBCluster",
+      "AWS::Elasticsearch::Domain",
+      // queues/streams: SNS, SQS, Kinesis streams
+      "AWS::SNS::Topic",
+      "AWS::SQS::Queue",
+      "AWS::Kinesis::Stream",
+      // loadbalancers
+      "AWS::ElasticLoadBalancing::LoadBalancer",
+      "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      // cloudfront
+      "AWS::CloudFront::Distribution",
+      // API gateway
+      "AWS::ApiGateway::RestApi",
+      "AWS::ApiGateway::DomainName",
+      // buckets (although we think they can't be deleted with content)
+      "AWS::S3::Bucket",
+      // DNS infrastructure
+      "AWS::Route53::HostedZone",
+      "AWS::Route53::RecordSet",
+      "AWS::Route53::RecordSetGroup",
+      // Private types
+      "Guardian::DNS::RecordSet",
     )
-  }
 
-  // Provide
+  private[this] val ALLOW_ALL_POLICY =
+    """{
+      |  "Statement" : [
+      |    {
+      |      "Effect" : "Allow",
+      |      "Action" : "Update:*",
+      |      "Principal": "*",
+      |      "Resource" : "*"
+      |    }
+      |  ]
+      |}
+      |""".stripMargin
 
   /** Policy to prevent destructive updates to stateful resources.
     *
@@ -78,8 +76,7 @@ object StackPolicy {
     * AWS account. We want to protect these resources, but the stack policy will
     * fail if resources are specified which don't exist on the target account.
     */
-  def DENY_REPLACE_DELETE_POLICY(privateSensitiveTypes: Set[String]): StackPolicy = {
-    StackPolicy("DenyReplaceDelete",
+  private[this] def DENY_REPLACE_DELETE_POLICY(sensitiveTypes: Set[String]): String =
       s"""{
          |  "Statement" : [
          |    {
@@ -90,7 +87,7 @@ object StackPolicy {
          |      "Condition" : {
          |        "StringEquals" : {
          |          "ResourceType" : [
-         |            ${sensitiveResourceTypes.++(privateSensitiveTypes.toList).mkString("\"","\",\n\"", "\"")}
+         |            ${sensitiveResourceTypes.mkString("\"","\",\n\"", "\"")}
          |          ]
          |        }
          |      }
@@ -104,14 +101,14 @@ object StackPolicy {
          |  ]
          |}
          |""".stripMargin
-    )
-  }
+
+
 
   def toMarkdown(policy: StackPolicy): String = {
     s"""**${policy.name}**:
       |
       |```
-      |${policy.body}
+      |${toPolicyDoc(policy, sensitiveResourceTypes, () => sensitiveResourceTypes)}
       |```
       |""".stripMargin
   }
@@ -120,37 +117,27 @@ object StackPolicy {
 class SetStackPolicyTask(
                           region: Region,
                           stackLookup: CloudFormationStackMetadata,
-                          val updateStrategy: Strategy = MostlyHarmless,
+                          val stackPolicy: StackPolicy,
                           )(implicit val keyRing: KeyRing) extends Task {
   override def execute(resources: DeploymentResources, stopFlag: => Boolean): Unit = {
     CloudFormation.withCfnClient(keyRing, region, resources) { cfnClient =>
       val (stackName, changeSetType, _) = stackLookup.lookup(resources.reporter, cfnClient)
-
-      val stackPolicy = updateStrategy match {
-        case MostlyHarmless =>
-          withCfnClient(keyRing, region, resources) { cfnClient =>
-            val privateTypes = privateSensitiveResourceTypes(cfnClient)
-            StackPolicy.DENY_REPLACE_DELETE_POLICY(privateTypes)
-          }
-
-        case Dangerous => StackPolicy.ALLOW_ALL_POLICY
-      }
+      val policyDoc = toPolicyDoc(stackPolicy, sensitiveResourceTypes, () => privateResourceTypes(cfnClient))
 
       changeSetType match {
         case ChangeSetType.CREATE => resources.reporter.info(s"Stack $stackName not found - no need to update policy")
-        case _ => {
-          resources.reporter.info(s"Setting update policy for stack $stackName to ${stackPolicy.name}")
-          resources.reporter.info(s"Body of stack policy is: ${stackPolicy.body}.")
+        case _ =>
+          resources.reporter.info(s"Setting update policy for stack $stackName to ${stackPolicy}")
+          resources.reporter.info(s"Body of stack policy is: ${policyDoc}.")
           cfnClient.setStackPolicy(
             SetStackPolicyRequest.builder
               .stackName(stackName)
-              .stackPolicyBody(stackPolicy.body)
+              .stackPolicyBody(policyDoc)
               .build()
           )
-        }
       }
     }
   }
 
-  override def description: String = s"Set stack update policy with update strategy $updateStrategy."
+  override def description: String = s"Set stack update policy to ${stackPolicy.name}"
 }

--- a/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
@@ -42,7 +42,12 @@ object StackPolicy {
     "AWS::ApiGateway::RestApi",
     "AWS::ApiGateway::DomainName",
     // buckets (although we think they can't be deleted with content)
-    "AWS::S3::Bucket"
+    "AWS::S3::Bucket",
+    // DNS infrastructure
+    "Guardian::DNS::RecordSet",
+    "AWS::Route53::HostedZone",
+    "AWS::Route53::RecordSet",
+    "AWS::Route53::RecordSetGroup"
   )
 
   val DENY_REPLACE_DELETE_POLICY: StackPolicy = StackPolicy("DenyReplaceDelete",

--- a/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
@@ -13,7 +13,8 @@ case object DenyReplaceDeletePolicy extends StackPolicy
 object StackPolicy {
 
   def toPolicyDoc(policy: StackPolicy, sensitiveResourceTypes: Set[String], accountPrivateTypes: () => Set[String]): String = policy match {
-    case AllowAllPolicy => ALLOW_ALL_POLICY
+    case AllowAllPolicy =>
+      ALLOW_ALL_POLICY
     case DenyReplaceDeletePolicy =>
       val sensitiveResources = sensitiveResourceTypes.filter(t => t.startsWith("AWS") || accountPrivateTypes().contains(t))
       DENY_REPLACE_DELETE_POLICY(sensitiveResources)
@@ -25,8 +26,9 @@ object StackPolicy {
     response.typeSummaries().asScala.map(_.typeName()).toSet
   }
 
-  // CFN resource types that have state or are likely to exist in
-  // external config such as DNS or application config
+  /** CFN resource types that have state or are likely to exist in external
+   * config such as DNS or application config.
+   */
   val sensitiveResourceTypes: Set[String] =
     Set(
       // databases: RDS, DynamoDB, DocumentDB, Elastic
@@ -70,12 +72,6 @@ object StackPolicy {
       |}
       |""".stripMargin
 
-  /** Policy to prevent destructive updates to stateful resources.
-    *
-    * @param privateSensitiveTypes private types that are defined for the target
-    * AWS account. We want to protect these resources, but the stack policy will
-    * fail if resources are specified which don't exist on the target account.
-    */
   private[this] def DENY_REPLACE_DELETE_POLICY(sensitiveTypes: Set[String]): String =
       s"""{
          |  "Statement" : [

--- a/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
@@ -140,6 +140,7 @@ class SetStackPolicyTask(
         case ChangeSetType.CREATE => resources.reporter.info(s"Stack $stackName not found - no need to update policy")
         case _ => {
           resources.reporter.info(s"Setting update policy for stack $stackName to ${stackPolicy.name}")
+          resources.reporter.info(s"Body of stack policy is: ${stackPolicy.body}.")
           cfnClient.setStackPolicy(
             SetStackPolicyRequest.builder
               .stackName(stackName)

--- a/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
@@ -70,6 +70,14 @@ object StackPolicy {
     )
   }
 
+  // Provide
+
+  /** Policy to prevent destructive updates to stateful resources.
+    *
+    * @param privateSensitiveTypes private types that are defined for the target
+    * AWS account. We want to protect these resources, but the stack policy will
+    * fail if resources are specified which don't exist on the target account.
+    */
   def DENY_REPLACE_DELETE_POLICY(privateSensitiveTypes: Set[String]): StackPolicy = {
     StackPolicy("DenyReplaceDelete",
       s"""{
@@ -120,9 +128,6 @@ class SetStackPolicyTask(
 
       val stackPolicy = updateStrategy match {
         case MostlyHarmless =>
-          // Only include private (custom Guardian) types if they are defined for
-          // the target account. If we include them when they are not yet defined,
-          // the SetStackPolicyTask will fail.
           withCfnClient(keyRing, region, resources) { cfnClient =>
             val privateTypes = privateSensitiveResourceTypes(cfnClient)
             StackPolicy.DENY_REPLACE_DELETE_POLICY(privateTypes)

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -8,6 +8,7 @@ import magenta.artifact.S3Path
 import magenta.fixtures._
 import magenta.tasks.CloudFormation.{SpecifiedValue, UseExistingValue}
 import magenta.tasks.CloudFormationParameters.{ExistingParameter, InputParameter, TemplateParameter}
+import magenta.tasks.StackPolicy.privateSensitiveResourceTypes
 import magenta.tasks.UpdateCloudFormationTask._
 import magenta.tasks._
 import org.scalatest.{EitherValues, Inside}
@@ -58,14 +59,14 @@ class CloudFormationTest extends AnyFlatSpec with Matchers with Inside with Eith
     tasks should have size(7)
 
     tasks(0) shouldBe a[SetStackPolicyTask]
-    tasks(0).asInstanceOf[SetStackPolicyTask].stackPolicy shouldBe StackPolicy.DENY_REPLACE_DELETE_POLICY
+    tasks(0).asInstanceOf[SetStackPolicyTask].updateStrategy shouldBe MostlyHarmless
     tasks(1) shouldBe a[CreateChangeSetTask]
     tasks(2) shouldBe a[CheckChangeSetCreatedTask]
     tasks(3) shouldBe a[ExecuteChangeSetTask]
     tasks(4) shouldBe a[CheckUpdateEventsTask]
     tasks(5) shouldBe a[DeleteChangeSetTask]
     tasks(6) shouldBe a[SetStackPolicyTask]
-    tasks(6).asInstanceOf[SetStackPolicyTask].stackPolicy shouldBe StackPolicy.ALLOW_ALL_POLICY
+    tasks(6).asInstanceOf[SetStackPolicyTask].updateStrategy shouldBe Dangerous
   }
 
   it should "generate stack policy tasks in the correct order when manageStackPolicy is true and update strategy is Dangerous" in {
@@ -77,14 +78,14 @@ class CloudFormationTest extends AnyFlatSpec with Matchers with Inside with Eith
     tasks should have size(7)
 
     tasks(0) shouldBe a[SetStackPolicyTask]
-    tasks(0).asInstanceOf[SetStackPolicyTask].stackPolicy shouldBe StackPolicy.ALLOW_ALL_POLICY
+    tasks(0).asInstanceOf[SetStackPolicyTask].updateStrategy shouldBe Dangerous
     tasks(1) shouldBe a[CreateChangeSetTask]
     tasks(2) shouldBe a[CheckChangeSetCreatedTask]
     tasks(3) shouldBe a[ExecuteChangeSetTask]
     tasks(4) shouldBe a[CheckUpdateEventsTask]
     tasks(5) shouldBe a[DeleteChangeSetTask]
     tasks(6) shouldBe a[SetStackPolicyTask]
-    tasks(6).asInstanceOf[SetStackPolicyTask].stackPolicy shouldBe StackPolicy.ALLOW_ALL_POLICY
+    tasks(6).asInstanceOf[SetStackPolicyTask].updateStrategy shouldBe Dangerous
   }
 
   it should "ignore amiTags when amiParametersToTags and amiTags are provided" in {

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -8,7 +8,7 @@ import magenta.artifact.S3Path
 import magenta.fixtures._
 import magenta.tasks.CloudFormation.{SpecifiedValue, UseExistingValue}
 import magenta.tasks.CloudFormationParameters.{ExistingParameter, InputParameter, TemplateParameter}
-import magenta.tasks.StackPolicy.privateSensitiveResourceTypes
+import magenta.tasks.StackPolicy.privateResourceTypes
 import magenta.tasks.UpdateCloudFormationTask._
 import magenta.tasks._
 import org.scalatest.{EitherValues, Inside}
@@ -59,14 +59,14 @@ class CloudFormationTest extends AnyFlatSpec with Matchers with Inside with Eith
     tasks should have size(7)
 
     tasks(0) shouldBe a[SetStackPolicyTask]
-    tasks(0).asInstanceOf[SetStackPolicyTask].updateStrategy shouldBe MostlyHarmless
+    tasks(0).asInstanceOf[SetStackPolicyTask].stackPolicy shouldBe DenyReplaceDeletePolicy
     tasks(1) shouldBe a[CreateChangeSetTask]
     tasks(2) shouldBe a[CheckChangeSetCreatedTask]
     tasks(3) shouldBe a[ExecuteChangeSetTask]
     tasks(4) shouldBe a[CheckUpdateEventsTask]
     tasks(5) shouldBe a[DeleteChangeSetTask]
     tasks(6) shouldBe a[SetStackPolicyTask]
-    tasks(6).asInstanceOf[SetStackPolicyTask].updateStrategy shouldBe Dangerous
+    tasks(6).asInstanceOf[SetStackPolicyTask].stackPolicy shouldBe AllowAllPolicy
   }
 
   it should "generate stack policy tasks in the correct order when manageStackPolicy is true and update strategy is Dangerous" in {
@@ -78,14 +78,14 @@ class CloudFormationTest extends AnyFlatSpec with Matchers with Inside with Eith
     tasks should have size(7)
 
     tasks(0) shouldBe a[SetStackPolicyTask]
-    tasks(0).asInstanceOf[SetStackPolicyTask].updateStrategy shouldBe Dangerous
+    tasks(0).asInstanceOf[SetStackPolicyTask].stackPolicy shouldBe AllowAllPolicy
     tasks(1) shouldBe a[CreateChangeSetTask]
     tasks(2) shouldBe a[CheckChangeSetCreatedTask]
     tasks(3) shouldBe a[ExecuteChangeSetTask]
     tasks(4) shouldBe a[CheckUpdateEventsTask]
     tasks(5) shouldBe a[DeleteChangeSetTask]
     tasks(6) shouldBe a[SetStackPolicyTask]
-    tasks(6).asInstanceOf[SetStackPolicyTask].updateStrategy shouldBe Dangerous
+    tasks(6).asInstanceOf[SetStackPolicyTask].stackPolicy shouldBe AllowAllPolicy
   }
 
   it should "ignore amiTags when amiParametersToTags and amiTags are provided" in {

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -8,7 +8,7 @@ import magenta.artifact.S3Path
 import magenta.fixtures._
 import magenta.tasks.CloudFormation.{SpecifiedValue, UseExistingValue}
 import magenta.tasks.CloudFormationParameters.{ExistingParameter, InputParameter, TemplateParameter}
-import magenta.tasks.StackPolicy.privateResourceTypes
+import magenta.tasks.StackPolicy.accountPrivateTypes
 import magenta.tasks.UpdateCloudFormationTask._
 import magenta.tasks._
 import org.scalatest.{EitherValues, Inside}

--- a/magenta-lib/src/test/scala/magenta/tasks/SetStackPolicyTaskTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/SetStackPolicyTaskTest.scala
@@ -1,0 +1,99 @@
+package magenta.tasks
+
+import magenta.tasks.StackPolicy.sensitiveResourceTypes
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.{TagDescription => _}
+
+class SetStackPolicyTaskTest extends AnyFlatSpec with Matchers {
+
+  "toPolicyDoc" should "return an allow doc when policy is AllowAllPolicy" in {
+    val got = StackPolicy.toPolicyDoc(AllowAllPolicy, StackPolicy.sensitiveResourceTypes, () => Set.empty)
+    val want =
+      """{
+        |  "Statement" : [
+        |    {
+        |      "Effect" : "Allow",
+        |      "Action" : "Update:*",
+        |      "Principal": "*",
+        |      "Resource" : "*"
+        |    }
+        |  ]
+        |}
+        |""".stripMargin
+
+    got shouldBe want
+  }
+
+  it should "return a deny doc when policy is DenyReplaceDeletePolicy, including supported private types" in {
+    val got = StackPolicy.toPolicyDoc(
+      DenyReplaceDeletePolicy,
+      StackPolicy.sensitiveResourceTypes,
+      () => Set("Guardian::DNS::RecordSet")
+    )
+
+    val want =
+      s"""{
+         |  "Statement" : [
+         |    {
+         |      "Effect" : "Deny",
+         |      "Action" : ["Update:Replace", "Update:Delete"],
+         |      "Principal": "*",
+         |      "Resource" : "*",
+         |      "Condition" : {
+         |        "StringEquals" : {
+         |          "ResourceType" : [
+         |            ${sensitiveResourceTypes.mkString("\"","\",\n\"", "\"")}
+         |          ]
+         |        }
+         |      }
+         |    },
+         |    {
+         |      "Effect" : "Allow",
+         |      "Action" : "Update:*",
+         |      "Principal": "*",
+         |      "Resource" : "*"
+         |    }
+         |  ]
+         |}
+         |""".stripMargin
+
+    got shouldBe want
+  }
+
+  it should "return a deny doc when policy is DenyReplaceDeletePolicy, excluding unsupported private types" in {
+    val got = StackPolicy.toPolicyDoc(
+      DenyReplaceDeletePolicy,
+      StackPolicy.sensitiveResourceTypes,
+      () => Set.empty
+    )
+
+    val want =
+      s"""{
+         |  "Statement" : [
+         |    {
+         |      "Effect" : "Deny",
+         |      "Action" : ["Update:Replace", "Update:Delete"],
+         |      "Principal": "*",
+         |      "Resource" : "*",
+         |      "Condition" : {
+         |        "StringEquals" : {
+         |          "ResourceType" : [
+         |            ${sensitiveResourceTypes.filterNot(_ == "Guardian::DNS::RecordSet").mkString("\"","\",\n\"", "\"")}
+         |          ]
+         |        }
+         |      }
+         |    },
+         |    {
+         |      "Effect" : "Allow",
+         |      "Action" : "Update:*",
+         |      "Principal": "*",
+         |      "Resource" : "*"
+         |    }
+         |  ]
+         |}
+         |""".stripMargin
+
+    got shouldBe want
+  }
+}

--- a/magenta-lib/src/test/scala/magenta/tasks/SetStackPolicyTaskTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/SetStackPolicyTaskTest.scala
@@ -1,6 +1,6 @@
 package magenta.tasks
 
-import magenta.tasks.StackPolicy.sensitiveResourceTypes
+import magenta.tasks.StackPolicy.allSensitiveResourceTypes
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.elasticloadbalancingv2.model.{TagDescription => _}
@@ -8,7 +8,7 @@ import software.amazon.awssdk.services.elasticloadbalancingv2.model.{TagDescript
 class SetStackPolicyTaskTest extends AnyFlatSpec with Matchers {
 
   "toPolicyDoc" should "return an allow doc when policy is AllowAllPolicy" in {
-    val got = StackPolicy.toPolicyDoc(AllowAllPolicy, StackPolicy.sensitiveResourceTypes, () => Set.empty)
+    val got = StackPolicy.toPolicyDoc(AllowAllPolicy, StackPolicy.allSensitiveResourceTypes, () => Set.empty)
     val want =
       """{
         |  "Statement" : [
@@ -28,7 +28,7 @@ class SetStackPolicyTaskTest extends AnyFlatSpec with Matchers {
   it should "return a deny doc when policy is DenyReplaceDeletePolicy, including supported private types" in {
     val got = StackPolicy.toPolicyDoc(
       DenyReplaceDeletePolicy,
-      StackPolicy.sensitiveResourceTypes,
+      StackPolicy.allSensitiveResourceTypes,
       () => Set("Guardian::DNS::RecordSet")
     )
 
@@ -43,7 +43,7 @@ class SetStackPolicyTaskTest extends AnyFlatSpec with Matchers {
          |      "Condition" : {
          |        "StringEquals" : {
          |          "ResourceType" : [
-         |            ${sensitiveResourceTypes.mkString("\"","\",\n\"", "\"")}
+         |            ${allSensitiveResourceTypes.mkString("\"","\",\n\"", "\"")}
          |          ]
          |        }
          |      }
@@ -64,7 +64,7 @@ class SetStackPolicyTaskTest extends AnyFlatSpec with Matchers {
   it should "return a deny doc when policy is DenyReplaceDeletePolicy, excluding unsupported private types" in {
     val got = StackPolicy.toPolicyDoc(
       DenyReplaceDeletePolicy,
-      StackPolicy.sensitiveResourceTypes,
+      StackPolicy.allSensitiveResourceTypes,
       () => Set.empty
     )
 
@@ -79,7 +79,7 @@ class SetStackPolicyTaskTest extends AnyFlatSpec with Matchers {
          |      "Condition" : {
          |        "StringEquals" : {
          |          "ResourceType" : [
-         |            ${sensitiveResourceTypes.filterNot(_ == "Guardian::DNS::RecordSet").mkString("\"","\",\n\"", "\"")}
+         |            ${allSensitiveResourceTypes.filterNot(_ == "Guardian::DNS::RecordSet").mkString("\"","\",\n\"", "\"")}
          |          ]
          |        }
          |      }


### PR DESCRIPTION
~~**This breaks CFN deploys in accounts where the `Guardian::DNS::RecordSet` has not been registered. It should not be merged until the private resource type has been registered with all accounts**~~

This change now detects whether or not 'Guardian::DNS::RecordSet' has been registered  as part of a deploy and acts accordingly.  As such it is ok to deploy.

## What does this change?

In https://github.com/guardian/riff-raff/pull/623 we introduced the concept of `sensitiveResourceTypes`. This is essentially a list of infrastructure resources that we don't want Riff-Raff to delete/replace during CloudFormation updates (unless the user has specifically enabled a more dangerous mode of deployment - see https://github.com/guardian/riff-raff/pull/626 and https://github.com/guardian/riff-raff/pull/627).

This PR adds resource types which manage DNS infrastructure to the list of `sensitiveResourceTypes`. 

This change should prevent users from accidentally deleting DNS records, which is particularly important now as we're about to allow/encourage users to manage NS1 DNS infrastructure via CloudFormation.

In addition, this change detects whether the 'Guardian::DNS::RecordSet' has been registered for the project being deployed and only includes it in the sensitiveResourceTypes list if it is registered.  As such it is backwards compatible and safe for projects that do not yet use this resource.

Logging was added to the riffraff deploy to display the stack policy so that it is easy to determine what resources have been applied during the deploy

**Testing** 
Unit tests ran successfully
Testing in CODE completed successfully.

**Details of testing in CODE**
This version of riffraff was deployed to CODE and then used to deploy one project with the 'Guardian::DNS::Recordset' registered (amigo) and one project without 'Guardian::DNS::Recordset' (frontend). 
Both deployed successfully. 
The logs of the deploy showed Guardian:DNS::Recordset policy was applied during deploy for the project which had the 'Guardian::DNS::Recordset' registered (amigo), but was not applied for the project which did not have this registered (frontend). This is the behaviour we expected and so the test is successful.