### PR TITLE
fix: Use safer `resourceStatusAsString` method

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -377,24 +377,24 @@ class CheckUpdateEventsTask(
 
   object StackEvent {
     def reportEvent(reporter: DeployReporter, e: StackEvent): Unit = {
-      reporter.info(s"${e.logicalResourceId} (${e.resourceType}): ${e.resourceStatus}")
+      reporter.info(s"${e.logicalResourceId} (${e.resourceType}): ${e.resourceStatusAsString}")
       if (e.resourceStatusReason != null) reporter.verbose(e.resourceStatusReason)
     }
     def isStackEvent(stackName: String)(e: StackEvent): Boolean =
       e.resourceType == "AWS::CloudFormation::Stack" && e.logicalResourceId == stackName
     def updateStart(stackName: String)(e: StackEvent): Boolean =
-      isStackEvent(stackName)(e) && (e.resourceStatus.toString == "UPDATE_IN_PROGRESS" || e.resourceStatus.toString == "CREATE_IN_PROGRESS")
+      isStackEvent(stackName)(e) && (e.resourceStatusAsString == "UPDATE_IN_PROGRESS" || e.resourceStatusAsString == "CREATE_IN_PROGRESS")
     def updateComplete(stackName: String)(e: StackEvent): Boolean =
-      isStackEvent(stackName)(e) && (e.resourceStatus.toString == "UPDATE_COMPLETE" || e.resourceStatus.toString == "CREATE_COMPLETE")
+      isStackEvent(stackName)(e) && (e.resourceStatusAsString == "UPDATE_COMPLETE" || e.resourceStatusAsString == "CREATE_COMPLETE")
 
     def updateFailed(e: StackEvent): Boolean = {
-      val failed = e.resourceStatus.toString.contains("FAILED") || e.resourceStatus.toString.contains("ROLLBACK")
-      logger.debug(s"${e.resourceStatus} - failed = $failed")
+      val failed = e.resourceStatusAsString.contains("FAILED") || e.resourceStatusAsString.contains("ROLLBACK")
+      logger.debug(s"${e.resourceStatusAsString} - failed = $failed")
       failed
     }
 
     def fail(reporter: DeployReporter, e: StackEvent): Unit = reporter.fail(
-      s"""${e.logicalResourceId}(${e.resourceType}}: ${e.resourceStatus}
+      s"""${e.logicalResourceId}(${e.resourceType}}: ${e.resourceStatusAsString}
             |${e.resourceStatusReason}""".stripMargin)
   }
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

There's been an odd occasion where the CloudFormation log in Riff-Raff shows an event as `null`.

`resourceStatus` is an enum and from [the docs](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/cloudformation/model/StackEvent.html#resourceStatus--):

> If the service returns an enum value that is not available in the current SDK version, resourceStatus will return ResourceStatus.UNKNOWN_TO_SDK_VERSION. The raw value returned by the service is available from resourceStatusAsString().

That is [`resourceStatusAsString`](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/cloudformation/model/StackEvent.html#resourceStatusAsString--) is safer to use.