### PR TITLE
Adding more information to how to fix a failed deploy page

### DIFF
--- a/riff-raff/public/docs/howto/fix-a-failed-deploy.md
+++ b/riff-raff/public/docs/howto/fix-a-failed-deploy.md
@@ -21,7 +21,7 @@ This will ensure that the new instances brought up by your failed deploy are ter
 See [here](https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-manual-scaling.html) for detailed steps on how to change the desired size of an ASG.
 
 ## Step 2 - remove scale-in protection
-Part of the  deploy process, when successful, is to remove scale-in protection from healthy live instances so they will be identified as the redundant ones which are removed during the next deploy. If the deployment has failed, it is possible this scale-in protection has been added to instances without being removed, so it needs to be manually removed before attempting the next deploy.
+If the deployment has failed, it is possible that some instances will still have scale-in protection enabled. In some cases this needs to be manually removed before attempting the next deploy.
 
 In the same ASG section of AWS (see Step 1 above),  after completing Step 1, navigate to the "Instance management" tab to check and remove all instances for scale-in protection: Click the checkbox next to an instance ID, select the "Actions" drop-down", select "Remove scale-in protection" if available (it will only be available if the instance has scale-in protection), then confirm.
 

--- a/riff-raff/public/docs/howto/fix-a-failed-deploy.md
+++ b/riff-raff/public/docs/howto/fix-a-failed-deploy.md
@@ -13,16 +13,20 @@ the desired capacity in excess of your configured max.
 
 ## Step 1 - get the ASG back to it's normal size
 
-Use the AWS console to change the desired size of the ASG back to the original value (typically half). 
+Use the AWS console to change the desired size of the ASG back to the original value (typically half). Access the AWS console via Janus, navigate to the EC2 section, then click "Autoscaling Groups." The desired size can be modified by clicking the "edit" button in the "Details" tab. The Riff-Raff error and logs should let you know which ASGs have been used for your given deploy.
 This will ensure that the new instances brought up by your failed deploy are terminated as Riff-Raff applies scale-in protection to existing instances before the deploy begins.
 
 See [here](https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-manual-scaling.html) for detailed steps on how to change the desired size of an ASG.
 
-## Step 2 -  do another deploy
-Once the ASG is back to it's normal size, redeploy the project to a known good version. 
+## Step 2 - remove scale-in protection
+Part of the  deploy process, when successful, is to remove scale-in protection from healthy live instances so they will be identified as the redundant ones which are removed during the next deploy. If the deployment has failed, it is possible this scale-in protection has been added to instances without being removed, so it needs to be manually removed before attempting the next deploy.
+
+In the same ASG section of AWS (see Step 1 above),  after completing Step 1, navigate to the "Instance management" tab to check and remove all instances for scale-in protection: Click the checkbox next to an instance ID, select the "Actions" drop-down", select "Remove scale-in protection" if available (it will only be available if the instance has scale-in protection), then confirm.
+
+See [here](https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-instance-protection.html) for more information on instance scale-in protection in ASGs.
+
+## Step 3 - repeat for other ASGs
+Check the Riff-Raff deployment logs to see if more than one ASG is used for the deploy. Repeat steps 1 and 2 for any other ASGs which may have been affected during the deploy. They may not be the ones listed as erroring, but could still have been halted at an intermediary state, and so need to be "reset" in order to do a successful redeployment.
+## Step 4 -  do another deploy
+Once the ASG is back to its normal size, redeploy the project to a known good version. 
 This will ensure that the correct artifact is deployed and that all live boxes are in the correct state.
-
-
-
-
-

--- a/riff-raff/public/docs/howto/fix-a-failed-deploy.md
+++ b/riff-raff/public/docs/howto/fix-a-failed-deploy.md
@@ -25,7 +25,7 @@ If the deployment has failed, it is possible that some instances will still have
 
 In the same ASG section of AWS (see Step 1 above),  after completing Step 1, navigate to the "Instance management" tab to check and remove all instances for scale-in protection: Click the checkbox next to an instance ID, select the "Actions" drop-down", select "Remove scale-in protection" if available (it will only be available if the instance has scale-in protection), then confirm.
 
-See [here](https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-instance-protection.html) for more information on instance scale-in protection in ASGs.
+See [here](https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-instance-protection.html) for more information on instance scale-in protection in ASGs, or in the case the UI navigation has shifted from what is described above. If the UI has changed, please open a PR to update these documents [here](https://github.com/guardian/riff-raff).
 
 ## Step 3 - repeat for other ASGs
 Check the Riff-Raff deployment logs to see if more than one ASG is used for the deploy. Repeat steps 1 and 2 for any other ASGs which may have been affected during the deploy. They may not be the ones listed as erroring, but could still have been halted at an intermediary state, and so need to be "reset" in order to do a successful redeployment.

--- a/riff-raff/public/docs/howto/fix-a-failed-deploy.md
+++ b/riff-raff/public/docs/howto/fix-a-failed-deploy.md
@@ -27,6 +27,7 @@ See [here](https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scalin
 
 ## Step 3 - repeat for other ASGs
 Check the Riff-Raff deployment logs to see if more than one ASG is used for the deploy. Repeat steps 1 and 2 for any other ASGs which may have been affected during the deploy. They may not be the ones listed as erroring, but could still have been halted at an intermediary state, and so need to be "reset" in order to do a successful redeployment.
+
 ## Step 4 -  do another deploy
 Once the ASG is back to its normal size, redeploy the project to a known good version. 
 This will ensure that the correct artifact is deployed and that all live boxes are in the correct state.


### PR DESCRIPTION
## What does this change?
Adding more documentation to account for dealing with scale-in protection, as this was an issue that had me confused for quite some time in attempting to redeploy.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
More comprehensive documentation should lead to quicker bug squashing by developers

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Scaring people away with too much reading?