### PR TITLE
Add warning around changing ASG

### DIFF
--- a/riff-raff/public/docs/howto/fix-a-failed-deploy.md
+++ b/riff-raff/public/docs/howto/fix-a-failed-deploy.md
@@ -13,7 +13,7 @@ the desired capacity in excess of your configured max.
 
 ## Step 1 - get the ASG back to its normal size
 
-Be aware that reducing the number of instances can lead to outages if they are under stress. Always check with the relevant team before peforming this action.
+Be aware that reducing the number of instances can lead to outages if they are under stress. Always check with the relevant team before performing this action.
 
 Use the AWS console to change the desired size of the ASG back to the original value (typically half). 
 This will ensure that the new instances brought up by your failed deploy are terminated as Riff-Raff applies scale-in protection to existing instances before the deploy begins.


### PR DESCRIPTION
## What does this change?

Adds a word of warning:

> Be aware that reducing the number of instances can lead to outages if they are under stress. Always check with the relevant team before performing this action.

## How to test

Navigate to the page: `/docs/howto/fix-a-failed-deploy`