### PR TITLE
Protect VPC resources from destructive changes

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
@@ -55,6 +55,17 @@ object StackPolicy {
       "AWS::Route53::HostedZone",
       "AWS::Route53::RecordSet",
       "AWS::Route53::RecordSetGroup",
+      // VPC
+      "AWS::EC2::EIP",
+      "AWS::EC2::InternetGateway",
+      "AWS::EC2::NatGateway",
+      "AWS::EC2::Route",
+      "AWS::EC2::RouteTable",
+      "AWS::EC2::Subnet",
+      "AWS::EC2::SubnetRouteTableAssociation",
+      "AWS::EC2::VPC",
+      "AWS::EC2::VPCEndpoint",
+      "AWS::EC2::VPCGatewayAttachment",
       // Private types
       "Guardian::DNS::RecordSet",
     )


### PR DESCRIPTION
## What does this change?

Protect VPC resources from destructive changes when doing a Cloudformation deploy.

## How to test

Try and delete things and see if RR says no.

Update: tested successfully:

![Screenshot 2021-11-05 at 15 29 20](https://user-images.githubusercontent.com/858402/140536414-31577f4c-7fed-4369-afa5-fcd341bc372e.png)

Though interesting to note the error is a bit cryptic as resource is `*`. This is because we block updates to all resources and then apply a condition to that policy by type.
