### PR TITLE
Tweaks to favourite project UI

### DIFF
--- a/riff-raff/app/assets/javascripts/form-autocomplete.coffee
+++ b/riff-raff/app/assets/javascripts/form-autocomplete.coffee
@@ -85,6 +85,14 @@ $ ->
       source:serverUrl
       minLength:0
 
+    addFavouriteProjectButton = $('#add-favourite-project-button')
+    updateFavouriteButton = ->
+      projectInputIsEmpty = input.val().trim() == ''
+      addFavouriteProjectButton.prop('disabled', projectInputIsEmpty)
+
+    input.on('change', updateFavouriteButton)
+    input.on('keyup', updateFavouriteButton)
+
   $('#projectInput').blur updateDeployInfo
 
   $('#buildInput').each ->
@@ -126,7 +134,7 @@ $ ->
     elemProjectInput = $('#projectInput')
     selectedProject = elemProjectInput.val()
 
-    if selectedProject?
+    if selectedProject
       addFavourite(selectedProject)
 
   renderFavourites()

--- a/riff-raff/app/assets/javascripts/form-autocomplete.coffee
+++ b/riff-raff/app/assets/javascripts/form-autocomplete.coffee
@@ -21,25 +21,34 @@ updateDeployInfo = () ->
       $("[rel='tooltip']").tooltip()
   )
 
+readFavourites = () ->
+  JSON.parse(localStorage.getItem('favouriteProjects'))
+
+writeFavourites = (newFavourites) ->
+  localStorage.setItem('favouriteProjects', JSON.stringify(newFavourites))
+
 addFavourite = (project) ->
-  favourites = JSON.parse(localStorage.getItem('favouriteProjects'))
+  favourites = readFavourites()
   newFavourites =
     if favourites?
-      favourites.push(project)
+      projectAlreadyFavourited = favourites.includes(project)
+      if !projectAlreadyFavourited
+        favourites.push(project)
+
       favourites
     else
       [project]
-  localStorage.setItem('favouriteProjects', JSON.stringify(newFavourites))
+  writeFavourites(newFavourites)
   renderFavourites()
 
 deleteFavourite = (project) ->
-  favourites = JSON.parse(localStorage.getItem('favouriteProjects'))
+  favourites = readFavourites()
   newFavourites =
     if favourites?
       favourites.filter (fav) -> fav != project
     else
       []
-  localStorage.setItem('favouriteProjects', JSON.stringify(newFavourites))
+  writeFavourites(newFavourites)
   renderFavourites()
 
 setupFavouriteHandlers = () ->
@@ -59,7 +68,7 @@ setupFavouriteHandlers = () ->
 
 renderFavourites = () ->
   container = $('#favourites-container')
-  favourites = JSON.parse(localStorage.getItem('favouriteProjects'))
+  favourites = readFavourites()
   if favourites? && favourites.length > 0
     container.removeClass('hidden')
     list = $('#favourites-list', container)

--- a/riff-raff/app/views/deploy/form.scala.html
+++ b/riff-raff/app/views/deploy/form.scala.html
@@ -68,7 +68,7 @@
 
             <div class="project-container">
                 @b3.text(deployForm("project"), '_label -> "Project", 'id -> "projectInput", Symbol("data-url") -> "/deployment/request/autoComplete/project", 'class -> "form-control input-md project-exact-match")
-                <button id="add-favourite-project-button" aria-label="Add to favourites" title="Add to favourites"><i class="glyphicon glyphicon-star"></i></button>
+                <button id="add-favourite-project-button" aria-label="Add to favourites" title="Add to favourites" disabled><i class="glyphicon glyphicon-star"></i></button>
             </div>
             @b3.text(deployForm("build"),  '_label -> "Build", 'id -> "buildInput", Symbol("data-url") -> "/deployment/request/autoComplete/build", 'class -> "form-control input-md")
             @b3.select(


### PR DESCRIPTION
## What does this change?

I ❤️  the new favourite project feature in Riff Raff. This PR makes a couple of small tweaks to the UI:

### 1. Make it harder to favourite an empty project name

I'd like to have the UI only allow you to favourite when you've entered a "real" project name, but I think this incremental improvement is worth adding along the way.

Before:

![2021-11-12 14 18 47](https://user-images.githubusercontent.com/379839/141481503-ffceef5c-296d-4885-91f3-d689f436ffda.gif)

After:

![2021-11-12 14 19 05](https://user-images.githubusercontent.com/379839/141481527-7384d4a5-3980-458f-ac7d-93205344bfd4.gif)

### 2. Make it harder to favourite duplicate projects

Before:

![2021-11-12 14 20 25](https://user-images.githubusercontent.com/379839/141481763-2cc67137-9e8e-477b-85d3-bdab1abbb010.gif)

After:

![2021-11-12 14 20 52](https://user-images.githubusercontent.com/379839/141481806-dafac07e-2855-4f71-b0bf-ca9699d20895.gif)

## How to test

1. Try click the favourite star when the project name field is empty. The button should be disabled and a new favourite should not be added.

2. Favourite a project, then try favouriting the same project again. A duplicate should not be added.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
