### PR TITLE
fix!: Set `publicReadAcl` to `false` by default

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
@@ -35,11 +35,14 @@ object S3 extends DeploymentType {
 
   val publicReadAcl = Param[Boolean]("publicReadAcl",
     """
-      |Whether the uploaded artifacts should be given the PublicRead Canned ACL. (Default is true!) Note that the
-      |AWS default S3 bucket setting is to block all public access, which doesn't play nicely with `publicReadAcl`
-      |when set to true. If public access to the bucket is restricted then you should set `publicReadAcl` to `false`.
+      |Whether the uploaded artifacts should be given the PublicRead Canned ACL.
+      |
+      |If public access to the bucket is restricted (which is the AWS default), `publicReadAcl` should be `false`.
+      |If the bucket content needs to be public, it's better to control this via the bucket policy.
+      |
+      |See https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html.
     """.stripMargin
-  ).default(true)
+  ).default(false)
 
   val cacheControl = Param[List[PatternValue]]("cacheControl",
     """

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -89,8 +89,7 @@ class DeploymentTypeTest extends AnyFlatSpec with Matchers with Inside with Mock
         "bucket-1234",
         Seq(sourceS3Package -> "test-stack/CODE/myapp"),
         cacheControlPatterns = List(PatternValue(".*", "no-cache")),
-        surrogateControlPatterns = List(PatternValue(".*", "max-age=3600")),
-        publicReadAcl = true
+        surrogateControlPatterns = List(PatternValue(".*", "max-age=3600"))
       ))
     )
   }


### PR DESCRIPTION
Expands on #665.

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Following the principle of least privilege, set the `publicAcl` to `false` by default. This matches the default in the [`S3Upload` task](https://github.com/guardian/riff-raff/blob/dfc93996016cd37df8d4ede2f66f669556a39172/magenta-lib/src/main/scala/magenta/tasks/tasks.scala#L29).

This also fits with AWS's own [docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html):

> A majority of modern use cases in Amazon S3 no longer require the use of ACLs, and we recommend that you disable ACLs except in unusual circumstances where you need to control access for each object individually.

See https://github.com/guardian/riff-raff/pull/141 for a discussion about this - the overall conclusion was to have a default of `false` too.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

More `s3-upload` deployment types work first time?

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

This change would break projects that rely on the default being `true` and have not explicitly set the value in their `riff-raff.yaml`. It's pretty difficult to identify these projects - there are a _lot_ or projects that [explicitly set it to `false`](https://github.com/search?p=1&q=org%3Aguardian+publicReadAcl+filename%3Adeploy.json+filename%3Ariff-raff.yml+filename%3Ariff-raff.yaml&type=Code) though!

I'd suggest we address any issues when they come up.