### PR TITLE
feat!: Make `publicReadAcl` parameter to `s3-upload` type required

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
@@ -35,11 +35,15 @@ object S3 extends DeploymentType {
 
   val publicReadAcl = Param[Boolean]("publicReadAcl",
     """
-      |Whether the uploaded artifacts should be given the PublicRead Canned ACL. (Default is true!) Note that the
-      |AWS default S3 bucket setting is to block all public access, which doesn't play nicely with `publicReadAcl`
-      |when set to true. If public access to the bucket is restricted then you should set `publicReadAcl` to `false`.
-    """.stripMargin
-  ).default(true)
+      |Whether the uploaded artifacts should be given the PublicRead Canned ACL.
+      |
+      |If public access to the bucket is restricted (which is the AWS default), `publicReadAcl` should be `false`.
+      |If the bucket content needs to be public, it's better to control this via the bucket policy.
+      |
+      |See https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html.
+    """.stripMargin,
+      optional = false
+  )
 
   val cacheControl = Param[List[PatternValue]]("cacheControl",
     """

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -57,13 +57,14 @@ class DeploymentTypeTest extends AnyFlatSpec with Matchers with Inside with Mock
     thrown.getMessage should equal ("Package myapp [aws-s3] requires parameter cacheControl of type List")
   }
 
-  it should "log a warning when a default is explictly set" in {
+  it should "log a warning when a default is explicitly set" in {
     val mockReporter = mock[DeployReporter]
 
     val data: Map[String, JsValue] = Map(
       "bucket" -> JsString("bucket-1234"),
       "cacheControl" -> JsString("monkey"),
-      "prefixStage" -> JsBoolean(true)
+      "prefixStage" -> JsBoolean(true),
+      "publicReadAcl" -> JsBoolean(true)
     )
 
     val p = DeploymentPackage("myapp", app1, data, "aws-s3", sourceS3Package, deploymentTypes)
@@ -78,7 +79,8 @@ class DeploymentTypeTest extends AnyFlatSpec with Matchers with Inside with Mock
     val data: Map[String, JsValue] = Map(
       "bucket" -> JsString("bucket-1234"),
       "cacheControl" -> JsString("no-cache"),
-      "surrogateControl" -> JsString("max-age=3600")
+      "surrogateControl" -> JsString("max-age=3600"),
+      "publicReadAcl" -> JsBoolean(true)
     )
 
     val p = DeploymentPackage("myapp", app1, data, "aws-s3", sourceS3Package, deploymentTypes)
@@ -101,7 +103,8 @@ class DeploymentTypeTest extends AnyFlatSpec with Matchers with Inside with Mock
       "cacheControl" -> Json.arr(
         Json.obj("pattern" -> "^sub", "value" -> "no-cache"),
         Json.obj("pattern" -> ".*", "value" -> "public; max-age:3600")
-      )
+      ),
+      "publicReadAcl" -> JsBoolean(true)
     )
 
     val p = DeploymentPackage("myapp", app1, data, "aws-s3", sourceS3Package, deploymentTypes)
@@ -117,7 +120,8 @@ class DeploymentTypeTest extends AnyFlatSpec with Matchers with Inside with Mock
       "cacheControl" -> JsString("no-cache"),
       "pathPrefixResource" -> JsString("s3-path-prefix"),
       "prefixStage" -> JsBoolean(false), // when we are using pathPrefixResource, we generally don't need or want the stage prefixe - we're already varying based on stage
-      "prefixPackage" -> JsBoolean(false)
+      "prefixPackage" -> JsBoolean(false),
+      "publicReadAcl" -> JsBoolean(true)
     )
 
     val p = DeploymentPackage("myapp", app1, data, "aws-s3", sourceS3Package, deploymentTypes)


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This is part of a migration effort to changing the default of `publicReadAcl` to `false` (https://github.com/guardian/riff-raff/pull/664).

By marking the parameter as required (aka not optional) an error will be thrown complaining about a missing parameter, meaning:
  - the deploy fails until the parameter is explicitly set
  - previous deploys are not effected, therefore the app still works

BREAKING CHANGE: `publicReadAcl` is now required to be set for `s3-upload` type.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Update your `riff-raff.yaml`, removing the `publicReadAcl` parameter and try to deploy it.

OR try to deploy a build from https://github.com/guardian/cdk-static-site/pull/1.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

It is easier to set the default of `publicReadAcl` to `false` as we can guarantee projects that are relying on the current default of `true` have explicitly set the value.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

An example of the UX you're greeted with when `publicReadAcl` isn't set.

![image](https://user-images.githubusercontent.com/836140/148090687-1f48c105-84ac-4fcb-b795-37e679e8817e.png)
