### PR TITLE
Scala 2.13, SBT 1.5.7, Play 2.8 (and related upgrades)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ readme.html
 .project
 .settings
 .cache
+.bsp/

--- a/build.sbt
+++ b/build.sbt
@@ -5,18 +5,16 @@ import sbtbuildinfo.BuildInfoKeys.buildInfoKeys
 
 val commonSettings = Seq(
   organization := "com.gu",
-  scalaVersion := "2.12.8",
-  scalacOptions ++= Seq("-deprecation", "-feature", "-language:postfixOps,reflectiveCalls,implicitConversions", "-Ypartial-unification"
+  scalaVersion := "2.13.7",
+
+  // Temporarily disable warnings during 2.13 migration to focus on actual errors.
+  scalacOptions ++= Seq("-nowarn", "-feature", "-language:postfixOps,reflectiveCalls,implicitConversions"
 //    , "-Xfatal-warnings" TODO: Akka Agents have been deprecated. Once they have been replaced we can re-enable, but that's not trivial
   ),
-  scalacOptions in(Compile, doc) ++= Seq(
+  Compile / doc / scalacOptions ++= Seq(
     "-no-link-warnings" // Suppresses problems with Scaladoc @throws links
   ),
-  version := "1.0",
-  resolvers ++= Seq(
-    "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/",
-    "Guardian Github Releases" at "https://guardian.github.com/maven/repo-releases"
-  )
+  version := "1.0"
 )
 
 lazy val root = project.in(file("."))
@@ -30,7 +28,7 @@ lazy val lib = project.in(file("magenta-lib"))
   .settings(Seq(
     libraryDependencies ++= magentaLibDeps,
 
-    testOptions in Test += Tests.Argument("-oF")
+    Test / testOptions += Tests.Argument("-oF")
   ))
 
 lazy val riffraff = project.in(file("riff-raff"))
@@ -51,16 +49,15 @@ lazy val riffraff = project.in(file("riff-raff"))
 
     buildInfoKeys := Seq[BuildInfoKey](
       name, version, scalaVersion, sbtVersion,
-      BuildInfoKey.constant("gitCommitId", riffRaffBuildInfo.value.revision),
-      BuildInfoKey.constant("buildNumber", riffRaffBuildInfo.value.buildIdentifier)
+      "gitCommitId" -> riffRaffBuildInfo.value.revision,
+      "buildNumber" -> riffRaffBuildInfo.value.buildIdentifier
     ),
     buildInfoOptions += BuildInfoOption.BuildTime,
     buildInfoPackage := "riffraff",
 
-    resolvers += "Brian Clapper Bintray" at "https://dl.bintray.com/bmc/maven",
     libraryDependencies ++= riffRaffDeps,
 
-    javaOptions in Universal ++= Seq(
+    Universal / javaOptions ++= Seq(
       s"-Dpidfile.path=/dev/null",
       "-J-XX:MaxRAMFraction=2",
       "-J-XX:InitialRAMFraction=2",
@@ -69,9 +66,9 @@ lazy val riffraff = project.in(file("riff-raff"))
       s"-J-Xlog:gc:/var/log/${packageName.value}/gc.log"
     ),
 
-    packageName in Universal := normalizedName.value,
-    topLevelDirectory in Universal := Some(normalizedName.value),
-    riffRaffPackageType := (packageZipTarball in Universal).value,
+    Universal / packageName := normalizedName.value,
+    Universal / topLevelDirectory := Some(normalizedName.value),
+    riffRaffPackageType := (Universal / packageZipTarball).value,
     riffRaffArtifactResources  := Seq(
       riffRaffPackageType.value -> s"${name.value}/${name.value}.tgz",
       baseDirectory.value / "bootstrap.sh" -> s"${name.value}/bootstrap.sh",
@@ -87,9 +84,9 @@ lazy val riffraff = project.in(file("riff-raff"))
       </dependencies>
     },
 
-    fork in Test := false,
+    Test / fork := false,
 
-    includeFilter in (Assets, LessKeys.less) := "*.less",
+    Assets / LessKeys.less / includeFilter := "*.less",
 
-    pipelineStages in Assets := Seq(digest)
+    Assets / pipelineStages := Seq(digest)
   ))

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormationDeploymentTypeParameters.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormationDeploymentTypeParameters.scala
@@ -116,7 +116,7 @@ trait CloudFormationDeploymentTypeParameters {
       case (None, Some(tags)) => Map(amiParameter(pkg, target, reporter) -> tags)
       case _ => Map.empty
     }
-    map.mapValues(prefixEncrypted(amiEncrypted(pkg, target, reporter)))
+    map.view.mapValues(prefixEncrypted(amiEncrypted(pkg, target, reporter))).toMap
   }
 
   def getLatestAmi(pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter,

--- a/magenta-lib/src/main/scala/magenta/deployment_type/param_reads/PatternValue.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/param_reads/PatternValue.scala
@@ -13,7 +13,7 @@ object PatternValue {
       json match {
         case JsString(default) => JsSuccess(List(PatternValue(".*", default)))
         case JsArray(patternValues) =>
-          patternValues.zipWithIndex.foldLeft(Valid(Nil): Validated[List[(JsPath, Seq[JsonValidationError])], List[PatternValue]]) {
+          patternValues.zipWithIndex.foldLeft(Valid(Nil): Validated[List[(JsPath, scala.collection.Seq[JsonValidationError])], List[PatternValue]]) {
             case (acc, (value, index)) =>
               val validated = Json.fromJson[PatternValue](value) match {
                 case JsSuccess(v, _) => Valid(List(v))

--- a/magenta-lib/src/main/scala/magenta/graph/Graph.scala
+++ b/magenta-lib/src/main/scala/magenta/graph/Graph.scala
@@ -248,15 +248,14 @@ case class Graph[T](edges: Set[Edge[T]]) {
   /** Builds a new graph by applying a function to each value in this graph. This retains the structure of the graph
     * but replaces the values of any [[magenta.graph.ValueNode]]. You cannot map two distinct values in the graph to a
     * single value as this would alter the structure of the graph.
-    *
-    * @param f function to apply to each existing value
+    *    * @param f function to apply to each existing value
     * @tparam R the type of the value in the new graph
     * @return new graph with the same structure but values from the function
     */
   def map[R](f: T => R): Graph[R] = {
-    val newNodeMap: Map[Node[T], Node[R]] = valueNodes.map { currentNode =>
+    val newNodeMap: Map[Node[T], Node[R]] = (valueNodes.map { currentNode =>
       currentNode -> ValueNode(f(currentNode.value))
-    }.toMap ++ Map(StartNode -> StartNode, EndNode -> EndNode)
+    }.toMap ++ Map[Node[T], Node[R]](StartNode -> StartNode, EndNode -> EndNode)).toMap
     assert(newNodeMap.size == newNodeMap.values.toSet.size, "Source nodes must be mapped onto unique target nodes")
     val newEdges = edges.map { oldEdge =>
       Edge(newNodeMap(oldEdge.from), newNodeMap(oldEdge.to), oldEdge.priority)
@@ -392,10 +391,10 @@ case class Graph[T](edges: Set[Edge[T]]) {
   override def toString: String = {
     val identifiers = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
     val nodeNumbers = (nodeList ::: (nodes -- nodeList).toList).zipWithIndex
-    val nodeNumberMap: Map[Node[T], String] = nodeNumbers.toMap.mapValues{
+    val nodeNumberMap: Map[Node[T], String] = nodeNumbers.toMap.view.mapValues{
       case index if index < identifiers.length => identifiers(index).toString
       case index => (index - identifiers.length).toString
-    }
+    }.toMap
     val numberedEdges = edges.toList.map { case Edge(from, to, priority) =>
       (nodeNumberMap(from), priority, nodeNumberMap(to))
     }.sorted

--- a/magenta-lib/src/main/scala/magenta/input/RiffRaffYamlReader.scala
+++ b/magenta-lib/src/main/scala/magenta/input/RiffRaffYamlReader.scala
@@ -16,7 +16,7 @@ object RiffRaffYamlReader {
     // list instead of an unordered map
     def reads(json: JsValue): JsResult[List[(String, V)]] = json match {
       case JsObject(linkedMap) =>
-        type Errors = Seq[(JsPath, Seq[JsonValidationError])]
+        type Errors = scala.collection.Seq[(JsPath, scala.collection.Seq[JsonValidationError])]
         def locate(e: Errors, key: String) = e.map { case (p, valerr) => (JsPath \ key) ++ p -> valerr }
 
         linkedMap.foldLeft(Right(Nil): Either[Errors, List[(String, V)]]) {

--- a/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentResolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentResolver.scala
@@ -2,10 +2,9 @@ package magenta.input.resolver
 
 import cats.data.Validated.{Invalid, Valid}
 import cats.data.{Validated, NonEmptyList => NEL}
-import cats.syntax.apply._
-import cats.syntax.cartesian._
-import cats.syntax.traverse._
 import cats.instances.list._
+import cats.syntax.apply._
+import cats.syntax.traverse._
 import magenta.input._
 import play.api.libs.json.JsValue
 

--- a/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentTypeResolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentTypeResolver.scala
@@ -23,9 +23,18 @@ object DeploymentTypeResolver {
     invalidActions.map(invalids => Invalid(
       ConfigErrors(deployment.name, s"Invalid action ${invalids.toList.mkString(", ")} for type ${deployment.`type`}"))
     ).getOrElse {
-      import henkan.convert.Syntax._
       Validated.fromOption(actions.map(as =>
-        deployment.to[Deployment].set(actions = as)
+        Deployment(
+          name = deployment.name,
+          `type` = deployment.`type`,
+          stacks = deployment.stacks,
+          regions = deployment.regions,
+          actions = as,
+          app = deployment.app,
+          contentDirectory = deployment.contentDirectory,
+          dependencies = deployment.dependencies,
+          parameters = deployment.parameters,
+        )
       ), ConfigErrors(deployment.name, s"Either specify at least one action or omit the actions parameter"))
     }
   }

--- a/magenta-lib/src/main/scala/magenta/logging.scala
+++ b/magenta-lib/src/main/scala/magenta/logging.scala
@@ -164,11 +164,6 @@ sealed trait Message extends EnumEntry {
 
 case object Message extends Enum[Message] with PlayJsonEnum[Message] {
 
-  sealed trait ContextMessage extends Message {
-    def originalMessage: Message
-    override def deployParameters: Option[DeployParameters] = originalMessage.deployParameters
-  }
-
   case class Deploy(parameters: DeployParameters) extends Message {
     lazy val text = s"deploy for ${parameters.build.projectName} (build ${parameters.build.id}) to stage ${parameters.stage.name}"
     override lazy val deployParameters = Some(parameters)

--- a/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
@@ -142,7 +142,7 @@ case class CullInstancesWithTerminationTag(info: AutoScalingGroupInfo, region: R
 
             isTaggedForTermination && !isAlreadyTerminating
           })
-        val orderedInstancesToKill = instancesToKill.transposeBy(_.availabilityZone)
+        val orderedInstancesToKill = instancesToKill.toSeq.transposeBy(_.availabilityZone)
         try {
           resources.reporter.verbose(s"Culling instances: ${orderedInstancesToKill.map(_.instanceId).mkString(", ")}")
           orderedInstancesToKill.foreach(instance => ASG.cull(asg, instance, asgClient, elbClient))

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -169,7 +169,7 @@ object CloudFormationParameters {
       .collect { case ExistingParameter(key, _, _) if allRequiredParamNames.contains(key) => key -> UseExistingValue }
       .toMap
     // Convert the full list of specified parameters
-    val specifiedParametersMap: Map[String, ParameterValue] = specifiedParameters.mapValues(SpecifiedValue.apply)
+    val specifiedParametersMap: Map[String, ParameterValue] = specifiedParameters.view.mapValues(SpecifiedValue.apply).toMap
     // Get the deployment parameters that are present in the template
     val deployParametersInTemplate: Map[String, ParameterValue] = deployParameters
       .collect { case (key, value) if allRequiredParamNames.contains(key) => key -> SpecifiedValue(value) }

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
@@ -12,6 +12,7 @@ import magenta.deployment_type.param_reads.PatternValue
 import magenta.tasks.Task
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import scala.collection.parallel.CollectionConverters._
 
 case class GCSUpload(
   bucket: String,

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -17,6 +17,7 @@ import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.control.NonFatal
+import scala.collection.parallel.CollectionConverters._
 
 case class S3Upload(
   region: Region,

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -18,6 +18,7 @@ import play.api.libs.json.{JsBoolean, JsString, JsValue, Json}
 import software.amazon.awssdk.services.cloudformation.model.{Change, ChangeSetType, Parameter}
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sts.StsClient
+import magenta.deployment_type.{CloudFormation => CloudFormationDeploymentType}
 
 import scala.concurrent.ExecutionContext.global
 
@@ -27,7 +28,7 @@ class CloudFormationTest extends AnyFlatSpec with Matchers with Inside with Eith
   implicit val artifactClient: S3Client = null
   implicit val stsClient: StsClient = null
   val region = Region("eu-west-1")
-  val deploymentTypes: Seq[CloudFormation.type] = Seq(CloudFormation)
+  val deploymentTypes: Seq[CloudFormationDeploymentType.type] = Seq(CloudFormationDeploymentType)
   val app = App("app")
   val testStack = Stack("cfn")
   val cfnStackName = s"cfn-app-PROD"
@@ -36,7 +37,7 @@ class CloudFormationTest extends AnyFlatSpec with Matchers with Inside with Eith
 
   private def generateTasks(data: Map[String, JsValue] = Map("cloudFormationStackByTags" -> JsBoolean(false)), updateStrategy: Strategy = MostlyHarmless) = {
     val resources = DeploymentResources(reporter, lookupEmpty, artifactClient, stsClient, global)
-    CloudFormation.actionsMap("updateStack").taskGenerator(p(data), resources, DeployTarget(parameters(updateStrategy = updateStrategy), testStack, region))
+    CloudFormationDeploymentType.actionsMap("updateStack").taskGenerator(p(data), resources, DeployTarget(parameters(updateStrategy = updateStrategy), testStack, region))
   }
 
   it should "generate the tasks in the correct order when manageStackPolicy is false" in {

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -7,7 +7,7 @@ import magenta._
 import magenta.artifact.S3Path
 import magenta.deployment_type.param_reads.PatternValue
 import magenta.fixtures._
-import magenta.tasks._
+import magenta.tasks.{S3Upload, UpdateS3Lambda}
 import org.mockito.Mockito._
 import org.mockito.MockitoSugar
 import org.scalatest.Inside

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,14 +7,13 @@ object Dependencies {
     val aws = "2.17.35"
     val jackson = "2.9.8"
     val awsRds = "1.11.563"
-    val enumeratumPlay = "1.5.15"
+    val enumeratumPlay = "1.7.0"
   }
 
   val commonDeps = Seq(
-    "io.reactivex" %% "rxscala" % "0.26.5",
-    "org.parboiled" %% "parboiled" % "2.1.5",
-    "org.typelevel" %% "cats-core" % "1.0.1",
-    "com.kailuowang" %% "henkan-convert" % "0.2.10",
+    "io.reactivex" %% "rxscala" % "0.27.0",
+    "org.parboiled" %% "parboiled" % "2.1.8",
+    "org.typelevel" %% "cats-core" % "2.7.0",
     "org.scalatest" %% "scalatest" % "3.2.9" % Test,
     "org.mockito" %% "mockito-scala" % "1.16.37" % Test
   )
@@ -23,7 +22,6 @@ object Dependencies {
     "com.squareup.okhttp3" % "okhttp" % "3.14.0",
     "org.bouncycastle" % "bcprov-jdk15on" % "1.61",
     "org.bouncycastle" % "bcpg-jdk15on" % "1.61",
-    "com.github.seratch.com.veact" %% "scala-ssh" % "0.8.0-1" exclude ("org.bouncycastle", "bcpkix-jdk15on"),
     "ch.qos.logback" % "logback-classic" % "1.2.0",
     "software.amazon.awssdk" % "core" % Versions.aws,
     "software.amazon.awssdk" % "autoscaling" % Versions.aws,
@@ -35,13 +33,14 @@ object Dependencies {
     "software.amazon.awssdk" % "cloudformation" % Versions.aws,
     "software.amazon.awssdk" % "sts" % Versions.aws,
     "software.amazon.awssdk" % "ssm" % Versions.aws,
-    "com.gu" %% "fastly-api-client" % "0.4.0",
+    "com.gu" %% "fastly-api-client" % "0.4.1",
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % Versions.jackson,
     "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jackson,
-    "com.typesafe.play" %% "play-json" % "2.7.2",
+    "com.typesafe.play" %% "play-json" % "2.8.2",
     "com.beachape" %% "enumeratum-play-json" % Versions.enumeratumPlay,
     "com.google.apis" % "google-api-services-deploymentmanager" % "v2-rev75-1.25.0",
-    "com.google.apis" % "google-api-services-storage" % "v1-rev171-1.25.0"
+    "com.google.apis" % "google-api-services-storage" % "v1-rev171-1.25.0",
+    "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4"
   ).map((m: ModuleID) =>
     // don't even ask why I need to do this
     m.excludeAll(ExclusionRule(organization = "com.google.code.findbugs", name = "jsr305"))
@@ -50,17 +49,18 @@ object Dependencies {
   val riffRaffDeps = commonDeps ++ Seq(
     evolutions,
     jdbc,
-    "com.gu" %% "play-googleauth" % "0.7.7",
-    "com.gu.play-secret-rotation" %% "aws-parameterstore" % "0.12",
+    "com.gu.play-googleauth" %% "play-v28" % "2.2.2",
+    "com.gu.play-secret-rotation" %% "play-v28" % "0.33",
+    "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "0.33",
     "com.typesafe.akka" %% "akka-agent" % "2.5.26",
     "org.pegdown" % "pegdown" % "1.6.0",
-    "com.adrianhurt" %% "play-bootstrap" % "1.2-P26-B3-RC2",
-    "com.gu" %% "scanamo" % "1.0.0-M6",
+    "com.adrianhurt" %% "play-bootstrap" % "1.6.1-P28-B3",
+    "org.scanamo" %% "scanamo" % "1.0.0-M11",
     "software.amazon.awssdk" % "dynamodb" % Versions.aws,
     "software.amazon.awssdk" % "sns" % Versions.aws,
     "org.quartz-scheduler" % "quartz" % "2.3.0",
-    "com.gu" %% "anghammarad-client" % "1.1.3",
-    "org.webjars" %% "webjars-play" % "2.7.0-1",
+    "com.gu" %% "anghammarad-client" % "1.2.0",
+    "org.webjars" %% "webjars-play" % "2.7.3",
     "org.webjars" % "jquery" % "3.1.1",
     "org.webjars" % "jquery-ui" % "1.12.1",
     "org.webjars" % "bootstrap" % "3.3.7",
@@ -69,15 +69,14 @@ object Dependencies {
     "net.logstash.logback" % "logstash-logback-encoder" % "5.3",
     "com.gu" % "kinesis-logback-appender" % "1.4.4",
     "org.slf4j" % "jul-to-slf4j" % "1.7.30",
-    "org.scalikejdbc" %% "scalikejdbc" % "3.3.3",
+    "org.scalikejdbc" %% "scalikejdbc" % "3.5.0",
     "org.postgresql" % "postgresql" % "42.2.5",
     "com.beachape" %% "enumeratum-play" % Versions.enumeratumPlay,
-    "com.whisk" %% "docker-testkit-scalatest" % "0.9.8" % "test",
-    "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.8" % "test",
+    "com.whisk" %% "docker-testkit-scalatest" % "0.9.9" % "test",
+    "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.9" % "test",
     filters,
     ws,
-    "com.typesafe.akka" %% "akka-testkit" % "2.5.21" % Test,
-    "org.gnieh" %% "diffson-play-json" % "2.2.1" % Test,
+    "com.typesafe.akka" %% "akka-testkit" % "2.6.17" % Test,
     "com.amazonaws" % "aws-java-sdk-rds" % Versions.awsRds
   ).map((m: ModuleID) =>
     // don't even ask why I need to do this

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.6
+sbt.version=1.5.7

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.18
+sbt.version=1.5.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,15 +1,10 @@
-resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
-
 // keep in sync with the play version in Dependencies
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.25")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.11")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.0")
-addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 
-addSbtPlugin("com.gu" % "sbt-teamcity-test-reporting-plugin" % "1.5")
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.12")
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
-
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -52,9 +52,9 @@ class AppComponents(context: Context, config: Config, passwordProvider: Password
 
   val secretStateSupplier: SnapshotProvider = {
     new parameterstore.SecretSupplier(
-      TransitionTiming(usageDelay = ofMinutes(3), overlapDuration = ofHours(2)),
-      "/Example/PlayAppSecret",
-      parameterstore.AwsSdkV2(SsmClient.builder().build())
+      transitionTiming = TransitionTiming(usageDelay = ofMinutes(3), overlapDuration = ofHours(2)),
+      parameterName = config.auth.secretStateSupplierKeyName,
+      ssmClient = parameterstore.AwsSdkV2(SsmClient.builder().build())
     )
   }
 

--- a/riff-raff/app/ci/BoundedSet.scala
+++ b/riff-raff/app/ci/BoundedSet.scala
@@ -3,7 +3,7 @@ package ci
 import scala.collection.immutable.Queue
 
 class BoundedSet[T](queue: Queue[T], maxSize: Int) extends Set[T] {
-  def +(elem: T): BoundedSet[T] = {
+  override def incl(elem: T): BoundedSet[T] = {
     if (contains(elem)) {
       new BoundedSet(pushToBack(queue, elem), maxSize)
     } else {
@@ -18,7 +18,7 @@ class BoundedSet[T](queue: Queue[T], maxSize: Int) extends Set[T] {
     (queue.slice(0, currentPos) ++ queue.slice(currentPos + 1, queue.size)).enqueue(item)
   }
 
-  def -(elem: T) = new BoundedSet[T](queue.filter(_ != elem), maxSize)
+  override def excl(elem: T) = new BoundedSet[T](queue.filter(_ != elem), maxSize)
 
   def iterator = queue.iterator
 }

--- a/riff-raff/app/ci/CIBuild.scala
+++ b/riff-raff/app/ci/CIBuild.scala
@@ -8,6 +8,7 @@ import org.joda.time.DateTime
 import controllers.Logging
 import magenta.Build
 import magenta.artifact.S3Object
+import scala.collection.Seq
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/riff-raff/app/ci/S3Build.scala
+++ b/riff-raff/app/ci/S3Build.scala
@@ -9,6 +9,7 @@ import play.api.libs.json._
 import scala.util.Try
 import scala.util.control.NonFatal
 import cats.syntax.either._
+import scala.collection.Seq
 
 case class S3Build(
   id: Long,

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -72,7 +72,7 @@ class Config(configuration: TypesafeConfig, startTime: DateTime) extends Logging
 
     lazy val clientId: String = getStringOpt("auth.clientId").getOrException("No client ID configured")
     lazy val clientSecret: String = getStringOpt("auth.clientSecret").getOrException("No client secret configured")
-    lazy val redirectUrl: String = getStringOpt("auth.redirectUrl").getOrElse(s"${urls.publicPrefix}${routes.Login.oauth2Callback().url}")
+    lazy val redirectUrl: String = getStringOpt("auth.redirectUrl").getOrElse(s"${urls.publicPrefix}${routes.Login.oauth2Callback.url}")
     lazy val domain: String = getStringOpt("auth.domain").getOrException("No auth domain configured")
     lazy val superusers: List[String] = getStringList("auth.superusers")
     lazy val secretStateSupplierKeyName: String = getStringOpt("auth.secretStateSupplier.keyName").getOrElse("/RiffRaff/PlayApplicationSecret")

--- a/riff-raff/app/controllers/Application.scala
+++ b/riff-raff/app/controllers/Application.scala
@@ -42,17 +42,17 @@ case class DropDownMenuItem(title:String, items: Seq[SingleMenuItem], target: Ca
 
 class Menu(config: Config) {
   lazy val menuItems = Seq(
-    SingleMenuItem("Home", routes.Application.index(), identityRequired = false),
-    SingleMenuItem("History", routes.DeployController.history()),
-    SingleMenuItem("Deploy", routes.DeployController.deploy()),
+    SingleMenuItem("Home", routes.Application.index, identityRequired = false),
+    SingleMenuItem("History", routes.DeployController.history),
+    SingleMenuItem("Deploy", routes.DeployController.deploy),
     DropDownMenuItem("Deployment Info", deployInfoMenu),
     DropDownMenuItem("Configuration", Seq(
-      SingleMenuItem("Continuous Deployment", routes.ContinuousDeployController.list()),
-      SingleMenuItem("Hooks", routes.HooksController.list()),
-      SingleMenuItem("Authorisation", routes.Login.authList(), enabled = config.auth.allowList.useDatabase),
-      SingleMenuItem("API keys", routes.Api.listKeys()),
-      SingleMenuItem("Restrictions", routes.Restrictions.list()),
-      SingleMenuItem("Schedules", routes.ScheduleController.list())
+      SingleMenuItem("Continuous Deployment", routes.ContinuousDeployController.list),
+      SingleMenuItem("Hooks", routes.HooksController.list),
+      SingleMenuItem("Authorisation", routes.Login.authList, enabled = config.auth.allowList.useDatabase),
+      SingleMenuItem("API keys", routes.Api.listKeys),
+      SingleMenuItem("Restrictions", routes.Restrictions.list),
+      SingleMenuItem("Schedules", routes.ScheduleController.list)
     )),
     DropDownMenuItem("Documentation", Seq(
       SingleMenuItem("Deployment Types", routes.Application.documentation("magenta-lib/types")),
@@ -64,11 +64,11 @@ class Menu(config: Config) {
 
   lazy val deployInfoMenu = Seq(
     SingleMenuItem("Hosts", routes.Application.deployInfoHosts()),
-    SingleMenuItem("Resources", routes.Application.deployInfoData()),
-    SingleMenuItem("About", routes.Application.deployInfoAbout())
+    SingleMenuItem("Resources", routes.Application.deployInfoData),
+    SingleMenuItem("About", routes.Application.deployInfoAbout)
   )
 
-  lazy val loginMenuItem = SingleMenuItem("Login", routes.Login.loginAction(), identityRequired = false)
+  lazy val loginMenuItem = SingleMenuItem("Login", routes.Login.loginAction, identityRequired = false)
 }
 
 class Application(config: Config,

--- a/riff-raff/app/controllers/ContinuousDeployController.scala
+++ b/riff-raff/app/controllers/ContinuousDeployController.scala
@@ -53,7 +53,7 @@ class ContinuousDeployController(config: Config,
           form.id, form.projectName, form.stage, form.branchMatcher, Trigger(form.trigger), request.user.fullName, new DateTime()
         )
         continuousDeploymentConfigRepository.setContinuousDeployment(config)
-        Redirect(routes.ContinuousDeployController.list())
+        Redirect(routes.ContinuousDeployController.list)
       }
     )
   }
@@ -61,7 +61,7 @@ class ContinuousDeployController(config: Config,
   def edit(id: String) = authAction { implicit request =>
     continuousDeploymentConfigRepository.getContinuousDeployment(UUID.fromString(id)).map{ deploymentConfig =>
       Ok(views.html.continuousDeployment.form(config, menu)(continuousDeploymentForm.fill(ConfigForm(deploymentConfig)), prismLookup))
-    }.getOrElse(Redirect(routes.ContinuousDeployController.list()))
+    }.getOrElse(Redirect(routes.ContinuousDeployController.list))
   }
 
   def delete(id: String) = authAction { implicit request =>
@@ -72,7 +72,7 @@ class ContinuousDeployController(config: Config,
           continuousDeploymentConfigRepository.deleteContinuousDeployment(UUID.fromString(id))
       }
     )
-    Redirect(routes.ContinuousDeployController.list())
+    Redirect(routes.ContinuousDeployController.list)
   }
 
 }

--- a/riff-raff/app/controllers/DeployController.scala
+++ b/riff-raff/app/controllers/DeployController.scala
@@ -200,13 +200,13 @@ class DeployController(config: Config,
       case (k, v) => k + "=" + URLEncoder.encode(v, "UTF-8")
     }.mkString("&")
 
-    val url = s"${routes.DeployController.deployAgain().url}?$queryString"
+    val url = s"${routes.DeployController.deployAgain.url}?$queryString"
     Redirect(url)
   }
 
   def markAsFailed = AuthAction { implicit request =>
     UuidForm.form.bindFromRequest().fold(
-      _ => Redirect(routes.DeployController.history()),
+      _ => Redirect(routes.DeployController.history),
       form => {
         form.action match {
           case "markAsFailed" =>

--- a/riff-raff/app/controllers/HooksController.scala
+++ b/riff-raff/app/controllers/HooksController.scala
@@ -67,7 +67,7 @@ class HooksController(config: Config,
       f => {
         val config = HookConfig(f.id,f.projectName,f.stage,f.url,f.enabled,new DateTime(),request.user.fullName, f.method, f.postBody)
         hookConfigRepository.setPostDeployHook(config)
-        Redirect(routes.HooksController.list())
+        Redirect(routes.HooksController.list)
       }
     )
   }
@@ -76,7 +76,7 @@ class HooksController(config: Config,
     val uuid = UUID.fromString(id)
     hookConfigRepository.getPostDeployHook(uuid).map{ hc =>
       Ok(views.html.hooks.form(config, menu)(hookForm.fill(HookForm(hc.id,hc.projectName,hc.stage,hc.url,hc.enabled, hc.method, hc.postBody)), prismLookup))
-    }.getOrElse(Redirect(routes.HooksController.list()))
+    }.getOrElse(Redirect(routes.HooksController.list))
   }
 
   def delete(id: String) = authAction { implicit request =>
@@ -87,6 +87,6 @@ class HooksController(config: Config,
           hookConfigRepository.deletePostDeployHook(UUID.fromString(id))
       }
     )
-    Redirect(routes.HooksController.list())
+    Redirect(routes.HooksController.list)
   }
 }

--- a/riff-raff/app/controllers/Restrictions.scala
+++ b/riff-raff/app/controllers/Restrictions.scala
@@ -65,7 +65,7 @@ class Restrictions(config: Config,
             val newConfig = RestrictionConfig(f.id, f.projectName, f.stage, new DateTime(), request.user.fullName,
               request.user.email, f.editingLocked, f.allowlist, f.continuousDeployment, f.note)
             restrictionConfigDynamoRepository.setRestriction(newConfig)
-            Redirect(routes.Restrictions.list())
+            Redirect(routes.Restrictions.list)
           case Left(Error(reason)) =>
             Forbidden(s"Not possible to update this restriction: $reason")
         }
@@ -84,14 +84,14 @@ class Restrictions(config: Config,
         restrictionForm = form,
         saveDisabled = cannotSave
       ))
-    }.getOrElse(Redirect(routes.Restrictions.list()))
+    }.getOrElse(Redirect(routes.Restrictions.list))
   }
 
   def delete(id: String) = authAction { request =>
     RestrictionChecker.isEditable(restrictionConfigDynamoRepository.getRestriction(UUID.fromString(id)), request.user, config.auth.superusers) match {
       case Right(_) =>
         restrictionConfigDynamoRepository.deleteRestriction(UUID.fromString(id))
-        Redirect(routes.Restrictions.list())
+        Redirect(routes.Restrictions.list)
       case Left(Error(reason)) =>
         Forbidden(s"Not possible to delete this restriction: $reason")
     }

--- a/riff-raff/app/controllers/ScheduleController.scala
+++ b/riff-raff/app/controllers/ScheduleController.scala
@@ -75,7 +75,7 @@ class ScheduleController(config: Config,
         val config = form.toConfig(new DateTime(), request.user.fullName)
         scheduleRepository.setSchedule(config)
         deployScheduler.reschedule(config)
-        Redirect(routes.ScheduleController.list())
+        Redirect(routes.ScheduleController.list)
       }
     )
   }
@@ -97,7 +97,7 @@ class ScheduleController(config: Config,
           deployScheduler.cancel(uuid)
       }
     )
-    Redirect(routes.ScheduleController.list())
+    Redirect(routes.ScheduleController.list)
   }
 
 }

--- a/riff-raff/app/controllers/api.scala
+++ b/riff-raff/app/controllers/api.scala
@@ -172,10 +172,10 @@ class Api(config: Config,
 
   def delete = authAction { implicit request =>
     apiKeyForm.bindFromRequest().fold(
-      errors => Redirect(routes.Api.listKeys()),
+      errors => Redirect(routes.Api.listKeys),
       apiKey => {
         datastore.deleteApiKey(apiKey)
-        Redirect(routes.Api.listKeys())
+        Redirect(routes.Api.listKeys)
       }
     )
   }

--- a/riff-raff/app/controllers/authentication.scala
+++ b/riff-raff/app/controllers/authentication.scala
@@ -119,7 +119,7 @@ class Login(config: Config, menu: Menu, deployments: Deployments, datastore: Dat
       email => {
         val auth = AuthorisationRecord(email.toLowerCase.trim, request.user.fullName, new DateTime())
         datastore.setAuthorisation(auth)
-        Redirect(routes.Login.authList())
+        Redirect(routes.Login.authList)
       }
     )
   }
@@ -129,9 +129,9 @@ class Login(config: Config, menu: Menu, deployments: Deployments, datastore: Dat
       log.info(s"${request.user.fullName} deleted authorisation for $email")
       datastore.deleteAuthorisation(email)
     } )
-    Redirect(routes.Login.authList())
+    Redirect(routes.Login.authList)
   }
 
-  override val failureRedirectTarget: Call = routes.Login.login()
-  override val defaultRedirectTarget: Call = routes.Application.index()
+  override val failureRedirectTarget: Call = routes.Login.login
+  override val defaultRedirectTarget: Call = routes.Application.index
 }

--- a/riff-raff/app/notification/FailureNotificationContents.scala
+++ b/riff-raff/app/notification/FailureNotificationContents.scala
@@ -23,7 +23,7 @@ class FailureNotificationContents(prefix: String) {
   }
 
   val scheduledDeployConfigUrl: String = {
-    val path = routes.ScheduleController.list()
+    val path = routes.ScheduleController.list
     prefix + path.url
   }
 

--- a/riff-raff/app/notification/HookTemplate.scala
+++ b/riff-raff/app/notification/HookTemplate.scala
@@ -15,7 +15,10 @@ class HookTemplate(val input: ParserInput, record: DeployRecordDocument, urlEnco
 
   def Param = rule { SimpleParam | Tag }
 
-  def SimpleParam = rule { HookTemplate.paramSubstitutions.mapValues(f => encode(f(record))) }
+  def SimpleParam = {
+    val params = HookTemplate.paramSubstitutions.view.mapValues(f => encode(f(record))).toMap
+    rule { params }
+  }
 
   def Tag = rule { "tag." ~ capture( oneOrMore(Alpha | '-' | '_')) ~> (tagName =>
     encode(record.parameters.tags.getOrElse(tagName, ""))

--- a/riff-raff/app/persistence/ContinuousDeploymentConfigRepository.scala
+++ b/riff-raff/app/persistence/ContinuousDeploymentConfigRepository.scala
@@ -3,8 +3,9 @@ package persistence
 import java.util.UUID
 
 import ci.{ContinuousDeploymentConfig, Trigger}
-import com.gu.scanamo.syntax._
-import com.gu.scanamo.{DynamoFormat, Table}
+import org.scanamo.syntax._
+import org.scanamo.auto._
+import org.scanamo.{DynamoFormat, Table}
 import cats.syntax.either._
 import conf.Config
 
@@ -21,11 +22,11 @@ class ContinuousDeploymentConfigRepository(config: Config) extends DynamoReposit
     exec(table.scan()).flatMap(_.toOption)
 
   def getContinuousDeployment(id: UUID): Option[ContinuousDeploymentConfig] =
-    exec(table.get('id -> id)).flatMap(_.toOption)
+    exec(table.get("id" -> id)).flatMap(_.toOption)
 
   def setContinuousDeployment(cd: ContinuousDeploymentConfig): Unit =
     exec(table.put(cd))
 
   def deleteContinuousDeployment(id: UUID): Unit =
-    exec(table.delete('id -> id))
+    exec(table.delete("id" -> id))
 }

--- a/riff-raff/app/persistence/DynamoRepository.scala
+++ b/riff-raff/app/persistence/DynamoRepository.scala
@@ -2,15 +2,15 @@ package persistence
 
 import java.util.UUID
 
-import com.gu.scanamo.ops._
-import com.gu.scanamo.{DynamoFormat, Scanamo}
+import org.scanamo.ops._
+import org.scanamo.{DynamoFormat, Scanamo}
 import conf.Config
 import org.joda.time.DateTime
 
 abstract class DynamoRepository(config: Config) {
 
   val client = config.dynamoDb.client
-  def exec[A](ops: ScanamoOps[A]): A = Scanamo.exec(client)(ops)
+  def exec[A](ops: ScanamoOps[A]): A = Scanamo(client).exec(ops)
   def tablePrefix: String
 
   // TODO set up Dynamo local

--- a/riff-raff/app/persistence/HookConfigRepository.scala
+++ b/riff-raff/app/persistence/HookConfigRepository.scala
@@ -2,10 +2,11 @@ package persistence
 
 import java.util.UUID
 
-import com.gu.scanamo.{DynamoFormat, Table}
+import org.scanamo.{DynamoFormat, Table}
 import notification.{HookConfig, HttpMethod}
 import cats.syntax.either._
 import conf.Config
+import org.scanamo.auto._
 
 class HookConfigRepository(config: Config) extends DynamoRepository(config) {
 
@@ -16,13 +17,13 @@ class HookConfigRepository(config: Config) extends DynamoRepository(config) {
 
   val table = Table[HookConfig](tableName)
 
-  import com.gu.scanamo.syntax._
+  import org.scanamo.syntax._
 
-  def getPostDeployHook(id: UUID): Option[HookConfig] = exec(table.get('id -> id)).flatMap(_.toOption)
+  def getPostDeployHook(id: UUID): Option[HookConfig] = exec(table.get("id" -> id)).flatMap(_.toOption)
   def getPostDeployHook(projectName: String, stage: String): Seq[HookConfig] =
-    exec(table.index("hook-config-project").query('projectName -> projectName)).flatMap(_.toOption)
+    exec(table.index("hook-config-project").query("projectName" -> projectName)).flatMap(_.toOption)
         .filter(_.stage == stage)
   def getPostDeployHookList:Iterable[HookConfig] = exec(table.scan()).flatMap(_.toOption)
   def setPostDeployHook(config: HookConfig): Unit = exec(table.put(config))
-  def deletePostDeployHook(id: UUID): Unit = exec(table.delete('id -> id))
+  def deletePostDeployHook(id: UUID): Unit = exec(table.delete("id" -> id))
 }

--- a/riff-raff/app/persistence/RestrictionConfigDynamoRepository.scala
+++ b/riff-raff/app/persistence/RestrictionConfigDynamoRepository.scala
@@ -2,23 +2,24 @@ package persistence
 
 import java.util.UUID
 
-import com.gu.scanamo.Table
+import org.scanamo.Table
 import restrictions.{RestrictionConfig, RestrictionsConfigRepository}
 import cats.syntax.either._
 import conf.Config
+import org.scanamo.auto._
 
 class RestrictionConfigDynamoRepository(config: Config) extends DynamoRepository(config) with RestrictionsConfigRepository {
   def tablePrefix = "riffraff-restriction-config"
 
   val table = Table[RestrictionConfig](tableName)
 
-  import com.gu.scanamo.syntax._
+  import org.scanamo.syntax._
 
   def setRestriction(config: RestrictionConfig): Unit = exec(table.put(config))
-  def getRestriction(id: UUID): Option[RestrictionConfig] = exec(table.get('id -> id)).flatMap(_.toOption)
-  def deleteRestriction(id: UUID): Unit = exec(table.delete('id -> id))
+  def getRestriction(id: UUID): Option[RestrictionConfig] = exec(table.get("id" -> id)).flatMap(_.toOption)
+  def deleteRestriction(id: UUID): Unit = exec(table.delete("id" -> id))
   def getRestrictionList: Iterable[RestrictionConfig] = exec(table.scan()).flatMap(_.toOption)
 
   def getRestrictions(projectName: String): Seq[RestrictionConfig] =
-    exec(table.index("restriction-config-projectName").query('projectName -> projectName)).flatMap(_.toOption)
+    exec(table.index("restriction-config-projectName").query("projectName" -> projectName)).flatMap(_.toOption)
 }

--- a/riff-raff/app/persistence/ScheduleRepository.scala
+++ b/riff-raff/app/persistence/ScheduleRepository.scala
@@ -3,8 +3,9 @@ package persistence
 import java.util.UUID
 
 import ci.Trigger
-import com.gu.scanamo.syntax._
-import com.gu.scanamo.{DynamoFormat, Table}
+import org.scanamo.syntax._
+import org.scanamo.{DynamoFormat, Table}
+import org.scanamo.auto._
 import conf.Config
 import schedule.ScheduleConfig
 
@@ -21,11 +22,11 @@ class ScheduleRepository(config: Config) extends DynamoRepository(config) {
     exec(table.scan()).flatMap(_.toOption)
 
   def getSchedule(id: UUID): Option[ScheduleConfig] =
-    exec(table.get('id -> id)).flatMap(_.toOption)
+    exec(table.get("id" -> id)).flatMap(_.toOption)
 
   def setSchedule(schedule: ScheduleConfig): Unit =
     exec(table.put(schedule))
 
   def deleteSchedule(id: UUID): Unit =
-    exec(table.delete('id -> id))
+    exec(table.delete("id" -> id))
 }

--- a/riff-raff/app/persistence/TargetDynamoRepository.scala
+++ b/riff-raff/app/persistence/TargetDynamoRepository.scala
@@ -1,10 +1,12 @@
 package persistence
 
 import ci.Target
-import com.gu.scanamo.Table
-import com.gu.scanamo.error.DynamoReadError
+import org.scanamo.Table
+import org.scanamo.error.DynamoReadError
 import conf.Config
 import org.joda.time.DateTime
+import org.scanamo.auto._
+import org.scanamo.syntax._
 
 case class TargetId(targetKey: String, projectName: String, region: String, stack: String, app: String, lastSeen: DateTime) {
   def matches(target: Target): Boolean = region == target.region && stack == target.stack && app == target.app
@@ -19,18 +21,18 @@ class TargetDynamoRepository(config: Config) extends DynamoRepository(config) {
   def tablePrefix = "riffraff-target-ids"
   val table = Table[TargetId](tableName)
 
-  import com.gu.scanamo.syntax._
+  import org.scanamo.syntax._
 
   def set(target: Target, projectName: String, lastSeen: DateTime): Option[Either[DynamoReadError, TargetId]] =
     exec(table.put(TargetId(target, projectName, lastSeen)))
 
   def get(targetKey: String, projectName: String): Option[TargetId] = {
-    exec(table.get('targetKey -> targetKey and 'projectName -> projectName)).flatMap(_.toOption)
+    exec(table.get("targetKey" -> targetKey and "projectName" -> projectName)).flatMap(_.toOption)
   }
 
   def find(target: Target): List[TargetId] = {
     val key = TargetId.targetKey(target)
-    exec(table.query('targetKey -> key))
+    exec(table.query("targetKey" -> key))
       .flatMap(_.toOption)
       .filter(_.matches(target)) // make sure this is not a weird collision due to use of separator in fields
   }

--- a/riff-raff/app/resources/PrismLookup.scala
+++ b/riff-raff/app/resources/PrismLookup.scala
@@ -116,7 +116,7 @@ class PrismLookup(config: Config, wsClient: WSClient, secretProvider: SecretProv
   }
 
   def hosts = new HostLookup {
-    def parseHosts(json: JsValue, entity: String = "instances"):Seq[Host] = {
+    def parseHosts(json: JsValue, entity: String = "instances"): Seq[Host] = {
       val tryHosts = (json \ "data" \ entity).as[JsArray].value.map { jsHost =>
         Try(jsHost.as[Host])
       }
@@ -128,7 +128,7 @@ class PrismLookup(config: Config, wsClient: WSClient, secretProvider: SecretProv
       if (errors.nonEmpty) log.warn(s"Encountered ${errors.size} (of ${tryHosts.size}) $entity records that could not be parsed in Prism response")
       if (log.isDebugEnabled) errors.foreach(e => log.debug("Couldn't parse instance from Prism data", e.exception))
 
-      tryHosts.flatMap {
+      tryHosts.toSeq.flatMap {
         case Success(hosts) => Some(hosts)
         case _ => None
       }

--- a/riff-raff/app/views/api/form.scala.html
+++ b/riff-raff/app/views/api/form.scala.html
@@ -1,6 +1,5 @@
 @import conf.Config
 @(config: Config, menu: Menu)(apiForm: Form[String])(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], messages: Messages)
-@import b3.vertical.fieldConstructor
 @import helper.CSRF
 
 @main("Create new API key", request) {
@@ -8,12 +7,12 @@
     <h2>Create new API key</h2>
     <hr/>
 
-    @b3.form(action=routes.Api.createKey()) {
+    @b3.vertical.form(action=routes.Api.createKey) { implicit fc =>
         @CSRF.formField
         @b3.text(apiForm("application"), '_label -> "Application that will use this key")
         <div class="actions">
             <button name="action" type="submit" value="save" class="btn btn-primary">Create</button> or
-            <a href="@routes.Api.listKeys()" class="btn btn-danger">Cancel</a>
+            <a href="@routes.Api.listKeys" class="btn btn-danger">Cancel</a>
         </div>
     }
 }(config, menu)

--- a/riff-raff/app/views/api/list.scala.html
+++ b/riff-raff/app/views/api/list.scala.html
@@ -5,7 +5,7 @@
 @main("API keys", request) {
     <h2>API keys</h2>
     <hr/>
-    <p><a class="btn btn-primary" href="@routes.Api.createKeyForm()"><i class="glyphicon glyphicon-plus glyphicon-white"></i> Create new API key</a></p>
+    <p><a class="btn btn-primary" href="@routes.Api.createKeyForm"><i class="glyphicon glyphicon-plus glyphicon-white"></i> Create new API key</a></p>
     <div class="content">
         @if(keyList.isEmpty) {
             <div class="alert alert-warning"><strong>No API keys.</strong></div>
@@ -32,7 +32,7 @@
                         <td>@key.lastUsed.map(utils.DateFormats.Short.print).getOrElse("never")</td>
                         <td>@key.totalCalls</td>
                         <td>
-                        @helper.form(routes.Api.delete(), 'class -> "modal-form") {
+                        @helper.form(routes.Api.delete, 'class -> "modal-form") {
                             @CSRF.formField
                             <button class="btn btn-xs btn-danger" name="key" value="@key.key"><i class="glyphicon glyphicon-trash glyphicon glyphicon-white"></i> Delete</button>
                         }

--- a/riff-raff/app/views/auth/form.scala.html
+++ b/riff-raff/app/views/auth/form.scala.html
@@ -1,6 +1,5 @@
 @import conf.Config
 @(config: Config, menu: Menu)(hookForm: Form[String])(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], messages: Messages)
-@import b3.vertical.fieldConstructor
 @import helper.CSRF
 
 @main("Authorise a new user", request) {
@@ -8,12 +7,12 @@
     <h2>Authorise a new user</h2>
     <hr/>
 
-    @b3.form(action=routes.Login.authSave()) {
+    @b3.vertical.form(action=routes.Login.authSave) { implicit fc =>
         @CSRF.formField
         @b3.text(hookForm("email"), '_label -> "Email address of user")
         <div class="actions">
             <button name="action" type="submit" value="save" class="btn btn-primary">Save</button> or
-            <a href="@routes.Login.authList()" class="btn btn-danger">Cancel</a>
+            <a href="@routes.Login.authList" class="btn btn-danger">Cancel</a>
         </div>
     }
 }(config, menu)

--- a/riff-raff/app/views/auth/list.scala.html
+++ b/riff-raff/app/views/auth/list.scala.html
@@ -5,7 +5,7 @@
 @main("Authorisation List", request) {
     <h2>Authorisation List</h2>
     <hr/>
-    <p><a class="btn btn-primary" href="@routes.Login.authForm()"><i class="glyphicon glyphicon-plus glyphicon glyphicon-white"></i> Add authorisation</a></p>
+    <p><a class="btn btn-primary" href="@routes.Login.authForm"><i class="glyphicon glyphicon-plus glyphicon glyphicon-white"></i> Add authorisation</a></p>
     <div class="content">
     @if(authList.isEmpty) {
         <div class="alert alert-warning"><strong>No authorisations.</strong></div>
@@ -36,7 +36,7 @@
                             })
                         </td>
                         <td>
-                        @helper.form(routes.Login.authDelete(), 'class -> "modal-form") {
+                        @helper.form(routes.Login.authDelete, 'class -> "modal-form") {
                             @CSRF.formField
                             <button class="btn btn-xs btn-danger" name="email" value="@auth.email"><i class="glyphicon glyphicon-trash glyphicon glyphicon-white"></i> Delete</button>
                         }

--- a/riff-raff/app/views/auth/login.scala.html
+++ b/riff-raff/app/views/auth/login.scala.html
@@ -15,7 +15,7 @@
         </div>
         }
 
-        <form action="@routes.Login.loginAction()" method="get">
+        <form action="@routes.Login.loginAction" method="get">
             <input value="Log In" class="btn btn-primary" type="submit">
         </form>
     </div>

--- a/riff-raff/app/views/continuousDeployment/form.scala.html
+++ b/riff-raff/app/views/continuousDeployment/form.scala.html
@@ -1,7 +1,6 @@
 @import conf.Config
 @(config: Config, menu: Menu)(configForm: Form[controllers.ContinuousDeployController.ConfigForm], prismLookup: resources.PrismLookup)(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], messages: Messages)
 @import ci.Trigger._
-@import b3.vertical.fieldConstructor
 @import helper.CSRF
 
 @main("Continuous Deployment", request, List("form-autocomplete")) {
@@ -9,7 +8,7 @@
     <h2>Continuous Deployment Configuration</h2>
     <hr/>
 
-    @b3.form(action=routes.ContinuousDeployController.save) {
+    @b3.vertical.form(action=routes.ContinuousDeployController.save) { implicit fc =>
         @CSRF.formField
         @snippets.inputHidden(configForm("id"))
 
@@ -42,7 +41,7 @@
 
         <div class="actions">
             <button name="action" type="submit" value="save" class="btn btn-primary">Save</button> or
-            <a href="@routes.ContinuousDeployController.list()" class="btn btn-danger">Cancel</a>
+            <a href="@routes.ContinuousDeployController.list" class="btn btn-danger">Cancel</a>
         </div>
     }
 }(config, menu)

--- a/riff-raff/app/views/continuousDeployment/list.scala.html
+++ b/riff-raff/app/views/continuousDeployment/list.scala.html
@@ -14,7 +14,7 @@
         </div>
     }
     <hr/>
-    <p><a class="btn btn-primary" href="@routes.ContinuousDeployController.form()"><i class="glyphicon glyphicon-plus glyphicon glyphicon-white"></i> Add new configuration</a></p>
+    <p><a class="btn btn-primary" href="@routes.ContinuousDeployController.form"><i class="glyphicon glyphicon-plus glyphicon glyphicon-white"></i> Add new configuration</a></p>
     <div class="content">
     @if(configs.isEmpty) {
         <div class="alert alert-warning"><strong>No configurations.</strong></div>

--- a/riff-raff/app/views/deploy/deployConfirmation.scala.html
+++ b/riff-raff/app/views/deploy/deployConfirmation.scala.html
@@ -37,7 +37,7 @@
 
         <div class="actions">
             <button name="confirmation" type="submit" value="confirm" class="btn btn-primary">Confirm</button> or
-            <a href="@routes.Application.index()" class="btn btn-danger">Cancel</a>
+            <a href="@routes.Application.index" class="btn btn-danger">Cancel</a>
         </div>
     }
     }

--- a/riff-raff/app/views/deploy/deployHistory.scala.html
+++ b/riff-raff/app/views/deploy/deployHistory.scala.html
@@ -3,7 +3,7 @@
 
 @if(restrictions.nonEmpty) {
     <div class="alert alert-warning" role="alert">
-        <p><strong>Deployment restricted</strong></p> <p>There are currently <a href="@routes.Restrictions.list()">restrictions</a>
+        <p><strong>Deployment restricted</strong></p> <p>There are currently <a href="@routes.Restrictions.list">restrictions</a>
             that prevent you from deploying <strong>@projectName</strong>@maybeStage.map{ stage => to <strong>@stage</strong>}:</p>
         @restrictions.map { restriction =>
             <p>

--- a/riff-raff/app/views/deploy/form.scala.html
+++ b/riff-raff/app/views/deploy/form.scala.html
@@ -3,7 +3,6 @@
 @import magenta.Strategy
 @import magenta.Strategy.MostlyHarmless
 @(config: Config, menu: Menu)(changeFreeze: ChangeFreeze)(deployForm: Form[controllers.forms.DeployParameterForm], prismLookup: resources.PrismLookup)(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], messages: Messages)
-@import b3.vertical.fieldConstructor
 @import helper.CSRF
 
 @main("Deploy request", request, List("form-autocomplete", "collapsing")) {
@@ -56,7 +55,7 @@
     </style>
 
     <div class="col-md-6">
-    @b3.form(routes.DeployController.processForm, 'class -> "well") {
+    @b3.vertical.form(routes.DeployController.processForm, 'class -> "well") { implicit fc =>
         @CSRF.formField
         <fieldset>
             <legend>What would you like to deploy?</legend>
@@ -106,7 +105,7 @@
             <div class="actions">
                 <button name="action" type="submit" value="preview" class="btn btn-default">Preview...</button>
                 <button id="modalConfirm" name="action" type="submit" value="deploy" class="btn btn-primary">Deploy Now</button>
-                <a href="@routes.Application.index()" class="btn btn-danger">Cancel</a>
+                <a href="@routes.Application.index" class="btn btn-danger">Cancel</a>
             </div>
         </fieldset>
     }

--- a/riff-raff/app/views/deploy/history.scala.html
+++ b/riff-raff/app/views/deploy/history.scala.html
@@ -10,7 +10,7 @@
     <script>
             $(function () { graph({
                 "container_id": 'deploy-chart',
-                "data_path": '@{routes.Api.historyGraph().url}',
+                "data_path": '@{routes.Api.historyGraph.url}',
                 "height": '100',
                 "renderer": 'bar'
             })  })
@@ -30,7 +30,7 @@
         <div class="graph-legend"></div>
     </div>
 
-    <div data-ajax-refresh="@{routes.DeployController.historyContent()}?@request.rawQueryString" data-ajax-interval="60000">
+    <div data-ajax-refresh="@{routes.DeployController.historyContent}?@request.rawQueryString" data-ajax-interval="60000">
         <p class="loading">Loading...</p>
         <div class="alert alert-danger error" style="display:none"><strong>An error occurred whilst fetching the most recent deployment history</strong></div>
         <div class="content"></div>

--- a/riff-raff/app/views/deploy/historyFilter.scala.html
+++ b/riff-raff/app/views/deploy/historyFilter.scala.html
@@ -7,20 +7,20 @@
             <li class="dropdown@if(view.filter.stage.isDefined){ active}">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Stage@view.filter.stage.map{s=>: <strong>@s</strong>} <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                    <li@if(!view.filter.stage.isDefined){ class="active"}><a href="@{routes.DeployController.history()}?@{view.replaceFilter(_.withStage(None)).q}">All</a></li>
+                    <li@if(!view.filter.stage.isDefined){ class="active"}><a href="@{routes.DeployController.history}?@{view.replaceFilter(_.withStage(None)).q}">All</a></li>
                     <li class="divider"></li>
                     @for(stage <- prismLookup.stages) {
-                        <li @if(Some(stage)==view.filter.stage){class="active"}><a href="@{routes.DeployController.history()}?@{view.replaceFilter(_.withStage(Some(stage))).q}">@stage</a></li>
+                        <li @if(Some(stage)==view.filter.stage){class="active"}><a href="@{routes.DeployController.history}?@{view.replaceFilter(_.withStage(Some(stage))).q}">@stage</a></li>
                     }
                 </ul>
             </li>
             <li class="dropdown@if(view.filter.status.isDefined){ active}">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Status@view.filter.status.map{s=>: <strong>@s</strong>} <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                    <li@if(!view.filter.status.isDefined){ class="active"}><a href="@{routes.DeployController.history()}?@{view.replaceFilter(_.withStatus(None)).q}">All</a></li>
+                    <li@if(!view.filter.status.isDefined){ class="active"}><a href="@{routes.DeployController.history}?@{view.replaceFilter(_.withStatus(None)).q}">All</a></li>
                     <li class="divider"></li>
                     @for(status <- RunState.values.toList.filterNot(_==RunState.ChildRunning).sortBy(_.toString)) {
-                        <li @if(Some(status)==view.filter.status){class="active"}><a href="@{routes.DeployController.history()}?@{view.replaceFilter(_.withStatus(Some(status))).q}">@status</a></li>
+                        <li @if(Some(status)==view.filter.status){class="active"}><a href="@{routes.DeployController.history}?@{view.replaceFilter(_.withStatus(Some(status))).q}">@status</a></li>
                     }
                 </ul>
             </li>
@@ -31,14 +31,14 @@
                         <input id="projectInput" name="projectName" value="@view.filter.projectName.getOrElse("")" data-url="/deployment/request/autoComplete/project" class="form-control" />
                         <span class="input-group-btn">
                             <button class="btn btn-primary" id="projectNameGo"><i class="glyphicon glyphicon-filter"></i> Filter</button>
-                            <a class="btn btn-danger" href="@{routes.DeployController.history()}?@{view.replaceFilter(_.withProjectName(None)).q}"><i class="glyphicon glyphicon-remove"></i> Clear</a>
+                            <a class="btn btn-danger" href="@{routes.DeployController.history}?@{view.replaceFilter(_.withProjectName(None)).q}"><i class="glyphicon glyphicon-remove"></i> Clear</a>
                         </span>
                     </div>
                 </div>
             </li>
             @if(!view.filter.default) {
             <li>
-                <a href="@routes.DeployController.history()?@{view.replaceFilter(_ => DeployFilter()).q}"><i class="glyphicon glyphicon-remove"></i> Clear all filters</a>
+                <a href="@routes.DeployController.history?@{view.replaceFilter(_ => DeployFilter()).q}"><i class="glyphicon glyphicon-remove"></i> Clear all filters</a>
             </li>
             }
         </ul>
@@ -48,7 +48,7 @@
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Deploys per page@view.pagination.pageSize.map{s=>: <strong>@s</strong>} <b class="caret"></b></a>
                 <ul class="dropdown-menu">
                     @for(count <- List(20,50,100)) {
-                        <li @if(Some(count)==view.pagination.pageSize){class="active"}><a href="@{routes.DeployController.history()}?@{view.replacePagination(_.withPageSize(Some(count))).q}">@count</a></li>
+                        <li @if(Some(count)==view.pagination.pageSize){class="active"}><a href="@{routes.DeployController.history}?@{view.replacePagination(_.withPageSize(Some(count))).q}">@count</a></li>
                     }
                 </ul>
             </li>

--- a/riff-raff/app/views/hooks/form.scala.html
+++ b/riff-raff/app/views/hooks/form.scala.html
@@ -1,6 +1,5 @@
 @import conf.Config
 @(config: Config, menu: Menu)(hookForm: Form[controllers.HookForm], prismLookup: resources.PrismLookup)(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], messages: Messages)
-@import b3.vertical.fieldConstructor
 @import helper.CSRF
 
 @main("Create Post Deploy Hook", request) {
@@ -10,7 +9,7 @@
 
     <div class="row">
         <div class="col-md-7">
-            @b3.form(action=routes.HooksController.save) {
+            @b3.vertical.form(action=routes.HooksController.save) { implicit fc =>
             @CSRF.formField
 
             @snippets.inputHidden(hookForm("id"))
@@ -37,7 +36,7 @@
 
             <div class="actions">
                 <button name="action" type="submit" value="save" class="btn btn-primary">Save</button> or
-                <a href="@routes.HooksController.list()" class="btn btn-danger">Cancel</a>
+                <a href="@routes.HooksController.list" class="btn btn-danger">Cancel</a>
             </div>
         </div>
 

--- a/riff-raff/app/views/hooks/list.scala.html
+++ b/riff-raff/app/views/hooks/list.scala.html
@@ -6,7 +6,7 @@
 @main("Post Deploy Hooks", request) {
     <h2>Post Deploy Hooks</h2>
     <hr/>
-    <p><a class="btn btn-primary" href="@routes.HooksController.form()"><i class="glyphicon glyphicon-plus glyphicon glyphicon-white"></i> Add new hook</a></p>
+    <p><a class="btn btn-primary" href="@routes.HooksController.form"><i class="glyphicon glyphicon-plus glyphicon glyphicon-white"></i> Add new hook</a></p>
     <div class="content">
     @if(hooks.isEmpty) {
         <div class="alert alert-warning"><strong>No deploy hooks.</strong></div>

--- a/riff-raff/app/views/menu/appmenubar.scala.html
+++ b/riff-raff/app/views/menu/appmenubar.scala.html
@@ -12,9 +12,9 @@
                         <span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu">
-                        <li><a href="@routes.Login.profile()">Profile</a></li>
+                        <li><a href="@routes.Login.profile">Profile</a></li>
                         <li class="divider"></li>
-                        <li><a href="@routes.Login.logout()">Sign Out</a></li>
+                        <li><a href="@routes.Login.logout">Sign Out</a></li>
                     </ul>
                 </li>
             </ul>

--- a/riff-raff/app/views/preview/yaml/showTasks.scala.html
+++ b/riff-raff/app/views/preview/yaml/showTasks.scala.html
@@ -1,5 +1,4 @@
 @import views.html.helper.magenta.PreviewHelper
-@import b3.inline.fieldConstructor
 @import magenta.input.DeploymentKey
 @*
 We use checkedKeys here separately from the form as Play! forms do not deal well with repeated checkboxes. We could try
@@ -10,7 +9,7 @@ to make it fit in the Play idea of forms but it's far from trivial. Be warned!
         form: Form[forms.DeployParameterForm], checkedKeys: List[magenta.input.DeploymentKey])(
  implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], messages: Messages)
 
-@b3.formCSRF(routes.DeployController.processForm) {
+@b3.inline.formCSRF(routes.DeployController.processForm) { implicit fc =>
     @b3.hiddens(
         "project" -> form.value.map(_.project).get,
         "build" -> form.value.map(_.build).get,

--- a/riff-raff/app/views/restrictions/form.scala.html
+++ b/riff-raff/app/views/restrictions/form.scala.html
@@ -1,4 +1,3 @@
-@import b3.vertical.fieldConstructor
 @import helper.CSRF
 @import _root_.restrictions.RestrictionForm
 @import conf.Config
@@ -11,7 +10,7 @@
 
     <div class="row">
         <div class="col-md-7">
-            @b3.formCSRF(action=routes.Restrictions.save) {
+            @b3.vertical.formCSRF(action=routes.Restrictions.save) { implicit fc =>
 
             @snippets.inputHidden(restrictionForm("id"))
 
@@ -57,7 +56,7 @@
 
             <div class="actions">
                 <button name="action" type="submit" value="save" class="btn btn-primary" @if(saveDisabled){disabled="disabled"}>Save</button> or
-                <a href="@routes.Restrictions.list()" class="btn btn-danger">Cancel</a>
+                <a href="@routes.Restrictions.list" class="btn btn-danger">Cancel</a>
             </div>
         </div>
     </div>

--- a/riff-raff/app/views/restrictions/list.scala.html
+++ b/riff-raff/app/views/restrictions/list.scala.html
@@ -15,7 +15,7 @@
         choice.</p>
         <p>Further docs available <a href="/docs/riffraff/restrictions.md">here</a></p>
     </div>
-    <p><a class="btn btn-primary" href="@routes.Restrictions.form()"><i class="glyphicon glyphicon-plus glyphicon glyphicon-white"></i> Add new restriction</a></p>
+    <p><a class="btn btn-primary" href="@routes.Restrictions.form"><i class="glyphicon glyphicon-plus glyphicon glyphicon-white"></i> Add new restriction</a></p>
     <div class="content">
     @if(configs.isEmpty) {
         <div class="alert alert-warning"><strong>No restrictions.</strong></div>

--- a/riff-raff/app/views/schedule/form.scala.html
+++ b/riff-raff/app/views/schedule/form.scala.html
@@ -1,6 +1,5 @@
 @import conf.Config
 @(config: Config, menu: Menu)(configForm: Form[controllers.ScheduleController.ScheduleForm], prismLookup: resources.PrismLookup, timeZones: List[String])(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], messages: Messages)
-@import b3.vertical.fieldConstructor
 @import helper.CSRF
 
 @main("Schedule", request, List("form-autocomplete", "form-timezone")) {
@@ -8,7 +7,7 @@
     <h2>Schedule Configuration</h2>
     <hr/>
 
-    @b3.form(action=routes.ScheduleController.save) {
+    @b3.vertical.form(action=routes.ScheduleController.save) { implicit fc =>
         @CSRF.formField
         @snippets.inputHidden(configForm("id"))
 
@@ -48,7 +47,7 @@
 
         <div class="actions">
             <button name="action" type="submit" value="save" class="btn btn-primary">Save</button> or
-            <a href="@routes.ScheduleController.list()" class="btn btn-danger">Cancel</a>
+            <a href="@routes.ScheduleController.list" class="btn btn-danger">Cancel</a>
         </div>
     }
 }(config, menu)

--- a/riff-raff/app/views/schedule/list.scala.html
+++ b/riff-raff/app/views/schedule/list.scala.html
@@ -9,7 +9,7 @@
 @main("Schedule Configurations", request) {
     <h2>Schedule Configurations</h2>
     <hr/>
-    <p><a class="btn btn-primary" href="@routes.ScheduleController.form()"><i class="glyphicon glyphicon-plus glyphicon glyphicon-white"></i> Add new schedule</a></p>
+    <p><a class="btn btn-primary" href="@routes.ScheduleController.form"><i class="glyphicon glyphicon-plus glyphicon glyphicon-white"></i> Add new schedule</a></p>
     <div class="content">
     @if(configs.isEmpty) {
         <div class="alert alert-warning"><strong>No configurations.</strong></div>

--- a/riff-raff/app/views/snippets/pagination.scala.html
+++ b/riff-raff/app/views/snippets/pagination.scala.html
@@ -1,15 +1,15 @@
 @(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], pagination: deployment.Pagination)
 <div class="text-center">
     <ul class="pagination pagination-sm">
-        <li @if(!pagination.hasPrevious){class="disabled"}><a href="@pagination.first(routes.DeployController.history())">««</a></li>
-        <li @if(!pagination.hasPrevious){class="disabled"}><a href="@pagination.previous(routes.DeployController.history())">«</a></li>
+        <li @if(!pagination.hasPrevious){class="disabled"}><a href="@pagination.first(routes.DeployController.history)">««</a></li>
+        <li @if(!pagination.hasPrevious){class="disabled"}><a href="@pagination.previous(routes.DeployController.history)">«</a></li>
         @for(page <- pagination.pageList) {
-        <li @if(pagination.page==page){class="active"}><a href="@pagination.toPage(routes.DeployController.history(),page)">@page</a></li>
+        <li @if(pagination.page==page){class="active"}><a href="@pagination.toPage(routes.DeployController.history,page)">@page</a></li>
         }
         @if(pagination.pageCount.isEmpty) {
             <li class="disabled"><a href="#">…</a></li>
         }
-        <li @if(!pagination.hasNext){class="disabled"}><a href="@pagination.next(routes.DeployController.history())">»</a></li>
-        <li @if(!pagination.hasLast){class="disabled"}><a href="@pagination.last(routes.DeployController.history())">»»</a></li>
+        <li @if(!pagination.hasNext){class="disabled"}><a href="@pagination.next(routes.DeployController.history)">»</a></li>
+        <li @if(!pagination.hasLast){class="disabled"}><a href="@pagination.last(routes.DeployController.history)">»»</a></li>
     </ul>
 </div>

--- a/riff-raff/app/views/snippets/recordTable.scala.html
+++ b/riff-raff/app/views/snippets/recordTable.scala.html
@@ -109,22 +109,22 @@
                             @maybeFilter.map { filter =>
                                 <li role="separator" class="divider"></li>
                                 <li><a href="@{
-                                    routes.DeployController.history()
+                                    routes.DeployController.history
                                 }?@{
                                     filter.replaceFilter(_.withStage(Some(record.parameters.stage.name))).q
                                 }">Filter Stage=<strong>@record.parameters.stage.name</strong></a></li>
                                 <li><a href="@{
-                                    routes.DeployController.history()
+                                    routes.DeployController.history
                                 }?@{
                                     filter.replaceFilter(_.withProjectName(Some(record.parameters.build.projectName))).q
                                 }">Filter Project=<strong>@record.parameters.build.projectName</strong></a></li>
                                 <li><a href="@{
-                                    routes.DeployController.history()
+                                    routes.DeployController.history
                                 }?@{
                                     filter.replaceFilter(_.withStatus(Some(record.state))).q
                                 }">Filter Status=<strong>@record.state.toString</strong></a></li>
                                 <li><a href="@{
-                                    routes.DeployController.history()
+                                    routes.DeployController.history
                                 }?@{
                                     filter.replaceFilter(_.withDeployer(Some(record.parameters.deployer.name))).q
                                 }">Filter Deployer=<strong>@record.parameters.deployer.name</strong></a></li>

--- a/riff-raff/app/views/test/debugLogViewer.scala.html
+++ b/riff-raff/app/views/test/debugLogViewer.scala.html
@@ -10,7 +10,7 @@
     <p>@record.metaData.toString</p>
 
     <span>
-    @helper.form(action=routes.Testing.actionUUID(), 'class -> "modal-form") {
+    @helper.form(action=routes.Testing.actionUUID, 'class -> "modal-form") {
         @CSRF.formField
         <input type="hidden" name="uuid" value="@record.uuid"/>
         <button name="action" type="submit" value="deleteV2" class="btn btn-danger btn-xs"><i class="glyphicon glyphicon-trash glyphicon glyphicon-white"></i> Delete</button>

--- a/riff-raff/app/views/test/form.scala.html
+++ b/riff-raff/app/views/test/form.scala.html
@@ -1,12 +1,11 @@
 @import conf.Config
 @(testForm: Form[controllers.Testing.TestForm])(config: Config, menu: Menu)(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], messages: Messages)
-@import b3.vertical.fieldConstructor
 @import helper.CSRF
 
 @main("Test form", request) {
     <h2>Test form</h2>
 
-    @b3.form(action=routes.Testing.formPost) {
+    @b3.vertical.form(action=routes.Testing.formPost) { implicit fc =>
         @CSRF.formField
 
         @b3.text(testForm("project"))
@@ -16,7 +15,7 @@
         <div class="actions">
             <button name="action" type="submit" value="preview" class="btn btn-primary">Preview...</button> or
             <button name="action" type="submit" value="deploy" class="btn btn-danger">Deploy Now</button> or
-            <a href="@routes.Application.index()" class="btn btn-danger">Cancel</a>
+            <a href="@routes.Application.index" class="btn btn-danger">Cancel</a>
         </div>
     }
 }(config, menu)

--- a/riff-raff/app/views/test/uuidList.scala.html
+++ b/riff-raff/app/views/test/uuidList.scala.html
@@ -31,7 +31,7 @@
         <td>V2</td>
         <td>
           <span>
-          @helper.form(action=routes.Testing.actionUUID(), 'class -> "modal-form") {
+          @helper.form(action=routes.Testing.actionUUID, 'class -> "modal-form") {
             @CSRF.formField
             <input type="hidden" name="uuid" value="@deploy.uuid"/>
             <button name="action" type="submit" value="deleteV2" class="btn btn-danger btn-xs"><i class="glyphicon glyphicon-trash glyphicon glyphicon-white"></i> V2</button>

--- a/riff-raff/app/views/validation/validationForm.scala.html
+++ b/riff-raff/app/views/validation/validationForm.scala.html
@@ -1,12 +1,11 @@
 @import conf.Config
 @(config: Config, menu: Menu)(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity])
-@import b3.vertical.fieldConstructor
 @import helper.CSRF
 
 @main("Validation form", request) {
     <div class="clearfix"><p>&nbsp;</p></div>
     <div class="col-md-6">
-    @b3.form(routes.Application.validateConfiguration, 'class -> "well") {
+    @b3.vertical.form(routes.Application.validateConfiguration, 'class -> "well") { implicit fc =>
         @CSRF.formField
         <fieldset>
             <legend>Paste your riff-raff.yaml content to validate it...</legend>

--- a/riff-raff/test/MappingTest.scala
+++ b/riff-raff/test/MappingTest.scala
@@ -12,7 +12,7 @@ import persistence.{AllDocument, DeploymentKeysSelectorDocument}
 import persistence.DeployDocument
 import persistence._
 
-class MappingTest extends AnyFlatSpec with Matchers with Utilities with PersistenceTestInstances with Logging {
+class MappingTest extends AnyFlatSpec with Matchers with PersistenceTestInstances with Logging {
   "RecordConverter" should "transform a deploy record into a deploy document" in {
     RecordConverter(testRecord).deployDocument should be(
       DeployRecordDocument(

--- a/riff-raff/test/RepresentationTest.scala
+++ b/riff-raff/test/RepresentationTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import persistence._
 
-class RepresentationTest extends AnyFlatSpec with Matchers with Utilities with PersistenceTestInstances {
+class RepresentationTest extends AnyFlatSpec with Matchers with PersistenceTestInstances {
 
   "MessageDocument" should "convert from log messages to documents" in {
     deploy.asMessageDocument should be(DeployDocument)

--- a/riff-raff/test/Utilities.scala
+++ b/riff-raff/test/Utilities.scala
@@ -2,7 +2,6 @@ package test
 
 import java.util.UUID
 import deployment.DeployRecord
-import gnieh.diffson.playJson._
 import magenta.ContextMessage._
 import magenta.Message._
 import magenta.Strategy.MostlyHarmless
@@ -10,11 +9,7 @@ import magenta._
 import magenta.input.All
 import org.joda.time.DateTime
 import persistence.{LogDocument, RecordConverter}
-import play.api.libs.json.Json
 
-trait Utilities {
-  def compareJson(from: String, to: String) = JsonDiff.diff(Json.parse(from), Json.parse(to), remember = true)
-}
 
 trait PersistenceTestInstances {
   val testTime = new DateTime()


### PR DESCRIPTION
**Note, I have disabled compilation warnings for now (there remain a lot, mostly due to deprecations), as I plan on tackling these in a follow up PR.**

**Note, depends on https://github.com/guardian/riff-raff/pull/667 (now live).**

## What does this change?
Scala -> 2.13 (previously 2.12)
Play  -> 2.8 (2.6)
SBT   -> 1.5.6 (0.13)

This was a bit of a gigantic upgrade due to dependency binary
incompatibilities (dependency coupling) and general breaking
changes.

Hopefully in future we can do smaller and more frequent updates.

To break down the changes:

### 1. Removal of some niche dependencies

The list is: diffson-play-json, scala-ssh, henkan-convert.

These were either unused or used only a little.

### 2. .mapValues -> .view.mapValues(...).toMap

https://docs.scala-lang.org/overviews/core/collections-migration-213.html#what-are-the-breaking-changes

### 3. other Scala 2.12 and 2.13 changes

* .par now requires a special import
* Seq is now core.immutable.Seq
* import precendence and shadowing seems to have changed (see:
  scala/scala#6589), which I *think* caused this issue
  as task and deployment_types packages share many names
* requirement to drop parens when a method (typically controller
  method) was defined without them
* etc.

### 4. library breaking changes

For example, in the Guardian's own Play Secret and GoogleAuth
libraries, or in the Boostrap ('b3') library, especially in
how forms are defined.

### 5. SBT changes

The deprecation of 'in' for '/' instead.

## How to test

CI, and then a manual test of key functionality in CODE.