### PR TITLE
Use Java 11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,9 +65,8 @@ lazy val riffraff = project.in(file("riff-raff"))
       "-J-XX:MaxRAMFraction=2",
       "-J-XX:InitialRAMFraction=2",
       "-J-XX:MaxMetaspaceSize=300m",
-      "-J-XX:+PrintGCDetails",
-      "-J-XX:+PrintGCDateStamps",
-      s"-J-Xloggc:/var/log/${packageName.value}/gc.log"
+      "-J-Xlog:gc*",
+      s"-J-Xlog:gc:/var/log/${packageName.value}/gc.log"
     ),
 
     packageName in Universal := normalizedName.value,

--- a/riff-raff/bootstrap.sh
+++ b/riff-raff/bootstrap.sh
@@ -77,6 +77,10 @@ chown -R ${USER} ${HOME}
 # try to clean up
 rm /tmp/${APP}.tgz || true
 
+# create GC log directory (Java process fails to start without this pre-existing)
+mkdir -p /var/log/${USER}
+chown ${USER} /var/log/${USER}
+
 # Service
 cat > /etc/systemd/system/${APP}.service << EOF
 [Unit]

--- a/riff-raff/riff-raff.yaml
+++ b/riff-raff/riff-raff.yaml
@@ -12,7 +12,7 @@ deployments:
     app: riff-raff
     parameters:
       amiTags:
-        Recipe: arm64-bionic-java8-deploy-infrastructure
+        Recipe: arm64-bionic-java11-deploy-infrastructure
         AmigoStage: PROD
         BuiltBy: amigo
       amiEncrypted: true


### PR DESCRIPTION
## What does this change?

Switch from Java 8 to Java 11. There are potential performance gains but the main motivation is that some libraries require Java 11 now to function.  Specifically the Guardian's Play Secret Rotation library ultimately depends (via https://github.com/guardian/play-secret-rotation/blob/main/build.sbt#L18) on https://github.com/ben-manes/caffeine/releases/tag/v3.0.0 which required Java 11 to work.

When running with Java 8 the following error is seen:

    java.lang.UnsupportedClassVersionError: JVMCFRE003 bad major version; class=com/github/benmanes/caffeine/cache/Weigher, offset=6

## How to test

In theory this should *just work*. But we will test on CODE.