### PR TITLE
fix: Use raw YAML to determine Anghammarad targets

### DIFF
--- a/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentResolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentResolver.scala
@@ -89,7 +89,7 @@ object DeploymentResolver {
   }
 }
 
-private [resolver] case class PartiallyResolvedDeployment(
+case class PartiallyResolvedDeployment(
   name: String,
   `type`: String,
   stacks: NEL[String],

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -121,7 +121,7 @@ class AppComponents(context: Context, config: Config, passwordProvider: Password
   val continuousDeployment = new ContinuousDeployment(config, changeFreeze, buildPoller, deployments, continuousDeploymentConfigRepository)
   val previewCoordinator = new PreviewCoordinator(config,prismLookup, availableDeploymentTypes, ioExecutionContext)
   val artifactHousekeeper = new ArtifactHousekeeping(config, deployments)
-  val scheduledDeployNotifier = new DeployFailureNotifications(config, availableDeploymentTypes, targetResolver, prismLookup)
+  val scheduledDeployNotifier = new DeployFailureNotifications(config, targetResolver, prismLookup)
 
   val authAction = new AuthAction[AnyContent](
     googleAuthConfig, routes.Login.loginAction(), controllerComponents.parsers.default)(executionContext)


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Currently, we validate the `riff-raff.yaml` before identifying targets for an Anghammarad notification. This is fine until we change the rules for what makes a valid `riff-raff.yaml` file!

In this change we remove the validation step and instead use the raw YAML file.

See https://github.com/guardian/riff-raff/pull/665 which is causing deployments to fail if they are missing a parameter.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

In the scenario where a deployment fails due to a missing parameter in `riff-raff.yaml`, teams continue to get notified directly.
