### PR TITLE
Attempt fix of scheduled deploys issue

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/GCP.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/GCP.scala
@@ -1,25 +1,25 @@
 package magenta.tasks.gcp
 
-import java.io.{ByteArrayInputStream, IOException}
 import cats.syntax.either._
-import com.google.api.client.googleapis.apache.GoogleApacheHttpTransport
+import com.google.api.client.googleapis.apache.v2.GoogleApacheHttpTransport
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.http.HttpResponseException
-import com.google.api.client.http.apache.ApacheHttpTransport
-import com.google.api.client.json.jackson2.JacksonFactory
-import com.google.api.services.storage.Storage
+import com.google.api.client.http.apache.v2.ApacheHttpTransport
+import com.google.api.client.json.gson.GsonFactory
 import com.google.api.services.deploymentmanager.model.Operation.Error.Errors
 import com.google.api.services.deploymentmanager.model._
 import com.google.api.services.deploymentmanager.{DeploymentManager, DeploymentManagerScopes}
+import com.google.api.services.storage.Storage
 import magenta.tasks.gcp.GCPRetryHelper.Result
 import magenta.{ApiStaticCredentials, DeployReporter, DeploymentResources, KeyRing, Loggable}
 
+import java.io.{ByteArrayInputStream, IOException}
 import scala.collection.JavaConverters._
 
 object GCP {
   lazy val httpTransport: ApacheHttpTransport = GoogleApacheHttpTransport.newTrustedTransport
-  lazy val jsonFactory: JacksonFactory = JacksonFactory.getDefaultInstance
+  lazy val jsonFactory: GsonFactory = GsonFactory.getDefaultInstance
   val scopes: Seq[String] = Seq(
     DeploymentManagerScopes.CLOUD_PLATFORM
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val aws = "2.17.35"
+    val aws = "2.17.109"
     val jackson = "2.9.8"
     val awsRds = "1.11.563"
     val enumeratumPlay = "1.7.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,7 +39,7 @@ object Dependencies {
     "com.typesafe.play" %% "play-json" % "2.8.2",
     "com.beachape" %% "enumeratum-play-json" % Versions.enumeratumPlay,
     "com.google.apis" % "google-api-services-deploymentmanager" % "v2-rev75-1.25.0",
-    "com.google.apis" % "google-api-services-storage" % "v1-rev171-1.25.0",
+    "com.google.cloud" % "google-cloud-storage" % "2.2.3",
     "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4"
   ).map((m: ModuleID) =>
     // don't even ask why I need to do this


### PR DESCRIPTION
[(re https://github.com/guardian/riff-raff/pull/666](https://github.com/guardian/riff-raff/pull/666#issuecomment-1010990152)

The error seen is:

    software.amazon.awssdk.core.exception.SdkClientException Unable to marshall request to JSON: Can not write a field name, expecting a value

And it is kicked off here:

magenta.tasks.UpdateS3Lambda.$anonfun$execute$7(tasks.scala:263)

though ultimately is thrown from the AWS SDK.

It's a bit unclear why this has broken. The surrounded code has not been changed by the upgrades PR. And there are not many similar reports, but an example is:

https://github.com/aws/aws-sdk-java-v2/issues/2875

As the inputs to the call look okay (we log them in the build) for now bumping the library makes sense as a first effort at a fix.