### PR TITLE
fix: Handle no-op ChangeSets more gracefully

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
@@ -14,33 +14,27 @@ object AmiCloudFormationParameter extends DeploymentType with CloudFormationDepl
       |You will need to add this as a dependency to your autoscaling deploy in your riff-raff.yaml to guard against race conditions.
     """.stripMargin
 
-  val update = Action("update",
-    """
-      |Given AMI tags, this will resolve the latest matching AMI and update the AMI parameter
-      | on the provided CloudFormation stack.
-    """.stripMargin
-  ){ (pkg, resources, target) => {
-      implicit val keyRing = resources.assembleKeyring(target, pkg)
-      val reporter = resources.reporter
-      val amiParameterMap: Map[CfnParam, TagCriteria] = getAmiParameterMap(pkg, target, reporter)
-      val cloudFormationStackLookupStrategy = getCloudFormationStackLookupStrategy(pkg, target, reporter)
+  val update = Action("update", "Given AMI tags, this will resolve the latest matching AMI and update the AMI parameter on the provided CloudFormation stack."){ (pkg, resources, target) => {
+    implicit val keyRing = resources.assembleKeyring(target, pkg)
+    val reporter = resources.reporter
+    val amiParameterMap: Map[CfnParam, TagCriteria] = getAmiParameterMap(pkg, target, reporter)
+    val cloudFormationStackLookupStrategy = getCloudFormationStackLookupStrategy(pkg, target, reporter)
 
-      List(
-        UpdateAmiCloudFormationParameterTask(
-          target.region,
-          cloudFormationStackLookupStrategy,
-          amiParameterMap,
-          getLatestAmi(pkg, target, reporter, resources.lookup),
-          target.parameters.stage,
-          target.stack
-        ),
-        new CheckUpdateEventsTask(
-          target.region,
-          cloudFormationStackLookupStrategy
-        )
+    List(
+      UpdateAmiCloudFormationParameterTask(
+        target.region,
+        cloudFormationStackLookupStrategy,
+        amiParameterMap,
+        getLatestAmi(pkg, target, reporter, resources.lookup),
+        target.parameters.stage,
+        target.stack
+      ),
+      new CheckUpdateEventsTask(
+        target.region,
+        cloudFormationStackLookupStrategy
       )
-    }
-  }
+    )
+  }}
 
   def defaultActions = List(update)
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
@@ -20,6 +20,7 @@ object AmiCloudFormationParameter extends DeploymentType with CloudFormationDepl
     val amiParameterMap: Map[CfnParam, TagCriteria] = getAmiParameterMap(pkg, target, reporter)
     val cloudFormationStackLookupStrategy = getCloudFormationStackLookupStrategy(pkg, target, reporter)
 
+    // TODO wrap this CloudFormation update in a ChangeSet. See `Cloudformation.scala`.
     List(
       UpdateAmiCloudFormationParameterTask(
         target.region,

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -148,9 +148,9 @@ object CloudFormation extends DeploymentType with CloudFormationDeploymentTypePa
         target.region,
         stackLookup
       ),
-      new CheckUpdateEventsTask(
+      new CheckUpdateEventsForChangeSetTask(
         target.region,
-        cloudFormationStackLookupStrategy
+        stackLookup
       ),
       new DeleteChangeSetTask(
         target.region,


### PR DESCRIPTION
Easiest to review [w/out whitespace](https://github.com/guardian/riff-raff/pull/671/files?diff=split&w=1).

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The `cloud-formation` deployment type in Riff-Raff has a number of steps (well, [tasks](https://github.com/guardian/riff-raff/blob/3bf2aa3529fda6f536a698c712c0186812147477/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala#L135-L184)):
  1. Set the update policy on the CloudFormation stack to guard against deleting stateful resources
  2. Create a [ChangeSet](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-changesets.html)
  3. Execute the ChangeSet
  4. Watch the CloudFormation event log to determine when 3 has finished
  5. Revert 1

Currently in step 4, we're only looking at the _first_ page of CloudFormation events and we expect to find an `UPDATE_IN_PROGRESS` or `CREATE_IN_PROGRESS` event in the list. When we don't, the deploy currently [fails](https://github.com/guardian/riff-raff/blob/dacc0dedc6ec23816d213c39e1b7af3e321b772f/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala#L347) with `No events found at all for stack...`.

<details>
  <summary>Riff-Raff screenshot</summary>
  
  ![image](https://user-images.githubusercontent.com/836140/149344770-db26236e-b64b-444b-afe6-97440bdb73d7.png)
</details>

This happens if a CloudFormation update generates _lots_ of items in the event log, causing the `UPDATE_IN_PROGRESS` or `CREATE_IN_PROGRESS` events off the first page.

In this change we update step 4, exiting early if the change set created in step 2 will not yield changes to the stack. Meaning we only look at the event log when necessary. This logic already happens for [step 3](https://github.com/guardian/riff-raff/blob/0b43d431c3a75f2fa38b21fdb9e210cdc19d86a9/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala#L141-L142).

After a discussion with @nicl @jacobwinch and @michaelwmcnamara, we think it would actually be better to check the [`ExecutionStatus`](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DescribeChangeSet.html#:~:text=length%20of%201024.-,ExecutionStatus,-If%20the%20change) of a change set instead of the CloudFormation event log to determine when a change set has finished executing. This also reduces the chance of us observing an event that was _not_ triggered by a deploy (somehow!) but still treating it as though it was part of the deploy. We'll get this added to the backlog.

This change is still valuable though as it results in our skipping of step 4 above all together.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

1. Deploy `main` to CODE
2. Identify a stack who's CloudFormation event log has `UPDATE_IN_PROGRESS` off the first page.
3. Make a no-op change to a CloudFormation template, e.g. add a `.` to a parameter's description
4. Perform a `cloud-formation` deployment and observe it fail, similar to the above screenshot
5. Deploy this branch to CODE
6. Perform a `cloud-formation` deployment and observe it succeed. Specifically the `CheckUpdateEventsTask` step should succeed with `No changes to perform for ... on stack...` rather than failing with `No events found at all for stack...`.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Fewer deployment failures.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

Building of tech dept! As noted in the `TODO`s added in this PR, we'd ideally wrap the `ami-cloudformation-parameter` deployment type in the above ChangeSet logic. This is good as ChangeSet's offer another audit trail but also because `CheckUpdateEventsTask` is shared between the `cloud-formation` type and the `ami-cloudformation-parameter` type. For `CheckUpdateEventsTask` to check if a ChangeSet actually includes any changes, the types within `CheckUpdateEventsTask` need updating. This wasn't immediately trivial. That is, this PR is the pragmatic solution.