### PR TITLE
fix: Poll CloudFormation events within `ExecuteChangeSetTask`

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -148,10 +148,6 @@ object CloudFormation extends DeploymentType with CloudFormationDeploymentTypePa
         target.region,
         stackLookup
       ),
-      new CheckUpdateEventsForChangeSetTask(
-        target.region,
-        stackLookup
-      ),
       new DeleteChangeSetTask(
         target.region,
         stackLookup

--- a/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
@@ -4,11 +4,14 @@ import magenta.artifact.S3Path
 import magenta.tasks.CloudFormationParameters.{ExistingParameter, InputParameter, TemplateParameter}
 import magenta.tasks.UpdateCloudFormationTask._
 import magenta.{ApiRoleCredentials, DeployReporter, DeploymentResources, KeyRing, Region}
+import org.joda.time.{DateTime, Duration}
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient
 import software.amazon.awssdk.services.cloudformation.model.ChangeSetStatus._
-import software.amazon.awssdk.services.cloudformation.model.{Change, ChangeSetType, DeleteChangeSetRequest, DescribeChangeSetRequest, ExecuteChangeSetRequest}
+import software.amazon.awssdk.services.cloudformation.model.{Change, ChangeSetType, DeleteChangeSetRequest, DescribeChangeSetRequest, ExecuteChangeSetRequest, ListChangeSetsRequest, StackEvent}
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sts.StsClient
 
+import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.util.{Success, Try}
 
@@ -130,6 +133,17 @@ class ExecuteChangeSetTask(
                             region: Region,
                             stackLookup: CloudFormationStackMetadata,
 )(implicit val keyRing: KeyRing, artifactClient: S3Client) extends Task {
+
+  private def getChangeSetExecutionStatus(cfnClient: CloudFormationClient, changeSetArn: String): String = {
+    val request = DescribeChangeSetRequest.builder().changeSetName(changeSetArn).build()
+    val response = cfnClient.describeChangeSet(request)
+    response.executionStatusAsString()
+  }
+
+  private def isChangeSetExecutionComplete(cfnClient: CloudFormationClient, changeSetArn: String): Boolean = {
+    getChangeSetExecutionStatus(cfnClient, changeSetArn) == "EXECUTE_COMPLETE"
+  }
+
   override def execute(resources: DeploymentResources, stopFlag: => Boolean): Unit = {
     CloudFormation.withCfnClient(keyRing, region, resources) { cfnClient =>
       val (stackName, _, _) = stackLookup.lookup(resources.reporter, cfnClient)
@@ -137,6 +151,8 @@ class ExecuteChangeSetTask(
 
       val describeRequest = DescribeChangeSetRequest.builder().changeSetName(changeSetName).stackName(stackName).build()
       val describeResponse = cfnClient.describeChangeSet(describeRequest)
+
+      val changeSetArn = describeResponse.changeSetId()
 
       if (describeResponse.changes.isEmpty) {
         resources.reporter.info(s"No changes to perform for $changeSetName on stack $stackName")
@@ -147,6 +163,11 @@ class ExecuteChangeSetTask(
 
         val request = ExecuteChangeSetRequest.builder().changeSetName(changeSetName).stackName(stackName).build()
         cfnClient.executeChangeSet(request)
+        
+        import magenta.tasks.StackEventPoller.check
+
+        // poll events and wait for completion
+        check(stackName, cfnClient, resources, stopFlag, None, Some(() => isChangeSetExecutionComplete(cfnClient, changeSetArn)))
       }
     }
   }

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -343,26 +343,26 @@ class CheckUpdateEventsTask(
 }
 
 class CloudFormationStackEventPoller(stackName: String, cfnClient: CloudFormationClient, resources: DeploymentResources, stopFlag: => Boolean) extends Loggable {
-  private def reportEvent(reporter: DeployReporter, e: StackEvent): Unit = {
+  private[this] def reportEvent(reporter: DeployReporter, e: StackEvent): Unit = {
     reporter.info(s"${e.logicalResourceId} (${e.resourceType}): ${e.resourceStatusAsString}")
     if (e.resourceStatusReason != null) reporter.verbose(e.resourceStatusReason)
   }
-  private def isStackEvent(stackName: String)(e: StackEvent): Boolean =
+  private[this] def isStackEvent(stackName: String)(e: StackEvent): Boolean =
     e.resourceType == "AWS::CloudFormation::Stack" && e.logicalResourceId == stackName
 
-  private def updateStart(stackName: String)(e: StackEvent): Boolean =
+  private[this] def updateStart(stackName: String)(e: StackEvent): Boolean =
     isStackEvent(stackName)(e) && (e.resourceStatusAsString == "UPDATE_IN_PROGRESS" || e.resourceStatusAsString == "CREATE_IN_PROGRESS")
 
-  private def updateComplete(stackName: String)(e: StackEvent): Boolean =
+  private[this] def updateComplete(stackName: String)(e: StackEvent): Boolean =
     isStackEvent(stackName)(e) && (e.resourceStatusAsString == "UPDATE_COMPLETE" || e.resourceStatusAsString == "CREATE_COMPLETE")
 
-  private def updateFailed(e: StackEvent): Boolean = {
+  private[this] def updateFailed(e: StackEvent): Boolean = {
     val failed = e.resourceStatusAsString.contains("FAILED") || e.resourceStatusAsString.contains("ROLLBACK")
     logger.debug(s"${e.resourceStatusAsString} - failed = $failed")
     failed
   }
 
-  private def fail(reporter: DeployReporter, e: StackEvent): Unit = reporter.fail(
+  private[this] def fail(reporter: DeployReporter, e: StackEvent): Unit = reporter.fail(
     s"""${e.logicalResourceId}(${e.resourceType}}: ${e.resourceStatusAsString}
        |${e.resourceStatusReason}""".stripMargin)
 

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -326,8 +326,6 @@ class CheckUpdateEventsTask(
   override def execute(resources: DeploymentResources, stopFlag: => Boolean): Unit = {
     CloudFormation.withCfnClient(keyRing, region, resources) { cfnClient =>
 
-      import StackEvent._
-
       val stackName = stackLookupStrategy match {
         case LookupByName(name) => name
         case strategy@LookupByTags(tags) =>
@@ -336,91 +334,73 @@ class CheckUpdateEventsTask(
           stack.stackName
       }
 
-      @tailrec
-      def check(lastSeenEvent: Option[StackEvent]): Unit = {
-        val result = CloudFormation.describeStackEvents(stackName, cfnClient)
-        val events = result.stackEvents.asScala
-
-        lastSeenEvent match {
-          case None =>
-            events.find(updateStart(stackName)) match {
-              case None => resources.reporter.fail(s"No events found at all for stack $stackName")
-              case Some(e) =>
-                val age = new Duration(new DateTime(e.timestamp().toEpochMilli), new DateTime()).getStandardSeconds
-                if (age > 30) {
-                  resources.reporter.verbose("No recent IN_PROGRESS events found (nothing within last 30 seconds)")
-                } else {
-                  reportEvent(resources.reporter, e)
-                  check(Some(e))
-                }
-              }
-          case Some(event) =>
-            val newEvents = events.takeWhile(_.timestamp.isAfter(event.timestamp))
-            newEvents.reverse.foreach(reportEvent(resources.reporter, _))
-            newEvents.filter(updateFailed).foreach(fail(resources.reporter, _))
-
-            val complete = newEvents.exists(updateComplete(stackName))
-            if (!complete && !stopFlag) {
-              Thread.sleep(5000)
-              check(Some(newEvents.headOption.getOrElse(event)))
-            }
-        }
-      }
-
-      check(None)
+      StackEventPoller.check(stackName, cfnClient, resources, stopFlag, None)
     }
   }
 
-  object StackEvent {
-    def reportEvent(reporter: DeployReporter, e: StackEvent): Unit = {
-      reporter.info(s"${e.logicalResourceId} (${e.resourceType}): ${e.resourceStatusAsString}")
-      if (e.resourceStatusReason != null) reporter.verbose(e.resourceStatusReason)
-    }
-    def isStackEvent(stackName: String)(e: StackEvent): Boolean =
-      e.resourceType == "AWS::CloudFormation::Stack" && e.logicalResourceId == stackName
-    def updateStart(stackName: String)(e: StackEvent): Boolean =
-      isStackEvent(stackName)(e) && (e.resourceStatusAsString == "UPDATE_IN_PROGRESS" || e.resourceStatusAsString == "CREATE_IN_PROGRESS")
-    def updateComplete(stackName: String)(e: StackEvent): Boolean =
-      isStackEvent(stackName)(e) && (e.resourceStatusAsString == "UPDATE_COMPLETE" || e.resourceStatusAsString == "CREATE_COMPLETE")
-
-    def updateFailed(e: StackEvent): Boolean = {
-      val failed = e.resourceStatusAsString.contains("FAILED") || e.resourceStatusAsString.contains("ROLLBACK")
-      logger.debug(s"${e.resourceStatusAsString} - failed = $failed")
-      failed
-    }
-
-    def fail(reporter: DeployReporter, e: StackEvent): Unit = reporter.fail(
-      s"""${e.logicalResourceId}(${e.resourceType}}: ${e.resourceStatusAsString}
-            |${e.resourceStatusReason}""".stripMargin)
-  }
 
   def description = s"Checking events on update for stack $stackLookupStrategy"
 }
 
-/*
-We're sub-classing `CheckUpdateEventsTask` in order to first check if a ChangeSet has yielded any changes - only poll for CloudWatch Events if it did.
-Ideally this check would sit in `CheckUpdateEventsTask` itself, however `CheckUpdateEventsTask` is used by the `AmiCloudFormationParameter` deployment type, which is not yet ChangeSet aware.
-TODO Make `AmiCloudFormationParameter` deployment type ChangeSet aware.
- */
-class CheckUpdateEventsForChangeSetTask(
-  region: Region,
-  stackLookup: CloudFormationStackMetadata
-)(implicit override val keyRing: KeyRing) extends CheckUpdateEventsTask(region, stackLookup.strategy) {
-  override def execute(resources: DeploymentResources, stopFlag: => Boolean): Unit = {
-    CloudFormation.withCfnClient(keyRing, region, resources) { cfnClient =>
-      val (stackName, _, _) = stackLookup.lookup(resources.reporter, cfnClient)
-      val changeSetName = stackLookup.changeSetName
+object StackEventPoller extends Loggable {
+  @tailrec
+  def check(
+    stackName: String,
+    cfnClient: CloudFormationClient,
+    resources: DeploymentResources,
+    stopFlag: => Boolean,
+    lastSeenEvent: Option[StackEvent],
+    completeChecks: Option[() => Boolean] = None
+  ): Unit = {
+    val result = CloudFormation.describeStackEvents(stackName, cfnClient)
+    val events = result.stackEvents.asScala
 
-      val describeRequest = DescribeChangeSetRequest.builder().changeSetName(changeSetName).stackName(stackName).build()
-      val describeResponse = cfnClient.describeChangeSet(describeRequest)
+    lastSeenEvent match {
+      case None =>
+        events.find(updateStart(stackName)) match {
+          case None => resources.reporter.fail(s"No events found at all for stack $stackName")
+          case Some(e) =>
+            val age = new Duration(new DateTime(e.timestamp().toEpochMilli), new DateTime()).getStandardSeconds
+            if (age > 30) {
+              resources.reporter.verbose("No recent IN_PROGRESS events found (nothing within last 30 seconds)")
+            } else {
+              reportEvent(resources.reporter, e)
+              check(stackName, cfnClient, resources, stopFlag, Some(e))
+            }
+        }
+      case Some(event) =>
+        val newEvents = events.takeWhile(_.timestamp.isAfter(event.timestamp))
+        newEvents.reverse.foreach(reportEvent(resources.reporter, _))
+        newEvents.filter(updateFailed).foreach(fail(resources.reporter, _))
 
-      if (describeResponse.changes.isEmpty) {
-        resources.reporter.info(s"No changes to perform for $changeSetName on stack $stackName")
-      } else {
-        super.execute(resources, stopFlag)
-      }
+        val additionalCompletionChecks = completeChecks.getOrElse(() => true)
+
+        val complete = newEvents.exists(updateComplete(stackName)) && additionalCompletionChecks()
+        if (!complete && !stopFlag) {
+          Thread.sleep(5000)
+          check(stackName, cfnClient, resources, stopFlag, Some(newEvents.headOption.getOrElse(event)))
+        }
     }
   }
 
-  override def description = s"Checking events for change set ${stackLookup.changeSetName} on stack ${stackLookup.strategy}"
+  def reportEvent(reporter: DeployReporter, e: StackEvent): Unit = {
+    reporter.info(s"${e.logicalResourceId} (${e.resourceType}): ${e.resourceStatusAsString}")
+    if (e.resourceStatusReason != null) reporter.verbose(e.resourceStatusReason)
+  }
+  def isStackEvent(stackName: String)(e: StackEvent): Boolean =
+    e.resourceType == "AWS::CloudFormation::Stack" && e.logicalResourceId == stackName
+  def updateStart(stackName: String)(e: StackEvent): Boolean =
+    isStackEvent(stackName)(e) && (e.resourceStatusAsString == "UPDATE_IN_PROGRESS" || e.resourceStatusAsString == "CREATE_IN_PROGRESS")
+  def updateComplete(stackName: String)(e: StackEvent): Boolean =
+    isStackEvent(stackName)(e) && (e.resourceStatusAsString == "UPDATE_COMPLETE" || e.resourceStatusAsString == "CREATE_COMPLETE")
+
+  def updateFailed(e: StackEvent): Boolean = {
+    val failed = e.resourceStatusAsString.contains("FAILED") || e.resourceStatusAsString.contains("ROLLBACK")
+    logger.debug(s"${e.resourceStatusAsString} - failed = $failed")
+    failed
+  }
+
+  def fail(reporter: DeployReporter, e: StackEvent): Unit = reporter.fail(
+    s"""${e.logicalResourceId}(${e.resourceType}}: ${e.resourceStatusAsString}
+          |${e.resourceStatusReason}""".stripMargin)
 }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -46,28 +46,26 @@ class CloudFormationTest extends AnyFlatSpec with Matchers with Inside with Eith
     )
 
     val tasks = generateTasks(data)
-    tasks should have size(5)
+    tasks should have size(4)
 
     tasks(0) shouldBe a[CreateChangeSetTask]
     tasks(1) shouldBe a[CheckChangeSetCreatedTask]
     tasks(2) shouldBe a[ExecuteChangeSetTask]
-    tasks(3) shouldBe a[CheckUpdateEventsTask]
-    tasks(4) shouldBe a[DeleteChangeSetTask]
+    tasks(3) shouldBe a[DeleteChangeSetTask]
   }
 
   it should "generate stack policy tasks in the correct order when manageStackPolicy is true (default)" in {
     val tasks = generateTasks()
-    tasks should have size(7)
+    tasks should have size(6)
 
     tasks(0) shouldBe a[SetStackPolicyTask]
     tasks(0).asInstanceOf[SetStackPolicyTask].stackPolicy shouldBe DenyReplaceDeletePolicy
     tasks(1) shouldBe a[CreateChangeSetTask]
     tasks(2) shouldBe a[CheckChangeSetCreatedTask]
     tasks(3) shouldBe a[ExecuteChangeSetTask]
-    tasks(4) shouldBe a[CheckUpdateEventsTask]
-    tasks(5) shouldBe a[DeleteChangeSetTask]
-    tasks(6) shouldBe a[SetStackPolicyTask]
-    tasks(6).asInstanceOf[SetStackPolicyTask].stackPolicy shouldBe AllowAllPolicy
+    tasks(4) shouldBe a[DeleteChangeSetTask]
+    tasks(5) shouldBe a[SetStackPolicyTask]
+    tasks(5).asInstanceOf[SetStackPolicyTask].stackPolicy shouldBe AllowAllPolicy
   }
 
   it should "generate stack policy tasks in the correct order when manageStackPolicy is true and update strategy is Dangerous" in {
@@ -76,17 +74,16 @@ class CloudFormationTest extends AnyFlatSpec with Matchers with Inside with Eith
     )
 
     val tasks = generateTasks(data, updateStrategy = Dangerous)
-    tasks should have size(7)
+    tasks should have size(6)
 
     tasks(0) shouldBe a[SetStackPolicyTask]
     tasks(0).asInstanceOf[SetStackPolicyTask].stackPolicy shouldBe AllowAllPolicy
     tasks(1) shouldBe a[CreateChangeSetTask]
     tasks(2) shouldBe a[CheckChangeSetCreatedTask]
     tasks(3) shouldBe a[ExecuteChangeSetTask]
-    tasks(4) shouldBe a[CheckUpdateEventsTask]
-    tasks(5) shouldBe a[DeleteChangeSetTask]
-    tasks(6) shouldBe a[SetStackPolicyTask]
-    tasks(6).asInstanceOf[SetStackPolicyTask].stackPolicy shouldBe AllowAllPolicy
+    tasks(4) shouldBe a[DeleteChangeSetTask]
+    tasks(5) shouldBe a[SetStackPolicyTask]
+    tasks(5).asInstanceOf[SetStackPolicyTask].stackPolicy shouldBe AllowAllPolicy
   }
 
   it should "ignore amiTags when amiParametersToTags and amiTags are provided" in {


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

In https://github.com/guardian/riff-raff/pull/671 we made some changes exiting early if a ChangeSet does not yield any changes. We accomplished this by calling `DescribeChangeSet` within `CheckUpdateEventsForChangeSetTask`. This happens  _after_ `ExecuteChangeSetTask` but it is too late! It appears a ChangeSet cannot be described by _name_ once it has been executed; it can only be described using the _ARN_.

<details>
<summary>CLI examples of `DescribeChangeSet` oddities</summary>

This fails:

```console
➜ aws cloudformation describe-change-set --change-set-name deploy-1642157037866 --stack-name REDACTED

An error occurred (ChangeSetNotFound) when calling the DescribeChangeSet operation: ChangeSet [deploy-1642157037866] does not exist
```

Whereas this passes:

```console
➜ aws cloudformation describe-change-set --change-set-name arn:aws:cloudformation:eu-west-1:REDACTED:changeSet/deploy-1642157037866/72832978-90fc-4408-955f-4426d4cf2ef9
{
    "Changes": [
        {
            "Type": "Resource",
            "ResourceChange": {
                "Action": "Modify",
                "LogicalResourceId": "AutoScalingGroupAmiableASGFCD99427",
                "PhysicalResourceId": "amiable-gucdk-PROD-AutoScalingGroupAmiableASGFCD99427-SZXECQFFBHKX",
                "ResourceType": "AWS::AutoScaling::AutoScalingGroup",
                "Replacement": "Conditional",
                "Scope": [
                    "Properties"
                ],
                "Details": [
                    {
                        "Target": {
                            "Attribute": "Properties",
                            "Name": "LaunchConfigurationName",
                            "RequiresRecreation": "Conditionally"
                        },
                        "Evaluation": "Static",
                        "ChangeSource": "ResourceReference",
                        "CausingEntity": "AutoScalingGroupAmiableLaunchConfig09A6D8E3"
                    }
                ]
            }
        },
        {
            "Type": "Resource",
            "ResourceChange": {
                "Action": "Modify",
                "LogicalResourceId": "AutoScalingGroupAmiableLaunchConfig09A6D8E3",
                "PhysicalResourceId": "amiable-gucdk-PROD-AutoScalingGroupAmiableLaunchConfig09A6D8E3-EY0YNXSNHM4Y",
                "ResourceType": "AWS::AutoScaling::LaunchConfiguration",
                "Replacement": "True",
                "Scope": [
                    "Properties"
                ],
                "Details": [
                    {
                        "Target": {
                            "Attribute": "Properties",
                            "Name": "ImageId",
                            "RequiresRecreation": "Always"
                        },
                        "Evaluation": "Static",
                        "ChangeSource": "ParameterReference",
                        "CausingEntity": "AMIAmiable"
                    },
                    {
                        "Target": {
                            "Attribute": "Properties",
                            "Name": "ImageId",
                            "RequiresRecreation": "Always"
                        },
                        "Evaluation": "Dynamic",
                        "ChangeSource": "DirectModification"
                    }
                ]
            }
        }
    ],
    "ChangeSetName": "deploy-1642157037866",
    "ChangeSetId": "REDACTED",
    "StackId": "REDACTED",
    "StackName": "REDACTED",
    "Description": null,
    "CreationTime": "2022-01-14T10:43:59.447000+00:00",
    "ExecutionStatus": "EXECUTE_COMPLETE",
    "Status": "CREATE_COMPLETE",
}
```

</details>

In this change, we perform the CloudFormation event log polling _within_ `ExecuteChangeSetTask` as opposed to after it. This is necessary because we don't (yet) have a mechanism to _conditionally_ perform a `Task`. That is, it is not possible to call `CheckUpdateEventsForChangeSetTask` if and only if `ExecuteChangeSetTask` generated changes to the CloudFormation stack.

It is also not possible to pass data _between_ tasks. We only know the ChangeSet name [within the task orchestrator](https://github.com/guardian/riff-raff/blob/2c394948bc6b0241b58e220a672c8046f15e919a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala#L118-L159), therefore `DescribeChangeSet` cannot be performed within `CheckUpdateEventsForChangeSetTask` as it is after `ExecuteChangeSetTask`. The only option is to combine the two (and consequently remove `CheckUpdateEventsForChangeSetTask` as it's now unused).

By performing the event log polling within `ExecuteChangeSetTask`, we're also able to observe the execution status of the ChangeSet. Now, in addition to waiting for the event log to contain a "complete" message, we also wait until the ChangeSet has successfully completed.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Given https://github.com/guardian/riff-raff/pull/671 caused deploys to fail (also demonstrating that https://github.com/guardian/riff-raff/pull/671 wasn't tested on CODE 😬 ), we'd expect deploys made with this branch to succeed and the event log to be printed within `ExecuteChangeSetTask`.

**From CODE**
![image](https://user-images.githubusercontent.com/836140/149578214-dec97941-085d-43a4-9328-8cbcfebec17a.png)

As previously [noted](https://github.com/guardian/riff-raff/pull/670#issuecomment-1012950596), we could benefit from integration testing!