### PR TITLE
refactor: Push ChangeSet logic into the `CloudFormation` object

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -423,6 +423,41 @@ object CloudFormation {
     client.createChangeSet(requestWithTemplate.build())
   }
 
+  def describeChangeSetByName(stackName: String, changeSetName: String, client: CloudFormationClient): DescribeChangeSetResponse =
+    client.describeChangeSet(
+      DescribeChangeSetRequest
+        .builder()
+        .stackName(stackName)
+        .changeSetName(changeSetName)
+        .build()
+    )
+
+  def describeChangeSetByArn(changeSetArn: String, client: CloudFormationClient): DescribeChangeSetResponse =
+    client.describeChangeSet(
+      DescribeChangeSetRequest
+        .builder()
+        .changeSetName(changeSetArn)
+        .build()
+    )
+
+  def executeChangeSet(stackName: String, changeSetName: String, client: CloudFormationClient): ExecuteChangeSetResponse =
+    client.executeChangeSet(
+      ExecuteChangeSetRequest
+        .builder()
+        .stackName(stackName)
+        .changeSetName(changeSetName)
+        .build()
+    )
+
+  def deleteChangeSet(stackName: String, changeSetName: String, client: CloudFormationClient): DeleteChangeSetResponse =
+    client.deleteChangeSet(
+      DeleteChangeSetRequest
+        .builder()
+        .stackName(stackName)
+        .changeSetName(changeSetName)
+        .build()
+    )
+
   def describeStack(name: String, client: CloudFormationClient) =
     try {
       client.describeStacks(

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -7,7 +7,7 @@ import magenta.{DeployReporter, DeployTarget, DeploymentPackage, DeploymentResou
 import org.joda.time.{DateTime, Duration}
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient
-import software.amazon.awssdk.services.cloudformation.model.{ChangeSetType, CloudFormationException, DescribeChangeSetRequest, Parameter, StackEvent}
+import software.amazon.awssdk.services.cloudformation.model.{ChangeSetType, CloudFormationException, Parameter, StackEvent}
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.sts.StsClient


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The aim of this is to follow the existing style in the repo where the [`CloudFormation` object](https://github.com/guardian/riff-raff/blob/6572e28a24e657af5406a70d8fd44fa2cb841892/magenta-lib/src/main/scala/magenta/tasks/AWS.scala#L354) makes requests to AWS.

This is a no-op.