### PR TITLE
Hide problematic /deployinfo/hosts page

### DIFF
--- a/riff-raff/app/controllers/Application.scala
+++ b/riff-raff/app/controllers/Application.scala
@@ -63,7 +63,6 @@ class Menu(config: Config) {
   )
 
   lazy val deployInfoMenu = Seq(
-    SingleMenuItem("Hosts", routes.Application.deployInfoHosts()),
     SingleMenuItem("Resources", routes.Application.deployInfoData),
     SingleMenuItem("About", routes.Application.deployInfoAbout)
   )

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -7,7 +7,7 @@ GET         /                                               controllers.Applicat
 
 GET         /deployinfo/about                               controllers.Application.deployInfoAbout
 GET         /deployinfo/data                                controllers.Application.deployInfoData
-GET         /deployinfo/hosts                               controllers.Application.deployInfoHosts(app?="")
+#GET         /deployinfo/hosts                               controllers.Application.deployInfoHosts(app?="")
 
 # Docs
 GET         /docs/                                          controllers.Application.documentation(resource="")


### PR DESCRIPTION
## What does this change?

This PR prevents users from accessing some problematic functionality which is currently causing the application to crash. We will other reinstate this functionality (or tidy it up properly) when we understand the issue/functionality better.