### PR TITLE
Specify region and provider for SSM client to help with running locally

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ Assuming you have a reasonably recent version of Java installed,
  * Create a basic configuration file at ~/.gu/riff-raff.conf (S3 and postgres config is probably the minimum)
  * Run `./script/start` from the project root (add `--debug` to attach a remote debugger on port 9999)
  * Visit http://localhost:9000/
- * Details of how to configure Riff-Raff can then be found at http://localhost:9000/docs/riffraff/properties 
+ * Details of how to configure Riff-Raff can then be found at http://localhost:9000/docs/riffraff/administration/properties 
 
 
 What is still left to do?

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -54,7 +54,7 @@ class AppComponents(context: Context, config: Config, passwordProvider: Password
     new parameterstore.SecretSupplier(
       transitionTiming = TransitionTiming(usageDelay = ofMinutes(3), overlapDuration = ofHours(2)),
       parameterName = config.auth.secretStateSupplierKeyName,
-      ssmClient = parameterstore.AwsSdkV2(SsmClient.builder().build())
+      ssmClient = parameterstore.AwsSdkV2(config.auth.secretStateSupplierClient)
     )
   }
 
@@ -113,7 +113,7 @@ class AppComponents(context: Context, config: Config, passwordProvider: Password
   val targetResolver = new TargetResolver(config, buildPoller, availableDeploymentTypes, targetDynamoRepository)
   val deployments = new Deployments(deploymentEngine, builds, documentStoreConverter, restrictionConfigDynamoRepository)
   val continuousDeployment = new ContinuousDeployment(config, changeFreeze, buildPoller, deployments, continuousDeploymentConfigRepository)
-  val previewCoordinator = new PreviewCoordinator(config,prismLookup, availableDeploymentTypes, ioExecutionContext)
+  val previewCoordinator = new PreviewCoordinator(config, prismLookup, availableDeploymentTypes, ioExecutionContext)
   val artifactHousekeeper = new ArtifactHousekeeping(config, deployments)
   val scheduledDeployNotifier = new DeployFailureNotifications(config, targetResolver, prismLookup)
 

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -19,6 +19,7 @@ import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sts.StsClient
 import utils.{DateFormats, UnnaturalOrdering}
 import riffraff.BuildInfo
+import software.amazon.awssdk.services.ssm.SsmClient
 
 import scala.jdk.CollectionConverters._
 import scala.util.{Success, Try}
@@ -77,6 +78,10 @@ class Config(configuration: TypesafeConfig, startTime: DateTime) extends Logging
     lazy val superusers: List[String] = getStringList("auth.superusers")
     lazy val secretStateSupplierKeyName: String = getStringOpt("auth.secretStateSupplier.keyName").getOrElse("/RiffRaff/PlayApplicationSecret")
     lazy val secretStateSupplierRegion: String = getStringOpt("auth.secretStateSupplier.region").getOrElse("eu-west-1")
+    lazy val secretStateSupplierClient = SsmClient.builder()
+      .credentialsProvider(credentialsProviderChain(None, None))
+      .region(AWSRegion.of(secretStateSupplierRegion))
+      .build()
   }
 
   object concurrency {


### PR DESCRIPTION
## What does this change?
Adds a region and credentials provider for the SSM client we use to fetch the play application secret. This was done to avoid a common error on startup, when a users `default` profile would be used instead of `deployTools`. I believe the important addition is `ProfileCredentialsProvider.create("deployTools")` from the `credentialsProviderChain` we are now utilising. Presumably this worked for some people depending on their local AWS defaults.

While I was there, I also noticed an incorrect link on the readme.

## How to test
Works locally, but I'll try it on CODE just in case the provider chain fails there. We just need the application to load.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
