### PR TITLE
Correct documentation for CFN deployment type

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -104,7 +104,7 @@ object CloudFormation extends DeploymentType with CloudFormationDeploymentTypePa
       |${StackPolicy.toMarkdown(AllowAllPolicy)}
       |""".stripMargin,
     optional = true
-  )
+  ).default(manageStackPolicyDefault)
 
   val updateStack = Action("updateStack",
     """


### PR DESCRIPTION
## What does this change?

![image](https://user-images.githubusercontent.com/19384074/164688331-670da8dc-2d0a-4a54-8ab2-61f3692552ba.png)

The description for `manageStackPolicy` states that the default is `true` but in the `Default` column it is incorrectly listed as having `<no default>`. This PR should fix the docs.
