### PR TITLE
Add VCS URL tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ readme.html
 .settings
 .cache
 .bsp/
+
+.bloop
+.metals
+.vscode
+metals.sbt
+project/project

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -165,13 +165,17 @@ class CloudFormation(vcsUrlLookup: VcsLookup) extends DeploymentType with CloudF
         templatePath(pkg, target, reporter)
     }
 
+    // The tag name here ('gu:repo') and format ('guardian/:reponame') MUST
+    // mirror the tag name and format used by @guardian/cdk.
+    val guRepoTag = ("gu:repo" -> vcsUrlLookup.get(target.parameters.build.projectName, target.parameters.build.id))
+
     val tasks: List[Task] = List(
       new CreateChangeSetTask(
         target.region,
         templatePath = S3Path(pkg.s3Package, cfnTemplateFile),
         stackLookup,
         unresolvedParameters,
-        stackTags = unresolvedParameters.stackTags.getOrElse(Map.empty) + ("vcsUrl" -> vcsUrlLookup.get(target.parameters.build.projectName, target.parameters.build.id))
+        stackTags = unresolvedParameters.stackTags.getOrElse(Map.empty) + guRepoTag,
       ),
       new CheckChangeSetCreatedTask(
         target.region,

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -12,8 +12,16 @@ import org.joda.time.DateTime
 
 import scala.collection.mutable.ListBuffer
 
+trait VcsLookup {
+  def get(projectName: String, buildId: String): String
+}
+
+// For testing purposes
+object NoopVcsUrlLookup extends VcsLookup { def get(projectName: String, buildId: String): String = "unknown"}  
+
+
 //noinspection TypeAnnotation
-object CloudFormation extends DeploymentType with CloudFormationDeploymentTypeParameters with Loggable {
+class CloudFormation(vcsUrlLookup: VcsLookup) extends DeploymentType with CloudFormationDeploymentTypeParameters with Loggable {
 
   val name = "cloud-formation"
   def documentation =
@@ -162,7 +170,8 @@ object CloudFormation extends DeploymentType with CloudFormationDeploymentTypePa
         target.region,
         templatePath = S3Path(pkg.s3Package, cfnTemplateFile),
         stackLookup,
-        unresolvedParameters
+        unresolvedParameters,
+        stackTags = unresolvedParameters.stackTags.getOrElse(Map.empty) + ("vcsUrl" -> vcsUrlLookup.get(target.parameters.build.projectName, target.parameters.build.id))
       ),
       new CheckChangeSetCreatedTask(
         target.region,

--- a/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
@@ -16,7 +16,8 @@ class CreateChangeSetTask(
                            region: Region,
                            templatePath: S3Path,
                            stackLookup: CloudFormationStackMetadata,
-                           val unresolvedParameters: CloudFormationParameters
+                           val unresolvedParameters: CloudFormationParameters,
+                           val stackTags: Map[String, String]
 )(implicit val keyRing: KeyRing, artifactClient: S3Client) extends Task {
 
   override def execute(resources: DeploymentResources, stopFlag: => Boolean ) = if (!stopFlag) {
@@ -58,7 +59,7 @@ class CreateChangeSetTask(
           val maybeExecutionRole = CloudFormation.getExecutionRole(keyRing)
           maybeExecutionRole.foreach(role => resources.reporter.verbose(s"Using execution role $role"))
 
-          CloudFormation.createChangeSet(resources.reporter, stackLookup.changeSetName, changeSetType, stackName, unresolvedParameters.stackTags, template, awsParameters, maybeExecutionRole, cfnClient)
+          CloudFormation.createChangeSet(resources.reporter, stackLookup.changeSetName, changeSetType, stackName, Some(stackTags), template, awsParameters, maybeExecutionRole, cfnClient)
         }
       }
     }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -27,8 +27,10 @@ class CloudFormationTest extends AnyFlatSpec with Matchers with Inside with Eith
   implicit val reporter: DeployReporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
   implicit val artifactClient: S3Client = null
   implicit val stsClient: StsClient = null
+
+  val cloudformationDeploymentType = new CloudFormationDeploymentType(NoopVcsUrlLookup)
   val region = Region("eu-west-1")
-  val deploymentTypes: Seq[CloudFormationDeploymentType.type] = Seq(CloudFormationDeploymentType)
+  val deploymentTypes: Seq[CloudFormationDeploymentType] = Seq(cloudformationDeploymentType)
   val app = App("app")
   val testStack = Stack("cfn")
   val cfnStackName = s"cfn-app-PROD"
@@ -37,7 +39,7 @@ class CloudFormationTest extends AnyFlatSpec with Matchers with Inside with Eith
 
   private def generateTasks(data: Map[String, JsValue] = Map("cloudFormationStackByTags" -> JsBoolean(false)), updateStrategy: Strategy = MostlyHarmless) = {
     val resources = DeploymentResources(reporter, lookupEmpty, artifactClient, stsClient, global)
-    CloudFormationDeploymentType.actionsMap("updateStack").taskGenerator(p(data), resources, DeployTarget(parameters(updateStrategy = updateStrategy), testStack, region))
+    cloudformationDeploymentType.actionsMap("updateStack").taskGenerator(p(data), resources, DeployTarget(parameters(updateStrategy = updateStrategy), testStack, region))
   }
 
   it should "generate the tasks in the correct order when manageStackPolicy is false" in {

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -35,6 +35,7 @@ import utils.{ChangeFreeze, ElkLogging, HstsFilter, ScheduledAgent}
 import java.time.Duration.{ofHours, ofMinutes}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
+import utils.VCSInfo
 
 class AppComponents(context: Context, config: Config, passwordProvider: PasswordProvider) extends BuiltInComponentsFromContext(context)
   with RotatingSecretComponents
@@ -86,7 +87,8 @@ class AppComponents(context: Context, config: Config, passwordProvider: Password
 
   object CustomVcsUrlLookup extends VcsLookup {
     def get(projectName: String, buildId: String): String = {
-      builds.build(projectName, buildId).map(_.vcsURL).getOrElse("unknown")
+      val url = builds.build(projectName, buildId).map(_.vcsURL)
+      url.flatMap(VCSInfo.normalise).getOrElse("unknown")
     }
   }
 

--- a/riff-raff/app/ci/CIBuild.scala
+++ b/riff-raff/app/ci/CIBuild.scala
@@ -19,6 +19,7 @@ trait CIBuild {
   def number: String
   def id: Long
   def startTime: DateTime
+  def vcsURL: String
   def toMagentaBuild: Build = Build(jobName, number)
 }
 

--- a/riff-raff/app/utils/VCSInfo.scala
+++ b/riff-raff/app/utils/VCSInfo.scala
@@ -66,4 +66,13 @@ object VCSInfo extends Logging {
       }
     }
   }
+
+  def normalise(url: String): Option[String] = {
+    url match {
+      case GitHubProtocol(path) => Some(path)
+      case GitHubUser(path) => Some(path)
+      case GitHubWeb(path) => Some(path)
+      case _ => None
+    }
+  }
 }

--- a/riff-raff/test/docs/DeployTypeDocsTest.scala
+++ b/riff-raff/test/docs/DeployTypeDocsTest.scala
@@ -44,7 +44,7 @@ class DeployTypeDocsTest extends AnyFlatSpec with Matchers {
   it should "successfully generate documentation for the standard set of deployment types" in {
     // we can't easily check correctness, but we can check exceptions are not thrown
     val availableDeploymentTypes = Seq(
-      S3, AutoScaling, Fastly, CloudFormation, Lambda, AmiCloudFormationParameter, SelfDeploy, GcpDeploymentManager
+      S3, AutoScaling, Fastly, new CloudFormation(NoopVcsUrlLookup), Lambda, AmiCloudFormationParameter, SelfDeploy, GcpDeploymentManager
     )
     val result = DeployTypeDocs.generateDocs(availableDeploymentTypes)
     result.size shouldBe availableDeploymentTypes.size

--- a/riff-raff/test/utils/VCSInfoTest.scala
+++ b/riff-raff/test/utils/VCSInfoTest.scala
@@ -20,4 +20,17 @@ class VCSInfoTest extends AnyFunSuite with Matchers {
     val info = VCSInfo("https://github.com/guardian/contributions-frontend.git", "98a1cffadbe564d570b15c2113c07a28cbe835ee")
     info.get.baseUrl shouldBe new URI("https://github.com/guardian/contributions-frontend")
   }
+
+  test("normalises repository string") {
+    val cases = Map(
+      "git@github.com:guardian/actions-riff-raff.git" -> Some("guardian/actions-riff-raff"),
+      "https://github.com/guardian/actions-riff-raff.git" -> Some("guardian/actions-riff-raff"),
+      "git://github.com/guardian/actions-riff-raff.git" -> Some("guardian/actions-riff-raff"),
+      "http://example.com/actions-riff-raff.git" -> None,
+    )
+
+    cases.foreach{ case (url, want) => {
+      VCSInfo.normalise(url) shouldBe want
+    }}
+  }
 }


### PR DESCRIPTION
Adds a `vcsUrl` tag to Cloudformation stacks on update to clarify ownership and discoverability.

Tested successfully on CODE:

<img width="823" alt="Screenshot 2022-04-22 at 17 22 01" src="https://user-images.githubusercontent.com/858402/164755117-743cfe5f-2445-436d-aee5-21879de35c12.png">
