### PR TITLE
Favourite stage button

### DIFF
--- a/riff-raff/app/assets/javascripts/form-autocomplete.coffee
+++ b/riff-raff/app/assets/javascripts/form-autocomplete.coffee
@@ -86,15 +86,18 @@ renderFavourites = () ->
   else
     container.addClass('hidden')
 
+
+favouriteStageItem = 'favouriteStage'
+
 readFavouriteStage = () ->
-  localStorage.getItem('favouriteStage')
+  localStorage.getItem(favouriteStageItem)
 
 writeFavouriteStage = (newFavourite) ->
-  localStorage.setItem('favouriteStage', newFavourite)
+  localStorage.setItem(favouriteStageItem, newFavourite)
   favouriteStageSelected()
 
 removeFavouriteStage = () ->
-  localStorage.removeItem('favouriteStage')
+  localStorage.removeItem(favouriteStageItem)
   favouriteStageNotSelected()
 
 updateFavouriteStageButton = () ->

--- a/riff-raff/app/assets/javascripts/form-autocomplete.coffee
+++ b/riff-raff/app/assets/javascripts/form-autocomplete.coffee
@@ -21,14 +21,14 @@ updateDeployInfo = () ->
       $("[rel='tooltip']").tooltip()
   )
 
-readFavourites = () ->
+readFavouriteProjects = () ->
   JSON.parse(localStorage.getItem('favouriteProjects'))
 
-writeFavourites = (newFavourites) ->
+writeFavouriteProjects = (newFavourites) ->
   localStorage.setItem('favouriteProjects', JSON.stringify(newFavourites))
 
-addFavourite = (project) ->
-  favourites = readFavourites()
+addFavouriteProject = (project) ->
+  favourites = readFavouriteProjects()
   newFavourites =
     if favourites?
       projectAlreadyFavourited = favourites.includes(project)
@@ -38,17 +38,17 @@ addFavourite = (project) ->
       favourites
     else
       [project]
-  writeFavourites(newFavourites)
+  writeFavouriteProjects(newFavourites)
   renderFavourites()
 
 deleteFavourite = (project) ->
-  favourites = readFavourites()
+  favourites = readFavouriteProjects()
   newFavourites =
     if favourites?
       favourites.filter (fav) -> fav != project
     else
       []
-  writeFavourites(newFavourites)
+  writeFavouriteProjects(newFavourites)
   renderFavourites()
 
 setupFavouriteHandlers = () ->
@@ -68,7 +68,7 @@ setupFavouriteHandlers = () ->
 
 renderFavourites = () ->
   container = $('#favourites-container')
-  favourites = readFavourites()
+  favourites = readFavouriteProjects()
   if favourites? && favourites.length > 0
     container.removeClass('hidden')
     list = $('#favourites-list', container)
@@ -85,6 +85,34 @@ renderFavourites = () ->
     setupFavouriteHandlers()
   else
     container.addClass('hidden')
+
+readFavouriteStage = () ->
+  localStorage.getItem('favouriteStage')
+
+writeFavouriteStage = (newFavourite) ->
+  localStorage.setItem('favouriteStage', newFavourite)
+  favouriteStageSelected()
+
+removeFavouriteStage = () ->
+  localStorage.removeItem('favouriteStage')
+  favouriteStageNotSelected()
+
+updateFavouriteStageButton = () ->
+  currentStage = $('#stage').val()
+  favouriteStage = readFavouriteStage()
+
+  if (favouriteStage == currentStage)
+    favouriteStageSelected()
+  else
+    favouriteStageNotSelected()
+
+favouriteStageNotSelected = () ->
+  $('#add-favourite-stage-button').removeClass('hidden');
+  $('#remove-favourite-stage-button').addClass('hidden');
+
+favouriteStageSelected = () ->
+  $('#add-favourite-stage-button').addClass('hidden');
+  $('#remove-favourite-stage-button').removeClass('hidden');
 
 $ ->
   $('#projectInput').each ->
@@ -132,7 +160,17 @@ $ ->
     if (!menuOpen)
       $(e.target).autocomplete("search")
 
+  $('#stage').each ->
+    stageInput = $(this)
+
+    favouriteStage = readFavouriteStage()
+    if (favouriteStage)
+      stageInput.val(favouriteStage)
+      favouriteStageSelected()
+      updateDeployInfo()
+
   $('#stage').change ->
+    updateFavouriteStageButton()
     updateDeployInfo()
 
   updateDeployInfo()
@@ -144,7 +182,20 @@ $ ->
     selectedProject = elemProjectInput.val()
 
     if selectedProject
-      addFavourite(selectedProject)
+      addFavouriteProject(selectedProject)
+
+  $('#add-favourite-stage-button').click (e) ->
+    e.preventDefault()
+
+    elemProjectInput = $('#stage')
+    selectedStage = elemProjectInput.val()
+
+    if selectedStage
+      writeFavouriteStage(selectedStage)
+
+  $('#remove-favourite-stage-button').click (e) ->
+    e.preventDefault()
+    removeFavouriteStage()
 
   renderFavourites()
 

--- a/riff-raff/app/views/deploy/form.scala.html
+++ b/riff-raff/app/views/deploy/form.scala.html
@@ -33,14 +33,14 @@
         .glyphicon-star {
             margin-left: 1px;
         }
-        .project-container {
+        .project-container, .stage-container {
             display: flex;
         }
-        #projectInput_field {
+        #projectInput_field, #stage_field {
             flex: 1;
             margin-right: 5px;
         }
-        #add-favourite-project-button {
+        #add-favourite-project-button, #add-favourite-stage-button, #remove-favourite-stage-button {
             top: 29px;
             position: relative;
             height: 100%;
@@ -67,18 +67,22 @@
 
             <div class="project-container">
                 @b3.text(deployForm("project"), Symbol("_label") -> "Project", Symbol("id") -> "projectInput", Symbol("data-url") -> "/deployment/request/autoComplete/project", Symbol("class") -> "form-control input-md project-exact-match")
-                <button id="add-favourite-project-button" aria-label="Add to favourites" title="Add to favourites" disabled><i class="glyphicon glyphicon-star"></i></button>
+                <button id="add-favourite-project-button" aria-label="Add to favourites" title="Add to favourites" disabled><i class="glyphicon glyphicon-star-empty"></i></button>
             </div>
             @b3.text(deployForm("build"),  Symbol("_label") -> "Build", Symbol("id") -> "buildInput", Symbol("data-url") -> "/deployment/request/autoComplete/build", Symbol("class") -> "form-control input-md")
-            @b3.select(
-                deployForm("stage"),
-                helper.options(prismLookup.stages.toList),
-                Symbol("_default") -> "--- Choose a stage ---",
-                Symbol("_label") -> "Stage",
-                Symbol("_error") -> deployForm.globalError.map(_.withMessage("Please select deployment stage")),
-                Symbol("id") -> "stage",
-                Symbol("class") -> "form-control"
-            )
+            <div class="stage-container">
+                @b3.select(
+                    deployForm("stage"),
+                    helper.options(prismLookup.stages.toList),
+                    Symbol("_default") -> "--- Choose a stage ---",
+                    Symbol("_label") -> "Stage",
+                    Symbol("_error") -> deployForm.globalError.map(_.withMessage("Please select deployment stage")),
+                    Symbol("id") -> "stage",
+                    Symbol("class") -> "form-control"
+                )
+                <button id="add-favourite-stage-button" aria-label="Set as default" title="Set as default"><i class="glyphicon glyphicon-star-empty"></i></button>
+                <button id="remove-favourite-stage-button" class="hidden" aria-label="Unset as default" title="Unset as default"><i class="glyphicon glyphicon-star"></i></button>
+            </div>
 
             <div class="form-group">
                 <span class="display-inline" role="button" data-toggle="collapse" href="#advanced" aria-expanded="false" aria-controls="advanced">


### PR DESCRIPTION
On the deploy page I'd like to always have CODE pre-selected for the stage. But perhaps not everyone does, so I've added a button for toggling a "favourite" stage.

### Stage is not favourite (empty star) -
![Screen Shot 2022-04-28 at 09 11 41](https://user-images.githubusercontent.com/1513454/165707963-ef0e8fec-3680-4d2b-98e8-eceb5b28ba20.png)


### Stage is favourite (filled star) -
![Screen Shot 2022-04-28 at 09 11 36](https://user-images.githubusercontent.com/1513454/165707982-e9eb096b-4e43-40c0-8501-058e3e5d2504.png)


### Visiting the deploy page without a favourite stage still means no default value -
![Screen Shot 2022-04-28 at 09 10 37](https://user-images.githubusercontent.com/1513454/165707771-221acd5d-1551-4b9c-94ce-79f634c99666.png)
