### PR TITLE
feat: Add `/requestInstanceRotation` endpoint

### DIFF
--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -9,7 +9,7 @@ import controllers._
 import deployment.preview.PreviewCoordinator
 import deployment.{DeploymentEngine, Deployments}
 import housekeeping.ArtifactHousekeeping
-import lifecycle.{Lifecycle, RotateInstanceWhenInactive, ShutdownWhenInactive}
+import lifecycle.{Lifecycle, ShutdownWhenInactive, TerminateInstanceWhenInactive}
 import magenta.deployment_type._
 import magenta.tasks.AWS
 import notification.{DeployFailureNotifications, GrafanaAnnotationLogger, HooksClient}
@@ -148,7 +148,7 @@ class AppComponents(context: Context, config: Config, passwordProvider: Password
   val hooksClient = new HooksClient(datastore, hookConfigRepository, wsClient, executionContext)
 
   val shutdownWhenInactive = new ShutdownWhenInactive(deployments)
-  val rotateInstanceWhenInactive = new RotateInstanceWhenInactive(deployments, config)
+  val rotateInstanceWhenInactive = new TerminateInstanceWhenInactive(deployments, config)
 
   val lifecycleSingletons: Seq[Lifecycle] = Seq(
     ScheduledAgent,

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -148,7 +148,7 @@ class AppComponents(context: Context, config: Config, passwordProvider: Password
   val hooksClient = new HooksClient(datastore, hookConfigRepository, wsClient, executionContext)
 
   val shutdownWhenInactive = new ShutdownWhenInactive(deployments)
-  val rotateInstanceWhenInactive = new RotateInstanceWhenInactive(deployments)
+  val rotateInstanceWhenInactive = new RotateInstanceWhenInactive(deployments, config)
 
   val lifecycleSingletons: Seq[Lifecycle] = Seq(
     ScheduledAgent,

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -187,7 +187,7 @@ class AppComponents(context: Context, config: Config, passwordProvider: Password
   val targetController = new TargetController(config, menu, deployments, targetDynamoRepository, authAction, controllerComponents)
   val loginController = new Login(config, menu, deployments, datastore, controllerComponents, authAction, googleAuthConfig)
   val testingController = new Testing(config, menu, datastore, prismLookup, documentStoreConverter, authAction, controllerComponents, artifactHousekeeper, deployments)
-  val managementController = new Management(controllerComponents, shutdownWhenInactive.switch, deployments)
+  val managementController = new Management(controllerComponents, shutdownWhenInactive)
 
   override lazy val httpErrorHandler = new DefaultHttpErrorHandler(environment, configuration, sourceMapper, Some(router)) {
     override def onServerError(request: RequestHeader, t: Throwable): Future[Result] = {

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -19,7 +19,6 @@ import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sts.StsClient
 import utils.{DateFormats, UnnaturalOrdering}
 import riffraff.BuildInfo
-import software.amazon.awssdk.services.autoscaling.AutoScalingClient
 import software.amazon.awssdk.services.ssm.SsmClient
 
 import scala.jdk.CollectionConverters._
@@ -234,8 +233,7 @@ class Config(configuration: TypesafeConfig, startTime: DateTime) extends Logging
       // TODO read config from more generic location
       lazy val anghammaradTopicARN: String = getString("scheduledDeployment.anghammaradTopicARN")
 
-      lazy val asgClient: AutoScalingClient = AutoScalingClient
-        .builder()
+      lazy val ec2Client: Ec2Client = Ec2Client.builder()
         .credentialsProvider(credentialsProviderChain(None, None))
         .region(AWSRegion.of(regionName))
         .build()

--- a/riff-raff/app/controllers/Management.scala
+++ b/riff-raff/app/controllers/Management.scala
@@ -1,17 +1,15 @@
 package controllers
 
-import deployment.Deployments
-import magenta.Switchable
-import play.api.mvc.{BaseController, ControllerComponents}
+import lifecycle.ShutdownWhenInactive
+import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 
 class Management(
   val controllerComponents: ControllerComponents,
-  val shutdownSwitch: Switchable,
-  val deployments: Deployments,
+  val shutdown: ShutdownWhenInactive,
 ) extends BaseController with Logging {
 
-  def requestShutdown() = Action { request =>
-    shutdownSwitch.switchOn()
+  def requestShutdown(): Action[AnyContent] = Action { _ =>
+    shutdown.switch.switchOn()
     Ok("Shutdown requested.")
   }
 }

--- a/riff-raff/app/controllers/Management.scala
+++ b/riff-raff/app/controllers/Management.scala
@@ -1,15 +1,21 @@
 package controllers
 
-import lifecycle.ShutdownWhenInactive
+import lifecycle.{RotateInstanceWhenInactive, ShutdownWhenInactive}
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 
 class Management(
   val controllerComponents: ControllerComponents,
   val shutdown: ShutdownWhenInactive,
+  val rotateInstance: RotateInstanceWhenInactive
 ) extends BaseController with Logging {
 
   def requestShutdown(): Action[AnyContent] = Action { _ =>
     shutdown.switch.switchOn()
     Ok("Shutdown requested.")
+  }
+
+  def requestInstanceRotation(): Action[AnyContent] = Action { _ =>
+    rotateInstance.switch.switchOn()
+    Ok("Instance rotation requested.")
   }
 }

--- a/riff-raff/app/controllers/Management.scala
+++ b/riff-raff/app/controllers/Management.scala
@@ -1,12 +1,12 @@
 package controllers
 
-import lifecycle.{RotateInstanceWhenInactive, ShutdownWhenInactive}
+import lifecycle.{ShutdownWhenInactive, TerminateInstanceWhenInactive}
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 
 class Management(
   val controllerComponents: ControllerComponents,
   val shutdown: ShutdownWhenInactive,
-  val rotateInstance: RotateInstanceWhenInactive
+  val rotateInstance: TerminateInstanceWhenInactive
 ) extends BaseController with Logging {
 
   def requestShutdown(): Action[AnyContent] = Action { _ =>

--- a/riff-raff/app/lifecycle/ShutdownWhenInactive.scala
+++ b/riff-raff/app/lifecycle/ShutdownWhenInactive.scala
@@ -59,9 +59,9 @@ class ShutdownWhenInactive(val deployments: Deployments) extends WhenInactive {
   override def action(): Unit = System.exit(EXITCODE)
 }
 
-class RotateInstanceWhenInactive(val deployments: Deployments, config: Config) extends WhenInactive {
-  override val name: String = "rotate-instance-when-inactive"
-  override val description: String = "Rotate underlying EC2 instance to get a new AMI by terminating the instance and expecting the ASG to launch a replacement."
+class TerminateInstanceWhenInactive(val deployments: Deployments, config: Config) extends WhenInactive {
+  override val name: String = "terminate-instance-when-inactive"
+  override val description: String = "Terminate underlying EC2 instance and expect the ASG to launch a replacement running a newer AMI."
 
   override def action(): Unit = {
     val instanceId: String = EC2MetadataUtils.getInstanceId

--- a/riff-raff/app/lifecycle/ShutdownWhenInactive.scala
+++ b/riff-raff/app/lifecycle/ShutdownWhenInactive.scala
@@ -7,11 +7,10 @@ import controllers.Logging
 import deployment.{Deployments, Record}
 import magenta.DefaultSwitch
 import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils
-import software.amazon.awssdk.services.autoscaling.model.TerminateInstanceInAutoScalingGroupRequest
+import software.amazon.awssdk.services.ec2.model.TerminateInstancesRequest
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
-import scala.util.Try
 
 trait WhenInactive extends Lifecycle with Logging {
   val name: String
@@ -86,12 +85,7 @@ class RotateInstanceWhenInactive(val deployments: Deployments, config: Config) e
       client = config.management.aws.snsClient
     ).recover { case ex => log.error(s"Failed to send notification (via Anghammarad)", ex) }
 
-    val request = TerminateInstanceInAutoScalingGroupRequest
-      .builder()
-      .instanceId(instanceId)
-      .shouldDecrementDesiredCapacity(false)
-      .build()
-
-    config.management.aws.asgClient.terminateInstanceInAutoScalingGroup(request)
+    val request = TerminateInstancesRequest.builder().instanceIds(instanceId).build()
+    config.management.aws.ec2Client.terminateInstances(request)
   }
 }

--- a/riff-raff/app/lifecycle/ShutdownWhenInactive.scala
+++ b/riff-raff/app/lifecycle/ShutdownWhenInactive.scala
@@ -31,7 +31,7 @@ trait WhenInactive extends Lifecycle with Logging {
     Future {
       log.info(s"Attempting to $name: trying to atomically disable deployment")
       if (deployments.atomicDisableDeploys) {
-        log.info("Deployment disabled, shutting down JVM")
+        log.info(s"Deployment disabled. Shutting down JVM so $name can be completed.")
         // wait a while for AJAX update requests to complete
         blocking(Thread.sleep(2000L))
         action()

--- a/riff-raff/app/lifecycle/ShutdownWhenInactive.scala
+++ b/riff-raff/app/lifecycle/ShutdownWhenInactive.scala
@@ -7,37 +7,49 @@ import magenta.DefaultSwitch
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
 
-class ShutdownWhenInactive(deployments: Deployments) extends Lifecycle with Logging {
-  val EXITCODE = 217
+trait WhenInactive extends Lifecycle with Logging {
+  val name: String
+  val description: String
+  val deployments: Deployments
+
+  def action(): Unit
 
   // switch to enable this mode
-  lazy val switch = new DefaultSwitch("shutdown-when-inactive", s"Shutdown riff-raff when there are no running deploys. Turning this on will cause RiffRaff to exit with exitcode $EXITCODE as soon as the last queued deploy finishes.", false) {
-    override def switchOn() = {
+  lazy val switch: DefaultSwitch = new DefaultSwitch(name, description, false) {
+    override def switchOn(): Unit = {
       super.switchOn()
-      // try and shutdown immediately
-      attemptShutdown()
+      attemptAction()
     }
   }
 
-  def attemptShutdown(): Unit = {
+  def attemptAction(): Unit = {
     Future {
-      log.info("Attempting to shutdown: trying to atomically disable deployment")
+      log.info(s"Attempting to $name: trying to atomically disable deployment")
       if (deployments.atomicDisableDeploys) {
         log.info("Deployment disabled, shutting down JVM")
         // wait a while for AJAX update requests to complete
         blocking(Thread.sleep(2000L))
-        System.exit(EXITCODE)
+        action()
       } else {
         val activeBuilds: Iterable[Record] = deployments.getControllerDeploys.filterNot(_.isDone)
         val activeBuildsLog = activeBuilds.map(record => s"${record.uuid} with status ${record.state}")
-        log.info(s"RiffRaff not yet inactive (Still running: ${activeBuildsLog.mkString(", ")}), deferring shutdown request")
+        log.info(s"RiffRaff not yet inactive (Still running: ${activeBuildsLog.mkString(", ")}), deferring $name request")
       }
     }
   }
 
-  val sub = deployments.completed.subscribe(_ => if (switch.isSwitchedOn) attemptShutdown())
+  val sub = deployments.completed.subscribe(_ => if (switch.isSwitchedOn) attemptAction())
 
   // add hooks to listen and exit when desired
   def init(): Unit = { }
   def shutdown(): Unit = { sub.unsubscribe() }
+}
+
+class ShutdownWhenInactive(val deployments: Deployments) extends WhenInactive {
+  val EXITCODE = 217
+
+  override val name: String = "shutdown-when-inactive"
+  override val description: String = s"Shutdown riff-raff when there are no running deploys. Turning this on will cause RiffRaff to exit with exitcode $EXITCODE as soon as the last queued deploy finishes."
+
+  override def action(): Unit = System.exit(EXITCODE)
 }

--- a/riff-raff/app/lifecycle/ShutdownWhenInactive.scala
+++ b/riff-raff/app/lifecycle/ShutdownWhenInactive.scala
@@ -53,3 +53,10 @@ class ShutdownWhenInactive(val deployments: Deployments) extends WhenInactive {
 
   override def action(): Unit = System.exit(EXITCODE)
 }
+
+class RotateInstanceWhenInactive(val deployments: Deployments) extends WhenInactive {
+  override val name: String = "rotate-instance-when-inactive"
+  override val description: String = "Rotate underlying EC2 instance to get a new AMI by terminating the instance and expecting the ASG to launch a replacement."
+
+  override def action(): Unit = ???
+}

--- a/riff-raff/app/lifecycle/ShutdownWhenInactive.scala
+++ b/riff-raff/app/lifecycle/ShutdownWhenInactive.scala
@@ -1,11 +1,17 @@
 package lifecycle
 
+import com.gu.anghammarad.Anghammarad
+import com.gu.anghammarad.models._
+import conf.Config
 import controllers.Logging
 import deployment.{Deployments, Record}
 import magenta.DefaultSwitch
+import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils
+import software.amazon.awssdk.services.autoscaling.model.TerminateInstanceInAutoScalingGroupRequest
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
+import scala.util.Try
 
 trait WhenInactive extends Lifecycle with Logging {
   val name: String
@@ -54,9 +60,38 @@ class ShutdownWhenInactive(val deployments: Deployments) extends WhenInactive {
   override def action(): Unit = System.exit(EXITCODE)
 }
 
-class RotateInstanceWhenInactive(val deployments: Deployments) extends WhenInactive {
+class RotateInstanceWhenInactive(val deployments: Deployments, config: Config) extends WhenInactive {
   override val name: String = "rotate-instance-when-inactive"
   override val description: String = "Rotate underlying EC2 instance to get a new AMI by terminating the instance and expecting the ASG to launch a replacement."
 
-  override def action(): Unit = ???
+  override def action(): Unit = {
+    val instanceId: String = EC2MetadataUtils.getInstanceId
+
+    Anghammarad.notify(
+      subject = s"Riff-Raff (${config.stage}) is about to undergo scheduled maintenance",
+      message =
+        s"""
+          |Riff-Raff is about to undergo scheduled maintenance to rotate the AMI.
+          |Please anticipate 503 responses whilst this completes.
+          |It usually takes around 5 minutes to complete and is starting now as there are not running deploys.
+          |
+          |The current instance $instanceId will be terminated and replaced by the ASG.
+          |
+          |""".stripMargin,
+      sourceSystem = "riff-raff",
+      target = List(Stack("deploy"), App("riff-raff"), Stage(config.stage)),
+      actions = List.empty,
+      channel = All,
+      topicArn = config.management.aws.anghammaradTopicARN,
+      client = config.management.aws.snsClient
+    ).recover { case ex => log.error(s"Failed to send notification (via Anghammarad)", ex) }
+
+    val request = TerminateInstanceInAutoScalingGroupRequest
+      .builder()
+      .instanceId(instanceId)
+      .shouldDecrementDesiredCapacity(false)
+      .build()
+
+    config.management.aws.asgClient.terminateInstanceInAutoScalingGroup(request)
+  }
 }

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -128,3 +128,4 @@ GET         /assets/*file                                   controllers.Assets.v
 
 # Management endpoints
 POST        /requestShutdown                                controllers.Management.requestShutdown()
+POST        /requestInstanceRotation                        controllers.Management.requestInstanceRotation()


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

There is a requirement to keep the age of our AMIs down. We achieve this in (most) apps via the [ami-cloudformation-parameter](https://github.com/guardian/riff-raff/blob/13fdb406e8ea032f0a3843682abc7be4e84e5aa8/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala#L9-L15), [auto-scaling](https://github.com/guardian/riff-raff/blob/13fdb406e8ea032f0a3843682abc7be4e84e5aa8/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala#L93-L104) deployment types, and scheduled deploys.

An `auto-scaling` deployment is not possible with Riff-Raff, instead it [employs](https://github.com/guardian/riff-raff/blob/main/riff-raff/riff-raff.yaml) a [self-deploy](https://github.com/guardian/riff-raff/blob/13fdb406e8ea032f0a3843682abc7be4e84e5aa8/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala#L8-L14).

Today, we are manually keeping the age of the AMI down - every so often we will send comms about a few minutes of downtime and terminate the instance. Although this works, it's a chore.

In this change a new `/requestInstanceRotation` endpoint is created (it acts similar to the `/requestShutdown` endpoint). When a request is made, Riff-Raff will:
  - Check there are no current deploys running
  - If there are, it will try again after a delay
  - If there are not:
    - A notification will be sent via [Anghammarad](https://github.com/guardian/anghammarad)
    - A request is made to terminate the instance within an ASG, and the ASG is expected to launch a new one in its place
    - The new instance will be running a [later AMI](https://github.com/guardian/riff-raff/blob/13fdb406e8ea032f0a3843682abc7be4e84e5aa8/riff-raff/riff-raff.yaml#L10-L18)

The intention here is to call this endpoint within a cronjob (in a separate PR), automating the task.

The method of using on the ASG to launch a new instance is fairly fast. Running `aws autoscaling terminate-instance-in-auto-scaling-group --no-should-decrement-desired-capacity` saw downtime of just over 2 minutes.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Deploy to CODE
- Call the endpoint (`ssm cmd -t riff-raff,CODE -p deployTools --cmd "curl --silent -X POST localhost:9000/requestInstanceRotation"`)
- Observe the ASG activity. You should see two events:
   1. `At <TIME> instance <INSTANCE-ID> was taken out of service in response to a user request.`
   2. `At <TIME> an instance was started in response to a difference between desired and actual capacity, increasing the capacity from 0 to 1.`

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

More automation, and less risk of human error.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

[Continuous deployments](https://github.com/guardian/recommendations/blob/main/continuous-deployment.md) that are triggered during the (roughly 2 minute) downtime will _not_ run, meaning users will have to manually deploy their change ([PRout](https://github.com/guardian/prout) can help surface this!). This risk can be somewhat mitigated by scheduling the cronjob to run just outside of typical working hours.

A similar concern applies to scheduled deployments. Any scheduled deployment that is due to start when Riff-Raff is unavailable will _not_ be automatically started when Riff-Raff becomes available again. As this is the current status quo, would suggest this be resolved in future work/PRs.