### PR TITLE
Add allowedStages

### DIFF
--- a/magenta-lib/src/main/scala/magenta/input/models.scala
+++ b/magenta-lib/src/main/scala/magenta/input/models.scala
@@ -51,6 +51,13 @@ case class DeploymentKeysSelector(keys: List[DeploymentKey]) extends DeploymentS
 case class RiffRaffDeployConfig(
   stacks: Option[List[String]],
   regions: Option[List[String]],
+
+  /**
+    * allowedStages is a list of supported stages for the deployment. If
+    * defined, attempts to deploy to an unlisted stage will fail.
+    */
+  allowedStages: Option[List[String]],
+
   templates: Option[Map[String, DeploymentOrTemplate]],
   deployments: List[(String, DeploymentOrTemplate)]
 )
@@ -78,6 +85,7 @@ case class DeploymentOrTemplate(
   template: Option[String],
   stacks: Option[List[String]],
   regions: Option[List[String]],
+  allowedStages: Option[List[String]], // While part of the model, this is always considered globally and should not be specified in a template
   actions: Option[List[String]],
   app: Option[String],
   contentDirectory: Option[String],
@@ -96,6 +104,7 @@ case class Deployment(
   `type`: String,
   stacks: NEL[String],
   regions: NEL[String],
+  allowedStages: Option[NEL[String]],
   actions: NEL[String],
   app: String,
   contentDirectory: String,

--- a/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentTypeResolver.scala
+++ b/magenta-lib/src/main/scala/magenta/input/resolver/DeploymentTypeResolver.scala
@@ -29,6 +29,7 @@ object DeploymentTypeResolver {
           `type` = deployment.`type`,
           stacks = deployment.stacks,
           regions = deployment.regions,
+          allowedStages = deployment.allowedStages,
           actions = as,
           app = deployment.app,
           contentDirectory = deployment.contentDirectory,

--- a/magenta-lib/src/test/scala/magenta/input/RiffRaffYamlReaderTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/RiffRaffYamlReaderTest.scala
@@ -20,7 +20,7 @@ class RiffRaffYamlReaderTest extends AnyFlatSpec with Matchers with ValidatedVal
     input.stacks.get.size should be(1)
     input.stacks.get should be(List("banana"))
     input.deployments.size should be(1)
-    input.deployments.head should be("monkey" -> DeploymentOrTemplate(Some("autoscaling"), None, None, None, None, None, None, None, None))
+    input.deployments.head should be("monkey" -> DeploymentOrTemplate(Some("autoscaling"), None, None, None, None, None, None, None, None, None))
   }
 
   it should "parse a more complex yaml example" in {
@@ -58,7 +58,7 @@ class RiffRaffYamlReaderTest extends AnyFlatSpec with Matchers with ValidatedVal
     input.stacks.get.size should be(2)
     input.stacks.get should be(List("banana", "cabbage"))
     input.templates.isDefined should be(true)
-    input.templates.get should be(Map("custom-auto" -> DeploymentOrTemplate(Some("autoscaling"),None, None, None, None, None, None, None, Some(Map(
+    input.templates.get should be(Map("custom-auto" -> DeploymentOrTemplate(Some("autoscaling"),None, None, None, None, None, None, None, None, Some(Map(
       "paramString" -> JsString("value1"),
       "paramNumber" -> JsNumber(2000),
       "paramList" -> JsArray(Seq(JsString("valueOne"), JsString("valueTwo"))),
@@ -66,11 +66,11 @@ class RiffRaffYamlReaderTest extends AnyFlatSpec with Matchers with ValidatedVal
     )))))
     input.deployments.size should be(3)
     input.deployments should contain("human" ->
-      DeploymentOrTemplate(None, Some("custom-auto"), Some(List("carrot")), None, Some(List("overridden")), None, None, Some(List("elephant")), Some(Map("paramString" -> JsString("value2")))))
+      DeploymentOrTemplate(None, Some("custom-auto"), Some(List("carrot")), None, None, Some(List("overridden")), None, None, Some(List("elephant")), Some(Map("paramString" -> JsString("value2")))))
     input.deployments should contain("monkey" ->
-      DeploymentOrTemplate(Some("autoscaling"), None, None, None, None, Some("ook"), None, Some(List("elephant")), None))
+      DeploymentOrTemplate(Some("autoscaling"), None, None, None, None, None, Some("ook"), None, Some(List("elephant")), None))
     input.deployments should contain("elephant" ->
-      DeploymentOrTemplate(Some("dung"), None, None, None, None, None, None, None, None))
+      DeploymentOrTemplate(Some("dung"), None, None, None, None, None, None, None, None, None))
     input.deployments.map(_._1) should be(List("human", "monkey", "elephant"))
   }
 

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentGraphActionFlatteningTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentGraphActionFlatteningTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 class DeploymentGraphActionFlatteningTest extends AnyFlatSpec with Matchers {
   "flattenActions" should "flatten out the actions in a deployment graph" in {
     val deployment =
-      Deployment("bob", "autoscaling", NEL.of("stackName"), NEL.of("eu-west-1"), NEL.of("action1", "action2"), "bob", "bob", Nil, Map.empty)
+      Deployment("bob", "autoscaling", NEL.of("stackName"), NEL.of("eu-west-1"), None, NEL.of("action1", "action2"), "bob", "bob", Nil, Map.empty)
     val graph = Graph(deployment)
     val flattenedGraph = DeploymentGraphActionFlattening.flattenActions(graph)
 

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentPrunerTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentPrunerTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 class DeploymentPrunerTest extends AnyFlatSpec with Matchers {
   import DeploymentPruner._
   val testDeployment = Deployment("testName", "testType", NEL.of("testStack"), NEL.of("testRegion"),
-    NEL.of("testAction"), "testName", "testName", Nil, Map.empty)
+    None, NEL.of("testAction"), "testName", "testName", Nil, Map.empty)
   val testStackAndRegionPruner = StackAndRegion("testStack", "testRegion")
 
   "StackAndRegion pruner" should "return None when either the region or stack isn't specified" in {

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTasksGraphBuilderTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTasksGraphBuilderTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class DeploymentTasksGraphBuilderTest extends AnyFlatSpec with Matchers {
-  val deployment = Deployment("bob", "autoscaling", NEL.of("stackName"), NEL.of("eu-west-1"), NEL.of("deploy"), "bob", "bob", Nil, Map.empty)
+  val deployment = Deployment("bob", "autoscaling", NEL.of("stackName"), NEL.of("eu-west-1"), None, NEL.of("deploy"), "bob", "bob", Nil, Map.empty)
 
   "buildGraph" should "build a simple graph for a single deployment" in {
     val graph = DeploymentGraphBuilder.buildGraph(List(deployment))

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTypeResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTypeResolverTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsNumber
 
 class DeploymentTypeResolverTest extends AnyFlatSpec with Matchers with ValidatedValues {
-  val deployment = PartiallyResolvedDeployment("bob", "stub-package-type", NEL.of("stack"), NEL.of("eu-west-1"), actions=None, "bob", "bob", Nil, Map.empty)
+  val deployment = PartiallyResolvedDeployment("bob", "stub-package-type", NEL.of("stack"), NEL.of("eu-west-1"), None, actions=None, "bob", "bob", Nil, Map.empty)
   val deploymentTypes = List(stubDeploymentType(Seq("upload", "deploy")))
 
   "validateDeploymentType" should "fail on invalid deployment type" in {

--- a/magenta-lib/src/test/scala/magenta/input/resolver/TaskResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/TaskResolverTest.scala
@@ -36,7 +36,7 @@ class TaskResolverTest extends AnyFlatSpec with Matchers with MockitoSugar with 
 
   "resolve" should "produce a deployment task" in {
     val deploymentTask = TaskResolver.resolve(
-      deployment = Deployment("test", "stub-package-type", NEL.of("stack"), NEL.of("region"),
+      deployment = Deployment("test", "stub-package-type", NEL.of("stack"), NEL.of("region"), Some(NEL.of("stage")),
         NEL.of("uploadArtifact", "deploy"), "app", "directory", Nil, Map("bucket" -> JsString("bucketName"))),
       deploymentResources = DeploymentResources(reporter, stubLookup(), artifactClient, stsClient, global),
       parameters = DeployParameters(Deployer("Test user"), Build("test-project", "1"), Stage("PROD"), updateStrategy = MostlyHarmless),
@@ -54,7 +54,7 @@ class TaskResolverTest extends AnyFlatSpec with Matchers with MockitoSugar with 
   "resolve" should "produce a deployment task with multiple regions" in {
     val deploymentTask = TaskResolver.resolve(
       deployment = Deployment("test", "stub-package-type", NEL.of("stack"), NEL.of("region-one", "region-two"),
-        NEL.of("uploadArtifact", "deploy"), "app", "directory", Nil, Map("bucket" -> JsString("bucketName"))),
+        Some(NEL.of("stage")), NEL.of("uploadArtifact", "deploy"), "app", "directory", Nil, Map("bucket" -> JsString("bucketName"))),
       deploymentResources = DeploymentResources(reporter, stubLookup(), artifactClient, stsClient, global),
       parameters = DeployParameters(Deployer("Test user"), Build("test-project", "1"), Stage("PROD"), updateStrategy = MostlyHarmless),
       deploymentTypes = deploymentTypes,
@@ -72,7 +72,7 @@ class TaskResolverTest extends AnyFlatSpec with Matchers with MockitoSugar with 
 
   "resolve" should "produce an error when the deployment type isn't found" in {
     val deploymentTask = TaskResolver.resolve(
-      deployment = Deployment("test", "autoscaling", NEL.of("stack"), NEL.of("region"), NEL.of("uploadArtifact", "deploy"), "app", "directory", Nil, Map("bucket" -> JsString("bucketName"))),
+      deployment = Deployment("test", "autoscaling", NEL.of("stack"), NEL.of("region"), Some(NEL.of("stage")), NEL.of("uploadArtifact", "deploy"), "app", "directory", Nil, Map("bucket" -> JsString("bucketName"))),
       deploymentResources = DeploymentResources(reporter, stubLookup(), artifactClient, stsClient, global),
       parameters = DeployParameters(Deployer("Test user"), Build("test-project", "1"), Stage("PROD"), updateStrategy = MostlyHarmless),
       deploymentTypes = Nil,

--- a/riff-raff/app/assets/javascripts/form-autocomplete.coffee
+++ b/riff-raff/app/assets/javascripts/form-autocomplete.coffee
@@ -16,9 +16,9 @@ updateStageInfo = () ->
     url: url,
     dataType: 'html',
     success: (stageOptions) ->
-      stageInput = document.getElementById('stage')
-      stageInput.innerHTML = stageOptions
-      stageInput.disabled = false
+      stageInput = $('#stage')
+      stageInput.html(stageOptions)
+      stageInput.prop('disabled', false)
   });
 
 updateDeployInfo = () ->

--- a/riff-raff/app/assets/javascripts/form-autocomplete.coffee
+++ b/riff-raff/app/assets/javascripts/form-autocomplete.coffee
@@ -135,8 +135,10 @@ $ ->
       close: (event,ui) ->
         menuOpen = false
         updateBuildInfo( input.val() )
+        updateStageInfo()
       select: (event,ui) ->
         updateBuildInfo( input.val() )
+        updateStageInfo()
       minLength:0
 
   $('#buildInput').on('input keyup',

--- a/riff-raff/app/assets/javascripts/form-autocomplete.coffee
+++ b/riff-raff/app/assets/javascripts/form-autocomplete.coffee
@@ -4,6 +4,23 @@ menuOpen = false
 updateBuildInfo = (buildNumber) ->
   $('#build-info').load(jsRoutes.controllers.DeployController.buildInfo(selectedProject, buildNumber).url)
 
+updateStageInfo = () ->
+  elemProjectInput = $('#projectInput')
+  isExactMatch = elemProjectInput.hasClass("project-exact-match")
+  selectedProject = elemProjectInput.val()
+  selectedBuild = $('#buildInput').val()
+
+  url = jsRoutes.controllers.DeployController.allowedStages(selectedProject, selectedBuild).url
+
+  $.ajax({
+    url: url,
+    dataType: 'html',
+    success: (stageOptions) ->
+      stageInput = document.getElementById('stage')
+      stageInput.innerHTML = stageOptions
+      stageInput.disabled = false
+  });
+
 updateDeployInfo = () ->
   elemProjectInput = $('#projectInput')
   isExactMatch = elemProjectInput.hasClass("project-exact-match")
@@ -131,6 +148,11 @@ $ ->
   $('#buildInput').focus (e) ->
     if (!menuOpen)
       $(e.target).autocomplete("search")
+
+  $('#buildInput').on('input keyup',
+    ->
+      updateStageInfo()
+  )
 
   $('#stage').change ->
     updateDeployInfo()

--- a/riff-raff/app/controllers/Application.scala
+++ b/riff-raff/app/controllers/Application.scala
@@ -192,6 +192,7 @@ class Application(config: Config,
       JavaScriptReverseRouter("jsRoutes")(
         routes.javascript.DeployController.stop,
         routes.javascript.DeployController.deployHistory,
+        routes.javascript.DeployController.allowedStages,
         routes.javascript.DeployController.dashboardContent,
         routes.javascript.DeployController.buildInfo,
         routes.javascript.DeployController.viewUUID,

--- a/riff-raff/app/views/deploy/form.scala.html
+++ b/riff-raff/app/views/deploy/form.scala.html
@@ -77,7 +77,8 @@
                 Symbol("_label") -> "Stage",
                 Symbol("_error") -> deployForm.globalError.map(_.withMessage("Please select deployment stage")),
                 Symbol("id") -> "stage",
-                Symbol("class") -> "form-control"
+                Symbol("class") -> "form-control",
+                Symbol("disabled") -> true
             )
 
             <div class="form-group">

--- a/riff-raff/app/views/deploy/form.scala.html
+++ b/riff-raff/app/views/deploy/form.scala.html
@@ -75,6 +75,7 @@
                 helper.options(prismLookup.stages.toList),
                 Symbol("_default") -> "--- Choose a stage ---",
                 Symbol("_label") -> "Stage",
+                Symbol("_help") -> "Nb. you can now constrain available stages by setting 'allowedStages' in your riff-raff.yaml.",
                 Symbol("_error") -> deployForm.globalError.map(_.withMessage("Please select deployment stage")),
                 Symbol("id") -> "stage",
                 Symbol("class") -> "form-control",

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -38,6 +38,7 @@ GET         /deployment/updates/:uuid                       controllers.DeployCo
 GET         /deployment/request/autoComplete/project        controllers.DeployController.autoCompleteProject(term:String)
 GET         /deployment/request/autoComplete/build          controllers.DeployController.autoCompleteBuild(project:String,term:String)
 GET         /deployment/request/history                     controllers.DeployController.deployHistory(project:String, stage:Option[String], isExactMatchProjectName:Option[Boolean])
+GET         /deployment/request/allowedStages               controllers.DeployController.allowedStages(project: String, id: String)
 GET         /deployment/request/buildInfo                   controllers.DeployController.buildInfo(project: String, build: String)
 
 

--- a/riff-raff/public/docs/reference/riff-raff.yaml.md
+++ b/riff-raff/public/docs/reference/riff-raff.yaml.md
@@ -1,13 +1,15 @@
 The riff-raff.yaml configuration file
 =====================================
 
-Whilst writing riff-raff.yaml files you are strongly advised to use the 
+Whilst writing riff-raff.yaml files you are strongly advised to use the
 [Validate Template feature](/configuration/validation) in Riff-Raff to get fast feedback.
 
 ```yaml
-stacks: 
+stacks:
   - String
 regions:
+  - String
+allowedStages:
   - String
 templates:
   map of DeploymentOrTemplate
@@ -19,7 +21,7 @@ deployments:
 
 List of default stack names used to identify resources for this deploy. See `stacks` in `DeploymentOrTemplate`.
 
-_Required:_ Conditional. A list of stacks must be provided for each deployment. This provides a default that will be 
+_Required:_ Conditional. A list of stacks must be provided for each deployment. This provides a default that will be
 used by a deployment when a list of stacks are not specified explicitly in the deployment or a template it inherits. If
 stacks are specified elsewhere then this is not needed.
 
@@ -27,9 +29,15 @@ stacks are specified elsewhere then this is not needed.
 
 List of default AWS region names that this should be deployed to. See `regions` in `DeploymentOrTemplate`.
 
-_Required:_ Conditional. A list of regions must be provided for each deployment. This provides a default that will be 
+_Required:_ Conditional. A list of regions must be provided for each deployment. This provides a default that will be
 used by a deployment when a list of regions are not specified explicitly in the deployment or a template it inherits. If
-regions are specified elsewhere then this is not needed. 
+regions are specified elsewhere then this is not needed.
+
+### allowedStages
+
+Optional list of permitted stages for the deployment. Typically used to prevent
+deployment to unsupported stages and also used to narrow the stage options for
+manual deployments.
 
 ### templates
 
@@ -49,40 +57,40 @@ DeploymentOrTemplate
 ```yaml
 type: String
 template: String
-stacks: 
+stacks:
   - String
-regions: 
+regions:
   - String
 actions:
   - String
-app: 
+app:
   - String
-contentDirectory: 
+contentDirectory:
   - String
-dependencies: 
+dependencies:
   - String
-parameters: 
+parameters:
   map of any
 ```
 
 ### type
 
-The deployment type for this deployment step. You can see the available deployment types and the related actions and 
+The deployment type for this deployment step. You can see the available deployment types and the related actions and
 parameters [here](../magenta-lib/types.md).
- 
+
 _Required:_ Conditional. One of `type` or `template` must be specified.
- 
+
 ### template
 
-The name of a template in the templates section from which to use as a starting point. The values of the fields in the 
-template will be used by default. Any values from the template can be overridden or supplemented (in the case of 
+The name of a template in the templates section from which to use as a starting point. The values of the fields in the
+template will be used by default. Any values from the template can be overridden or supplemented (in the case of
 `parameters`).
- 
+
 _Required:_ Conditional. One of `type` or `template` must be specified.
 
 ### stacks
 
-A stack name is used to lookup AWS credentials (effectively selecting which AWS account to deploy to), to locate 
+A stack name is used to lookup AWS credentials (effectively selecting which AWS account to deploy to), to locate
 auto scaling groups and cloudformation stacks and also to set sane defaults for many parameters.
 
 _Required:_ Conditional. A list of stacks must be provided for each deployment. If specified here it will override any
@@ -90,7 +98,7 @@ global default.
 
 ### regions
 
-List of default AWS region names that this should be deployed to. This must be a valid [AWS region code](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html?shortFooter=true#concepts-available-regions). 
+List of default AWS region names that this should be deployed to. This must be a valid [AWS region code](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html?shortFooter=true#concepts-available-regions).
 This is used to create AWS SDK clients before undertaking deployment operations.
 
 _Required:_ Conditional. A list of regions must be provided for each deployment. If specified here it will override any
@@ -100,7 +108,7 @@ global default.
 
 List of deployment type actions to execute for this deployment. See the [deployment types list](../magenta-lib/types.md)
 for the available actions of each type.
- 
+
 _Required:_ No. If not specified then the default set of actions will be executed according to the deployment type.
 
 ### app
@@ -127,16 +135,16 @@ _Required:_ No.
 Map of parameters for the deployment type. This can be used to specify various options that control how a deployment
 type should behave. Some examples are bucket names, MIME type mappings, cache control headers and deployment wait times.
 
-_Required:_ Conditional. Some deployment types have parameters which must be specified. See the 
+_Required:_ Conditional. Some deployment types have parameters which must be specified. See the
 [deployment types list](../magenta-lib/types.md) for the available and required parameters of each type.
 
 Examples
 --------
 
-In order to understand how Riff-Raff interprets these files feel free to copy the YAML and paste it into Validate 
+In order to understand how Riff-Raff interprets these files feel free to copy the YAML and paste it into Validate
 Template page in Riff-Raff.
 
-Here is a minimal auto scaling deploy example taken from [Prism](https://github.com/guardian/prism/blob/master/riff-raff.yaml). 
+Here is a minimal auto scaling deploy example taken from [Prism](https://github.com/guardian/prism/blob/master/riff-raff.yaml).
 
 ```yaml
 regions:

--- a/riff-raff/riff-raff.yaml
+++ b/riff-raff/riff-raff.yaml
@@ -1,5 +1,6 @@
 regions: [eu-west-1]
 stacks: [deploy]
+allowedStages: [CODE, PROD]
 deployments:
   riff-raff:
     type: self-deploy


### PR DESCRIPTION
e.g.

```
stacks:
- deploy
regions:
- eu-west-1
allowedStages:
- INFRA
deployments:
...
```

The new field is optional and takes a list of (string) stages.

If present, these stages are used in the UI dropdown when doing a manual deploy. New default behaviour for stage is also added:  first sorting the list, CODE (if allowed) is preferred, then the first non-PROD stage, and failing that the first stage is used.

Deploys (of any kind) fail if allowedStages is non-empty and does not contain the stage being deployed to.

Stage is now disabled initially:
![Screenshot 2022-04-29 at 15 25 25](https://user-images.githubusercontent.com/858402/165998362-7f5318c2-139f-4c38-9afc-f0a2bcf8107c.png)

Selecting a build (in this case with a riff-raff.yaml containing `allowedStages`:
![Screenshot 2022-04-29 at 15 25 44](https://user-images.githubusercontent.com/858402/165998368-5d8d82bd-f457-4c17-bf78-eca784f21598.png)

Stages are limited to those specified as allowed in the riff-raff.yaml file and 'CODE' is defaulted:
<img width="561" alt="Screenshot 2022-04-29 at 19 03 09" src="https://user-images.githubusercontent.com/858402/165998724-e1f92808-37e0-41c5-99bc-e3141d9383ab.png">

If you attempt a deploy to a disallowed stage, either through hacking the UI or via a misconfigured scheduled/continuous deploy (which are still possible), the deploy fails with a descriptive error message:

<img width="843" alt="Screenshot 2022-05-13 at 15 07 25" src="https://user-images.githubusercontent.com/858402/168301706-6a0458d4-08ea-4a52-b2e4-3e510d2d53d5.png">
