### PR TITLE
fix(rotation-timer): Ensure the instance rotation timer is started

### DIFF
--- a/riff-raff/bootstrap.sh
+++ b/riff-raff/bootstrap.sh
@@ -137,3 +137,9 @@ STATUS=$(systemctl is-active ${APP} || true)
 if [ "$STATUS" = "inactive" ]; then
   systemctl start ${APP}
 fi
+
+INSTANCE_ROTATION_STATUS=$(systemctl is-active ${APP}-instance-rotation.timer || true)
+if [ "$INSTANCE_ROTATION_STATUS" = "inactive" ]; then
+  systemctl enable ${APP}-instance-rotation.timer
+  systemctl start ${APP}-instance-rotation.timer
+fi


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Although #693 created a timer for Riff-Raff to self terminate, the timer was not activated. Oops!

![img](https://media.giphy.com/media/RBeddeaQ5Xo0E/giphy.gif)