### PR TITLE
Temporarily remove this to fix the deploy

### DIFF
--- a/riff-raff/riff-raff.yaml
+++ b/riff-raff/riff-raff.yaml
@@ -1,6 +1,5 @@
 regions: [eu-west-1]
 stacks: [deploy]
-allowedStages: [CODE, PROD]
 deployments:
   riff-raff:
     type: self-deploy


### PR DESCRIPTION
(Follow on from https://github.com/guardian/riff-raff/pull/692.)

Fixes the deploy of main, which currently can't deploy as the old main doesn't recognise this new riff-raff.yaml field.

Once merged and deployed, I'll raise a quick PR to re-add these lines.

Unfortunately this was not discovered during testing because I initially deployed the allowed stages branch to CODE pre adding these lines.