### PR TITLE
Re-add configuration

### DIFF
--- a/riff-raff/riff-raff.yaml
+++ b/riff-raff/riff-raff.yaml
@@ -1,5 +1,6 @@
 regions: [eu-west-1]
 stacks: [deploy]
+allowedStages: [CODE, PROD]
 deployments:
   riff-raff:
     type: self-deploy


### PR DESCRIPTION
Follow-on from https://github.com/guardian/riff-raff/pull/699 to reinstate now that `main` recognises the fields.