### PR TITLE
Protect some more API Gateway resources

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
@@ -49,6 +49,8 @@ object StackPolicy {
       // API gateway
       "AWS::ApiGateway::RestApi",
       "AWS::ApiGateway::DomainName",
+      "AWS::ApiGateway::BasePathMapping",
+      "AWS::ApiGateway::Stage",
       // buckets (although we think they can't be deleted with content)
       "AWS::S3::Bucket",
       // DNS infrastructure


### PR DESCRIPTION
## What does this change?

Whilst working on https://github.com/guardian/cdk/pull/1308, I realised that there were a couple more API Gateway resources that should not be deleted unless the user explicitly opts-in to `Dangerous` mode!

## How to test

I've deployed this to `CODE` and confirmed that a CFN deployment still works.

## How can we measure success?

Users are less likely to accidentally remove important resources, making downtime/incidents less likely.

## Have we considered potential risks?

If we add invalid items to this list it can break deployments, but this risk should be mitigated by testing in `CODE`.