### PR TITLE
Update targets for notifications where correct team cannot be identified

### DIFF
--- a/riff-raff/app/notification/FailureNotificationContents.scala
+++ b/riff-raff/app/notification/FailureNotificationContents.scala
@@ -37,7 +37,7 @@ class FailureNotificationContents(prefix: String) {
     )
   }
 
-  def scheduledDeployFailureNotificationContents(scheduledDeployError: ScheduledDeployNotificationError, teamTargetsSearch: (UUID, DeployParameters) => List[Target], riffRaffTargets: List[Target]): NotificationContentsWithTargets = {
+  def scheduledDeployFailureNotificationContents(scheduledDeployError: ScheduledDeployNotificationError, teamTargetsSearch: (UUID, DeployParameters) => List[Target], fallbackTargets: List[Target]): NotificationContentsWithTargets = {
     val subject = "Scheduled Deployment failed to start"
     scheduledDeployError match {
       case SkippedDueToPreviousFailure(record) =>
@@ -46,11 +46,11 @@ class FailureNotificationContents(prefix: String) {
         NotificationContentsWithTargets(contents, teamTargetsSearch(record.uuid, record.parameters))
       case SkippedDueToPreviousWaitingDeploy(record) =>
         val contents = NotificationContents(subject, scheduledDeployError.message, List(viewProblematicDeploy(record.uuid, "waiting")))
-        NotificationContentsWithTargets(contents, riffRaffTargets)
+        NotificationContentsWithTargets(contents, fallbackTargets)
       case NoDeploysFoundForStage(_, _) =>
         val scheduledDeployConfig = Action("View Scheduled Deployment configuration", scheduledDeployConfigUrl)
         val contents = NotificationContents(subject, scheduledDeployError.message, List(scheduledDeployConfig))
-        NotificationContentsWithTargets(contents, riffRaffTargets)
+        NotificationContentsWithTargets(contents, fallbackTargets)
     }
   }
 


### PR DESCRIPTION
## What does this change?

In some scenarios (e.g. if there is a malformed `riff-raff.yaml`), Riff-Raff cannot figure out where to send failed deployment notifications. To avoid dropping these alerts completely, we aim to send them to a fallback destination. The intention here was that these alerts should go to DevX/Riff-Raff maintainers, so that we can help to forward these on to the correct team and/or fix any failed deployments that occur due to bugs in Riff-Raff.

The exact email address that gets used for this fallback is defined via the Anghammarad config:

`"target": { "Stack": "deploy", "Stage": "PROD", "App": "riff-raff" }`

Recently this mapping has been updated. We now send alerts via Chat messages to the `DevX Stream` (public) channel and emails to the whole Engineering department. This is useful in some scenarios (e.g. to warn a wide audience about Riff-Raff downtime), but it means that these alerts are going to a much wider audience than they should.

This PR updates the targets so that alerts are sent to the DevX Ops & Security teams only (for now, at least!)

## How to test

Unit testing should be sufficient.

## How can we measure success?

We will send fewer irrelevant emails to the whole department 🙈 

## Have we considered potential risks?

Yes, I think this is a pretty low risk change.