### PR TITLE
Delete obsolate files in Google Cloud Platform deploys

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
@@ -193,11 +193,11 @@ object GcsTargetBucket {
             maybeDirectories: Option[Map[String, List[String]]],
             maybeFileTypes: Option[Map[String, List[String]]]): GcsTargetBucket = {
 
-      def listOrEmpty(maybeMap: Option[Map[String, List[String]]]) =
+      def listOrEmpty(m: Option[Map[String, List[String]]]) =
         (for{
-          map <- maybeMap
-          value <- map.get(stage)
-        } yield value).getOrElse(List.empty)
+          infoByStage <- m
+          info <- infoByStage.get(stage)
+        } yield info).getOrElse(List.empty)
 
 
       val directoriesToPurge = listOrEmpty(maybeDirectories).map( dir => if (prefix.isEmpty) dir else s"$prefix/$dir" )

--- a/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
@@ -61,18 +61,18 @@ object GCS extends DeploymentType {
   )
 
   val fileTypesToPruneByStage: Param[Map[String, List[String]]]  = Param[Map[String, List[String]]](
-    name = "directoriesToPruneByStage",
+    name = "fileTypesToPruneByStage",
     documentation =
       """
         |Specify the types of file to remove when they are no longer in the current upload. Use case: Remove obselete dags from an airflow to cloud composer deployment
         |```
-        |directoriesToPruneByStage:
+        |fileTypesToPruneByStage:
         | PROD: [py, json]
         | CODE: [py, json]
         |```
         |Or more likely in this case:
         |```
-        |directoriesToPruneByStage:
+        |fileTypesToPruneByStage:
         | PROD: [py, json]
         |```
         |

--- a/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
@@ -198,14 +198,14 @@ object GcsTargetBucket {
         } yield value).getOrElse(List.empty)
 
 
-      val directoriesToPurge = listOrEmpty(maybeDirectories).map( dir => if (prefix.isEmpty) dir else s"$prefix/dir" )
+      val directoriesToPurge = listOrEmpty(maybeDirectories).map( dir => if (prefix.isEmpty) dir else s"$prefix/$dir" )
       val fileTypesToPurge = listOrEmpty(maybeFileTypes)
-      GcsTargetBucket(name, directoriesToPurge, fileTypesToPurge)
+      GcsTargetBucket(name, directoriesToPurge, fileTypesToPurge, s"**$prefix**")
 
   }
 }
 
-case class GcsTargetBucket(name: String, directoriesToPurge: List[String], fileTypesToPurge: List[String]) {
+case class GcsTargetBucket(name: String, directoriesToPurge: List[String], fileTypesToPurge: List[String], prefix: String) {
 
   //Because prefix is passd as a seq
   def allDirectoriesToPurge(targetPaths: List[String], accumulatedDirectoryList: List[String] = List.empty): List[String] =

--- a/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
@@ -167,6 +167,9 @@ object GCS extends DeploymentType {
         packageName = if (prefixPackage(pkg, target, reporter)) Some(pkg.name) else None
       ))
 
+    resources.reporter.verbose(s"++++ Prefix is: **${prefix}**")
+
+
     val bucketConfig =  GcsTargetBucket( bucketName, target.parameters.stage.name, prefix,
       directoriesToPruneByStage.get(pkg), fileTypesToPruneByStage.get(pkg))
 
@@ -201,7 +204,6 @@ object GcsTargetBucket {
       val directoriesToPurge = listOrEmpty(maybeDirectories).map( dir => if (prefix.isEmpty) dir else s"$prefix/$dir" )
       val fileTypesToPurge = listOrEmpty(maybeFileTypes)
       GcsTargetBucket(name, directoriesToPurge, fileTypesToPurge, s"**$prefix**")
-
   }
 }
 

--- a/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
@@ -198,7 +198,7 @@ object GcsTargetBucket {
         } yield value).getOrElse(List.empty)
 
 
-      val directoriesToPurge = listOrEmpty(maybeDirectories).map( dir => if (prefix.isEmpty) dir else "$prefix/dir" )
+      val directoriesToPurge = listOrEmpty(maybeDirectories).map( dir => if (prefix.isEmpty) dir else s"$prefix/dir" )
       val fileTypesToPurge = listOrEmpty(maybeFileTypes)
       GcsTargetBucket(name, directoriesToPurge, fileTypesToPurge)
 

--- a/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
@@ -24,15 +24,22 @@ object GCS extends DeploymentType {
 
   //required configuration, you cannot upload without setting these
   val bucket = Param[String]("bucket", "GCS bucket to upload package files to (see also `bucketResource`)", optional = true)
-  val bucketByStage: Param[Map[String, String]] = Param[Map[String, String]](
+  val bucketByStage: Param[Map[String, Map[String, List[String]]]] = Param[Map[String, Map[String, List[String]]]](
     name = "bucketByStage",
     documentation =
       """
-        |A dict of stages to buckets in the package. When the current stage is found in here the bucket
-        |will be used from this dict. If it's not found here then it will fall back to `bucket` if it exists.
+        |A dict of stages to buckets in the package along with details of how When the current stage is found in here the bucket
+        |will be used from this dict. If it's not found here then it will fall back to `bucket` if it exists. If the name is defined here
+        | some other details can be included
+        |   -
+        |   - directoriesToPrune: A list of directories within the bucket. In each of these, recursively search for any files that aren't present in the current upload and remove them
         |```
         |bucketByStage:
-        |  PROD: prod-bucket
+        |  PROD:
+        |    name: [prod-bucket]
+        |    dirw
+        |
+        |
         |  CODE: code-bucket
         |```
         |""".stripMargin,
@@ -145,7 +152,6 @@ object GCS extends DeploymentType {
           paths = Seq(pkg.s3Package -> prefix),
           cacheControlPatterns = cacheControl(pkg, target, reporter),
           publicReadAcl = publicReadAcl(pkg, target, reporter),
-          removeObseleteFiles = removeObseleteFiles(pkg, target, reporter)
         )
       )
     }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
@@ -203,11 +203,11 @@ object GcsTargetBucket {
 
       val directoriesToPurge = listOrEmpty(maybeDirectories).map( dir => if (prefix.isEmpty) dir else s"$prefix/$dir" )
       val fileTypesToPurge = listOrEmpty(maybeFileTypes)
-      GcsTargetBucket(name, directoriesToPurge, fileTypesToPurge, s"**$prefix**")
+      GcsTargetBucket(name, directoriesToPurge, fileTypesToPurge)
   }
 }
 
-case class GcsTargetBucket(name: String, directoriesToPurge: List[String], fileTypesToPurge: List[String], prefix: String = "Dang") {
+case class GcsTargetBucket(name: String, directoriesToPurge: List[String], fileTypesToPurge: List[String]) {
 
   //Because prefix is passd as a seq
   def allDirectoriesToPurge(targetPaths: List[String], accumulatedDirectoryList: List[String] = List.empty): List[String] =

--- a/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
@@ -54,7 +54,6 @@ object GCS extends DeploymentType {
         |```
         |directoriesToPruneByStage:
         | PROD: [dags/dags, dags/guardian]
-        | CODE: [dags/dags, dags/guardian]
         |```
         |
          |""".stripMargin,

--- a/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
@@ -205,7 +205,7 @@ object GcsTargetBucket {
   }
 }
 
-case class GcsTargetBucket(name: String, directoriesToPurge: List[String], fileTypesToPurge: List[String], prefix: String) {
+case class GcsTargetBucket(name: String, directoriesToPurge: List[String], fileTypesToPurge: List[String], prefix: String = "Dang") {
 
   //Because prefix is passd as a seq
   def allDirectoriesToPurge(targetPaths: List[String], accumulatedDirectoryList: List[String] = List.empty): List[String] =

--- a/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
@@ -45,6 +45,7 @@ object GCS extends DeploymentType {
       """
         |A list of directories in the target buckets which will be pruned of any files not in the current upload for the current stage
         |Typically this is used to remove obsolete dags and associated python assets from a airflow deploy to cloud composer
+        |These are assumed to be relative to any configured prefix
         |```
         |directoriesToPruneByStage:
         | PROD: [dags/dags, dags/guardian]
@@ -167,8 +168,6 @@ object GCS extends DeploymentType {
         packageName = if (prefixPackage(pkg, target, reporter)) Some(pkg.name) else None
       ))
 
-    resources.reporter.verbose(s"++++ Prefix is: **${prefix}**")
-
 
     val bucketConfig =  GcsTargetBucket( bucketName, target.parameters.stage.name, prefix,
       directoriesToPruneByStage.get(pkg), fileTypesToPruneByStage.get(pkg))
@@ -207,14 +206,4 @@ object GcsTargetBucket {
   }
 }
 
-case class GcsTargetBucket(name: String, directoriesToPurge: List[String], fileTypesToPurge: List[String]) {
-
-  //Because prefix is passd as a seq
-  def allDirectoriesToPurge(targetPaths: List[String], accumulatedDirectoryList: List[String] = List.empty): List[String] =
-    targetPaths match {
-      case Nil => accumulatedDirectoryList
-      case head :: tail =>
-          val directoriesForThisPath = directoriesToPurge.map(dir => if (head.isEmpty) dir else s"$head/$dir")
-          allDirectoriesToPurge(tail, accumulatedDirectoryList ::: directoriesForThisPath)
-    }
-}
+case class GcsTargetBucket(name: String, directoriesToPurge: List[String], fileTypesToPurge: List[String])

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/GCP.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/GCP.scala
@@ -159,7 +159,8 @@ object GCP {
 }
 
 object GCS {
-  def withGCSClient[T](keyRing: KeyRing, resources: DeploymentResources)(block: Storage => T): T = block(GCP.StorageApi.client(    credentials = GCP.credentials.getCredentials(keyRing).getOrElse(resources.reporter.fail("Unable to build GCP credentials from keyring"))
+  def withGCSClient[T](keyRing: KeyRing, resources: DeploymentResources)(block: Storage => T): T = block(GCP.StorageApi.client(
+    credentials = GCP.credentials.getCredentials(keyRing).getOrElse(resources.reporter.fail("Unable to build GCP credentials from keyring"))
   ))
 }
 

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/GCP.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/GCP.scala
@@ -61,7 +61,7 @@ object GCP {
     case class DeploymentBundle(configPath: String, config: String, deps: Map[String, String])
 
     def client(creds: GoogleCredential): DeploymentManager = {
-      new DeploymentManager.Builder(httpTransport, jsonFactory, creds).setRootUrl("https://storage.googleapis.com/").build()
+      new DeploymentManager.Builder(httpTransport, jsonFactory, creds).build()
     }
 
     def toTargetConfiguration(bundle: DeploymentBundle): TargetConfiguration = {
@@ -124,7 +124,7 @@ object GCP {
 
   object StorageApi extends Loggable {
     def client(credentials: GoogleCredential): Storage = {
-      new Storage.Builder(httpTransport, jsonFactory, credentials).build()
+      new Storage.Builder(httpTransport, jsonFactory, credentials).setRootUrl("https://storage.googleapis.com/").build()
     }
   }
 

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/GCP.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/GCP.scala
@@ -159,8 +159,7 @@ object GCP {
 }
 
 object GCS {
-  def withGCSClient[T](keyRing: KeyRing, resources: DeploymentResources)(block: Storage => T): T = block(GCP.StorageApi.client(
-    credentials = GCP.credentials.getCredentials(keyRing).getOrElse(resources.reporter.fail("Unable to build GCP credentials from keyring"))
+  def withGCSClient[T](keyRing: KeyRing, resources: DeploymentResources)(block: Storage => T): T = block(GCP.StorageApi.client(    credentials = GCP.credentials.getCredentials(keyRing).getOrElse(resources.reporter.fail("Unable to build GCP credentials from keyring"))
   ))
 }
 

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/GCP.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/GCP.scala
@@ -61,7 +61,7 @@ object GCP {
     case class DeploymentBundle(configPath: String, config: String, deps: Map[String, String])
 
     def client(creds: GoogleCredential): DeploymentManager = {
-      new DeploymentManager.Builder(httpTransport, jsonFactory, creds).build()
+      new DeploymentManager.Builder(httpTransport, jsonFactory, creds).setRootUrl("https://storage.googleapis.com/").build()
     }
 
     def toTargetConfiguration(bundle: DeploymentBundle): TargetConfiguration = {

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
@@ -93,6 +93,7 @@ case class GCSUpload(
         }
       }
       currentlyDeployedObjectsList.par.foreach { case storageObjectToDelete =>
+        resources.reporter.verbose(s"Deleting obsolete file from GCP: ${storageObjectToDelete.getName}")
         val errorMessage = s"Could not 0emove obselete object ${storageObjectToDelete.getName}"
         GCP.api.retryWhen500orGoogleError(resources.reporter, errorMessage) {
           client.objects().delete(gcsTargetBucket.name, storageObjectToDelete.getName).execute

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
@@ -68,6 +68,7 @@ case class GCSUpload(
     val withClient = withClientFactory(keyRing, resources)
     withClient { client =>
 
+      resources.reporter.verbose(s"Paths are *$paths**")
       val currentlyDeployedObjectsList = getCurrentObjectsForDeletion(client)
       resources.reporter.verbose(s"Objects to delete ${currentlyDeployedObjectsList.size}")
 

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
@@ -29,7 +29,8 @@ case class GCSUpload(
   private val PublicAcl = Arrays.asList(new ObjectAccessControl().setEntity("allUsers").setRole("READER"))
 
   lazy val objectMappings: Seq[(S3Object, GCSPath)] = paths flatMap {
-    case (file, targetKey) => resolveMappings(file, targetKey, bucket.name)
+    case (file, targetKey) =>
+       resolveMappings(file, targetKey, bucket.name)
   }
 
   lazy val totalSize: Long = objectMappings.map{ case (source, _) => source.size }.sum
@@ -109,7 +110,10 @@ case class GCSUpload(
     else s"$key/$fileName"
 
   private def resolveMappings(path: S3Location, targetKey: String, targetBucket: String): Seq[(S3Object, GCSPath)] = {
-    path.listAll()(artifactClient).map { obj =>
+    val value = path.listAll()(artifactClient)
+    //logger.info(s"+++++++++ Object List size ${value.size}")
+    value.map { obj =>
+      //logger.info(s"Object: *${obj}*")
       obj -> GCSPath(targetBucket, subDirectoryPrefix(targetKey, obj.relativeTo(path)))
     }
   }

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
@@ -29,8 +29,7 @@ case class GCSUpload(
   private val PublicAcl = Arrays.asList(new ObjectAccessControl().setEntity("allUsers").setRole("READER"))
 
   lazy val objectMappings: Seq[(S3Object, GCSPath)] = paths flatMap {
-    case (file, targetKey) =>
-       resolveMappings(file, targetKey, bucket.name)
+    case (file, targetKey) => resolveMappings(file, targetKey, bucket.name)
   }
 
   lazy val totalSize: Long = objectMappings.map{ case (source, _) => source.size }.sum

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
@@ -140,7 +140,7 @@ case class GCSUpload(
              .list(gcsTargetBucket.name)
              .setPrefix(head)
             val allItemsForThisDirectory = getAllObjectsForDirectory(gcsQuery, itemsSoFar)
-            allObjectsInMatchingDirectories(tail, allItemsForThisDirectory )
+            allObjectsInMatchingDirectories(tail, itemsSoFar ::: allItemsForThisDirectory )
         }
 
     def tidyFileType(configuredFileType: String) : String = {

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
@@ -15,7 +15,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import scala.collection.parallel.CollectionConverters._
 
 case class GCSUpload(
-  bucket: String,
+  bucket: Map[String, List[String]],
   paths: Seq[(S3Location, String)],
   cacheControlPatterns: List[PatternValue] = Nil,
   publicReadAcl: Boolean = false,

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
@@ -8,31 +8,34 @@ import com.google.api.services.storage.Storage
 import com.google.api.services.storage.model.{ObjectAccessControl, StorageObject}
 import magenta.{DeploymentResources, KeyRing, Loggable, Stack, Stage}
 import magenta.artifact.{S3Location, S3Object, S3Path}
+import magenta.deployment_type.GcsTargetBucket
 import magenta.deployment_type.param_reads.PatternValue
 import magenta.tasks.Task
 import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.{DeleteObjectRequest, GetObjectRequest}
+
 import scala.collection.parallel.CollectionConverters._
 
+import scala.collection.JavaConverters._
+
 case class GCSUpload(
-  bucket: Map[String, List[String]],
+  bucket: GcsTargetBucket,
   paths: Seq[(S3Location, String)],
   cacheControlPatterns: List[PatternValue] = Nil,
-  publicReadAcl: Boolean = false,
-  removeObseleteFiles: Boolean = false
+  publicReadAcl: Boolean = false
 )(implicit val keyRing: KeyRing, artifactClient: S3Client,
   withClientFactory: (KeyRing, DeploymentResources) => (Storage => Unit) => Unit = GCS.withGCSClient[Unit]) extends Task with Loggable {
 
   private val PublicAcl = Arrays.asList(new ObjectAccessControl().setEntity("allUsers").setRole("READER"))
 
   lazy val objectMappings: Seq[(S3Object, GCSPath)] = paths flatMap {
-    case (file, targetKey) => resolveMappings(file, targetKey, bucket)
+    case (file, targetKey) => resolveMappings(file, targetKey, bucket.name)
   }
 
   lazy val totalSize: Long = objectMappings.map{ case (source, _) => source.size }.sum
 
   lazy val transfers: Seq[StorageObjectTransfer] = objectMappings.map { case (source, target) =>
-    val storageObject = new StorageObject().setBucket(bucket)
+    val storageObject = new StorageObject().setBucket(bucket.name)
                                            .setName(target.key)
                                            .setSize(BigInteger.valueOf(source.size))
                                            .setContentType(URLConnection.guessContentTypeFromName(target.key))
@@ -65,6 +68,8 @@ case class GCSUpload(
     val withClient = withClientFactory(keyRing, resources)
     withClient { client =>
 
+      val currentlyDeployedObjects = getCurrentObjectsForDeletion(client, bucket, transfers.map(_.target).toList)
+
       resources.reporter.verbose(s"Starting transfer of ${fileString(objectMappings.size)} ($totalSize bytes)")
       transfers.zipWithIndex.par.foreach { case (transfer, index) =>
         logger.debug(s"Transferring $transfer")
@@ -80,12 +85,18 @@ case class GCSUpload(
                                                   .build()
           val inputStream = resources.artifactClient.getObjectAsBytes(copyObjectRequest).asInputStream()
           val contentType = Option(transfer.target.getContentType).getOrElse(URLConnection.guessContentTypeFromStream(inputStream))
-          val result      = client.objects().insert(bucket, transfer.target, new InputStreamContent(contentType, inputStream)).execute()
+          val result      = client.objects().insert(bucket.name, transfer.target, new InputStreamContent(contentType, inputStream)).execute()
           logger.debug(s"Put object ${result.getName}: MD5: ${result.getMd5Hash} Metadata: ${result.getMetadata}")
           result
         }
       }
-
+      currentlyDeployedObjects.par.foreach { case storageObjectToDelete =>
+         logger.debug(s"Deleting object ${storageObjectToDelete.getName}")
+        val errorMessage = s"Could not 0emove obselete object ${storageObjectToDelete.getName}"
+        GCP.api.retryWhen500orGoogleError(resources.reporter, errorMessage) {
+          client.objects().delete(bucket.name, storageObjectToDelete.getName).execute
+        }
+      }
     }
     resources.reporter.verbose(s"Finished transfer of ${fileString(objectMappings.size)}")
   }
@@ -104,6 +115,82 @@ case class GCSUpload(
   }
 
   private def cacheControlLookup(fileName:String) = cacheControlPatterns.find(_.regex.findFirstMatchIn(fileName).isDefined).map(_.value)
+
+  private def getCurrentObjectsForDeletion(storage: Storage, gcsTargetBucket: GcsTargetBucket, objectsInThisDeploy: List[StorageObject]) : List[StorageObject] = {
+
+    //Gets all objects under a given directory
+    def getAllObjectsForDirectory(query: Storage#Objects#List,  foundSoFar: List[StorageObject] = List.empty): List[StorageObject] = {
+
+      val listResults = query.execute
+      val currentPageItems = Option(listResults.getItems).map(resultsSet => resultsSet.asScala).getOrElse(List.empty)
+      val allItemsFoundSoFar = foundSoFar ++ currentPageItems
+
+      Option(listResults.getNextPageToken) match {
+        case Some(token) => getAllObjectsForDirectory(query.setPageToken(token), allItemsFoundSoFar)
+        case None => allItemsFoundSoFar
+      }
+    }
+
+    def allObjectsInMatchingDirectories(directoriesToPurge: List[String], itemsSoFar: List[StorageObject] = List.empty): List[StorageObject] = {
+        directoriesToPurge match {
+          case Nil => itemsSoFar
+          case head :: tail =>
+            logger.debug(s"++++++++++++++ $head")
+            val gcsQuery = storage.objects()
+             .list(gcsTargetBucket.name)
+             .setPrefix(head)
+            val itemsFortitemsSoFar = getAllObjectsForDirectory(gcsQuery, itemsSoFar)
+            allObjectsInMatchingDirectories(tail, itemsFortitemsSoFar )
+        }
+    }
+
+    def tidyFileType(configuredFileType: String) : String = {
+      if (configuredFileType.startsWith("."))
+        configuredFileType
+      else
+      s".${configuredFileType}"
+    }
+
+    def filterListByFileTypes(baseList: List[StorageObject], filetypesToPurge: List[String]): List[StorageObject] =
+      filetypesToPurge match {
+        case Nil => baseList
+        case head :: tail =>
+          val safeFileExtension = tidyFileType(head)
+          filterListByFileTypes(baseList.filter(ob => ob.getName.endsWith(safeFileExtension)), tail)
+      }
+
+    def findCurrentObjectsNotInThisTransfer(objectsToCheckInCurrentDeploy: List[StorageObject], objectsPreviouslyDeployed: List[StorageObject], objectsToDelete: List[StorageObject] = Nil): List[StorageObject] = {
+      objectsToCheckInCurrentDeploy match {
+        case Nil => objectsToDelete
+        case head :: tail =>
+          objectsPreviouslyDeployed.find( so => so.getName == head.getName) match {
+            case Some(_) =>
+              //Was previously deployed and is being re-deployed, keep it
+              findCurrentObjectsNotInThisTransfer(tail, objectsPreviouslyDeployed, objectsToDelete)
+            case None =>
+              //Was previously deployed but not in this deploy. Delete it
+              findCurrentObjectsNotInThisTransfer(tail, objectsPreviouslyDeployed,  head :: objectsToDelete)
+          }
+
+      }
+    }
+
+    val allItemsForConfiguredDirectories = gcsTargetBucket.directoriesToPurge match {
+      //Nothing to delete = This isn't datatech's composer usecase, but hey ..
+      case Nil => List.empty
+      case directoriesToPurge => allObjectsInMatchingDirectories(directoriesToPurge)
+    }
+
+    val allItemsFilteredByType = filterListByFileTypes(allItemsForConfiguredDirectories, gcsTargetBucket.fileTypesToPurge)
+    logger.debug(s"Deployed: ${allItemsFilteredByType.map(_.getName)}")
+    logger.debug(s"To deploy: ${objectsInThisDeploy.map(_.getName)}")
+    logger.debug(s"To deployList: ${objectsInThisDeploy}")
+
+
+    val toDelete = findCurrentObjectsNotInThisTransfer(allItemsFilteredByType, objectsInThisDeploy)
+    logger.debug(s"There are ${toDelete.size} obbject to go ")
+    toDelete
+  }
 }
 
 case class StorageObjectTransfer(source: S3Object, target: StorageObject) {

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
@@ -68,8 +68,8 @@ case class GCSUpload(
     val withClient = withClientFactory(keyRing, resources)
     withClient { client =>
 
-      val currentlyDeployedObjects = getCurrentObjectsForDeletion(client)
-      logger.debug(s"Objects to delete ${currentlyDeployedObjects.size}")
+      val currentlyDeployedObjectsList = getCurrentObjectsForDeletion(client)
+      resources.reporter.verbose(s"Objects to delete ${currentlyDeployedObjectsList.size}")
 
 
       resources.reporter.verbose(s"Starting transfer of ${fileString(objectMappings.size)} ($totalSize bytes)")
@@ -92,7 +92,7 @@ case class GCSUpload(
           result
         }
       }
-      currentlyDeployedObjects.par.foreach { case storageObjectToDelete =>
+      currentlyDeployedObjectsList.par.foreach { case storageObjectToDelete =>
         val errorMessage = s"Could not 0emove obselete object ${storageObjectToDelete.getName}"
         GCP.api.retryWhen500orGoogleError(resources.reporter, errorMessage) {
           client.objects().delete(gcsTargetBucket.name, storageObjectToDelete.getName).execute

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
@@ -19,6 +19,7 @@ case class GCSUpload(
   paths: Seq[(S3Location, String)],
   cacheControlPatterns: List[PatternValue] = Nil,
   publicReadAcl: Boolean = false,
+  removeObseleteFiles: Boolean = false
 )(implicit val keyRing: KeyRing, artifactClient: S3Client,
   withClientFactory: (KeyRing, DeploymentResources) => (Storage => Unit) => Unit = GCS.withGCSClient[Unit]) extends Task with Loggable {
 
@@ -84,6 +85,7 @@ case class GCSUpload(
           result
         }
       }
+
     }
     resources.reporter.verbose(s"Finished transfer of ${fileString(objectMappings.size)}")
   }

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
@@ -68,10 +68,7 @@ case class GCSUpload(
     val withClient = withClientFactory(keyRing, resources)
     withClient { client =>
 
-      resources.reporter.verbose(s"Paths are *$paths**")
       val currentlyDeployedObjectsList = getCurrentObjectsForDeletion(client)
-      resources.reporter.verbose(s"Objects to delete ${currentlyDeployedObjectsList.size}")
-
 
       resources.reporter.verbose(s"Starting transfer of ${fileString(objectMappings.size)} ($totalSize bytes)")
       transfers.zipWithIndex.par.foreach { case (transfer, index) =>
@@ -94,7 +91,7 @@ case class GCSUpload(
         }
       }
       currentlyDeployedObjectsList.par.foreach { case storageObjectToDelete =>
-        resources.reporter.verbose(s"Deleting obsolete file from GCP: ${storageObjectToDelete.getName}")
+        resources.reporter.verbose(s"Deleting obsolete file from GCP: gcs://${gcsTargetBucket.name}/${storageObjectToDelete.getName}")
         val errorMessage = s"Could not 0emove obselete object ${storageObjectToDelete.getName}"
         GCP.api.retryWhen500orGoogleError(resources.reporter, errorMessage) {
           client.objects().delete(gcsTargetBucket.name, storageObjectToDelete.getName).execute

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
@@ -69,7 +69,7 @@ case class GCSUpload(
     withClient { client =>
 
       val currentlyDeployedObjects = getCurrentObjectsForDeletion(client)
-      logger.info(s"Objects to delete ${currentlyDeployedObjects.size}")
+      logger.debug(s"Objects to delete ${currentlyDeployedObjects.size}")
 
 
       resources.reporter.verbose(s"Starting transfer of ${fileString(objectMappings.size)} ($totalSize bytes)")

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/GCSTasks.scala
@@ -92,7 +92,7 @@ case class GCSUpload(
       }
       currentlyDeployedObjectsToDelete.par.foreach { case storageObjectToDelete =>
         resources.reporter.verbose(s"Deleting obsolete file from GCP: gcs://${gcsTargetBucket.name}/${storageObjectToDelete.getName}")
-        val errorMessage = s"Could not 0emove obselete object ${storageObjectToDelete.getName}"
+        val errorMessage = s"Could notremove obselete object ${storageObjectToDelete.getName}"
         GCP.api.retryWhen500orGoogleError(resources.reporter, errorMessage) {
           client.objects().delete(gcsTargetBucket.name, storageObjectToDelete.getName).execute
         }

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -390,7 +390,8 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
 
     verify(storageObjects, times(2)).list(any[String])
     verify(storageObjects, times(2)).insert(any[String], any[StorageObject], any[AbstractInputStreamContent])
-    verify(storageObjects, times(3)).delete(any[String], any[String])
+    //Delete everything in sub2 plus sub1/two.txt
+    verify(storageObjects, times(4)).delete(any[String], any[String])
     verifyNoMoreInteractions(storageObjects)
   }
 

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -390,7 +390,7 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
 
     verify(storageObjects, times(2)).list(any[String])
     verify(storageObjects, times(2)).insert(any[String], any[StorageObject], any[AbstractInputStreamContent])
-    //Delete everything in sub2 plus sub1/two.txt
+    //Delete everything in sub1 plus everything under test/124
     verify(storageObjects, times(4)).delete(any[String], any[String])
     verifyNoMoreInteractions(storageObjects)
   }

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -426,8 +426,6 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
     verifyNoMoreInteractions(storageObjects)
   }
 
-
-
   it should "only delete files in a configured directory" in new GcsDeleteOnUploadScope {
     def dirName = "test/123"
     def dirsToPrune: List[String] = List(dirName)
@@ -450,7 +448,6 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
   }
 
   it should "use different cache control" in  new GcsDirUploadScope {
-
     val patternValues = List(PatternValue("^keyPrefix/sub/", "public; max-age=3600"), PatternValue(".*", "no-cache"))
     val task = new GCSUpload(targetBucket, Seq(packageRoot -> "keyPrefix"), cacheControlPatterns = patternValues)(fakeKeyRing, artifactClient)
 
@@ -495,7 +492,6 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
 
     val sourceBucket = "artifact-bucket"
     val packageRoot = new S3Path("artifact-bucket", "test/123/package/")
-
 
     def targetBucket: GcsTargetBucket = GcsTargetBucket("destination-bucket", List.empty, List.empty)
     def magentaObjects: List[MagentaS3Object] =
@@ -569,9 +565,6 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
   }
 }
 
-
-
-
 class TestServer(port:Int = 9997) {
 
   def withResponse(response: String): Unit = {
@@ -583,5 +576,4 @@ class TestServer(port:Int = 9997) {
     socket.close()
     server.close()
   }
-
 }


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The datatech team would like to refine the GCS deployment type previously implemented here: https://github.com/guardian/riff-raff/pull/604 and here: https://github.com/guardian/riff-raff/pull/574. We use this deployment type to update our CODE and PROD instances of [Cloud Composer](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwjvta_i3Zv5AhXZgVwKHWgAC8cQFnoECAcQAQ&url=https%3A%2F%2Fcloud.google.com%2Fcomposer&usg=AOvVaw0BvoAUnha-00_IH8bqYzJs). This is the Google Cloud hosted implementation of [Apache Airflow](https://airflow.apache.org/]. 

For each deploy we upload a set of (mostly) python files to a GCS bucket. These files contain the [Dags](https://airflow.apache.org/docs/apache-airflow/stable/concepts/dags.html) defining the data-pipelines in the datalake, along with library code that supports them ( for example, modules to run [DBT](https://www.getdbt.com/) models, or create [Dataproc](https://cloud.google.com/dataproc) clusters and submit jobs to them, for example). These are managed as part of the [ophan datalake](https://github.com/guardian/ophan-data-lake/tree/main/airflow) repo in the `dags` and `guardian` directories. 

What we'd like is to alter the GCP dployment type so that when we remove dags ( or some other type of asset ) from our cloud composer code it can, optionally, be removed from the deploy bucket. This is what this does. In order to make this more generic, change the GCP configuration type to take a list of sub-folders and a list of file types and  remove any matching files which are no longer needed. This should be an optional configuration: for CODE, we'll want to retain the current functionality. 

I've added test cases for the new functionality and refactored the GCS test cases to extract common code and make each test a little more  readable.

I'll squash the commits on merge with all all encompassing commit message

## How to test

I deployed this branch to RiffRaff CODE and then used this Airflow branch https://github.com/guardian/ophan-data-lake/pull/6890 to check everything worked. You can replicate this by first deploying build #7373 to airflow CODE and then #7375. The first creates a couple small dag(.py) files in `dags/dags` and then the second deletes them. The deletions are `gcs://europe-west2-datatech-airfl-fdf1e4b5-bucket/dags/dags/commercial_dfp_impressions_backfill_test.py` and  gcs://europe-west2-datatech-airfl-fdf1e4b5-bucket/dags/dags/commercial_dfp_line_item_test.py `. The logs show these being deleted under the `uploadStaticFiles` deployment, task: `GCSUpload`.  Note: We'll only really want to do this for PROD, but in the above airflow builds the changes to `riffraff.yaml` have the configuration altered for CODE for testing purposes

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->


See above:

You'll probably need access to the: [Code Composer](https://console.cloud.google.com/storage/browser/europe-west2-datatech-airfl-fdf1e4b5-bucket/dags;tab=objects?project=datatech-platform-code&prefix=&forceOnObjectsSortingFiltering=false) Dags  folder(ask datatech).

Deploy this branch to riffaff code and then with that deploy **Ophan datalake PR to come** to `ophan:datalake:airflow` to CODE
confirm that there are no errors and that **Details to Come** files have been removed from the deploy bucket


## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

There should be no increase in errors for deploys to  `ophan:datalake:airflow` 


## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
