### PR TITLE
Revert "refactor: Rename `rotate` to `terminate` for consistency"

### DIFF
--- a/riff-raff/app/controllers/Management.scala
+++ b/riff-raff/app/controllers/Management.scala
@@ -6,7 +6,7 @@ import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 class Management(
   val controllerComponents: ControllerComponents,
   val shutdown: ShutdownWhenInactive,
-  val terminateInstance: TerminateInstanceWhenInactive
+  val rotateInstance: TerminateInstanceWhenInactive
 ) extends BaseController with Logging {
 
   def requestShutdown(): Action[AnyContent] = Action { _ =>
@@ -14,8 +14,8 @@ class Management(
     Ok("Shutdown requested.")
   }
 
-  def requestInstanceTermination(): Action[AnyContent] = Action { _ =>
-    terminateInstance.switch.switchOn()
-    Ok("Instance termination requested.")
+  def requestInstanceRotation(): Action[AnyContent] = Action { _ =>
+    rotateInstance.switch.switchOn()
+    Ok("Instance rotation requested.")
   }
 }

--- a/riff-raff/bootstrap.sh
+++ b/riff-raff/bootstrap.sh
@@ -61,9 +61,9 @@ APP_BUCKET="deploy-tools-dist"
 USER=$APP
 HOME="/home/$APP"
 
-INSTANCE_TERMINATION_SCHEDULE="WED *-*-* 08:00:00 Europe/London"
+INSTANCE_ROTATION_SCHEDULE="WED *-*-* 08:00:00 Europe/London"
 if [ "$STAGE" == "PROD" ]; then
-  INSTANCE_TERMINATION_SCHEDULE="THU *-*-* 08:00:00 Europe/London"
+  INSTANCE_ROTATION_SCHEDULE="THU *-*-* 08:00:00 Europe/London"
 fi
 
 # Install a new copy of the properties file
@@ -106,26 +106,26 @@ RestartForceExitStatus=217
 WantedBy=multi-user.target
 EOF
 
-cat > /etc/systemd/system/${APP}-instance-termination.service << EOF
+cat > /etc/systemd/system/${APP}-instance-rotation.service << EOF
 [Unit]
-Description=${APP} instance termination
+Description=${APP} instance rotation
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl --silent -X POST http://localhost:9000/requestInstanceTermination
+ExecStart=/usr/bin/curl --silent -X POST http://localhost:9000/requestInstanceRotation
 
 [Install]
 WantedBy=multi-user.target
 EOF
 
-cat > /etc/systemd/system/${APP}-instance-termination.timer << EOF
+cat > /etc/systemd/system/${APP}-instance-rotation.timer << EOF
 [Unit]
-Description=${APP} instance termination schedule
-Requires=${APP}-instance-termination.service
+Description=${APP} instance rotation schedule
+Requires=${APP}-instance-rotation.service
 
 [Timer]
-Unit=${APP}-instance-termination.service
-OnCalendar=${INSTANCE_TERMINATION_SCHEDULE}
+Unit=${APP}-instance-rotation.service
+OnCalendar=${INSTANCE_ROTATION_SCHEDULE}
 
 [Install]
 WantedBy=timers.target

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -129,4 +129,4 @@ GET         /assets/*file                                   controllers.Assets.v
 
 # Management endpoints
 POST        /requestShutdown                                controllers.Management.requestShutdown()
-POST        /requestInstanceTermination                     controllers.Management.requestInstanceTermination()
+POST        /requestInstanceRotation                        controllers.Management.requestInstanceRotation()


### PR DESCRIPTION
Reverts guardian/riff-raff#695

This refactoring isn't quite complete, and prevented Riff-Raff PROD from starting today as `bootstrap.sh` was referencing a file that no longer exists.

Reverting, and will try again in a follow-up PR.