### PR TITLE
Add workflows to enable dependency update batching

### DIFF
--- a/.github/workflows/dep-updates_pr-tracking-branch-to-default.yml
+++ b/.github/workflows/dep-updates_pr-tracking-branch-to-default.yml
@@ -1,0 +1,12 @@
+name: Create batch dependency update PR
+
+on:
+  schedule:
+    - cron: "35 10 * * MON"
+  # Provide support for manually triggering the workflow via GitHub.
+  workflow_dispatch:
+
+jobs:
+  pr-tracking-branch:
+    name: Open a PR from dependency-updates targeting main
+    uses: guardian/.github/.github/workflows/pr-batching_pr-tracking-branch-to-default.yml@v1

--- a/.github/workflows/dep-updates_set-automerge.yml
+++ b/.github/workflows/dep-updates_set-automerge.yml
@@ -1,0 +1,11 @@
+name: Set automerge on dependency update PRs
+
+on:
+  pull_request:
+    branches:
+      - dependency-updates
+
+jobs:
+  set-automerge:
+    name: Set automerge on opened PRs targeting the tracking branch
+    uses: guardian/.github/.github/workflows/pr-batching_set-automerge.yml@v1

--- a/.github/workflows/dep-updates_tracking-branch.yml
+++ b/.github/workflows/dep-updates_tracking-branch.yml
@@ -1,0 +1,11 @@
+name: Maintain dependency update batching branch
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-dependency-update-branch:
+    name: Keep tracking branch up to date with main
+    uses: guardian/.github/.github/workflows/pr-batching_tracking-branch.yml@v1


### PR DESCRIPTION
Adds a series of workflows that enable granular dependency updates from e.g. Scala Steward. It works by automatically merging PRs from those tools into a non-default branch before creating a single PR on a specified schedule.