### PR TITLE
feat(autoscaling): Enable deployment to a new ASG

### DIFF
--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -75,7 +75,7 @@ class AutoScalingTest extends AnyFlatSpec with Matchers with MockitoSugar with A
 
     withObjectMocked[AutoScalingGroupLookup.type] {
       val testInfo = testAsgInfo()
-      when(AutoScalingGroupLookup.getTargetAsg(*, *, *, *, *)) thenAnswer testInfo
+      when(AutoScalingGroupLookup.getTargetAsg(*, *, *, *, *)) thenAnswer Some(testInfo)
       val actual = AutoScaling.actionsMap("deploy").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient, stsClient, global), DeployTarget(parameters(), stack, region))
       val expected = List(
         WaitForStabilization(testInfo, 5 * 60 * 1000, Region("eu-west-1")),
@@ -111,7 +111,7 @@ class AutoScalingTest extends AnyFlatSpec with Matchers with MockitoSugar with A
     withObjectMocked[AutoScalingGroupLookup.type] {
       val testOldCfnAsg = testAsgInfo("testOldCfnAsg")
       val testNewCdkAsg = testAsgInfo("testNewCdkAsg")
-      when(AutoScalingGroupLookup.getTargetAsg(*, *, *, *, *)).thenReturn(testOldCfnAsg, testNewCdkAsg)
+      when(AutoScalingGroupLookup.getTargetAsg(*, *, *, *, *)).thenReturn(Some(testOldCfnAsg), Some(testNewCdkAsg))
       val actual = AutoScaling.actionsMap("deploy").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient, stsClient, global), DeployTarget(parameters(), stack, region))
       val expected = List(
         // All tasks for testOldCfnAsg
@@ -179,7 +179,7 @@ class AutoScalingTest extends AnyFlatSpec with Matchers with MockitoSugar with A
 
     withObjectMocked[AutoScalingGroupLookup.type] {
       val testInfo = testAsgInfo()
-      when(AutoScalingGroupLookup.getTargetAsg(*, *, *, *, *)) thenAnswer testInfo
+      when(AutoScalingGroupLookup.getTargetAsg(*, *, *, *, *)) thenAnswer Some(testInfo)
       val actual = AutoScaling.actionsMap("deploy").taskGenerator(p, DeploymentResources(reporter, lookupEmpty, artifactClient, stsClient, global), DeployTarget(parameters(), stack, region))
       val expected = List(
         WaitForStabilization(testInfo, 5 * 60 * 1000, Region("eu-west-1")),

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
@@ -69,7 +69,7 @@ class ASGTest extends AnyFlatSpec with Matchers with MockitoSugar {
       TagMatch("App", "logcabin"),
     )
     val group = ASG.groupWithTags(tags, asgClientMock, reporter)
-    group shouldBe desiredGroup
+    group shouldBe Some(desiredGroup)
   }
 
   it should "fail if more than one ASG matches the Stack and App tags (unless MigrationTagRequirements are specified)" in {
@@ -121,7 +121,7 @@ class ASGTest extends AnyFlatSpec with Matchers with MockitoSugar {
       TagExists("gu:riffraff:new-asg")
     )
     val group = ASG.groupWithTags(tags, asgClientMock, reporter)
-    group shouldBe desiredGroup
+    group shouldBe Some(desiredGroup)
   }
 
   it should "identify a single ASG based on Stack & App tags and MustNotBePresent MigrationTagRequirements" in {
@@ -144,7 +144,7 @@ class ASGTest extends AnyFlatSpec with Matchers with MockitoSugar {
       TagAbsent("gu:riffraff:new-asg")
     )
     val group = ASG.groupWithTags(tags, asgClientMock, reporter)
-    group shouldBe desiredGroup
+    group shouldBe Some(desiredGroup)
   }
 
   it should "wait for instances in ELB to stabilise if there is one" in {


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

As part of the pre-flight checks for an `autoscaling` deployment, Riff-Raff will attempt to lookup the ASG, and throw an error if it's unable to locate any. This behaviour is desired when deploying to an _existing_ ASG. However if we want to _create_ a new stack (from nothing) it means we cannot use Riff-Raff for the initial creation and have to resort to going directly to AWS. 😢 

In this change, we change the rules. If an ASG cannot be located _and_ the update strategy is `Dangerous` (see #626), then allow the deployment to continue. This allows us to use Riff-Raff to deploy a new stack from scratch! 🎉 

Note: If an ASG cannot be located and the update strategy is `MostlyHarmless`, we continue to fail, but provide a hint to the `Dangerous` option.

### Preferred solution
This change is more pragmatic than preferred, in that it helps solve the described problem, but not in the best way. A better version would be to improve the [dependency graph](https://github.com/guardian/riff-raff/blob/1b457280690f4d4b74fd0638bb0dedcb4c82c2d4/riff-raff/app/deployment/preview/Preview.scala#L32-L43). IIUC RIff-Raff builds a graph of steps and interdependencies, however it only uses this for ordering and not for validation checks.

An improvement could be to mark all children in the graph as passing their validation if the parent node has passed. That is, in the situation where we want to create a new stack, Riff-Raff should pass the ASG lookup if it's deemed the CloudFormation stack doesn't exist (an ASG deployment is dependant on a CloudFormation deployment).

Whilst this change does start to overload the `Dangerous` mode, it doesn't change it's meaning too much - deploying to an ASG that has not been discovered is `Dangerous` if you were expecting it to be discovered.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Deploy to CODE
- Deploy https://github.com/guardian/backend-101-scala-starter-akash1810 from scratch. It should be successful.

## Images

### Today
<img width="1164" alt="image" src="https://user-images.githubusercontent.com/836140/183309867-7253436d-fcbe-41fd-bcd1-86772ad9921a.png">

### Proposed
#### Error message with prompt
<img width="1163" alt="image" src="https://user-images.githubusercontent.com/836140/183309954-1d2c0c95-4bc5-4a34-a0c4-0af79250ec89.png">

### When deploying with `Dangerous` mode 🎉 
<img width="1162" alt="image" src="https://user-images.githubusercontent.com/836140/183309985-b46bc639-4d8f-4c5f-a070-ac6512551a24.png">
