### PR TITLE
feat: Add `prefixApp` parameter to `autoscaling` and `aws-s3` deployments

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -129,8 +129,8 @@ object S3Upload {
 
   def awsMimeTypeLookup(fileName: String): String = mimeTypes.getMimetype(new File(fileName))
 
-  def prefixGenerator(stack:Option[Stack] = None, stage:Option[Stage] = None, packageName:Option[String] = None): String = {
-    (stack.map(_.name) :: stage.map(_.name) :: packageName :: Nil).flatten.mkString("/")
+  def prefixGenerator(stack:Option[Stack] = None, stage:Option[Stage] = None, packageOrAppName:Option[String] = None): String = {
+    (stack.map(_.name) :: stage.map(_.name) :: packageOrAppName :: Nil).flatten.mkString("/")
   }
   def prefixGenerator(stack: Stack, stage: Stage, packageName: String): String =
     prefixGenerator(Some(stack), Some(stage), Some(packageName))

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -28,8 +28,8 @@ class DeploymentTypeTest extends AnyFlatSpec with Matchers with Inside with Mock
   val deploymentTypes = Seq(S3, Lambda)
 
   "Deployment types" should "automatically register params in the params Seq" in {
-    S3.params should have size 10
-    S3.params.map(_.name).toSet should be(Set("prefixStage","prefixPackage","prefixStack", "pathPrefixResource","bucket","publicReadAcl","bucketResource","cacheControl","surrogateControl","mimeTypes"))
+    S3.params should have size 11
+    S3.params.map(_.name).toSet should be(Set("prefixStage","prefixPackage","prefixStack", "prefixApp", "pathPrefixResource","bucket","publicReadAcl","bucketResource","cacheControl","surrogateControl","mimeTypes"))
   }
 
   private val sourceS3Package = S3Path("artifact-bucket", "test/123/static-files")


### PR DESCRIPTION
Requires #789, but only because I've branched off that.

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

For this `riff-raff.yaml` file:

```yaml
allowedStages:
  - PROD
regions:
  - eu-west-1
stacks:
  - deploy
deployments:
  backend-101-scala-starter-akash1810:
    type: autoscaling
    parameters:
      bucketSsmLookup: true
```

Riff-Raff will define:
  - package as `backend-101-scala-starter-akash1810`
  - stack as `deploy`
  - stage as `PROD`

When uploading the build artifact to S3, Riff-Raff will use the path:

```
s3://BUCKET/deploy/PROD/backend-101-scala-starter-akash1810/my-file.jar
```

The path can be customised via the [`prefixStage`, `prefixStack` and `prefixPackage` parameters](https://github.com/guardian/riff-raff/blob/1b457280690f4d4b74fd0638bb0dedcb4c82c2d4/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala#L58-L66). In this change, we add a `prefixApp` parameter to allow further customisation.

This is particularly useful when the `riff-raff.yaml` file is auto-generated (see https://github.com/guardian/cdk/pull/1372), and when the auto-generated `riff-raff.yaml` looks like this:

```yaml
allowedStages:
  - PROD
deployments:
  backend-101-scala-starter-akash1810-asg-upload-deploy-eu-west-1:
    type: autoscaling
    regions:
      - eu-west-1
    stacks:
      - deploy
    app: backend-101-scala-starter-akash1810
    contentDirectory: backend-101-scala-starter-akash1810
    parameters:
      bucketSsmLookup: true
      prefixApp: true
```

This means the S3 path can go from:

```
s3://BUCKET/deploy/PROD/backend-101-scala-starter-akash1810-asg-upload-deploy-eu-west-1/my-file.jar
```

to:

```
s3://BUCKET/deploy/PROD/backend-101-scala-starter-akash1810/my-file.jar
```

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Deploy this branch to CODE
- Deploy https://github.com/guardian/backend-101-scala-starter-akash1810 from scratch. It should be successful.