### PR TITLE
Revert "Revert "Dependency updates 2022-08-15""

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,1 +1,0 @@
-updates.ignore = [ { groupId = "com.adrianhurt", artifactId = "play-bootstrap" } ]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   object Versions {
     val aws = "2.17.109"
     val jackson = "2.13.3"
-    val awsRds = "1.12.277"
+    val awsRds = "1.12.281"
     val enumeratumPlay = "1.7.0"
   }
 
@@ -65,24 +65,24 @@ object Dependencies {
     evolutions,
     jdbc,
     "com.gu.play-googleauth" %% "play-v28" % "2.2.6",
-    "com.gu.play-secret-rotation" %% "play-v28" % "0.33",
-    "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "0.33",
+    "com.gu.play-secret-rotation" %% "play-v28" % "0.36",
+    "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "0.36",
     "com.typesafe.akka" %% "akka-agent" % "2.5.32",
     "org.pegdown" % "pegdown" % "1.6.0",
-    "com.adrianhurt" %% "play-bootstrap" % "1.6.1-P28-B3",
+    "com.adrianhurt" %% "play-bootstrap" % "1.6.1-P28-B3", // scala-steward:off,
     "org.scanamo" %% "scanamo" % "1.0.0-M11",
     "software.amazon.awssdk" % "dynamodb" % Versions.aws,
     "software.amazon.awssdk" % "sns" % Versions.aws,
     "org.quartz-scheduler" % "quartz" % "2.3.2",
     "com.gu" %% "anghammarad-client" % "1.2.0",
     "org.webjars" %% "webjars-play" % "2.8.13",
-    "org.webjars" % "jquery" % "3.1.1",
+    "org.webjars" % "jquery" % "3.6.0",
     "org.webjars" % "jquery-ui" % "1.13.2",
     "org.webjars" % "bootstrap" % "3.3.7",
     "org.webjars" % "jasny-bootstrap" % "3.1.3-2",
-    "org.webjars" % "momentjs" % "2.16.0",
+    "org.webjars" % "momentjs" % "2.29.4",
     "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
-    "com.gu" % "kinesis-logback-appender" % "1.4.4",
+    "com.gu" % "kinesis-logback-appender" % "2.1.0",
     "org.slf4j" % "jul-to-slf4j" % "1.7.36",
     "org.scalikejdbc" %% "scalikejdbc" % "3.5.0",
     "org.postgresql" % "postgresql" % "42.4.1",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val aws = "2.17.109"
+    val aws = "2.17.248"
     val jackson = "2.13.3"
     val awsRds = "1.12.281"
     val enumeratumPlay = "1.7.0"

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -151,7 +151,7 @@ class Config(configuration: TypesafeConfig, startTime: DateTime) extends Logging
     lazy val accessKey = getStringOpt("logging.aws.accessKey")
     lazy val secretKey = getStringOpt("logging.aws.secretKey")
     lazy val regionName = getStringOpt("logging.aws.region").getOrElse(defaultRegion)
-    lazy val credentialsProvider = legacyCredentialsProviderChain(accessKey, secretKey)
+    lazy val credentialsProvider = credentialsProviderChain(accessKey, secretKey)
   }
 
   object lookup {

--- a/riff-raff/app/utils/ElkLogging.scala
+++ b/riff-raff/app/utils/ElkLogging.scala
@@ -5,7 +5,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.Appender
 import ch.qos.logback.core.joran.spi.JoranException
 import ch.qos.logback.core.util.StatusPrinter
-import com.amazonaws.auth.AWSCredentialsProvider
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import com.gu.logback.appender.kinesis.KinesisAppender
 import controllers.Logging
 import net.logstash.logback.layout.LogstashLayout
@@ -19,7 +19,7 @@ import scala.util.control.NonFatal
 class ElkLogging(stage: String,
                  region: String,
                  loggingStreamName: Option[String],
-                 awsCredentialsProvider: AWSCredentialsProvider,
+                 awsCredentialsProvider: AwsCredentialsProvider,
                  applicationLifecycle: ApplicationLifecycle) extends Logging {
   def getContextTags: Map[String, String] = {
     val effective = Map(


### PR DESCRIPTION
Reverts guardian/riff-raff#802 to bring back the dependency update changes for this week. This time with a fix for the runtime issue encountered in the first attempt. We were (transitively) pulling in a new version of the v2 aws sdk (patch version 248), which turned out to be incompatible, at runtime, with the direct dependency on patch version 109.