### PR TITLE
Batch together dependency updates once a month

### DIFF
--- a/.github/workflows/dep-updates_pr-tracking-branch-to-default.yml
+++ b/.github/workflows/dep-updates_pr-tracking-branch-to-default.yml
@@ -2,7 +2,7 @@ name: Create batch dependency update PR
 
 on:
   schedule:
-    - cron: "35 10 * * MON"
+    - cron: "35 10 1 * *"
   # Provide support for manually triggering the workflow via GitHub.
   workflow_dispatch:
 


### PR DESCRIPTION
## What does this change?
Batch together dependency updates once a month instead of weekly to reduce maintenance burden. Note: security fixes should still be applied faster via a different process.