### PR TITLE
Get the latest state of the ASG before every ASGTask

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -234,6 +234,16 @@ object ASG {
   case class TagExists(key: String) extends TagRequirement
   case class TagAbsent(key: String) extends TagRequirement
 
+  def getGroupByName(name: String, client: AutoScalingClient, reporter: DeployReporter): AutoScalingGroup = {
+    val request = DescribeAutoScalingGroupsRequest.builder()
+      .autoScalingGroupNames(name)
+      .maxRecords(1)
+      .build()
+    val autoScalingGroups = client.describeAutoScalingGroups(request).autoScalingGroups().asScala.toList
+    // We've asked for one record and the name must be unique per Region per account
+    autoScalingGroups.headOption.getOrElse(reporter.fail(s"Failed to identify an autoscaling group with name ${name}"))
+  }
+
   def groupWithTags(tagRequirements: List[TagRequirement], client: AutoScalingClient, reporter: DeployReporter, strategy: Strategy = Strategy.MostlyHarmless): Option[AutoScalingGroup] = {
     case class ASGMatch(app:App, matches:List[AutoScalingGroup])
 


### PR DESCRIPTION
## What does this change?

This PR fixes a bug which resulted in Riff-Raff setting the desired AutoScaling group capacity incorrectly (and therefore deployments failing / getting into a weird state). 

The bug was caused by obtaining information about the AutoScaling group at the _very start_ of the deployment and then failing to refresh this information as the deployment proceeded. I suspect that this underlying problem may have also caused some other rare bugs/unusual behaviour too. 

I believe the problem was first introduced via https://github.com/guardian/riff-raff/pull/650 (more specifically [here](https://github.com/guardian/riff-raff/pull/650/files#diff-486da3a5337f0a0aef4f7881a9bf7830015c76f51b82be67053132d3bdaae222L170-L176)).

### More details on the bug

We noticed this bug affecting some deployments yesterday. The problematic deployments scaled up the AutoScaling group via CloudFormation before performing the [standard `autoscaling` deployment type](https://riffraff.gutools.co.uk/docs/magenta-lib/types#autoscaling). Although the CloudFormation updates worked correctly, Riff-Raff was unable to perform the `autoscaling` deployment.

[Here is an example of a deployment which runs into this bug](https://riffraff.gutools.co.uk/deployment/view/54fb92fe-a8c8-4306-9eb4-4757428e7588?verbose=1). The change being deployed be seen here: https://github.com/guardian/amiable/pull/254.

The core problem is shown below.

1. Riff-Raff updates the ASG capacity (via CFN), which causes the ASG to launch new instances (correct behaviour):

```
[11:40:16] task ExecuteChangeSetTask Execute change set deploy-<redacted> on stack with tags Map(Stage -> CODE, Stack -> deploy, App -> amiable)
  [11:40:17] Found stack amiable-gucdk-CODE <redacted>
  [11:40:17] Resource - ResourceChange(Action=Modify, LogicalResourceId=<redacted>, PhysicalResourceId=<redacted>, ResourceType=AWS::AutoScaling::AutoScalingGroup, Replacement=False, Scope=[Properties], Details=[ResourceChangeDetail(Target=ResourceTargetDefinition(Attribute=Properties, Name=MaxSize, RequiresRecreation=Never), Evaluation=Static, ChangeSource=DirectModification), ResourceChangeDetail(Target=ResourceTargetDefinition(Attribute=Properties, Name=MinSize, RequiresRecreation=Never), Evaluation=Static, ChangeSource=DirectModification)])
```

2. Riff-Raff patiently waits for the ASG to scale up (correct behaviour):

```
 [11:40:45] task WaitForStabilization Check the desired number of hosts in both the ASG (<redacted>) and ELB are up and that the number of hosts match
  [11:40:45] Looked up group matching tags List(TagMatch(Stage,CODE), TagMatch(Stack,deploy), TagMatch(App,amiable)); identified <redacted>
  [11:40:46] Only 1 of 3 V2 ELB instances healthy
  [11:40:46] Check failed on attempt #1 (Will wait for a further 299.802 seconds, retrying again after 30.0s)
  [11:41:16] Only 1 of 3 V2 ELB instances healthy
  [11:41:16] Check failed on attempt #2 (Will wait for a further 269.647 seconds, retrying again after 30.0s)
  [11:41:46] Only 1 of 3 V2 ELB instances healthy
  [11:41:46] Check failed on attempt #3 (Will wait for a further 239.502 seconds, retrying again after 30.0s)
  [11:42:16] Only 2 of 3 V2 ELB instances healthy
  [11:42:16] Check failed on attempt #4 (Will wait for a further 209.359 seconds, retrying again after 30.0s)
```

3. Riff-Raff promptly forgets that there should be 3 instances because it is using a cached version of the ASG info from the start of the deployment (incorrect behaviour!):

```
[11:42:46] task CheckGroupSize Checking there is enough capacity in ASG <redacted> to deploy
  [11:42:46] Looked up group matching tags List(TagMatch(Stage,CODE), TagMatch(Stack,deploy), TagMatch(App,amiable)); identified <redacted>
  [11:42:46] ASG desired = 1; ASG max = 2; Target = 2
```

4. So Riff-Raff decides that desired capacity should be 2 (incorrect behaviour!):

```
[11:42:47] task DoubleSize Double the size of the auto-scaling group called <redacted>
  [11:42:47] Looked up group matching tags List(TagMatch(Stage,CODE), TagMatch(Stack,deploy), TagMatch(App,amiable)); identified <redacted>
  [11:42:47] Doubling capacity to 2
  [11:42:47] Unhandled exception in task DoubleSize Double the size of the auto-scaling group called <redacted>
```

In the recreate the deployment fails at this step, but Riff-Raff can get further than this in some scenarios (depending on the min/desired capacities). Yesterday Riff-Raff was able to get as far as trying to [terminate instances](https://riffraff.gutools.co.uk/deployment/view/f22bd85c-767c-4ef4-a4ec-fdf10ce2f4f8?verbose=1). The behaviour that we saw yesterday with the Mobile team was worse, because it left the AWS resources in a weird state (one of the instances was part of the ASG but was not registered with the target group!).

## How to test

* I created a branch and confirmed that I could [recreate](https://riffraff.gutools.co.uk/deployment/view/54fb92fe-a8c8-4306-9eb4-4757428e7588?verbose=1) the problem that the Mobile team hit yesterday
* I deployed this build to `CODE`
* I confirmed that the branch which could not be deployed (via `main`/`PROD`) could be [deployed successfully](https://riffraff.code.dev-gutools.co.uk/deployment/view/4f670fa2-9788-4861-acdc-52a42b27cd2b?verbose=1) using this branch

## How can we measure success?

We should be able to update minimum/maximum ASG capacities and perform an `autoscaling` deployment via a single Riff-Raff deployment.

## Have we considered potential risks?

I think this is pretty low risk; IIUC this is the way that Riff-Raff worked prior to https://github.com/guardian/riff-raff/pull/650.

That said, this is a particularly important news day, so I intend to deploy this on Monday morning unless there are any objections.