### PR TITLE
Test out GHA builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,5 @@ jobs:
           # Ensure we don't overwrite existing (Teamcity) builds.
           # LAST_TEAMCITY_BUILD=TODO
           # export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
+          # Note, lib/test because riffraff/riffRaffUpload only tests the riffraff project.
           sbt clean compile lib/test riffraff/riffRaffUpload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,23 @@ on:
 
 jobs:
   test:
-    runs-on: 4core-ubuntu-latest
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Allow GitHub to request an OIDC JWT ID token, for exchange with `aws-actions/configure-aws-credentials`
+      # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#updating-your-github-actions-workflow
+      id-token: write
+
+      # Required for `actions/checkout`
+      contents: read
+
     steps:
       - uses: actions/checkout@v3
+
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: eu-west-1
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
       - name: Setup JDK
         uses: actions/setup-java@v3
@@ -23,7 +37,8 @@ jobs:
         run: |
           set -e
           # Ensure we don't overwrite existing (Teamcity) builds.
-          # LAST_TEAMCITY_BUILD=TODO
-          # export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
+          LAST_TEAMCITY_BUILD=2360
+          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
+
           # Note, lib/test because riffraff/riffRaffUpload only tests the riffraff project.
           sbt clean compile lib/test riffraff/riffRaffUpload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: 4core-ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
           # Ensure we don't overwrite existing (Teamcity) builds.
           # LAST_TEAMCITY_BUILD=TODO
           # export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          sbt clean compile riffraff/riffRaffUpload
+          sbt clean compile lib/test riffraff/riffRaffUpload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 jobs:
-  test:
+  ci:
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: corretto
+          java-version: 11
+
+      - name: build + test
+        run: |
+          sbt clean compile lib/test riffraff/riffRaffUpload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
           # Ensure we don't overwrite existing (Teamcity) builds.
           LAST_TEAMCITY_BUILD=2357
           export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          sbt clean compile lib/test riffraff/riffRaffUpload
+          sbt clean compile riffraff/riffRaffUpload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       - name: build + test
         run: |
           # Ensure we don't overwrite existing (Teamcity) builds.
+          set -e
           LAST_TEAMCITY_BUILD=2357
           export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
           sbt clean compile riffraff/riffRaffUpload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,14 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: corretto
           java-version: 11
 
       - name: build + test
         run: |
+          # Ensure we don't overwrite existing (Teamcity) builds.
+          LAST_TEAMCITY_BUILD=2357
+          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
           sbt clean compile lib/test riffraff/riffRaffUpload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: build + test
         run: |
-          # Ensure we don't overwrite existing (Teamcity) builds.
           set -e
-          LAST_TEAMCITY_BUILD=2357
-          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
+          # Ensure we don't overwrite existing (Teamcity) builds.
+          # LAST_TEAMCITY_BUILD=TODO
+          # export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
           sbt clean compile riffraff/riffRaffUpload


### PR DESCRIPTION
**Note, I have temporarily paused the Teamcity Riffraff build as part of this. We can unpause if we decide to rework this PR for any reason.**

*Note, the `riffRaffUpload` task has been temporarily removed until this is ready to merge to avoid clashing with Teamcity which isn't aware of other builds.*

Switch to GHA.

There are a few motivations here:

* move to GHA with associated benefits (CI in code, etc.)
* see whether as a result builds become less flaky (https://trello.com/c/nBdgDu2h/1432-move-riffraff-build-to-gha has details) - we'll probably only be able to answer this over time but it seems likely given the causes of some of the previous issues concern contention for resources on our Teamcity agents
* explore Scala GHA build times and to what extent larger runners help here (will do in subsequent PR as having issues with our custom runner atm - workflows are hanging).