### PR TITLE
fix: Add a warning message when `manageStackPolicy` is `false`

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -156,6 +156,10 @@ class CloudFormation(vcsUrlLookup: VcsLookup) extends DeploymentType with CloudF
         .orElse(getManageStackPolicyFromLookup)
         .getOrElse(manageStackPolicyDefault)
 
+    if(!manageStackPolicy) {
+      reporter.warning("You've opted out of having Riff-Raff protect resources during a CloudFormation deployment (`manageStackPolicy` = false). See https://riffraff.gutools.co.uk/docs/riffraff/advanced-settings.md.")
+    }
+
     val cfnTemplateFile: String = templateStagePaths(pkg, target, reporter).lift.apply(target.parameters.stage.name) match {
       case Some(file) =>
         logger.info(s"templateStagePaths property is set and has been resolved to $file")


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

In #623 we introduced a feature to protect stateful resources from being accidentally deleted. It is possible to opt-out of this with the `manageStackPolicy` flag, but it's not desired.

In this change we add a warning to the deployment log to surface the use of this flag.

The [consent-management-platform](https://github.com/guardian/consent-management-platform/blob/5b4b189303467d3d59c4cdc8c75b6e981691f159/riff-raff.yaml#L17) stack is one example of where we set `manageStackPolicy` to `false`. In this particular case, we're doing this because of a bug in Riff-Raff; Riff-Raff will apply [this stack policy](https://github.com/guardian/riff-raff/blob/fefe9f1df44f269edf6062ba928cf9127b52044c/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala#L32-L73) in all regions, however the `AWS::DocDB::DBCluster` resource is not available in the us-west-1 region and [this error](https://riffraff.gutools.co.uk/deployment/view/a4cd6707-f126-4e07-ace1-93fd32ccd636) results when trying to apply the policy to a stack in us-west-1:

```log
software.amazon.awssdk.services.cloudformation.model.CloudFormationException Error validating stack policy: Unknown resource type 'AWS::DocDB::DBCluster' in statement {}
```

Riff-Raff should build the policy document based on what resources are available in the target region.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Deploy to CODE
- Using CODE, deploy a project that sets `manageStackPolicy` to `false` (e.g. [AMIable](https://github.com/guardian/amiable/pull/279))
- Observe the warning message (see screenshot below)

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Teams are more aware when they're at risk.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

![image](https://user-images.githubusercontent.com/836140/194087958-a509deb6-2ca8-4879-883a-1b6d1accdbee.png)