### PR TITLE
ci: Explicitly set Riff-Raff project name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,6 +82,7 @@ lazy val riffraff = project.in(file("riff-raff"))
       baseDirectory.value / "bootstrap.sh" -> s"${name.value}/bootstrap.sh",
       baseDirectory.value / "riff-raff.yaml" -> "riff-raff.yaml"
     ),
+    riffRaffManifestProjectName := "tools::riffraff", // explicitly named for continuity following move from TeamCity to GitHub Actions
 
     ivyXML := {
       <dependencies>


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Explicitly configure the RIff-Raff project name following the move to GitHub Actions in #867, else we'd have to reconfigure the scheduled, continuous and restricted deployments.