### PR TITLE
fix(cloudformation): Detect regional availability of all resource types

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
@@ -1,8 +1,8 @@
 package magenta.tasks
-import magenta.tasks.StackPolicy.{accountPrivateTypes, allSensitiveResourceTypes, toPolicyDoc}
+import magenta.tasks.StackPolicy.{accountResourceTypes, allSensitiveResourceTypes, toPolicyDoc}
 import magenta.{DeploymentResources, KeyRing, Region}
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient
-import software.amazon.awssdk.services.cloudformation.model.{ChangeSetType, ListTypesRequest, SetStackPolicyRequest, Visibility}
+import software.amazon.awssdk.services.cloudformation.model.{Category, ChangeSetType, ListTypesRequest, RegistryType, SetStackPolicyRequest, TypeFilters, Visibility}
 
 import scala.jdk.CollectionConverters._
 
@@ -12,18 +12,59 @@ case object DenyReplaceDeletePolicy extends StackPolicy
 
 object StackPolicy {
 
-  def toPolicyDoc(policy: StackPolicy, sensitiveResourceTypes: Set[String], accountPrivateTypes: () => Set[String]): String = policy match {
+  def toPolicyDoc(policy: StackPolicy, sensitiveResourceTypes: Set[String], accountResourceTypes: () => Set[String]): String = policy match {
     case AllowAllPolicy =>
       ALLOW_ALL_POLICY
     case DenyReplaceDeletePolicy =>
-      val sensitiveResources = sensitiveResourceTypes.filter(t => t.startsWith("AWS") || accountPrivateTypes().contains(t))
+      val sensitiveResources = sensitiveResourceTypes.intersect(accountResourceTypes()).toList.sorted.toSet // alphabetical to make testing easier
       DENY_REPLACE_DELETE_POLICY(sensitiveResources)
   }
 
-  def accountPrivateTypes(client: CloudFormationClient): Set[String] = {
+  /**
+   * Returns the names of private resource types that can be CLoudFormed in a given region.
+   * Necessary because we've not deployed all our private resource types to all regions.
+   *
+   * @param client A CloudFormation client, with a set region
+   * @return A Set of Resource type names
+   * @see https://github.com/guardian/cfn-private-resource-types
+   */
+  private def accountPrivateTypes(client: CloudFormationClient): Set[String] = {
     val request =  ListTypesRequest.builder().visibility(Visibility.PRIVATE).build()
     val response = client.listTypesPaginator(request)
     response.typeSummaries().asScala.map(_.typeName()).toSet
+  }
+
+  /**
+   * Returns the names of AWS and private resource types that can be CloudFormed in a given region.
+   * Necessary because every region does not support every resource.
+   * For example AWS::DocDB::DBCluster is not supported in us-west-1.
+   *
+   * @param client A CloudFormation client, with a set region
+   * @return A Set of Resource type names
+   * @see https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/list-types.html
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html
+   */
+  private def accountAwsResourceTypes(client: CloudFormationClient): Set[String] = {
+    val request = ListTypesRequest.builder()
+      .visibility(Visibility.PUBLIC)
+      .`type`(RegistryType.RESOURCE)
+      .filters(
+        TypeFilters.builder()
+          .category(Category.AWS_TYPES)
+          .build()
+      ).build()
+    val response = client.listTypesPaginator(request)
+    response.typeSummaries().asScala.map(_.typeName()).toSet
+  }
+
+  /**
+   * Returns the names of AWS and Private resource types that can be CloudFormed in a given region.
+   *
+   * @param client A CloudFormation client, with a set region
+   * @return A Set of Resource type names
+   */
+  def accountResourceTypes(client: CloudFormationClient): Set[String] = {
+    accountAwsResourceTypes(client) ++ accountPrivateTypes(client)
   }
 
   /** CFN resource types that have state or are likely to exist in external
@@ -131,7 +172,7 @@ class SetStackPolicyTask(
   override def execute(resources: DeploymentResources, stopFlag: => Boolean): Unit = {
     CloudFormation.withCfnClient(keyRing, region, resources) { cfnClient =>
       val (stackName, changeSetType, _) = stackLookup.lookup(resources.reporter, cfnClient)
-      val policyDoc = toPolicyDoc(stackPolicy, allSensitiveResourceTypes, () => accountPrivateTypes(cfnClient))
+      val policyDoc = toPolicyDoc(stackPolicy, allSensitiveResourceTypes, () => accountResourceTypes(cfnClient))
 
       changeSetType match {
         case ChangeSetType.CREATE => resources.reporter.info(s"Stack $stackName not found - no need to update policy")

--- a/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
@@ -16,7 +16,7 @@ object StackPolicy {
     case AllowAllPolicy =>
       ALLOW_ALL_POLICY
     case DenyReplaceDeletePolicy =>
-      val sensitiveResources = sensitiveResourceTypes.intersect(accountResourceTypes()).toList.sorted.toSet // alphabetical to make testing easier
+      val sensitiveResources = sensitiveResourceTypes.intersect(accountResourceTypes())
       DENY_REPLACE_DELETE_POLICY(sensitiveResources)
   }
 
@@ -126,8 +126,10 @@ object StackPolicy {
       |}
       |""".stripMargin
 
-  private[this] def DENY_REPLACE_DELETE_POLICY(sensitiveTypes: Set[String]): String =
-      s"""{
+  private[this] def DENY_REPLACE_DELETE_POLICY(sensitiveTypes: Set[String]): String = {
+    val sortedSensitiveTypes = sensitiveTypes.toSeq.sorted // alphabetical to make testing easier
+
+    s"""{
          |  "Statement" : [
          |    {
          |      "Effect" : "Deny",
@@ -137,7 +139,7 @@ object StackPolicy {
          |      "Condition" : {
          |        "StringEquals" : {
          |          "ResourceType" : [
-         |            ${sensitiveTypes.mkString("\"","\",\n\"", "\"")}
+         |            ${sortedSensitiveTypes.mkString("\"","\",\n\"", "\"")}
          |          ]
          |        }
          |      }
@@ -151,7 +153,7 @@ object StackPolicy {
          |  ]
          |}
          |""".stripMargin
-
+  }
 
 
   def toMarkdown(policy: StackPolicy): String = {

--- a/magenta-lib/src/test/scala/magenta/tasks/SetStackPolicyTaskTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/SetStackPolicyTaskTest.scala
@@ -7,7 +7,7 @@ import software.amazon.awssdk.services.elasticloadbalancingv2.model.{TagDescript
 class SetStackPolicyTaskTest extends AnyFlatSpec with Matchers {
 
   "toPolicyDoc" should "return an allow doc when policy is AllowAllPolicy" in {
-    val got = StackPolicy.toPolicyDoc(AllowAllPolicy, StackPolicy.allSensitiveResourceTypes, () => Set.empty)
+    val got = StackPolicy.toPolicyDoc(AllowAllPolicy, () => Set.empty)
     val want =
       """{
         |  "Statement" : [
@@ -27,7 +27,6 @@ class SetStackPolicyTaskTest extends AnyFlatSpec with Matchers {
   it should "return a deny doc when policy is DenyReplaceDeletePolicy, including supported resource types" in {
     val got = StackPolicy.toPolicyDoc(
       DenyReplaceDeletePolicy,
-      StackPolicy.allSensitiveResourceTypes,
       () => Set(
         // sensitive AWS types
         "AWS::DocDB::DBCluster",
@@ -73,7 +72,6 @@ class SetStackPolicyTaskTest extends AnyFlatSpec with Matchers {
   it should "return a deny doc when policy is DenyReplaceDeletePolicy, excluding unsupported private types" in {
     val got = StackPolicy.toPolicyDoc(
       DenyReplaceDeletePolicy,
-      StackPolicy.allSensitiveResourceTypes,
       () => Set(
         "AWS::Kinesis::Stream", // sensitive AWS type
         "AWS::IAM::Role", // non-sensitive AWS type, should not appear in the policy


### PR DESCRIPTION
> **Note**
> Easier to review [commit by commit](https://github.com/guardian/riff-raff/pull/874/commits).

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Extends #653 to also check for regional availability of public AWS resource types. This is necessary because we've seen deployments fail in us-west-1 with:

```
software.amazon.awssdk.services.cloudformation.model.CloudFormationException Error validating stack policy: Unknown resource type 'AWS::DocDB::DBCluster' in statement {}
```

That is `AWS::DocDB::DBCluster` is not available in us-west-1.

This can be verified via:

```bash
➜ aws cloudformation list-types \
  --visibility PUBLIC \
  --type RESOURCE \
  --profile deployTools \
  --region us-west-1 \
  --filters Category=AWS_TYPES \
  | jq '.TypeSummaries[] | select(.TypeName == "AWS::DocDB::DBCluster")'
```

vs.

```bash
➜ aws cloudformation list-types \
  --visibility PUBLIC \
  --type RESOURCE \
  --profile deployTools \
  --region eu-west-1 \
  --filters Category=AWS_TYPES \
  | jq '.TypeSummaries[] | select(.TypeName == "AWS::DocDB::DBCluster")'

{
  "Type": "RESOURCE",
  "TypeName": "AWS::DocDB::DBCluster",
  "TypeArn": "arn:aws:cloudformation:eu-west-1::type/resource/AWS-DocDB-DBCluster",
  "LastUpdated": "2022-08-04T21:42:16.715000+00:00"
}
```

### Notes
#### [`list-types` API](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/list-types.html)
This API is described as:

> Returns summary information about extension that have been registered with CloudFormation.

This is also confirmed with AWS Support, who noted the canonical source of truth for regional resource availability is [this collection of JSON files](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html). However, the example usage above _does_ list "first party" resources. Additionally, the Java SDK has strong type support for this. Probably one to keep an eye on.

UPDATE: AWS Support have since responded:

> Overall, I believe your implementation of the AWS CloudFormation CLI ('list-types') command with the additional flag options is valid

#### Stack policy validation
Ideally we'd also be able to validate the JSON policy document before trying to apply it, however I can't find an API for this. Indeed, AWS Support confirm it does not exist. I've raised an issue - https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1355.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Deploy to CODE
- Deploy https://github.com/guardian/commercial-canaries/pull/36 to CODE, and observe no warning message
- Switch to verbose mode, and observe the policy applied to the eu-west-1, and us-west-1 regions (see below)

This has been done here - https://riffraff.code.dev-gutools.co.uk/deployment/view/b68d25cc-3e57-492c-9f59-9e4866dec926?verbose=1

![image](https://user-images.githubusercontent.com/836140/194274619-4c7283fc-6bc3-436c-8fbd-e31884dffcdb.png)

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

This should mean [usage of `manageStackPolicy = false`](https://github.com/search?l=YAML&q=org%3Aguardian+manageStackPolicy&type=Code) becomes less frequent as we typically set this to avoid the above error. Warning messages added in #872 should be seen less too.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

There are some signs that the `list-types` API might not be the correct one to use, but it _is_ working.