### PR TITLE
refactor: Simplify JSON for stack policy

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
@@ -136,7 +136,7 @@ object StackPolicy {
          |      "Condition" : {
          |        "StringEquals" : {
          |          "ResourceType" : [
-         |            ${resourcesToProtect.mkString("\"","\",\n\"", "\"")}
+         |            ${resourcesToProtect.mkString("\"","\",\"", "\"")}
          |          ]
          |        }
          |      }

--- a/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
@@ -18,7 +18,7 @@ object StackPolicy {
   }
 
   /**
-   * Returns the names of private resource types that can be CLoudFormed in a given region.
+   * Returns the names of private resource types that can be CloudFormed in a given region.
    * Necessary because we've not deployed all our private resource types to all regions.
    *
    * @param client A CloudFormation client, with a set region

--- a/magenta-lib/src/test/scala/magenta/tasks/SetStackPolicyTaskTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/SetStackPolicyTaskTest.scala
@@ -51,7 +51,9 @@ class SetStackPolicyTaskTest extends AnyFlatSpec with Matchers {
          |      "Condition" : {
          |        "StringEquals" : {
          |          "ResourceType" : [
-         |            ${Set("AWS::DocDB::DBCluster", "AWS::Kinesis::Stream", "Guardian::DNS::RecordSet").mkString("\"","\",\n\"", "\"")}
+         |            "AWS::DocDB::DBCluster",
+         |"AWS::Kinesis::Stream",
+         |"Guardian::DNS::RecordSet"
          |          ]
          |        }
          |      }

--- a/magenta-lib/src/test/scala/magenta/tasks/SetStackPolicyTaskTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/SetStackPolicyTaskTest.scala
@@ -51,9 +51,7 @@ class SetStackPolicyTaskTest extends AnyFlatSpec with Matchers {
          |      "Condition" : {
          |        "StringEquals" : {
          |          "ResourceType" : [
-         |            "AWS::DocDB::DBCluster",
-         |"AWS::Kinesis::Stream",
-         |"Guardian::DNS::RecordSet"
+         |            "AWS::DocDB::DBCluster","AWS::Kinesis::Stream","Guardian::DNS::RecordSet"
          |          ]
          |        }
          |      }


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

JSON formatting is hard...

We currently render a JSON array as:

```json
{
    "ResourceTypes": [
        "One",
"Two",
"Three"
    ]
}
```

That is, without indentation.

It should be:

```json
{
    "ResourceTypes": [
        "One",
        "Two",
        "Three"
    ]
}
```

However, there isn't much need to pretty-print this JSON blob as machines are the only consumers. In this change, we render a JSON array as a simple comma separated value:

```json
{
    "ResourceTypes": [
        "One","Two","Three"
    ]
}
```

This is functionally equivalent, and makes the tests simpler to read. That is, this is a no-op.

Also fixes a small typo.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See CI - all tests should continue to pass.