### PR TITLE
fix: Ensure log fits in a strict column

### DIFF
--- a/riff-raff/app/assets/stylesheets/magenta.less
+++ b/riff-raff/app/assets/stylesheets/magenta.less
@@ -64,6 +64,10 @@ ul.magenta-list {
   padding-left: 15px;
 }
 
+ul.magenta-reporttree {
+ overflow-wrap: break-word; 
+}
+
 .magenta-timestamp {
   display:none
 }


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Update the CSS for the log to ensure a strict column is observed.

In https://github.com/guardian/riff-raff/pull/881 we removed some new lines from a JSON object. This object gets printed in the UI, and without the newlines, it's breaking through the column.

In this change, we use [CSS](https://caniuse.com/wordwrap) to ensure this doesn't happen.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

N/A

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

https://riffraff.gutools.co.uk/deployment/view/5dd8d79f-0c42-4f9a-ab45-4171bddd8026 looks a bit nicer.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

> **Note**
> The background colour was added via the browser to demonstrate the boundary.

### Before
![image](https://user-images.githubusercontent.com/836140/195326427-e08ff95f-c791-4c36-b980-7a363da5e6a6.png)

### After
![image](https://user-images.githubusercontent.com/836140/195326546-a25c9233-c0e1-4ce4-8406-d181c47bedb8.png)
