### PR TITLE
Use bucket by ssm key by default

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/BucketParameters.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/BucketParameters.scala
@@ -6,6 +6,8 @@ import magenta.{DeployReporter, DeployTarget, DeploymentPackage}
 trait BucketParameters {
   this: DeploymentType =>
 
+  import BucketParametersDefaults._
+
   val bucketParam = Param[String]("bucket",
     documentation =
       """
@@ -18,26 +20,32 @@ trait BucketParameters {
     """Lookup the bucket for uploading distribution artifacts from SSM in the target account and region. This is
       |designed to be used in conjunction with a matching `AWS::SSM::Parameter::Value<String>` CFN parameter
       |on any related CloudFormation template.""".stripMargin
-  ).default(false)
+  ).default(bucketSsmLookupParamDefault)
 
   val bucketSsmKeyParam = Param[String]("bucketSsmKey",
     """The SSM key used to lookup the bucket name for uploading distribution artifacts.""".stripMargin
-  ).default("/account/services/artifact.bucket")
+  ).default(defaultSsmKeyParamDefault)
 
   def getTargetBucketFromConfig(pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter): Bucket = {
     val bucketSsmLookup = bucketSsmLookupParam(pkg, target, reporter)
     val maybeExplicitBucket = bucketParam.get(pkg)
 
     val bucket = (bucketSsmLookup, maybeExplicitBucket) match {
-      case (true, None) => BucketBySsmKey(bucketSsmKeyParam(pkg, target, reporter))
-      case (false, None) => BucketBySsmKey(bucketSsmKeyParam(pkg, target, reporter))
-      case (false, Some(explicitBucket)) => {
+      // Default to looking up target bucket from SSM
+      case (_, None) =>
+        BucketBySsmKey(bucketSsmKeyParam(pkg, target, reporter))
+      case (false, Some(explicitBucket)) =>
         reporter.warning("Explicit bucket name in riff-raff.yaml. Prefer to use bucketSsmLookup=true, removing private information from VCS.")
         BucketByName(explicitBucket)
-      }
-      case _ => reporter.fail("One and only one of the following must be set: the bucket parameter or bucketSsmLookup=true")
+      case (true, Some(explicitBucket)) =>
+        reporter.fail(s"Bucket name provided ($explicitBucket) & bucketSsmLookup=true, please choose one or omit both to default to SSM lookup.")
     }
     reporter.verbose(s"Resolved artifact bucket as $bucket")
     bucket
   }
+}
+
+object BucketParametersDefaults {
+  val bucketSsmLookupParamDefault = false
+  val defaultSsmKeyParamDefault = "/account/services/artifact.bucket"
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/BucketParameters.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/BucketParameters.scala
@@ -30,6 +30,7 @@ trait BucketParameters {
 
     val bucket = (bucketSsmLookup, maybeExplicitBucket) match {
       case (true, None) => BucketBySsmKey(bucketSsmKeyParam(pkg, target, reporter))
+      case (false, None) => BucketBySsmKey(bucketSsmKeyParam(pkg, target, reporter))
       case (false, Some(explicitBucket)) => {
         reporter.warning("Explicit bucket name in riff-raff.yaml. Prefer to use bucketSsmLookup=true, removing private information from VCS.")
         BucketByName(explicitBucket)

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -91,7 +91,7 @@ object S3 {
       case BucketByName(name) => name
       case BucketBySsmKey(ssmKey) =>
         try {
-          val resolvedBucket = withSsmClient { SSM.getParameter(reporter, _, ssmKey) }
+          val resolvedBucket = withSsmClient { SSM.getParameter(_, ssmKey) }
           reporter.verbose(s"Resolved bucket from SSM key $ssmKey to be $resolvedBucket")
           resolvedBucket
         } catch {
@@ -549,7 +549,7 @@ object SSM {
       .build())(block)
   }
 
-  def getParameter(reporter: DeployReporter, ssmClient: SsmClient, key: String): String =
+  def getParameter(ssmClient: SsmClient, key: String): String =
       ssmClient
         .getParameter(GetParameterRequest.builder.name(key).build)
         .parameter.value

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -25,7 +25,7 @@ import software.amazon.awssdk.services.lambda.model.{FunctionConfiguration, List
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model._
 import software.amazon.awssdk.services.ssm.SsmClient
-import software.amazon.awssdk.services.ssm.model.GetParameterRequest
+import software.amazon.awssdk.services.ssm.model.{GetParameterRequest, SsmException}
 import software.amazon.awssdk.services.sts.StsClient
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest.Builder
 
@@ -90,9 +90,14 @@ object S3 {
     bucket match {
       case BucketByName(name) => name
       case BucketBySsmKey(ssmKey) =>
-        val resolvedBucket = withSsmClient { SSM.getParameter(_, ssmKey) }
-        reporter.verbose(s"Resolved bucket from SSM key $ssmKey to be $resolvedBucket")
-        resolvedBucket
+        try {
+          val resolvedBucket = withSsmClient { SSM.getParameter(reporter, _, ssmKey) }
+          reporter.verbose(s"Resolved bucket from SSM key $ssmKey to be $resolvedBucket")
+          resolvedBucket
+        } catch {
+          case e: SsmException =>
+            reporter.fail(s"Explicit bucket name has not been provided and failed to read bucket from SSM parameter: $ssmKey", e)
+        }
     }
   }
 
@@ -544,10 +549,10 @@ object SSM {
       .build())(block)
   }
 
-  def getParameter(ssmClient: SsmClient, key: String): String = {
-    val result = ssmClient.getParameter(GetParameterRequest.builder.name(key).build)
-    result.parameter.value
-  }
+  def getParameter(reporter: DeployReporter, ssmClient: SsmClient, key: String): String =
+      ssmClient
+        .getParameter(GetParameterRequest.builder.name(key).build)
+        .parameter.value
 }
 
 object AWS extends Loggable {

--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.{JsBoolean, JsString, JsValue, Json}
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.ssm.SsmClient
-import software.amazon.awssdk.services.ssm.model.{GetParameterRequest, GetParameterResponse, Parameter}
+import software.amazon.awssdk.services.ssm.model.{GetParameterRequest, GetParameterResponse, Parameter, SsmException}
 import software.amazon.awssdk.services.sts.StsClient
 
 import scala.concurrent.ExecutionContext.global
@@ -105,8 +105,9 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
   }
 
   it should "refuse to work if a bucket name is provided and bucketSsmLookup is true" in {
+    val lambdaBucketName = "lambda-bucket"
     val dataWithoutStackOverride: Map[String, JsValue] = Map(
-      "bucket" -> JsString("lambda-bucket"),
+      "bucket" -> JsString(lambdaBucketName),
       "bucketSsmLookup" -> JsBoolean(true),
       "functionNames" -> Json.arr("MyFunction-")
     )
@@ -119,10 +120,11 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
         "updateLambda").taskGenerator(pkg, DeploymentResources(reporter, lookupEmpty, artifactClient, stsClient, global),
         DeployTarget(parameters(PROD), Stack("some-stack"), region))
     }
-    e.message shouldBe "One and only one of the following must be set: the bucket parameter or bucketSsmLookup=true"
+
+    e.message shouldBe s"Bucket name provided ($lambdaBucketName) & bucketSsmLookup=true, please choose one or omit both to default to SSM lookup."
   }
 
-  it should "refuse to work if bucket name is not provided and bucketSsmLookup is false" in {
+  it should "refuse to work if bucket name is not provided and no bucket is specified in SSM" in {
     val dataWithoutStackOverride: Map[String, JsValue] = Map(
       "functionNames" -> Json.arr("MyFunction-")
     )
@@ -130,12 +132,57 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
     val pkg = DeploymentPackage("lambda", app, dataWithoutStackOverride, "aws-lambda",
       S3Path("artifact-bucket", "test/123/lambda"), deploymentTypes)
 
+    val ssmClient = mock[SsmClient]
+
+    when(ssmClient.getParameter(ArgumentMatchers.any(classOf[GetParameterRequest]))).thenThrow(
+      SsmException.builder.message("Boom!").build()
+    )
+
+    object LambdaTest extends Lambda {
+      override def withSsm[T](keyRing: KeyRing, region: Region, resources: DeploymentResources): (SsmClient => T) => T = _ (ssmClient)
+    }
+
     val e = the [FailException] thrownBy {
-      Lambda.actionsMap(
+      LambdaTest.actionsMap(
         "updateLambda").taskGenerator(pkg, DeploymentResources(reporter, lookupEmpty, artifactClient, stsClient, global),
         DeployTarget(parameters(PROD), Stack("some-stack"), region))
     }
-    e.message shouldBe "One and only one of the following must be set: the bucket parameter or bucketSsmLookup=true"
+
+    val ssmKey = BucketParametersDefaults.defaultSsmKeyParamDefault
+    e.message shouldBe s"Explicit bucket name has not been provided and failed to read bucket from SSM parameter: $ssmKey"
+  }
+
+  it should "default to lookup bucket from SSM bucket name is not provided and bucketSsmLookup is false" in {
+    val dataWithoutStackOverride: Map[String, JsValue] = Map(
+      "functionNames" -> Json.arr("MyFunction-")
+    )
+    val app = App("lambda")
+    val pkg = DeploymentPackage("lambda", app, dataWithoutStackOverride, "aws-lambda",
+      S3Path("artifact-bucket", "test/123/lambda"), deploymentTypes)
+
+    val ssmClient = mock[SsmClient]
+
+    when(ssmClient.getParameter(ArgumentMatchers.any(classOf[GetParameterRequest]))).thenReturn(
+      GetParameterResponse.builder.parameter(Parameter.builder.value("bobbins").build).build
+    )
+    object LambdaTest extends Lambda {
+      override def withSsm[T](keyRing: KeyRing, region: Region, resources: DeploymentResources): (SsmClient => T) => T = _ (ssmClient)
+    }
+
+    val tasks = LambdaTest.actionsMap("updateLambda")
+      .taskGenerator(pkg, DeploymentResources(reporter, lookupEmpty, artifactClient, stsClient, global),
+        DeployTarget(parameters(PROD), Stack("some-stack"), region)
+      )
+
+    tasks shouldBe List(
+      UpdateS3Lambda(
+        function = LambdaFunctionName("some-stackMyFunction-PROD"),
+        s3Bucket = s"bobbins",
+        s3Key = "some-stack/PROD/lambda/lambda.zip",
+        region = defaultRegion
+      )
+    )
+
   }
 
   it should "lookup bucket from SSM when bucketSsmLookup is true" in {

--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
@@ -152,7 +152,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
     e.message shouldBe s"Explicit bucket name has not been provided and failed to read bucket from SSM parameter: $ssmKey"
   }
 
-  it should "default to lookup bucket from SSM bucket name is not provided and bucketSsmLookup is false" in {
+  it should "default to lookup bucket from SSM when bucket name is not provided and bucketSsmLookup is false" in {
     val dataWithoutStackOverride: Map[String, JsValue] = Map(
       "functionNames" -> Json.arr("MyFunction-")
     )


### PR DESCRIPTION
## What does this change?

This enable to omit the `bucketSsmLookup` parameter, which reduce `riff-raff.yaml` verbosity.
This looks to me a detail that is not necessary especially if we expect people to use this over explicit `bucket` parameter.  

This should enable this:

```yaml
stacks:
  - deploy
regions:
  - eu-west-1
allowedStages:
  - PROD
deployments:
  cdk-playground:
    type: autoscaling
    parameters:
```
