### PR TITLE
WIP: Add ssm bucket lookup support to aws-s3 deploy type

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -134,9 +134,6 @@ object AutoScaling extends DeploymentType with BucketParameters {
     groupsToUpdate.flatMap(asg => tasksPerAutoScalingGroup(asg))
   }
 
-  // TODO this is copied from `Lambda.scala` and could be DRYed out
-  def withSsm[T](keyRing: KeyRing, region: Region, resources: DeploymentResources): (SsmClient => T) => T = SSM.withSsmClient[T](keyRing, region, resources)
-
   val uploadArtifacts = Action("uploadArtifacts",
     """
       |Uploads the files in the deployment's directory to the specified bucket.
@@ -162,7 +159,7 @@ object AutoScaling extends DeploymentType with BucketParameters {
 
     val s3Bucket = S3Tasks.getBucketName(
       bucket,
-      withSsm(keyRing, target.region, resources),
+      SSM.withSsmClient(keyRing, target.region, resources),
       resources.reporter
     )
 

--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -5,7 +5,6 @@ import magenta.{App, DeployTarget, DeploymentPackage, DeploymentResources, KeyRi
 import magenta.tasks._
 import software.amazon.awssdk.services.autoscaling.model.AutoScalingGroup
 import magenta.tasks.{S3 => S3Tasks}
-import software.amazon.awssdk.services.ssm.SsmClient
 
 sealed trait MigrationTagRequirements
 case object NoMigration extends MigrationTagRequirements
@@ -155,7 +154,7 @@ object AutoScaling extends DeploymentType with BucketParameters {
       packageOrAppName = maybePackageOrAppName
     )
 
-    val bucket = getTargetBucketFromConfig(pkg, target, reporter)
+    val bucket = getTargetBucketFromConfig(pkg, target, resources)
 
     val s3Bucket = S3Tasks.getBucketName(
       bucket,

--- a/magenta-lib/src/main/scala/magenta/deployment_type/BucketParameters.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/BucketParameters.scala
@@ -1,7 +1,8 @@
 package magenta.deployment_type
 
+import magenta.deployment_type.S3.bucketResource
 import magenta.tasks.S3.{Bucket, BucketByName, BucketBySsmKey}
-import magenta.{DeployReporter, DeployTarget, DeploymentPackage}
+import magenta.{Datum, DeployReporter, DeployTarget, DeploymentPackage, DeploymentResources}
 
 trait BucketParameters {
   this: DeploymentType =>
@@ -24,19 +25,48 @@ trait BucketParameters {
     """The SSM key used to lookup the bucket name for uploading distribution artifacts.""".stripMargin
   ).default("/account/services/artifact.bucket")
 
-  def getTargetBucketFromConfig(pkg: DeploymentPackage, target: DeployTarget, reporter: DeployReporter): Bucket = {
-    val bucketSsmLookup = bucketSsmLookupParam(pkg, target, reporter)
-    val maybeExplicitBucket = bucketParam.get(pkg)
+  // legacy - better to use SSM to store the bucket name rather than rely on riffraff resources - see BucketParameters
+  val bucketResource = Param[String]("bucketResource",
+    """Deploy Info resource key to use to look up the S3 bucket to which the package files should be uploaded.
+      |
+      |This parameter is mutually exclusive with `bucket`, which can be used instead if you upload to the same bucket
+      |regardless of the target stage.
+    """.stripMargin,
+    optional = true
+  )
 
-    val bucket = (bucketSsmLookup, maybeExplicitBucket) match {
-      case (true, None) => BucketBySsmKey(bucketSsmKeyParam(pkg, target, reporter))
-      case (false, Some(explicitBucket)) => {
-        reporter.warning("Explicit bucket name in riff-raff.yaml. Prefer to use bucketSsmLookup=true, removing private information from VCS.")
-        BucketByName(explicitBucket)
+  def resourceLookupFor(resourceName: String, pkg: DeploymentPackage, target: DeployTarget, resources: DeploymentResources): Option[Datum] = {
+      val dataLookup = resources.lookup.data
+      val datumOpt = dataLookup.datum(resourceName, pkg.app, target.parameters.stage, target.stack)
+      if (datumOpt.isEmpty) {
+        def str(f: Datum => String) = s"[${dataLookup.get(resourceName).map(f).toSet.mkString(", ")}]"
+        resources.reporter.verbose(s"No datum found for resource=$resourceName app=${pkg.app} stage=${target.parameters.stage} stack=${target.stack} - values *are* defined for app=${str(_.app)} stage=${str(_.stage)} stack=${str(_.stack.mkString)}")
       }
-      case _ => reporter.fail("One and only one of the following must be set: the bucket parameter or bucketSsmLookup=true")
+      datumOpt
+  }
+
+  def getTargetBucketFromConfig(pkg: DeploymentPackage, target: DeployTarget, resources: DeploymentResources, keyRequired: Boolean = false): Bucket = {
+    val bucketSsmLookup = bucketSsmLookupParam(pkg, target, resources.reporter)
+    val maybeExplicitBucket = bucketParam.get(pkg)
+    val maybeBucketResource = bucketResource.get(pkg)
+
+    val bucket = (bucketSsmLookup, maybeExplicitBucket, maybeBucketResource) match {
+      case (true, None, None) =>
+        if (keyRequired) {
+          assert(bucketSsmKeyParam.get(pkg).isDefined, s"${bucketSsmKeyParam.name} is required for this deploy type")
+          BucketBySsmKey(bucketSsmKeyParam(pkg, target, resources.reporter))
+        } else
+          BucketBySsmKey(bucketSsmKeyParam(pkg, target, resources.reporter))
+      case (false, Some(explicitBucket), None) =>
+        resources.reporter.warning(s"Explicit bucket name in riff-raff.yaml. Prefer to use ${bucketSsmLookupParam.name}=true, removing private information from VCS.")
+        BucketByName(explicitBucket)
+      case (false, None, Some(resourceName)) =>
+        val data = resourceLookupFor(resourceName, pkg, target, resources)
+        assert(data.isDefined, s"Cannot find resource value for ${bucketResource(pkg, target, resources.reporter)} (${pkg.app} in ${target.parameters.stage.name})")
+        BucketByName(data.get.value)
+      case _ => resources.reporter.fail(s"One and only one of the following must be set: the ${bucketParam.name}, ${bucketResource.name}  or ${bucketSsmLookupParam.name}=true")
     }
-    reporter.verbose(s"Resolved artifact bucket as $bucket")
+    resources.reporter.verbose(s"Resolved artifact bucket as $bucket")
     bucket
   }
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -109,7 +109,6 @@ trait Lambda extends DeploymentType with BucketParameters {
     (prefix ::: List(target.parameters.stage.name, pkg.app.name, fileName)).mkString("/")
   }
 
-  def withSsm[T](keyRing: KeyRing, region: Region, resources: DeploymentResources): (SsmClient => T) => T = SSM.withSsmClient[T](keyRing, region, resources)
 
   val uploadLambda = Action("uploadLambda",
     """
@@ -120,7 +119,7 @@ trait Lambda extends DeploymentType with BucketParameters {
     lambdaToProcess(pkg, target, resources.reporter).map { lambda =>
       val s3Bucket = S3Tasks.getBucketName(
         lambda.s3Bucket,
-        withSsm(keyRing, target.region, resources),
+        SSM.withSsmClient(keyRing, target.region, resources),
         resources.reporter
       )
       val s3Key = makeS3Key(target, pkg, lambda.fileName, resources.reporter)
@@ -152,7 +151,7 @@ trait Lambda extends DeploymentType with BucketParameters {
     lambdaToProcess(pkg, target, resources.reporter).map { lambda =>
         val s3Bucket = S3Tasks.getBucketName(
           lambda.s3Bucket,
-          withSsm(keyRing, target.region, resources),
+          SSM.withSsmClient(keyRing, target.region, resources),
           resources.reporter
         )
         val s3Key = makeS3Key(target, pkg, lambda.fileName, resources.reporter)


### PR DESCRIPTION
## What does this change?
Following from https://github.com/guardian/riff-raff/pull/704 here's another deploy type that uses a bucket which could be fetched from SSM rather than being hard coded. 

It's a bit more complex for this deploy type as the current behaviour supports a 3rd way of getting a bucket name - riffraff deployment resources. These can be seen [here](https://riffraff.gutools.co.uk/deployinfo/data?key=aws-bucket) and represent the old way of not hard coding a bucket name. SSM is superior because (as far as I understand) the only way of updating riffraff deployment resources is via the configuration for riffraff itself.

As part of this PR I've pulled the 'bucket resource' logic into `BucketParameters` which complicates it somewhat but I think it's best for all this logic to be in one place.

Following @akash1810's suggestion, I've made the ssm key a required option for the `aws-s3` deploy type - it is common to use this deploy type to upload files to e.g. a public bucket for static files - so we shouldn't assume it's the normal distribution bucket for that AWS account. 

## How to test
This needs testing on CODE, something for my next 10% time unless anyone wants to grab it 😉 

## How can we measure success?
Fewer hard coded bucket names 🎉 