### PR TITLE
Bump to Scala 2.13.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ inThisBuild(List(
 
 val commonSettings = Seq(
   organization := "com.gu",
-  scalaVersion := "2.13.9",
+  scalaVersion := "2.13.10",
 
   scalacOptions ++= Seq("-feature", "-language:postfixOps,reflectiveCalls,implicitConversions"
 //    , "-Xfatal-warnings" TODO: Akka Agents have been deprecated. Once they have been replaced we can re-enable, but that's not trivial


### PR DESCRIPTION
To address https://github.com/scala/bug/issues/12650 (though no specific evidence this project is vulnerable) and also test out Nori for a wider bump across repos.