### PR TITLE
Warn if unable to determine Github repository for a deploy

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -13,11 +13,11 @@ import org.joda.time.DateTime
 import scala.collection.mutable.ListBuffer
 
 trait VcsLookup {
-  def get(projectName: String, buildId: String): String
+  def get(projectName: String, buildId: String): Option[String]
 }
 
 // For testing purposes
-object NoopVcsUrlLookup extends VcsLookup { def get(projectName: String, buildId: String): String = "unknown"}  
+object NoopVcsUrlLookup extends VcsLookup { def get(projectName: String, buildId: String): Option[String] = None}
 
 
 //noinspection TypeAnnotation
@@ -172,8 +172,8 @@ class CloudFormation(vcsUrlLookup: VcsLookup) extends DeploymentType with CloudF
     // The tag name here ('gu:repo') and format ('guardian/:reponame') MUST
     // mirror the tag name and format used by @guardian/cdk.
     val vcsUrl = vcsUrlLookup.get(target.parameters.build.projectName, target.parameters.build.id)
-    val guRepoTag = ("gu:repo" -> vcsUrl)
-    if (vcsUrl == "") {
+    val guRepoTag = ("gu:repo" -> vcsUrl.getOrElse("unknown"))
+    if (vcsUrl.isEmpty) {
       reporter.warning("Unable to detect the Github repository for your build. DevX require this information to provide better reporting for teams as part of the upcoming Service Catalogue. This info is probably missing because you are using an unsupported library (or custom script) to generate your Riffraff bundle. To fix this, we recommend that you use https://github.com/guardian/actions-riff-raff/ or, if you are using https://github.com/guardian/sbt-riffraff-artifact or https://github.com/guardian/node-riffraff-artifact, upgrade to the latest version.")
     }
 

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -171,8 +171,9 @@ class CloudFormation(vcsUrlLookup: VcsLookup) extends DeploymentType with CloudF
 
     // The tag name here ('gu:repo') and format ('guardian/:reponame') MUST
     // mirror the tag name and format used by @guardian/cdk.
-    val guRepoTag = ("gu:repo" -> vcsUrlLookup.get(target.parameters.build.projectName, target.parameters.build.id))
-    if (guRepoTag._2 == "") {
+    val vcsUrl = vcsUrlLookup.get(target.parameters.build.projectName, target.parameters.build.id)
+    val guRepoTag = ("gu:repo" -> vcsUrl)
+    if (vcsUrl == "") {
       reporter.warning("Unable to detect the Github repository for your build. DevX require this information to provide better reporting for teams as part of the upcoming Service Catalogue. This info is probably missing because you are using an unsupported library (or custom script) to generate your Riffraff bundle. To fix this, we recommend that you use https://github.com/guardian/actions-riff-raff/ or, if you are using https://github.com/guardian/sbt-riffraff-artifact or https://github.com/guardian/node-riffraff-artifact, upgrade to the latest version.")
     }
 

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -172,6 +172,9 @@ class CloudFormation(vcsUrlLookup: VcsLookup) extends DeploymentType with CloudF
     // The tag name here ('gu:repo') and format ('guardian/:reponame') MUST
     // mirror the tag name and format used by @guardian/cdk.
     val guRepoTag = ("gu:repo" -> vcsUrlLookup.get(target.parameters.build.projectName, target.parameters.build.id))
+    if (guRepoTag._2 == "") {
+      reporter.warning("Unable to detect the Github repository for your build (used to provide better reporting to teams). This is probably because you are using an unsupported library (or custom script) to generate your Riffraff bundle. To fix this, we recommend that you use https://github.com/guardian/actions-riff-raff/ instead.")
+    }
 
     val tasks: List[Task] = List(
       new CreateChangeSetTask(

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -173,7 +173,7 @@ class CloudFormation(vcsUrlLookup: VcsLookup) extends DeploymentType with CloudF
     // mirror the tag name and format used by @guardian/cdk.
     val guRepoTag = ("gu:repo" -> vcsUrlLookup.get(target.parameters.build.projectName, target.parameters.build.id))
     if (guRepoTag._2 == "") {
-      reporter.warning("Unable to detect the Github repository for your build (used to provide better reporting to teams). This is probably because you are using an unsupported library (or custom script) to generate your Riffraff bundle. To fix this, we recommend that you use https://github.com/guardian/actions-riff-raff/ instead.")
+      reporter.warning("Unable to detect the Github repository for your build. DevX require this information to provide better reporting for teams as part of the upcoming Service Catalogue. This info is probably missing because you are using an unsupported library (or custom script) to generate your Riffraff bundle. To fix this, we recommend that you use https://github.com/guardian/actions-riff-raff/ or, if you are using https://github.com/guardian/sbt-riffraff-artifact or https://github.com/guardian/node-riffraff-artifact, upgrade to the latest version.")
     }
 
     val tasks: List[Task] = List(

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -86,9 +86,9 @@ class AppComponents(context: Context, config: Config, passwordProvider: Password
   val builds = new Builds(buildPoller)
 
   object CustomVcsUrlLookup extends VcsLookup {
-    def get(projectName: String, buildId: String): String = {
+    def get(projectName: String, buildId: String): Option[String] = {
       val url = builds.build(projectName, buildId).map(_.vcsURL)
-      url.flatMap(VCSInfo.normalise).getOrElse("unknown")
+      url.flatMap(VCSInfo.normalise)
     }
   }
 


### PR DESCRIPTION
Riffraff adds a `gu:repo` tag to Cloudformation stacks as part of the cloud-formation deployment type. This information is used by the nascent `services.gutools.co.uk` to help identify owners of stacks and related metadata.

However, in many cases, Riffraff is unable to populate this tag as it is unable to determine the repository for a build. The repository information is taken from the `vcsURL` field in the (build.json) 'manifest' file for a deployment and older build methods (or bespoke/script-based approaches) do not populate this. The latest versions of sbt-riffraff-artifact ([here](https://github.com/guardian/sbt-riffraff-artifact/blob/main/src/main/scala/com/gu/riffraff/artifact/BuildManifest.scala#L25)), node-riffraff-artifact ([here](https://github.com/guardian/node-riffraff-artifact/blob/main/src/manifest.ts#L5)) and, of course, actions-riff-raff do provide this info though.

At the moment this is just a warning. At some point we may need to do additional comms and even fail builds to motivate people here but let's get more data first.