### PR TITLE
Record build tool

### DIFF
--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -1,34 +1,35 @@
 package magenta.deployment_type
 
 import magenta.Strategy.{Dangerous, MostlyHarmless}
-
-import java.util.UUID
 import magenta._
 import magenta.artifact.S3Path
+import magenta.deployment_type.{CloudFormation => CloudFormationDeploymentType}
 import magenta.fixtures._
 import magenta.tasks.CloudFormation.{SpecifiedValue, UseExistingValue}
 import magenta.tasks.CloudFormationParameters.{ExistingParameter, InputParameter, TemplateParameter}
-import magenta.tasks.StackPolicy.accountPrivateTypes
 import magenta.tasks.UpdateCloudFormationTask._
 import magenta.tasks._
-import org.scalatest.{EitherValues, Inside}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.{EitherValues, Inside}
 import play.api.libs.json.{JsBoolean, JsString, JsValue, Json}
-import software.amazon.awssdk.services.cloudformation.model.{Change, ChangeSetType, Parameter}
+import software.amazon.awssdk.services.cloudformation.model.{Change, ChangeSetType}
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sts.StsClient
-import magenta.deployment_type.{CloudFormation => CloudFormationDeploymentType}
 
+import java.util.UUID
 import scala.concurrent.ExecutionContext.global
 
+object EmptyBuildTags extends BuildTags {
+  def get(projectName: String, buildId: String): Map[String, String] = Map.empty
+}
 class CloudFormationTest extends AnyFlatSpec with Matchers with Inside with EitherValues {
   implicit val fakeKeyRing: KeyRing = KeyRing()
   implicit val reporter: DeployReporter = DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
   implicit val artifactClient: S3Client = null
   implicit val stsClient: StsClient = null
 
-  val cloudformationDeploymentType = new CloudFormationDeploymentType(NoopVcsUrlLookup)
+  val cloudformationDeploymentType = new CloudFormationDeploymentType(EmptyBuildTags)
   val region = Region("eu-west-1")
   val deploymentTypes: Seq[CloudFormationDeploymentType] = Seq(cloudformationDeploymentType)
   val app = App("app")

--- a/riff-raff/app/ci/CIBuild.scala
+++ b/riff-raff/app/ci/CIBuild.scala
@@ -20,6 +20,7 @@ trait CIBuild {
   def id: Long
   def startTime: DateTime
   def vcsURL: String
+  def buildTool: Option[String]
   def toMagentaBuild: Build = Build(jobName, number)
 }
 

--- a/riff-raff/app/ci/S3Build.scala
+++ b/riff-raff/app/ci/S3Build.scala
@@ -9,6 +9,7 @@ import play.api.libs.json._
 import scala.util.Try
 import scala.util.control.NonFatal
 import cats.syntax.either._
+
 import scala.collection.Seq
 
 case class S3Build(
@@ -19,7 +20,8 @@ case class S3Build(
   number: String,
   startTime: DateTime,
   revision: String,
-  vcsURL: String
+  vcsURL: String,
+  buildTool: Option[String],
 ) extends CIBuild
 
 case class S3Project(id: String, name: String) extends Job
@@ -64,7 +66,8 @@ class S3BuildOps(config: Config) extends Logging {
         (JsPath \ "buildNumber").read[String] and
         (JsPath \ "startTime").read[DateTime] and
         (JsPath \ "revision").read[String] and
-        (JsPath \ "vcsURL").read[String]
+        (JsPath \ "vcsURL").read[String] and
+        (JsPath \ "buildTool").readNullable[String]
       )(S3Build.apply _)
 
     Json.parse(json).validate[S3Build].asEither

--- a/riff-raff/test/ci/ContinuousDeploymentTest.scala
+++ b/riff-raff/test/ci/ContinuousDeploymentTest.scala
@@ -43,9 +43,9 @@ class ContinuousDeploymentTest extends AnyFlatSpec with Matchers {
   val contDeployConfigs = Seq(tdProdEnabled, tdCodeDisabled, td2ProdDisabled, td2QaEnabled)
   val contDeployBranchConfigs = Seq(tdProdEnabled, tdCodeDisabled, td2ProdDisabled, td2QaBranchEnabled, td2ProdBranchEnabled)
 
-  val tdB71 = S3Build(45397, "tools::deploy", "45397", "branch", "71", new DateTime(2013,1,25,14,42,47), "", "")
-  val td2B392 = S3Build(45400, "tools::deploy2", "45400", "branch", "392", new DateTime(2013,1,25,15,34,47), "", "")
-  val otherBranch = S3Build(45401, "tools::deploy2", "45401", "other", "393", new DateTime(2013,1,25,15,34,47), "", "")
+  val tdB71 = S3Build(45397, "tools::deploy", "45397", "branch", "71", new DateTime(2013,1,25,14,42,47), "", "", buildTool = None)
+  val td2B392 = S3Build(45400, "tools::deploy2", "45400", "branch", "392", new DateTime(2013,1,25,15,34,47), "", "", buildTool = None)
+  val otherBranch = S3Build(45401, "tools::deploy2", "45401", "other", "393", new DateTime(2013,1,25,15,34,47), "", "", buildTool = Some("guardian/actions-riff-raff"))
 
   it should "retry until finds success" in {
     var i = 0

--- a/riff-raff/test/ci/S3BuildTest.scala
+++ b/riff-raff/test/ci/S3BuildTest.scala
@@ -26,7 +26,7 @@ class S3BuildTest extends AnyFunSuite with Matchers with EitherValues {
 
     new S3BuildOps(config).parse(json).value shouldBe (
       S3Build(42, "foo", "foo", "master", "42", new DateTime(2017,3,14, 17, 57, 8),
-        "f29427661d227eaf3e6b89c75e76b99484d551c4", "git@github.com:guardian/riff-raff.git"))
+        "f29427661d227eaf3e6b89c75e76b99484d551c4", "git@github.com:guardian/riff-raff.git", buildTool = None))
   }
 
   test("parsing should not barf if buildNumber is not a number") {

--- a/riff-raff/test/docs/DeployTypeDocsTest.scala
+++ b/riff-raff/test/docs/DeployTypeDocsTest.scala
@@ -44,7 +44,7 @@ class DeployTypeDocsTest extends AnyFlatSpec with Matchers {
   it should "successfully generate documentation for the standard set of deployment types" in {
     // we can't easily check correctness, but we can check exceptions are not thrown
     val availableDeploymentTypes = Seq(
-      S3, AutoScaling, Fastly, new CloudFormation(NoopVcsUrlLookup), Lambda, AmiCloudFormationParameter, SelfDeploy, GcpDeploymentManager
+      S3, AutoScaling, Fastly, new CloudFormation(EmptyBuildTags), Lambda, AmiCloudFormationParameter, SelfDeploy, GcpDeploymentManager
     )
     val result = DeployTypeDocs.generateDocs(availableDeploymentTypes)
     result.size shouldBe availableDeploymentTypes.size


### PR DESCRIPTION
Adds the buildTool as a tag on Cloudformation deploys. This will help us to track usage of build tools for services. The particular focus is @guardian/actions-riff-raff but the solution is general.

Note, as part of this, the reporter error for missing vcsUrl has been removed - looking more closely at the code, I believe deploys should already fail if this is not present so the warning here is redundant.

See also: https://github.com/guardian/actions-riff-raff/pull/23.