### PR TITLE
Add Lambda Layer deployment type

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaLayer.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaLayer.scala
@@ -60,7 +60,7 @@ object LambdaLayer extends DeploymentType with BucketParameters {
 
     layerNameParam.get(pkg) match {
       case Some(name) => UpdateLambdaLayer(
-        layer = LambdaLayerName(s"$name$stage"),
+        layer = LambdaLayerName(name),
         fileName = fileNameParam(pkg, target, reporter),
         region = target.region,
         s3Bucket = bucket

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaLayer.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaLayer.scala
@@ -1,0 +1,152 @@
+package magenta.deployment_type
+
+import magenta.artifact.S3Path
+import magenta.tasks.{SSM, UpdateS3LambdaLayer}
+import magenta.{DeployReporter, DeployTarget, DeploymentPackage, DeploymentResources, KeyRing, Region, tasks}
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.ssm.SsmClient
+
+object LambdaLayer extends LambdaLayer
+
+trait LambdaLayer extends DeploymentType with BucketParameters {
+  val name = "aws-lambda-layer"
+  val documentation =
+    """
+      |Provides deploy actions to upload and update Lambda layers.
+      |
+      """.stripMargin
+
+  val layerNameParam = Param[String]("layerNames",
+    """One or more layer names to update with the code from fileNameParam.
+      |""".stripMargin,
+    optional = false
+  )
+
+  val fileNameParam = Param[String](
+    "fileName",
+    "The name of the archive of the function",
+    deprecatedDefault = true
+  )
+    .defaultFromContext((pkg, _) => Right(s"${pkg.name}.zip"))
+
+  val prefixStackToKeyParam = Param[Boolean](
+    "prefixStackToKey",
+    documentation = "Whether to prefix `package` to the S3 location"
+  ).default(true)
+
+  def withSsm[T](
+                  keyRing: KeyRing,
+                  region: Region,
+                  resources: DeploymentResources
+                ): (SsmClient => T) => T = SSM.withSsmClient[T](keyRing, region, resources)
+
+  def makeS3Key(
+                 target: DeployTarget,
+                 pkg: DeploymentPackage,
+                 fileName: String,
+                 reporter: DeployReporter
+               ): String = {
+    val prefixStack = prefixStackToKeyParam(pkg, target, reporter)
+    val prefix = if (prefixStack) List(target.stack.name) else Nil
+    (prefix ::: List(target.parameters.stage.name, pkg.app.name, fileName))
+      .mkString("/")
+  }
+
+  def layerToProcess(
+                       pkg: DeploymentPackage,
+                       target: DeployTarget,
+                       reporter: DeployReporter
+                     ): UpdateLambdaLayer = {
+    val bucket = getTargetBucketFromConfig(pkg, target, reporter)
+    val stage = target.parameters.stage.name
+
+    layerNameParam.get(pkg) match {
+      case Some(name) => UpdateLambdaLayer(
+        layer = LambdaLayerName(s"$name$stage"),
+        fileName = fileNameParam(pkg, target, reporter),
+        region = target.region,
+        s3Bucket = bucket
+      )
+      case None => reporter.fail(s"Lambda layer name not defined")
+    }
+  }
+
+  val uploadLayer = Action(
+    "uploadLayer",
+    """
+      |Uploads the lambda layer to S3.
+    """.stripMargin
+  ) { (pkg, resources, target) =>
+    implicit val keyRing: KeyRing = resources.assembleKeyring(target, pkg)
+    implicit val artifactClient: S3Client = resources.artifactClient
+
+    val layer = layerToProcess(
+      pkg = pkg,
+      target = target,
+      reporter = resources.reporter
+    )
+
+    val s3Bucket = tasks.S3.getBucketName(
+      bucket = layer.s3Bucket,
+      withSsmClient = withSsm(keyRing, target.region, resources),
+      reporter = resources.reporter
+    )
+
+    val s3Key = makeS3Key(target, pkg, layer.fileName, resources.reporter)
+    val uploadTask = tasks.S3Upload(
+      region = layer.region,
+      bucket = s3Bucket,
+      paths = Seq(S3Path(pkg.s3Package, layer.fileName) -> s3Key)
+    )
+
+    List(uploadTask)
+  }
+
+  val updateLayer = Action(
+    "updateLayer",
+    """
+      |Updates the lambda layer to use new code using the PublishLayerVersion API.
+    """.stripMargin
+  ) { (pkg, resources, target) =>
+    implicit val keyRing: KeyRing = resources.assembleKeyring(target, pkg)
+    implicit val artifactClient: S3Client = resources.artifactClient
+
+    val updateLayer = layerToProcess(
+      pkg = pkg,
+      target = target,
+      reporter = resources.reporter
+    )
+
+    val s3Bucket = tasks.S3.getBucketName(
+      bucket = updateLayer.s3Bucket,
+      withSsmClient = withSsm(keyRing, target.region, resources),
+      reporter = resources.reporter
+    )
+
+    val s3Key = makeS3Key(
+      target = target,
+      pkg = pkg,
+      fileName = updateLayer.fileName,
+      reporter = resources.reporter
+    )
+
+    val updateTask = UpdateS3LambdaLayer(
+      updateLayer.layer,
+      s3Bucket,
+      s3Key,
+      updateLayer.region
+    )
+
+    List(updateTask)
+  }
+
+  def defaultActions = List(uploadLayer, updateLayer)
+}
+
+case class LambdaLayerName(name: String)
+case class UpdateLambdaLayer(
+  layer: LambdaLayerName,
+  fileName: String,
+  region: Region,
+  s3Bucket: tasks.S3.Bucket
+)

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaLayer.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaLayer.scala
@@ -6,9 +6,7 @@ import magenta.{DeployReporter, DeployTarget, DeploymentPackage, DeploymentResou
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.ssm.SsmClient
 
-object LambdaLayer extends LambdaLayer
-
-trait LambdaLayer extends DeploymentType with BucketParameters {
+object LambdaLayer extends DeploymentType with BucketParameters {
   val name = "aws-lambda-layer"
   val documentation =
     """

--- a/magenta-lib/src/main/scala/magenta/deployment_type/LambdaLayer.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/LambdaLayer.scala
@@ -16,8 +16,8 @@ trait LambdaLayer extends DeploymentType with BucketParameters {
       |
       """.stripMargin
 
-  val layerNameParam = Param[String]("layerNames",
-    """One or more layer names to update with the code from fileNameParam.
+  val layerNameParam = Param[String]("layerName",
+    """The layer name to update with the code from fileNameParam.
       |""".stripMargin,
     optional = false
   )

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -126,6 +126,7 @@ class AppComponents(
     Fastly,
     new CloudFormation(DefaultBuildTags),
     Lambda,
+    LambdaLayer,
     AmiCloudFormationParameter,
     SelfDeploy,
     GcpDeploymentManager,


### PR DESCRIPTION
## What does this change?

In order to deploy new versions of lambda layers via riff-raff in a sensible manner we should add support for an aws-lambda-layer deployment type to riff-raff.

Currently this is possible using the aws-s3 deployment type, but that mechanism results in complete replacement of the layer. This is unsuitable as if layers are being used to support devx functionality in our estate we must have a mechanism of safely updating those layers.

The deployment mechanism in riff-raff should use the [PublishLayerVersion](https://docs.aws.amazon.com/lambda/latest/dg/API_PublishLayerVersion.html) API in AWS to update layers creating new versions without replacing the layer (and consequently creating new ARNs each time).

Currently this deployment type will publish a new version every time it is deployed, and will not clean up old versions. I think this behaviour is acceptable, but we may want to modify it if we find this deployment type gets more usage.

<img width="1126" alt="Screenshot 2022-12-14 at 15 41 58" src="https://user-images.githubusercontent.com/953792/207641173-c91af577-5dc9-4ece-b7b5-9bcd8e6969cd.png">

It is safe to manually delete older versions without impacting the lambdas that use those old versions, they will continue to function but you will not be able to create new lambdas that make use of those deleted layers.

## How do we know this works?

This has been tested in code, and you can see a successful deployment of https://github.com/guardian/ssm-to-env/pull/4:
- https://riffraff.code.dev-gutools.co.uk/deployment/view/1447ba5e-1a50-4e6f-99ec-98aacebffa2b
