### PR TITLE
Disable flaky tests

### DIFF
--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
@@ -266,7 +266,12 @@ class ASGTest extends AnyFlatSpec with Matchers with MockitoSugar {
     group shouldBe Some(desiredGroup)
   }
 
-  it should "wait for instances in ELB to stabilise if there is one" in {
+  // TODO: these tests regularly fail with `An illegal reflective access
+  // operation has occurred`. This appears to be caused by Mockito when mocking
+  // the `ApplicationELBClient` and/or `ClassicELBClient` classes. We should
+  // investigate this further and re-enable these tests once fixed.œ
+
+  it should "wait for instances in ELB to stabilise if there is one" ignore {
     val appELBClient = mock[ApplicationELBClient]
     val classicELBClient = mock[ClassicELBClient]
 
@@ -289,7 +294,7 @@ class ASGTest extends AnyFlatSpec with Matchers with MockitoSugar {
     ) shouldBe Right(())
   }
 
-  it should "wait for instances in an ELB target group to be healthy" in {
+  it should "wait for instances in an ELB target group to be healthy" ignore {
     val appELBClient = mock[ApplicationELBClient]
     val classicELBClient = mock[ClassicELBClient]
 
@@ -312,7 +317,7 @@ class ASGTest extends AnyFlatSpec with Matchers with MockitoSugar {
     ) shouldBe Right(())
   }
 
-  it should "wait for classic ELB and ELB target group to report as healthy" in {
+  it should "wait for classic ELB and ELB target group to report as healthy" ignore {
     val appELBClient = mock[ApplicationELBClient]
     val classicELBClient = mock[ClassicELBClient]
 
@@ -345,7 +350,7 @@ class ASGTest extends AnyFlatSpec with Matchers with MockitoSugar {
     ) shouldBe Right(())
   }
 
-  it should "just check ASG health for stability if there is no ELB" in {
+  it should "just check ASG health for stability if there is no ELB" ignore {
     val appELBClient = mock[ApplicationELBClient]
     val classicELBClient = mock[ClassicELBClient]
 


### PR DESCRIPTION
These tests frequently (perhaps 50% of runs or more) fail with:

scala.reflect.internal.Symbols$CyclicReference: illegal cyclic reference involving class DescribeInstanceHealthResponse

A full test run with failures can be found [here](https://github.com/guardian/riff-raff/actions/runs/3676832331/jobs/6218284172).

We should fix this, but in the meantime let's ensure our tests are reliable.
