### PR TITLE
fix: Use correct values for `gu:repo` and `gu:build-tool`

### DIFF
--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -114,8 +114,8 @@ class AppComponents(
       val default = "unknown"
 
       Map(
-        "gu:repo" -> buildTool.getOrElse(default),
-        "gu:build-tool" -> repoUrl.getOrElse(default)
+        "gu:build-tool" -> buildTool.getOrElse(default),
+        "gu:repo" -> repoUrl.getOrElse(default)
       )
     }
   }


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Uses the correct value for the `gu:repo` and `gu:build-tool` tags.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

TBD.