### PR TITLE
Remove bucketResource

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
@@ -29,7 +29,7 @@ object GCS extends DeploymentType {
   // required configuration, you cannot upload without setting these
   val bucket = Param[String](
     "bucket",
-    "GCS bucket to upload package files to (see also `bucketResource`)",
+    "GCS bucket to upload package files to",
     optional = true
   )
   val bucketByStage: Param[Map[String, String]] = Param[Map[String, String]](

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -33,7 +33,7 @@ class DeploymentTypeTest
   val deploymentTypes = Seq(S3, Lambda)
 
   "Deployment types" should "automatically register params in the params Seq" in {
-    S3.params should have size 13
+    S3.params should have size 12
     S3.params.map(_.name).toSet should be(
       Set(
         "prefixStage",
@@ -41,7 +41,6 @@ class DeploymentTypeTest
         "prefixStack",
         "prefixApp",
         "bucket",
-        "bucketResource",
         "bucketSsmKey",
         "bucketSsmKeyStageParam",
         "bucketSsmLookup",


### PR DESCRIPTION
**Note: blocked by/depends on https://github.com/guardian/reuse-content/pull/40.**

Following on from https://github.com/guardian/riff-raff/pull/941 we can now delete this parameter too.

There is only a single user of this parameter, and the purpose (varying bucket by stage) is better achieved with the new [bucketSsmKeyStageParam](https://github.com/guardian/riff-raff/blob/23443fc9fe1fd8da5619cb74aef9be3d41376218/magenta-lib/src/main/scala/magenta/deployment_type/BucketParameters.scala#L31).