### PR TITLE
fix: Add `AWS::EFS::FileSystem` to set of protected resources

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
@@ -137,6 +137,8 @@ object StackPolicy {
       "AWS::EC2::VPC",
       "AWS::EC2::VPCEndpoint",
       "AWS::EC2::VPCGatewayAttachment",
+      // Storage that persists outside of EC2 life-cycle
+      "AWS::EFS::FileSystem",
       // Private types
       "Guardian::DNS::RecordSet"
     )


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Configure Riff-Raff to protect EFS, as it holds state.

Use-cases for EFS include persisting data across instance rotations, resulting in little/no service disruption. When an instance rotates into service, it'll mount the EFS volume and not need to rebuild any state, as it has it.

Examples include:
  - Grid FTP using EFS to hold transferred images
  - TeamCity server using EFS to hold configuration, logs, caches, etc

It's worth noting that, as ever, "Dangerous" mode will allow you to delete/replace these resources.

See https://docs.aws.amazon.com/efs/latest/ug/how-it-works.html.