### PR TITLE
feat(aws-s3): Allow customisation of upload path to S3

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -264,6 +264,7 @@ object AutoScaling extends DeploymentType with BucketParameters {
     }
 
     val prefix = S3Upload.prefixGenerator(
+      delimiter = "/",
       stack =
         if (prefixStack(pkg, target, reporter)) Some(target.stack) else None,
       stage =

--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala
@@ -26,6 +26,12 @@ object S3 extends DeploymentType with BucketParameters {
         |""".stripMargin
   ).default(false)
 
+  val prefixDelimiter = Param[String](
+    "prefixDelimiter",
+    documentation = "The delimiter to use between prefixes when forming the object path",
+    optional = true
+  ).default("/")
+
   val bucketResource = Param[String](
     "bucketResource",
     """Deploy Info resource key to use to look up the S3 bucket to which the package files should be uploaded.
@@ -180,6 +186,7 @@ object S3 extends DeploymentType with BucketParameters {
       }
 
       val prefix: String = S3Upload.prefixGenerator(
+        delimiter = prefixDelimiter(pkg, target, reporter),
         stack =
           if (prefixStack(pkg, target, reporter)) Some(target.stack) else None,
         stage =

--- a/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/SelfDeploy.scala
@@ -41,7 +41,7 @@ object SelfDeploy extends DeploymentType {
     val reporter = resources.reporter
     implicit val artifactClient = resources.artifactClient
     val prefix =
-      S3Upload.prefixGenerator(target.stack, target.parameters.stage, pkg.name)
+      S3Upload.prefixGenerator("/", target.stack, target.parameters.stage, pkg.name)
     List(
       S3Upload(
         target.region,

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -199,15 +199,16 @@ object S3Upload {
     mimeTypes.getMimetype(new File(fileName))
 
   def prefixGenerator(
+      delimiter: String,
       stack: Option[Stack] = None,
       stage: Option[Stage] = None,
-      packageOrAppName: Option[String] = None
+      packageOrAppName: Option[String] = None,
   ): String = {
     (stack.map(_.name) :: stage.map(_.name) :: packageOrAppName :: Nil).flatten
-      .mkString("/")
+      .mkString(delimiter)
   }
-  def prefixGenerator(stack: Stack, stage: Stage, packageName: String): String =
-    prefixGenerator(Some(stack), Some(stage), Some(packageName))
+  def prefixGenerator(delimiter: String, stack: Stack, stage: Stage, packageName: String): String =
+    prefixGenerator(delimiter, Some(stack), Some(stage), Some(packageName))
 }
 
 case class PutReq(

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -33,13 +33,14 @@ class DeploymentTypeTest
   val deploymentTypes = Seq(S3, Lambda)
 
   "Deployment types" should "automatically register params in the params Seq" in {
-    S3.params should have size 13
+    S3.params should have size 14
     S3.params.map(_.name).toSet should be(
       Set(
         "prefixStage",
         "prefixPackage",
         "prefixStack",
         "prefixApp",
+        "prefixDelimiter",
         "bucket",
         "bucketResource",
         "bucketSsmKey",


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Allow for the upload path to S3 to be customised.

By default, create a directory for each prefix, e.g. `/<stack>/<stage>/files`.

Within Interactives, there is a desire to upload to `/<stack>-<stage>/files`, so introduce a new optional parameter `prefixDelimiter` to support this. Specifically, [`interactive-atom-maker`](https://github.com/guardian/interactive-atom-maker) is [configured](https://github.com/guardian/interactive-atom-maker/blob/983da014e0afe623f0c211f77a92f10a371fed2b/src/main/scala/app/Config.scala#L52) to read from `atoms-STAGE` (TBD!)

See https://github.com/guardian/csti-wip-interactive-template.