### PR TITLE
fix: Observe `Encrypted` when set in `amiParametersToTags`

### DIFF
--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -3,6 +3,7 @@ package magenta.deployment_type
 import magenta.Strategy.{Dangerous, MostlyHarmless}
 import magenta._
 import magenta.artifact.S3Path
+import magenta.deployment_type.CloudFormationDeploymentTypeParameters.CfnParam
 import magenta.deployment_type.{CloudFormation => CloudFormationDeploymentType}
 import magenta.fixtures._
 import magenta.tasks.CloudFormation.{SpecifiedValue, UseExistingValue}
@@ -556,7 +557,8 @@ class CloudFormationTest
       None,
       Map.empty,
       Map.empty,
-      (_: String) => (_: String) => (_: Map[String, String]) => None
+      (_: CfnParam) =>
+        (_: String) => (_: String) => (_: Map[String, String]) => None
     )
 
     val params = resolve(
@@ -588,7 +590,8 @@ class CloudFormationTest
       None,
       Map.empty,
       Map.empty,
-      (_: String) => (_: String) => (_: Map[String, String]) => None
+      (_: CfnParam) =>
+        (_: String) => (_: String) => (_: Map[String, String]) => None
     )
 
     val params = resolve(
@@ -628,7 +631,8 @@ class CloudFormationTest
       None,
       Map.empty,
       Map.empty,
-      (_: String) => (_: String) => (_: Map[String, String]) => None
+      (_: CfnParam) =>
+        (_: String) => (_: String) => (_: Map[String, String]) => None
     )
 
     val params = resolve(
@@ -668,7 +672,8 @@ class CloudFormationTest
       None,
       userParameters,
       Map.empty,
-      (_: String) => (_: String) => (_: Map[String, String]) => None
+      (_: CfnParam) =>
+        (_: String) => (_: String) => (_: Map[String, String]) => None
     )
 
     val params = resolve(
@@ -707,7 +712,8 @@ class CloudFormationTest
       None,
       Map.empty,
       Map.empty,
-      (_: String) => (_: String) => (_: Map[String, String]) => None
+      (_: CfnParam) =>
+        (_: String) => (_: String) => (_: Map[String, String]) => None
     )
 
     val params = resolve(


### PR DESCRIPTION
## Background
In https://github.com/guardian/riff-raff/pull/479 the parameter `amiEncrypted` was added to the `riff-raff.yaml` file, with the following behaviour:
  - Default of `false`
  - When `false`, Riff-Raff locates AMIs without the `Encrypted` tag, or where the tag is set to `false`
  - When `true`, Riff-Raff locates AMIs with the `Encrypted` set to `true`

The value of `amiEncrypted` is applied to _all_ AMIs in the stack.

The `amiParametersToTags` parameter allows one to describe the characteristics of multiple AMIs in the stack, independently. However, it's not currently possible to set encryption independently across these AMIs.

## What does this change?
In this change, we update the `getLatestAmi` logic to support the use-case where a stack has multiple AMIs, and where each can be encrypted, or not.

For example:
```yaml
deployments:
  update-cloudformation:
    type: "cloud-formation"
    parameters:
      amiParametersToTags:
        elasticsearchAmi:
          BuiltBy: "amigo"
          Recipe: "elk-elasticsearch"
          AmigoStage: "PROD"
          Encrypted: "true" # <-- this
         kibanaAmi:
           BuiltBy: "amigo"
           Recipe: "elk-kibana"
           AmigoStage: "PROD"
           Encrypted: "false" # <-- this   
```

> **Note**
> It could be argued that we should not support unencrypted workflows anymore! If so, a lot of this logic can be removed.
> 
> This'll require an amount of careful consideration so that we don't accidentally break deployments. That is, this PR is valuable today.

## How to test
> **Note**
> I couldn't quite work out the easiest way to unit test this. Help wanted!

Behaviours should include:
1. `amiEncrypted` set to `true` should result in an encrypted AMI being used, as before
2. `amiEncrypted` set to `false` should result in an unencrypted AMI being used, as before
3. `amiParametersToTags/Encrypted` set to `"true"` should result in an encrypted AMI being used
4. `amiParametersToTags/Encrypted` set to `"false"` should result in an encrypted AMI being used
5. Absence of `amiEncrypted` and `amiParametersToTags/Encrypted` should result in an unencrypted AMI being used, as before

I've raised some PRs in [cdk-playground](https://github.com/guardian/cdk-playground) to help test this change:
- https://github.com/guardian/cdk-playground/pull/327
- https://github.com/guardian/cdk-playground/pull/328

With these PRs we can explicitly test behaviours 1, 3, and 5 (and implicitly test 2, and 4):
1. Deploy this branch to Riff-Raff CODE
2. Using Riff-Raff CODE, deploy `main` of `devx::cdk-playground`
3. Observe the AMI in use _does not_ have an `Encrypted` tag set to `true`
4. Using Riff-Raff CODE, deploy one of the `cdk-playground` PRs above
5. Observe the AMI in use _does_ have an `Encrypted` tag set to `true`
6. Using Riff-Raff CODE, deploy `main` of `devx::cdk-playground`
7. Observe the AMI in use _does not_ have an `Encrypted` tag set to `true`
8. Using Riff-Raff CODE, deploy the other `cdk-playground` PR above
9. Observe the AMI in use _does_ have an `Encrypted` tag set to `true`

### Some helpful scripts
#### Find the value of the AMI Parameter
```sh
aws cloudformation describe-stacks \
  --stack-name playground-PROD-cdk-playground \
  jq -r '.Stacks[].Parameters[] | select(.ParameterKey =="AMICdkplayground") | .ParameterValue'
```

#### Find an AMI's tags
```sh
aws ec2 describe-images \
  --image-ids ami-00000000000000000 \
  jq -r '.Images[].Tags[]'
```

FYI unencrypted AMIs live in the DevX account. Tags are not copied when sharing AMIs across accounts, so when using the `developerPlayground` account profile, the unencrypted AMI will not have any tags.