### PR TITLE
Fix CODEOWNERS to work as intended

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,1 @@
-* @guardian/devx-operations
-* @guardian/devx-reliability
-* @guardian/devx-security
+* @guardian/devx-operations @guardian/devx-reliability @guardian/devx-security


### PR DESCRIPTION
## What does this change?

The current expected behaviour is that all devx teams listed can approve PRs, the actual behaviour is the last rule takes precedence and only devx-security can approve PRs. 

See also https://github.com/guardian/deploy-tools-platform/pull/666