### PR TITLE
Use arm64-focal-java11-deploy-infrastructure as the AMI

### DIFF
--- a/riff-raff/riff-raff.yaml
+++ b/riff-raff/riff-raff.yaml
@@ -13,7 +13,7 @@ deployments:
     app: riff-raff
     parameters:
       amiTags:
-        Recipe: arm64-bionic-java11-deploy-infrastructure
+        Recipe: arm64-focal-java11-deploy-infrastructure
         AmigoStage: PROD
         BuiltBy: amigo
       amiEncrypted: true


### PR DESCRIPTION
## What does this change?

Move to use https://amigo.gutools.co.uk/recipes/arm64-focal-java11-deploy-infrastructure.

This will allow us to:

- Move Riff-Raff to 20.04 to avoid the 18.04 EOL
- Test whether the new `arm64-focal-java11-deploy-infrastructure` image is working as expected

## How to test

Deploy this PR to the CODE environment and check the EC2 instances with the new AMI are successfully brought into service & that we can access the Riff-Raff UI.

Riff-Raff's self-deployment process downloads a new artefact and restarts the service, to test (and deploy) this change we'll need to cycle the instance via the `requestInstanceRotation` endpoint.

This can be done as follows:

```
ssm cmd -t riff-raff,CODE -p deployTools --cmd "curl --silent -X POST localhost:9000/requestInstanceRotation"
```

See: https://riffraff.code.dev-gutools.co.uk/deployment/view/d5d0d840-02c2-419a-857a-2cd82f84707e

## How can we measure success?

Can we use the focal AMI to successfully deploy AMIable?

## Have we considered potential risks?

Riff-Raff is not deployable with Focal base AMIs, we'll revert.