### PR TITLE
fix: Fallback to `amiEncrypted` when `amiParametersToTags/Encrypted` is absent

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormationDeploymentTypeParameters.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormationDeploymentTypeParameters.scala
@@ -165,7 +165,11 @@ trait CloudFormationDeploymentTypeParameters {
               params
                 .getOrElse(amiCfnParam, Map.empty)
                 .get("Encrypted")
-                .contains("true")
+                .flatMap(_.toBooleanOption)
+                .getOrElse(
+                  // When `amiParametersToTags/Encrypted` is not explicitly set, fallback to `amiEncrypted`
+                  amiEncrypted(pkg, target, reporter)
+                )
             case _ => amiEncrypted(pkg, target, reporter)
           }
 


### PR DESCRIPTION
## What does this change?
The changes in #991 has caused https://riffraff.gutools.co.uk/deployment/view/58385bf3-b10f-47b3-afac-d9e53e1a7278 to fail.

This is because the `riff-raff.yaml` is:

```yaml
regions:
- eu-west-1
stacks:
- ophan
deployments:
  big-loader-es7:
    type: autoscaling
    dependencies:
    - update-ami
  update-ami:
      type: ami-cloudformation-parameter
      app: big-loader-es7
      parameters:
        amiEncrypted: true
        amiParametersToTags:
          ImageId:
            Recipe: ophan-ubuntu-bionic-ARM
            AmigoStage: PROD
            BuiltBy: amigo
```

That is, `amiParametersToTags/Encrypted` is not set, so `Encrypted=false` is used. However `Encrypted=true` should actually be used.

In this change we fallback to `amiEncrypted` if `amiParametersToTags/Encrypted` is absent.

Ideally, support for `amiEncrypted` would be dropped, however [multiple projects](https://github.com/search?q=org%3Aguardian+amiEncrypted+language%3AYAML&type=code&l=YAML) are using this parameter already.

## How to test
- [Deploy this branch to CODE](https://riffraff.code.dev-gutools.co.uk/deployment/view/0c8f8ec2-1c20-475f-8b35-ed82bea1c023)
- [Deploy `ophan:big-loader-es7` build 20132](https://riffraff.code.dev-gutools.co.uk/deployment/view/ef5e8edf-eecc-4136-8e3f-f34e3f2a41ea)
- Observe the correct AMI being used (see below)

![image](https://user-images.githubusercontent.com/836140/218714892-047e734c-68b3-4bc0-b771-f34808a2367b.png)
