### PR TITLE
feat: Add `prefixStagePaths` parameter to `aws-s3` deployments

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3ObjectPrefixParameters.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3ObjectPrefixParameters.scala
@@ -76,7 +76,7 @@ trait S3ObjectPrefixParameters {
         packageOrAppName = maybePackageOrAppName
       )
     } else {
-      prefixFromStagePaths.lift.apply(target.parameters.stage.name) match {
+      prefixFromStagePaths.get(target.parameters.stage.name) match {
         case Some(prefix) => prefix
         case _ =>
           reporter.fail(

--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3ObjectPrefixParameters.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3ObjectPrefixParameters.scala
@@ -1,0 +1,53 @@
+package magenta.deployment_type
+
+import magenta.{DeployReporter, DeployTarget, DeploymentPackage}
+import magenta.tasks.S3Upload
+
+trait S3ObjectPrefixParameters {
+  this: DeploymentType =>
+
+  val prefixStage: Param[Boolean] =
+    Param("prefixStage", "Prefix the S3 bucket key with the target stage")
+      .default(true)
+
+  val prefixPackage: Param[Boolean] =
+    Param("prefixPackage", "Prefix the S3 bucket key with the package name")
+      .default(true)
+
+  val prefixStack: Param[Boolean] =
+    Param("prefixStack", "Prefix the S3 bucket key with the target stack")
+      .default(true)
+
+  val prefixApp: Param[Boolean] = Param[Boolean](
+    name = "prefixApp",
+    documentation = """
+        |Whether to prefix `app` to the S3 location instead of `package`.
+        |
+        |When `true` `prefixPackage` will be ignored and `app` will be used over `package`, useful if `package` and `app` don't align.
+        |""".stripMargin
+  ).default(false)
+
+  def getPrefix(
+      pkg: DeploymentPackage,
+      target: DeployTarget,
+      reporter: DeployReporter
+  ): String = {
+    val maybePackageOrAppName: Option[String] = (
+      prefixPackage(pkg, target, reporter),
+      prefixApp(pkg, target, reporter)
+    ) match {
+      case (_, true)      => Some(pkg.app.name)
+      case (true, false)  => Some(pkg.name)
+      case (false, false) => None
+    }
+
+    S3Upload.prefixGenerator(
+      stack =
+        if (prefixStack(pkg, target, reporter)) Some(target.stack) else None,
+      stage =
+        if (prefixStage(pkg, target, reporter)) Some(target.parameters.stage)
+        else None,
+      packageOrAppName = maybePackageOrAppName
+    )
+  }
+}

--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3ObjectPrefixParameters.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3ObjectPrefixParameters.scala
@@ -83,13 +83,13 @@ trait S3ObjectPrefixParameters {
             s"""
                |Unable to locate prefix for stage ${target.parameters.stage.name}.
                |
-               |prefixFromStagePaths is set to:
+               |prefixStagePaths is set to:
                |
                |$prefixFromStagePaths
                |
                |To resolve, either:
                |  - Deploy to a known stage
-               |  - Update prefixFromStagePaths, adding a value for ${target.parameters.stage.name}
+               |  - Update prefixStagePaths, adding a value for ${target.parameters.stage.name}
                |""".stripMargin
           )
       }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3ObjectPrefixParameters.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3ObjectPrefixParameters.scala
@@ -30,6 +30,15 @@ trait S3ObjectPrefixParameters {
   val prefixStagePaths: Param[Map[String, String]] = Param[Map[String, String]](
     "prefixStagePaths",
     documentation = """
+        |This option allows full control over the paths used for each stage, and will override all other prefix options.
+        |
+        |This is a useful escape hatch if you find yourself in a scenario where you are deploying to a single bucket and
+        |the upload path between stages cannot be repeated.
+        |
+        |**Note:** For the most part, you should not use this.
+        |If at all possible, prefer to use a single bucket per-stage.
+        |
+        |See our recommendation here: https://github.com/guardian/recommendations/blob/main/AWS.md?plain=1#L70
         |```yaml
         |prefixStagePaths:
         |  CODE: atoms-CODE

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -33,13 +33,14 @@ class DeploymentTypeTest
   val deploymentTypes = Seq(S3, Lambda)
 
   "Deployment types" should "automatically register params in the params Seq" in {
-    S3.params should have size 12
+    S3.params should have size 13
     S3.params.map(_.name).toSet should be(
       Set(
         "prefixStage",
         "prefixPackage",
         "prefixStack",
         "prefixApp",
+        "prefixStagePaths",
         "bucket",
         "bucketSsmKey",
         "bucketSsmKeyStageParam",

--- a/magenta-lib/src/test/scala/magenta/deployment_type/S3ObjectPrefixParametersTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/S3ObjectPrefixParametersTest.scala
@@ -137,13 +137,13 @@ class S3ObjectPrefixParametersTest extends AnyFlatSpec with Matchers {
       """
          |Unable to locate prefix for stage UAT.
          |
-         |prefixFromStagePaths is set to:
+         |prefixStagePaths is set to:
          |
          |Map(CODE -> atoms-CODE, PROD -> atoms)
          |
          |To resolve, either:
          |  - Deploy to a known stage
-         |  - Update prefixFromStagePaths, adding a value for UAT
+         |  - Update prefixStagePaths, adding a value for UAT
          |""".stripMargin
     )
   }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/S3ObjectPrefixParametersTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/S3ObjectPrefixParametersTest.scala
@@ -1,0 +1,76 @@
+package magenta.deployment_type
+
+import magenta.artifact.S3Path
+import magenta.{
+  App,
+  DeployReporter,
+  DeployTarget,
+  DeploymentPackage,
+  Region,
+  Stack,
+  fixtures
+}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.{JsBoolean, JsValue}
+
+import java.util.UUID
+
+object TestS3DeploymentType
+    extends DeploymentType
+    with S3ObjectPrefixParameters {
+  def defaultActions = Nil
+
+  def documentation = "n/a"
+
+  def name = "n/a"
+}
+
+class S3ObjectPrefixParametersTest extends AnyFlatSpec with Matchers {
+  val target = DeployTarget(
+    fixtures.parameters(),
+    Stack("interactives"),
+    Region("eu-west-1")
+  )
+  val reporter =
+    DeployReporter.rootReporterFor(UUID.randomUUID(), target.parameters)
+
+  "The S3 upload path" should "be defaulted" in {
+    val pkg = S3ObjectPrefixParametersTest.pkg(Map.empty)
+    val path = TestS3DeploymentType.getPrefix(pkg, target, reporter)
+    path shouldBe "interactives/PROD/file-upload"
+  }
+
+  "The S3 upload path" should "change when prefixStage is set" in {
+    val pkg = S3ObjectPrefixParametersTest.pkg(
+      Map(
+        "prefixStage" -> JsBoolean(false)
+      )
+    )
+    val path = TestS3DeploymentType.getPrefix(pkg, target, reporter)
+    path shouldBe "interactives/file-upload"
+  }
+
+  "The S3 upload path" should "change when prefixStack is set" in {
+    val pkg = S3ObjectPrefixParametersTest.pkg(
+      Map(
+        "prefixStack" -> JsBoolean(false)
+      )
+    )
+    val path = TestS3DeploymentType.getPrefix(pkg, target, reporter)
+    path shouldBe "PROD/file-upload"
+  }
+}
+
+object S3ObjectPrefixParametersTest {
+  def pkg(params: Map[String, JsValue]): DeploymentPackage = {
+    DeploymentPackage(
+      name = "file-upload",
+      pkgApp = App("interactives-upload"),
+      pkgSpecificData = params,
+      deploymentTypeName = "n/a",
+      s3Package = S3Path("test", "test"),
+      deploymentTypes = Seq(TestS3DeploymentType)
+    )
+  }
+}


### PR DESCRIPTION
> **Note**
> Easiest to review [commit by commit](https://github.com/guardian/riff-raff/pull/1015/commits) as this change extracts some existing behaviour into a `trait` - [this specific change](https://github.com/guardian/riff-raff/pull/1015/commits/6b71973b00b5f2b04cb1c34e3381422a365e214f) should be considered a no-op.

## Background
In the `aws-s3` deployment type, the path within S3 that we upload to is controlled by the following parameters:
  - `prefixPackage`
  - `prefixStack`
  - `prefixApp`
  - `prefixStage`

This results in the path being the same regardless of the stage being deployed.

For example, for the file `image.jpg` and a _shared_ bucket the upload path will be something like `<bucket>/<STAGE>/image.jpg`. If the bucket was not shared across stages ([as recommended](https://github.com/guardian/recommendations/blob/main/AWS.md#s3)) the upload path will be something like `<bucket>/image.jpg`.

## What does this change?
Introduces a new `prefixStagePaths` parameter for the `aws-s3` deployment type.

This is to support services such as https://github.com/guardian/interactive-atom-maker. interactive-atom-maker is [configured](https://github.com/guardian/interactive-atom-maker/blob/983da014e0afe623f0c211f77a92f10a371fed2b/src/main/scala/app/Config.scala#L52) in a slightly non-standard way - CODE files live in `<bucket>/atoms-CODE/image.jpg`, PROD files live in `<bucket>/atoms/image.jpg`[^1]. The behaviour described above doesn't quite work here.

This change allows us to do:
```yaml
prefixStagePaths:
  - CODE: atoms-CODE
  - PROD: atoms
```

When set, `prefixStagePaths` takes precedence over all other `prefix<App|Stage|etc...>` options.

## How to test
Unit tests have been added to check:
- When `prefixStagePaths` is not set, we maintain existing behaviours of `prefixApp`, `prefixStage`, etc.
- What happens when `prefixStagePaths` is set
- When `prefixStagePaths` is set, describing stages of `CODE` and `PROD`, what happens when deploying stage of `UAT` (it should fail)
- When `prefixStagePaths` and `prefix*` are both set, what wins

For a practical demonstration of this new parameter, see https://github.com/guardian/csti-interactives/pull/53. To test, deploy this branch to CODE, then deploy a build from https://github.com/guardian/csti-interactives/pull/53, and observe the paths which Riff-Raff uploads files to.

## How can we measure success?
https://github.com/guardian/csti-interactives (specifically https://github.com/guardian/csti-interactives/pull/53) is able to use Riff-Raff for continuous delivery.

[^1]: We _could_ update how interactive-atom-maker works, however this would involve updating all the articles that reference the files in S3, which is non-trivial.