### PR TITLE
ci: Use custom `sbt` script that configures memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
           export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
 
           # Note, lib/test because riffraff/riffRaffUpload only tests the riffraff project.
-          sbt clean scalafmtCheckAll scalafmtSbtCheck compile lib/test riffraff/riffRaffUpload
+          ./sbt clean scalafmtCheckAll scalafmtSbtCheck compile lib/test riffraff/riffRaffUpload


### PR DESCRIPTION
## What does this change?
This is an attempt to resolve the OOM errors we sometimes see in CI. The [`sbt` script in this repo](https://github.com/guardian/riff-raff/blob/1e1ca44746c4876fea1d58d36689775ca165dd2f/sbt) customises the amount of memory available.

Example of OOM seen in CI:
```log
[error] Caught java.lang.OutOfMemoryError: Metaspace
[error] To best utilize classloader caching and to prevent file handle leaks, we recommend running sbt without a MaxMetaspaceSize limit. 
[error] 
java.lang.OutOfMemoryError: Metaspace
[error] java.lang.OutOfMemoryError: Metaspace
```

## How can we measure success?
A more stable build?
