### PR TITLE
skip scheduled deploys where last deploy was 'partial' to prevent unexpected/problematic behaviour

### DIFF
--- a/riff-raff/app/deployment/model.scala
+++ b/riff-raff/app/deployment/model.scala
@@ -29,6 +29,14 @@ case class NoDeploysFoundForStage(projectName: String, stage: String)
     s"A scheduled deploy didn't start because Riff-Raff has never deployed $projectName to $stage before. " +
       "Please inform the owner of this schedule as it's likely that they have made a configuration error."
 }
+case class SkippedDueToPreviousPartialDeploy(partialDeployRecord: Record)
+    extends ScheduledDeployNotificationError {
+  val message =
+    s"Scheduled Deployment for ${partialDeployRecord.parameters.build.projectName} to ${partialDeployRecord.parameters.stage.name} " +
+      s"didn't start because the most recent deploy was 'partial' (i.e. had some deploy steps skipped). " +
+      s"Please review the most recent deploy and manually deploy if it's now possible to deploy fully (all steps), " +
+      s"to ensure instances are running with the latest AMI."
+}
 case class SkippedDueToPreviousFailure(failedDeployRecord: Record)
     extends ScheduledDeployNotificationError {
   val message =

--- a/riff-raff/app/schedule/DeployJob.scala
+++ b/riff-raff/app/schedule/DeployJob.scala
@@ -42,6 +42,9 @@ class DeployJob extends Job with Logging {
 
     attemptToStartDeploy match {
       case Left(error: ScheduledDeployNotificationError) =>
+        log.info(
+          s"Scheduled deploy failed to start due to $error. A notification will be sent..."
+        )
         scheduledDeployNotifier.scheduledDeployFailureNotification(error)
       case Left(anotherError) =>
         log.warn(

--- a/riff-raff/test/schedule/DeployJobTest.scala
+++ b/riff-raff/test/schedule/DeployJobTest.scala
@@ -1,8 +1,14 @@
 package schedule
 
 import java.util.UUID
-import deployment.{DeployRecord, Error, SkippedDueToPreviousFailure}
+import deployment.{
+  DeployRecord,
+  Error,
+  SkippedDueToPreviousFailure,
+  SkippedDueToPreviousPartialDeploy
+}
 import magenta.Strategy.MostlyHarmless
+import magenta.input.{DeploymentKey, DeploymentKeysSelector}
 import magenta.{Build, DeployParameters, Deployer, RunState, Stage}
 import org.joda.time.DateTime
 import org.scalatest.EitherValues
@@ -10,60 +16,81 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class DeployJobTest extends AnyFlatSpec with Matchers with EitherValues {
-  val uuid = UUID.fromString("7fa2ee0a-8d90-4f7e-a38b-185f36fbc5aa")
+  private val uuid = UUID.fromString("7fa2ee0a-8d90-4f7e-a38b-185f36fbc5aa")
+
+  private val deployParameters = DeployParameters(
+    Deployer("Bob"),
+    Build("testProject", "1"),
+    Stage("TEST"),
+    updateStrategy = MostlyHarmless
+  )
+
   "createDeployParameters" should "return params if valid" in {
-    val record = new DeployRecord(
+    val record = DeployRecord(
       new DateTime(),
       uuid,
-      DeployParameters(
-        Deployer("Bob"),
-        Build("testProject", "1"),
-        Stage("TEST"),
-        updateStrategy = MostlyHarmless
-      ),
+      deployParameters,
       recordState = Some(RunState.Completed)
     )
-    DeployJob.createDeployParameters(record, true) shouldBe
+    DeployJob.createDeployParameters(
+      record,
+      scheduledDeploysEnabled = true
+    ) shouldBe
       Right(
         DeployParameters(
           Deployer("Scheduled Deployment"),
-          Build("testProject", "1"),
-          Stage("TEST"),
+          deployParameters.build,
+          deployParameters.stage,
           updateStrategy = MostlyHarmless
         )
       )
   }
 
   it should "produce an error if the last deploy didn't complete" in {
-    val record = new DeployRecord(
+    val record = DeployRecord(
       new DateTime(),
       uuid,
-      DeployParameters(
-        Deployer("Bob"),
-        Build("testProject", "1"),
-        Stage("TEST"),
-        updateStrategy = MostlyHarmless
-      ),
+      deployParameters,
       recordState = Some(RunState.Failed)
     )
-    DeployJob.createDeployParameters(record, true) shouldBe Left(
+    DeployJob.createDeployParameters(
+      record,
+      scheduledDeploysEnabled = true
+    ) shouldBe Left(
       SkippedDueToPreviousFailure(record)
     )
   }
 
-  it should "produce an error if scheduled deploys are disabled" in {
-    val record = new DeployRecord(
+  it should "produce an error if the last deploy was partial" in {
+    val record = DeployRecord(
       new DateTime(),
       uuid,
-      DeployParameters(
-        Deployer("Bob"),
-        Build("testProject", "1"),
-        Stage("TEST"),
-        updateStrategy = MostlyHarmless
+      deployParameters.copy(
+        selector = DeploymentKeysSelector(
+          List(DeploymentKey("name", "action", "stack", "region"))
+        )
       ),
       recordState = Some(RunState.Completed)
     )
-    DeployJob.createDeployParameters(record, false) shouldBe
+    DeployJob.createDeployParameters(
+      record,
+      scheduledDeploysEnabled = true
+    ) shouldBe Left(
+      SkippedDueToPreviousPartialDeploy(record)
+    )
+  }
+
+  it should "produce an error if scheduled deploys are disabled" in {
+    val record = DeployRecord(
+      new DateTime(),
+      uuid,
+      deployParameters,
+      recordState = Some(RunState.Completed)
+    )
+    DeployJob.createDeployParameters(
+      record,
+      scheduledDeploysEnabled = false
+    ) shouldBe
       Left(
         Error(
           "Scheduled deployments disabled. Would have deployed DeployParameters(Deployer(Scheduled Deployment),Build(testProject,1),Stage(TEST),All,MostlyHarmless)"


### PR DESCRIPTION
Recently, when @guardian/digital-cms were working on https://github.com/guardian/editorial-tools-production-monitoring/pull/316, they needed to do partial deploys (in order to test on secondary instances in PROD, but leave primary instances unaffected), meanwhile riff-raff performed the scheduled deploy for this project, **crucially a full deploy**, which in turn broke primary instances, this was quickly dealt with but perhaps if someone forgets that they did a partial deploy, then the current behaviour of riff-raff could cause some quite pernicious problems.

So now, if last deploy for a project was 'partial' then the scheduled deployed is skipped but users are notified (just like when previous deploy failed, as most likely the partial deploy was temporary).

