### PR TITLE
Don't expose branch regexs for CD, just names

### DIFF
--- a/riff-raff/app/views/continuousDeployment/form.scala.html
+++ b/riff-raff/app/views/continuousDeployment/form.scala.html
@@ -31,7 +31,7 @@
             Symbol("_label") -> "Stage",
             Symbol("_error") -> configForm.globalError.map(_.withMessage("Please select deployment stage"))
         )
-        @b3.text(configForm("branchMatcher"), Symbol("_label") -> "Branch RegEx")
+        @b3.text(configForm("branchMatcher"), Symbol("_label") -> "Branch Name")
         <legend>Trigger</legend>
         @b3.radio(
             configForm("trigger"),

--- a/riff-raff/app/views/continuousDeployment/list.scala.html
+++ b/riff-raff/app/views/continuousDeployment/list.scala.html
@@ -36,7 +36,7 @@
                 <tr @if(config.trigger == Disabled){ class="danger" }>
                     <td>@utils.DateFormats.Short.print(config.lastEdited) by <span class="label label-default">@config.user</span></td>
                     <td>@config.projectName</td>
-                    <td>@config.branchRE.toString()</td>
+                    <td>@config.branchMatcher.getOrElse("*")</td>
                     <td>@config.stage</td>
                     <td>@config.trigger match {
                         case SuccessfulBuild => { Build succeeds }

--- a/riff-raff/app/views/continuousDeployment/list.scala.html
+++ b/riff-raff/app/views/continuousDeployment/list.scala.html
@@ -24,7 +24,7 @@
                 <tr>
                     <th>Last edited</th>
                     <th>Project Name</th>
-                    <th>Branches</th>
+                    <th>Branch</th>
                     <th>Target Stage</th>
                     <th>Trigger</th>
                     <th></th>


### PR DESCRIPTION
## What does this change?

Looking at projects with CD configured, it seems that the only type of configuration we use is to specify a branch name, which gets converted to a regex (by adding start and end anchors). Let's simplify the UI and make it clear you can enter a branch name, and expose that name back to users, rather than the constructed regex. I've gotten confused in the past and added the `^` and `$` manually, which isn't necessary (I see a few instances of `^^main$$` in the CD configurations, so I don't think I'm the only one!)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

### List of CD projects

#### Before

Displays branches as regexes:

![Screenshot 2023-03-31 at 12 41 08](https://user-images.githubusercontent.com/379839/229111126-dd908ae1-8ef2-465b-86d0-9661929ae491.png)

#### After

Displays branch names:

![Screenshot 2023-03-31 at 12 39 10](https://user-images.githubusercontent.com/379839/229111163-50e0d799-a84f-4af2-9b01-484f4e24ba84.png)

### New CD Form

#### Before

Asks the user for a branch regex:

![Screenshot 2023-03-31 at 12 41 18](https://user-images.githubusercontent.com/379839/229111259-4b5d3f8b-09f3-4920-b278-8d0c3b281203.png)

#### After

Asks the user for a branch name:

![Screenshot 2023-03-31 at 12 39 43](https://user-images.githubusercontent.com/379839/229111323-7a3af22c-a689-4978-8d43-517aacf2e863.png)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
