### PR TITLE
WIP: Make branch matcher required in CD config

### DIFF
--- a/riff-raff/app/ci/ContinuousDeploymentConfig.scala
+++ b/riff-raff/app/ci/ContinuousDeploymentConfig.scala
@@ -13,13 +13,12 @@ case class ContinuousDeploymentConfig(
     id: UUID,
     projectName: String,
     stage: String,
-    branchMatcher: Option[String],
+    branchMatcher: String,
     trigger: Trigger.Mode,
     user: String,
     lastEdited: DateTime = new DateTime()
 ) {
-  lazy val branchRE =
-    branchMatcher.map(re => "^%s$".format(re).r).getOrElse(".*".r)
+  lazy val branchRE = "^%s$".format(branchMatcher).r
   lazy val buildFilter =
     (build: CIBuild) =>
       build.jobName == projectName && branchRE

--- a/riff-raff/app/controllers/ContinuousDeployController.scala
+++ b/riff-raff/app/controllers/ContinuousDeployController.scala
@@ -34,7 +34,7 @@ class ContinuousDeployController(
       "id" -> uuid,
       "projectName" -> nonEmptyText,
       "stage" -> nonEmptyText,
-      "branchMatcher" -> optional(text),
+      "branchMatcher" -> nonEmptyText,
       "trigger" -> number
     )(ConfigForm.apply)(ConfigForm.unapply)
   )
@@ -57,7 +57,7 @@ class ContinuousDeployController(
             UUID.randomUUID(),
             "",
             "",
-            None,
+            "",
             Trigger.SuccessfulBuild.id
           )
         ),
@@ -126,7 +126,7 @@ object ContinuousDeployController {
       id: UUID,
       projectName: String,
       stage: String,
-      branchMatcher: Option[String],
+      branchMatcher: String,
       trigger: Int
   )
   object ConfigForm {

--- a/riff-raff/app/views/continuousDeployment/list.scala.html
+++ b/riff-raff/app/views/continuousDeployment/list.scala.html
@@ -36,7 +36,7 @@
                 <tr @if(config.trigger == Disabled){ class="danger" }>
                     <td>@utils.DateFormats.Short.print(config.lastEdited) by <span class="label label-default">@config.user</span></td>
                     <td>@config.projectName</td>
-                    <td>@config.branchMatcher.getOrElse("*")</td>
+                    <td>@config.branchMatcher</td>
                     <td>@config.stage</td>
                     <td>@config.trigger match {
                         case SuccessfulBuild => { Build succeeds }

--- a/riff-raff/test/ci/ContinuousDeploymentTest.scala
+++ b/riff-raff/test/ci/ContinuousDeploymentTest.scala
@@ -49,7 +49,11 @@ class ContinuousDeploymentTest extends AnyFlatSpec with Matchers {
       Trigger.SuccessfulBuild,
       "Test user"
     )
-    val cdConfigs = Set(matchingProjectAndBranchEnabled, matchingProjectAndBranchDisabled, wrongProject)
+    val cdConfigs = Set(
+      matchingProjectAndBranchEnabled,
+      matchingProjectAndBranchDisabled,
+      wrongProject
+    )
 
     val params = ContinuousDeployment
       .getMatchesForSuccessfulBuilds(build, cdConfigs)
@@ -107,7 +111,10 @@ class ContinuousDeploymentTest extends AnyFlatSpec with Matchers {
     )
 
     val params = ContinuousDeployment
-      .getMatchesForSuccessfulBuilds(build, Set(projectDoesNotMatch, branchDoesNotMatch, cdDisabled))
+      .getMatchesForSuccessfulBuilds(
+        build,
+        Set(projectDoesNotMatch, branchDoesNotMatch, cdDisabled)
+      )
       .map(ContinuousDeployment.getDeployParams(_))
       .toSet
 
@@ -144,7 +151,10 @@ class ContinuousDeploymentTest extends AnyFlatSpec with Matchers {
     )
 
     val params = ContinuousDeployment
-      .getMatchesForSuccessfulBuilds(build, Set(nonMatchingBranch, matchingBranch))
+      .getMatchesForSuccessfulBuilds(
+        build,
+        Set(nonMatchingBranch, matchingBranch)
+      )
       .map(ContinuousDeployment.getDeployParams(_))
       .toSet
 


### PR DESCRIPTION
## What does this change?

Before, the branch matching defaulted to `.*` when configuring continuous deployment. This is rarely what we want, so make this a required field.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
