### PR TITLE
Add params for locating lambda artefact in S3 match autoscaling

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -189,7 +189,11 @@ trait Lambda extends DeploymentType with BucketParameters {
         else None
     )
 
-    List(prefix, fileName).mkString("/")
+    if (prefix.isEmpty) {
+      fileName
+    } else {
+      List(prefix, fileName).mkString("/")
+    }
   }
 
   def withSsm[T](


### PR DESCRIPTION
## What does this change?

Update the lambda deployment type to allow specifying whether to skip, stack, stage & app prefixed to lambda s3 location. This makes the deployment type more consistent with others (for example `autoscaling`), and is required for. https://github.com/guardian/cdk/pull/1838.

## How to test

Deploy to https://riffraff.code.dev-gutools.co.uk/, and attempt to use this to successfully deploy https://github.com/guardian/birthdays/pull/75, and some existing projects including lambdas to ensure the current behaviour has not changed.

## How can we measure success?

The `googleAuth` option in the `guEc2App` pattern can be used successfully by non-DevX teams.

## Have we considered potential risks?

Changing the lambda delpoyment type may impact existing users, thorough testing is needed!