### PR TITLE
Refactor Fastly tasks, add comment to deployed version

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/Fastly.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Fastly.scala
@@ -1,7 +1,7 @@
 package magenta.deployment_type
 
 import magenta.{DeployParameters, KeyRing}
-import magenta.tasks.UpdateFastlyConfigUtils
+import magenta.tasks.UpdateFastlyConfig
 import software.amazon.awssdk.services.s3.S3Client
 
 object Fastly extends DeploymentType {
@@ -32,7 +32,7 @@ object Fastly extends DeploymentType {
     implicit val deployParameters: DeployParameters = target.parameters
     resources.reporter.verbose(s"Keyring is $keyRing")
     List(
-      UpdateFastlyConfigUtils(pkg.s3Package)(
+      UpdateFastlyConfig(pkg.s3Package)(
         keyRing,
         artifactClient,
         deployParameters

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Fastly.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Fastly.scala
@@ -1,15 +1,17 @@
 package magenta.deployment_type
 
-import magenta.tasks.UpdateFastlyConfig
+import magenta.{DeployParameters, KeyRing}
+import magenta.tasks.UpdateFastlyConfigUtils
+import software.amazon.awssdk.services.s3.S3Client
 
 object Fastly extends DeploymentType {
   val name = "fastly"
-  val documentation =
+  val documentation: String =
     """
       |Deploy a new set of VCL configuration files to the [fastly](https://www.fastly.com/) CDN via the fastly API.
     """.stripMargin
 
-  val deploy = Action(
+  val deploy: Action = Action(
     "deploy",
     """
       |Undertakes the following using the fastly API:
@@ -25,11 +27,18 @@ object Fastly extends DeploymentType {
       | your VCL files to facilitate this.
     """.stripMargin
   ) { (pkg, resources, target) =>
-    implicit val keyRing = resources.assembleKeyring(target, pkg)
-    implicit val artifactClient = resources.artifactClient
+    implicit val keyRing: KeyRing = resources.assembleKeyring(target, pkg)
+    implicit val artifactClient: S3Client = resources.artifactClient
+    implicit val deployParameters: DeployParameters = target.parameters
     resources.reporter.verbose(s"Keyring is $keyRing")
-    List(UpdateFastlyConfig(pkg.s3Package)(keyRing, artifactClient))
+    List(
+      UpdateFastlyConfigUtils(pkg.s3Package)(
+        keyRing,
+        artifactClient,
+        deployParameters
+      )
+    )
   }
 
-  def defaultActions = List(deploy)
+  def defaultActions: List[Action] = List(deploy)
 }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/FastlyCompute.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/FastlyCompute.scala
@@ -93,8 +93,9 @@ object FastlyCompute extends DeploymentType with BucketParameters {
   ) { (pkg, resources, target) =>
     implicit val keyRing: KeyRing = resources.assembleKeyring(target, pkg)
     implicit val artifactClient: S3Client = resources.artifactClient
-    resources.reporter.verbose(s"Keyring is $keyRing")
-    List(UpdateFastlyPackage(pkg.s3Package)(keyRing, artifactClient))
+    implicit val deployParameters = target.parameters
+      resources.reporter.verbose(s"Keyring is $keyRing")
+    List(UpdateFastlyPackage(pkg.s3Package)(keyRing, artifactClient, deployParameters))
   }
 
   def defaultActions: List[Action] = List(uploadArtifacts, deploy)

--- a/magenta-lib/src/main/scala/magenta/deployment_type/FastlyCompute.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/FastlyCompute.scala
@@ -1,7 +1,12 @@
 package magenta.deployment_type
 
 import magenta.{DeployParameters, DeploymentResources, KeyRing, Region}
-import magenta.deployment_type.AutoScaling.{prefixApp, prefixPackage, prefixStack, prefixStage}
+import magenta.deployment_type.AutoScaling.{
+  prefixApp,
+  prefixPackage,
+  prefixStack,
+  prefixStage
+}
 import magenta.tasks.{FastlyComputeTasks, S3Upload, SSM}
 import magenta.tasks.{S3 => S3Tasks}
 import software.amazon.awssdk.services.s3.S3Client

--- a/magenta-lib/src/main/scala/magenta/deployment_type/FastlyCompute.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/FastlyCompute.scala
@@ -94,8 +94,14 @@ object FastlyCompute extends DeploymentType with BucketParameters {
     implicit val keyRing: KeyRing = resources.assembleKeyring(target, pkg)
     implicit val artifactClient: S3Client = resources.artifactClient
     implicit val deployParameters = target.parameters
-      resources.reporter.verbose(s"Keyring is $keyRing")
-    List(UpdateFastlyPackage(pkg.s3Package)(keyRing, artifactClient, deployParameters))
+    resources.reporter.verbose(s"Keyring is $keyRing")
+    List(
+      UpdateFastlyPackage(pkg.s3Package)(
+        keyRing,
+        artifactClient,
+        deployParameters
+      )
+    )
   }
 
   def defaultActions: List[Action] = List(uploadArtifacts, deploy)

--- a/magenta-lib/src/main/scala/magenta/deployment_type/FastlyCompute.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/FastlyCompute.scala
@@ -1,13 +1,8 @@
 package magenta.deployment_type
 
-import magenta.{DeploymentResources, KeyRing, Region}
-import magenta.deployment_type.AutoScaling.{
-  prefixApp,
-  prefixPackage,
-  prefixStack,
-  prefixStage
-}
-import magenta.tasks.{S3Upload, SSM, UpdateFastlyPackage}
+import magenta.{DeployParameters, DeploymentResources, KeyRing, Region}
+import magenta.deployment_type.AutoScaling.{prefixApp, prefixPackage, prefixStack, prefixStage}
+import magenta.tasks.{FastlyComputeTasks, S3Upload, SSM}
 import magenta.tasks.{S3 => S3Tasks}
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.ssm.SsmClient
@@ -93,10 +88,10 @@ object FastlyCompute extends DeploymentType with BucketParameters {
   ) { (pkg, resources, target) =>
     implicit val keyRing: KeyRing = resources.assembleKeyring(target, pkg)
     implicit val artifactClient: S3Client = resources.artifactClient
-    implicit val deployParameters = target.parameters
+    implicit val deployParameters: DeployParameters = target.parameters
     resources.reporter.verbose(s"Keyring is $keyRing")
     List(
-      UpdateFastlyPackage(pkg.s3Package)(
+      FastlyComputeTasks(pkg.s3Package)(
         keyRing,
         artifactClient,
         deployParameters

--- a/magenta-lib/src/main/scala/magenta/tasks/FastlyComputeTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/FastlyComputeTasks.scala
@@ -199,7 +199,7 @@ case class UpdateFastlyPackage(s3Package: S3Path)(implicit
           Project ${parameters.build.projectName}
           Stage ${parameters.stage}
           Build ${parameters.build.id}
-          Deployer${parameters.deployer}
+          Deployer ${parameters.deployer}
           """
         )
       )

--- a/magenta-lib/src/main/scala/magenta/tasks/FastlyComputeTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/FastlyComputeTasks.scala
@@ -138,7 +138,7 @@ case class FastlyComputeTasks(s3Package: S3Path)(implicit
     }
   }
 
-  private def activateVersion(
+  override def activateVersion(
       versionNumber: Int,
       client: FastlyApiClient,
       reporter: DeployReporter,

--- a/magenta-lib/src/main/scala/magenta/tasks/FastlyComputeTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/FastlyComputeTasks.scala
@@ -4,32 +4,24 @@ import java.util.concurrent.Executors
 import com.gu.fastly.api.FastlyApiClient
 import magenta._
 import magenta.artifact.{S3Object, S3Path}
-import play.api.libs.json.Json
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
-import scala.concurrent.duration._
-import scala.concurrent.{
-  Await,
-  ExecutionContext,
-  ExecutionContextExecutorService,
-  Future
-}
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
 import scala.io.Codec.ISO8859
 
-case class UpdateFastlyPackage(s3Package: S3Path)(implicit
+case class FastlyComputeTasks(s3Package: S3Path)(implicit
     val keyRing: KeyRing,
     artifactClient: S3Client,
     parameters: DeployParameters
-) extends Task {
+) extends Task
+    with FastlyUtils {
 
   implicit val ec: ExecutionContextExecutorService =
     ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(10))
-
-  def block[T](f: => Future[T]): T = Await.result(f, 1.minute)
 
   override def execute(
       resources: DeploymentResources,
@@ -63,41 +55,6 @@ case class UpdateFastlyPackage(s3Package: S3Path)(implicit
         .info(
           s"Fastly Compute@Edge service ${client.serviceId} - version $nextVersionNumber is now active"
         )
-    }
-  }
-
-  def stopOnFlag[T](stopFlag: => Boolean)(block: => T): T =
-    if (!stopFlag) block
-    else
-      throw DeployStoppedException(
-        "Deploy manually stopped during UpdateFastlyPackage"
-      )
-
-  private def getActiveVersionNumber(
-      client: FastlyApiClient,
-      reporter: DeployReporter,
-      stopFlag: => Boolean
-  ): Int = {
-    stopOnFlag(stopFlag) {
-      val versionList = block(client.versionList())
-      val versions = Json.parse(versionList.getResponseBody).as[List[Version]]
-      val activeVersion = versions.filter(x => x.active.getOrElse(false)).head
-      reporter.info(s"Current active version ${activeVersion.number}")
-      activeVersion.number
-    }
-  }
-
-  private def clone(
-      versionNumber: Int,
-      client: FastlyApiClient,
-      reporter: DeployReporter,
-      stopFlag: => Boolean
-  ): Int = {
-    stopOnFlag(stopFlag) {
-      val cloned = block(client.versionClone(versionNumber))
-      val clonedVersion = Json.parse(cloned.getResponseBody).as[Version]
-      reporter.info(s"Cloned version ${clonedVersion.number}")
-      clonedVersion.number
     }
   }
 
@@ -178,29 +135,6 @@ case class UpdateFastlyPackage(s3Package: S3Path)(implicit
         }
         reporter.info("Compute@Edge package successfully uploaded to Fastly")
       }
-    }
-  }
-
-  private def commentVersion(
-      versionNumber: Int,
-      client: FastlyApiClient,
-      reporter: DeployReporter,
-      parameters: DeployParameters,
-      stopFlag: => Boolean
-  ): Unit = {
-
-    stopOnFlag(stopFlag) {
-      reporter.info("Adding deployment information")
-      block(
-        client.versionComment(
-          versionNumber,
-          s"""
-          Deployed via Riff-Raff by ${parameters.deployer.name}
-          (${parameters.build.projectName}, ${parameters.stage.name},
-          build ${parameters.build.id})
-          """
-        )
-      )
     }
   }
 

--- a/magenta-lib/src/main/scala/magenta/tasks/FastlyComputeTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/FastlyComputeTasks.scala
@@ -195,11 +195,9 @@ case class UpdateFastlyPackage(s3Package: S3Path)(implicit
         client.versionComment(
           versionNumber,
           s"""
-          Deployed via Riff-Raff
-          Project ${parameters.build.projectName}
-          Stage ${parameters.stage}
-          Build ${parameters.build.id}
-          Deployer ${parameters.deployer}
+          Deployed via Riff-Raff by ${parameters.deployer.name}
+          (${parameters.build.projectName}, ${parameters.stage.name},
+          build ${parameters.build.id})
           """
         )
       )

--- a/magenta-lib/src/main/scala/magenta/tasks/FastlyTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/FastlyTasks.scala
@@ -20,7 +20,7 @@ object Vcl {
   implicit val reads: Reads[Vcl] = Json.reads[Vcl]
 }
 
-case class UpdateFastlyConfigUtils(s3Package: S3Path)(implicit
+case class UpdateFastlyConfig(s3Package: S3Path)(implicit
     val keyRing: KeyRing,
     artifactClient: S3Client,
     parameters: DeployParameters

--- a/magenta-lib/src/main/scala/magenta/tasks/FastlyTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/FastlyTasks.scala
@@ -1,37 +1,34 @@
 package magenta.tasks
 
 import java.util.concurrent.Executors
-
 import com.gu.fastly.api.FastlyApiClient
 import magenta._
 import magenta.artifact.S3Path
-import play.api.libs.json.{JsString, Json}
+import play.api.libs.json.{JsString, Json, Reads}
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 
-import scala.concurrent.duration._
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
 
 case class Version(number: Int, active: Option[Boolean])
 object Version {
-  implicit val reads = Json.reads[Version]
+  implicit val reads: Reads[Version] = Json.reads[Version]
 }
 
 case class Vcl(name: String)
 object Vcl {
-  implicit val reads = Json.reads[Vcl]
+  implicit val reads: Reads[Vcl] = Json.reads[Vcl]
 }
 
-case class UpdateFastlyConfig(s3Package: S3Path)(implicit
+case class UpdateFastlyConfigUtils(s3Package: S3Path)(implicit
     val keyRing: KeyRing,
-    artifactClient: S3Client
-) extends Task {
+    artifactClient: S3Client,
+    parameters: DeployParameters
+) extends Task
+    with FastlyUtils {
 
-  implicit val ec =
+  implicit val ec: ExecutionContextExecutorService =
     ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(10))
-
-  // No, I'm not happy about this, but it gets things working until we can make a larger change
-  def block[T](f: => Future[T]) = Await.result(f, 1.minute)
 
   override def execute(
       resources: DeploymentResources,
@@ -57,45 +54,19 @@ case class UpdateFastlyConfig(s3Package: S3Path)(implicit
         resources.reporter,
         stopFlag
       )
+
+      commentVersion(
+        nextVersionNumber,
+        client,
+        resources.reporter,
+        parameters,
+        stopFlag
+      )
+
       activateVersion(nextVersionNumber, client, resources.reporter, stopFlag)
 
       resources.reporter
         .info(s"Fastly version $nextVersionNumber is now active")
-    }
-  }
-
-  def stopOnFlag[T](stopFlag: => Boolean)(block: => T): T =
-    if (!stopFlag) block
-    else
-      throw new DeployStoppedException(
-        "Deploy manually stopped during UpdateFastlyConfig"
-      )
-
-  private def getActiveVersionNumber(
-      client: FastlyApiClient,
-      reporter: DeployReporter,
-      stopFlag: => Boolean
-  ): Int = {
-    stopOnFlag(stopFlag) {
-      val versionList = block(client.versionList())
-      val versions = Json.parse(versionList.getResponseBody).as[List[Version]]
-      val activeVersion = versions.filter(x => x.active.getOrElse(false))(0)
-      reporter.info(s"Current active version ${activeVersion.number}")
-      activeVersion.number
-    }
-  }
-
-  private def clone(
-      versionNumber: Int,
-      client: FastlyApiClient,
-      reporter: DeployReporter,
-      stopFlag: => Boolean
-  ): Int = {
-    stopOnFlag(stopFlag) {
-      val cloned = block(client.versionClone(versionNumber))
-      val clonedVersion = Json.parse(cloned.getResponseBody).as[Version]
-      reporter.info(s"Cloned version ${clonedVersion.number}")
-      clonedVersion.number
     }
   }
 
@@ -192,7 +163,7 @@ object FastlyApiClientProvider {
       case credentials: ApiStaticCredentials =>
         val serviceId = credentials.id
         val apiKey = credentials.secret
-        new FastlyApiClient(apiKey, serviceId)
+        FastlyApiClient(apiKey, serviceId)
     }
   }
 }

--- a/magenta-lib/src/main/scala/magenta/tasks/FastlyTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/FastlyTasks.scala
@@ -115,7 +115,7 @@ case class UpdateFastlyConfig(s3Package: S3Path)(implicit
     }
   }
 
-  private def activateVersion(
+  override def activateVersion(
       versionNumber: Int,
       client: FastlyApiClient,
       reporter: DeployReporter,

--- a/magenta-lib/src/main/scala/magenta/tasks/FastlyUtils.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/FastlyUtils.scala
@@ -65,4 +65,12 @@ trait FastlyUtils {
       )
     }
   }
+
+  protected def activateVersion(
+      nextVersionNumber: Int,
+      client: FastlyApiClient,
+      deployReporter: DeployReporter,
+      stopFlag: => Boolean
+  ): Unit
+
 }

--- a/magenta-lib/src/main/scala/magenta/tasks/FastlyUtils.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/FastlyUtils.scala
@@ -1,0 +1,68 @@
+package magenta.tasks
+import com.gu.fastly.api.FastlyApiClient
+import magenta.{DeployParameters, DeployReporter, DeployStoppedException}
+import play.api.libs.json.Json
+
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future}
+
+trait FastlyUtils {
+  protected def block[T](f: => Future[T]): T = Await.result(f, 1.minute)
+
+  protected def stopOnFlag[T](stopFlag: => Boolean)(block: => T): T =
+    if (!stopFlag) block
+    else
+      throw DeployStoppedException(
+        "Deploy manually stopped during UpdateFastlyConfig"
+      )
+
+  protected def getActiveVersionNumber(
+      client: FastlyApiClient,
+      reporter: DeployReporter,
+      stopFlag: => Boolean
+  ): Int = {
+    stopOnFlag(stopFlag) {
+      val versionList = block(client.versionList())
+      val versions = Json.parse(versionList.getResponseBody).as[List[Version]]
+      val activeVersion = versions.filter(x => x.active.getOrElse(false)).head
+      reporter.info(s"Current active version ${activeVersion.number}")
+      activeVersion.number
+    }
+  }
+
+  protected def clone(
+      versionNumber: Int,
+      client: FastlyApiClient,
+      reporter: DeployReporter,
+      stopFlag: => Boolean
+  ): Int = {
+    stopOnFlag(stopFlag) {
+      val cloned = block(client.versionClone(versionNumber))
+      val clonedVersion = Json.parse(cloned.getResponseBody).as[Version]
+      reporter.info(s"Cloned version ${clonedVersion.number}")
+      clonedVersion.number
+    }
+  }
+
+  protected def commentVersion(
+      versionNumber: Int,
+      client: FastlyApiClient,
+      reporter: DeployReporter,
+      parameters: DeployParameters,
+      stopFlag: => Boolean
+  ): Unit = {
+    stopOnFlag(stopFlag) {
+      reporter.info("Adding deployment information")
+      block(
+        client.versionComment(
+          versionNumber,
+          s"""
+          Deployed via Riff-Raff by ${parameters.deployer.name}
+          (${parameters.build.projectName}, ${parameters.stage.name},
+          build ${parameters.build.id})
+          """
+        )
+      )
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -47,7 +47,7 @@ object Dependencies {
       "software.amazon.awssdk" % "cloudformation" % Versions.aws,
       "software.amazon.awssdk" % "sts" % Versions.aws,
       "software.amazon.awssdk" % "ssm" % Versions.aws,
-      "com.gu" %% "fastly-api-client" % "0.5.0",
+      "com.gu" %% "fastly-api-client" % "0.6.0",
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % Versions.jackson,
       "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jackson,
       "com.typesafe.play" %% "play-json" % "2.9.4",


### PR DESCRIPTION
## What does this change?

`FastlyTasks` and `FastlyComputeTasks` currently share a few methods. When I introduced `FastlyComputeTasks`, I merely copy-pasted from `FastlyTasks`, but duplication of code is not great, so this PR attempts to fix that.

I have created a trait called `FastlyUtils` which `FastlyTasks` and `FastlyComputeTasks` now extend. It contains the following `protected` methods that are shared by both case classes:

- `block`
- `clone`
- `stopOnFlag`
- `getActiveVersionNumber`
- `commentVersion`
- `activateVersion` (abstract since implementation differs based on deployment type)

In particular, `commentVersion` is a new addition to the PR which is now available to the Fastly API client since v0.6.0. 
It lets Riff-Raff pass deployment information to Fastly, so the latest deployed version of the service now has a descriptive comment for a hopefully better audit trail, not only for Compute@Edge services, but also for traditional services that use VCL.

Apologies if the diff is annoying to read in some places - I have fixed a few IntelliJ warnings, such as giving explicit types to implicits.

Thank you @SHession and @davidfurey for suggesting this feature!

## How to test

I deployed this branch to Riff-Raff code and triggered a `fastly-compute` deployment.

<img width="1062" alt="image" src="https://user-images.githubusercontent.com/57295823/236541889-deec77a7-75eb-4ef7-af86-396f6c3229df.png">
