### PR TITLE
Warn if an AMI cannot be resolved during cloudformation deploy

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
@@ -66,6 +66,7 @@ class CreateChangeSetTask(
 
             val parameters = CloudFormationParameters
               .resolve(
+                resources.reporter,
                 unresolvedParameters,
                 accountNumber,
                 templateParameters,

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -562,6 +562,7 @@ class CloudFormationTest
     )
 
     val params = resolve(
+      reporter,
       cfp,
       "0123456789",
       List(
@@ -595,6 +596,7 @@ class CloudFormationTest
     )
 
     val params = resolve(
+      reporter,
       cfp,
       "0123456789",
       List(
@@ -636,6 +638,7 @@ class CloudFormationTest
     )
 
     val params = resolve(
+      reporter,
       cfp,
       "0123456789",
       List(
@@ -677,6 +680,7 @@ class CloudFormationTest
     )
 
     val params = resolve(
+      reporter,
       cfp,
       "0123456789",
       List(
@@ -717,6 +721,7 @@ class CloudFormationTest
     )
 
     val params = resolve(
+      reporter,
       cfp,
       "0123456789",
       List(


### PR DESCRIPTION
## What does this change?

Displays a warning if an AMI cannot be resolved during a cloudformation deploy. For now this is a warning to see how often this happened, but I think we should upgrade this to an error

## How to test

Deploy to CODE. Attempt to deploy a project that has a missing AMI.