### PR TITLE
Improve keyboard navigation for navbar

### DIFF
--- a/riff-raff/app/views/menu/appmenubar.scala.html
+++ b/riff-raff/app/views/menu/appmenubar.scala.html
@@ -7,7 +7,7 @@
         @if(identity.isDefined) {
             <ul class="btn-group pull-right hidden-xs nav navbar-nav">
                 <li>
-                    <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+                    <a href="#" class="btn-group" role="menu" data-toggle="dropdown" aria-haspopup="true" href="#">
                         <i class="glyphicon glyphicon-user"></i> @identity.get.fullName
                         <span class="caret"></span>
                     </a>
@@ -25,7 +25,7 @@
                 </li>
             </ul>
         }
-        <ul class="nav navbar-nav navbar-collapse collapse">
+        <ul class="nav navbar-nav navbar-collapse collapse d-flex align-items-center">
         @for(item <- menu.menuItems) {
             @menubaritem(request, item)
         }

--- a/riff-raff/app/views/menu/appmenubar.scala.html
+++ b/riff-raff/app/views/menu/appmenubar.scala.html
@@ -4,6 +4,11 @@
 
 @menubar(config){
     @defining(UserIdentity.fromRequest(request)) { identity =>
+        <ul class="nav navbar-nav navbar-collapse collapse d-flex align-items-center">
+            @for(item <- menu.menuItems) {
+                @menubaritem(request, item)
+            }
+        </ul>
         @if(identity.isDefined) {
             <ul class="btn-group pull-right hidden-xs nav navbar-nav">
                 <li>
@@ -25,10 +30,5 @@
                 </li>
             </ul>
         }
-        <ul class="nav navbar-nav navbar-collapse collapse d-flex align-items-center">
-        @for(item <- menu.menuItems) {
-            @menubaritem(request, item)
-        }
-        </ul>
     }
 }

--- a/riff-raff/app/views/menu/menubaritem.scala.html
+++ b/riff-raff/app/views/menu/menubaritem.scala.html
@@ -6,12 +6,12 @@
             <li@if(si.isActive(request)){ class="active"}><a href="@si.target">@si.title</a></li>
         }
         case ddi:DropDownMenuItem => {
-            <li class="dropdown@if(ddi.isActive(request)){ active}">
-                <a role="button" id="@ddi.hashCode" data-toggle="dropdown">@ddi.title <span class="caret"></span></a>
+            <li class="btn-group">
+                <a href="#" class="btn-group" role="menu" id="@ddi.hashCode" data-toggle="dropdown">@ddi.title <span class="caret"></span></a>
                 <ul class="dropdown-menu" role="menu" aria-labelledby="@ddi.hashCode">
-                @ddi.items.map { subItem =>
-                    @menubaritem(request, subItem)
-                }
+                    @ddi.items.map { subItem =>
+                        @menubaritem(request, subItem)
+                    }
                 </ul>
             </li>
         }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The navbar has some keyboard-navigation problems currently - the Configuration and Documentation dropdowns can't be selected by keyboard, and the Profile dropdown is focused before all the other items (with an unclear focus state with no focus ring).

This PR makes two changes to the navbar:
1. Makes the dropdowns keyboard-navigable with a focus ring visible
2. Re-orders the items in the DOM so that the profile dropdown is last (rather than second) - matching how the menu appears visually

## How to test

Run `riff-raff` locally or deploy to CODE according to the [instructions in the readme](https://github.com/guardian/riff-raff/blob/main/CONTRIBUTING.md).

Try navigating the menu with your keyboard. Can you select items with <kbd>enter</kbd> including the dropdowns? Do they show a focus ring?

## Images

| Before | After |
|---|---|
| ![riffraff-menu-before](https://github.com/guardian/riff-raff/assets/34686302/cf8b9c91-3f84-43c1-becf-eaf3fbee25f8) | ![riffraff-menu-after](https://github.com/guardian/riff-raff/assets/34686302/792ceef3-3fba-4f28-875d-7e942edd6c20) |

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [X] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [X] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
