### PR TITLE
Use info instead of error alert style when project never deployed

### DIFF
--- a/riff-raff/app/views/deploy/deployHistory.scala.html
+++ b/riff-raff/app/views/deploy/deployHistory.scala.html
@@ -16,9 +16,9 @@
     <h4>Last deploys of <em>@projectName</em> @maybeStage.map{ stage => to @stage }</h4>
     @snippets.recordTable(records, None, allColumns = false, popOutLink = true)
 } else {
-    <div class="alert alert-danger" role="alert">
+    <div class="alert alert-warning" role="alert">
         <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-        <span class="sr-only">Error:</span>
+        <span class="sr-only">Warning:</span>
         Riff Raff has not been used to deploy @projectName @maybeStage.map{ stage => to @stage }
     </div>
 }

--- a/riff-raff/app/views/deploy/deployHistory.scala.html
+++ b/riff-raff/app/views/deploy/deployHistory.scala.html
@@ -16,9 +16,9 @@
     <h4>Last deploys of <em>@projectName</em> @maybeStage.map{ stage => to @stage }</h4>
     @snippets.recordTable(records, None, allColumns = false, popOutLink = true)
 } else {
-    <div class="alert alert-warning" role="alert">
+    <div class="alert alert-info" role="alert">
         <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-        <span class="sr-only">Warning:</span>
+        <span class="sr-only">Info:</span>
         Riff Raff has not been used to deploy @projectName @maybeStage.map{ stage => to @stage }
     </div>
 }

--- a/riff-raff/app/views/deployTarget/selectVersion.scala.html
+++ b/riff-raff/app/views/deployTarget/selectVersion.scala.html
@@ -9,9 +9,9 @@
         <h4>Last deploys of <em>@targetId.projectName</em> to @stage</h4>
         @snippets.recordTable(records, None, allColumns = false, Some(("", views.html.deployTarget.deployButton.f)))
     } else {
-        <div class="alert alert-danger" role="alert">
+        <div class="alert alert-warning" role="alert">
             <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-            <span class="sr-only">Error:</span>
+            <span class="sr-only">Warning:</span>
             Riff Raff has not been used to deploy @targetId.projectName to @stage
         </div>
     }

--- a/riff-raff/app/views/deployTarget/selectVersion.scala.html
+++ b/riff-raff/app/views/deployTarget/selectVersion.scala.html
@@ -9,9 +9,9 @@
         <h4>Last deploys of <em>@targetId.projectName</em> to @stage</h4>
         @snippets.recordTable(records, None, allColumns = false, Some(("", views.html.deployTarget.deployButton.f)))
     } else {
-        <div class="alert alert-warning" role="alert">
+        <div class="alert alert-info" role="alert">
             <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-            <span class="sr-only">Warning:</span>
+            <span class="sr-only">Info:</span>
             Riff Raff has not been used to deploy @targetId.projectName to @stage
         </div>
     }


### PR DESCRIPTION
## What does this change?

- Changes the visual style of the `Riff Raff has not been used to deploy {{projectName}} to {{stage}}` alert from error to info, as I don't think this is an error state 

## Screenshots

| Before | After |
|--------|--------|
| ![image](https://github.com/guardian/riff-raff/assets/705427/00fa6e3b-f710-4f89-888b-6bcb5f4c1351) | ![image](https://github.com/guardian/riff-raff/assets/705427/b2e06208-70e2-4a4b-a2e5-806379b133f0) |
