### PR TITLE
Add S3 object tags to Lambda artifacts

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -221,7 +221,7 @@ trait Lambda extends DeploymentType with BucketParameters {
         lambda.region,
         s3Bucket,
         Seq(S3Path(pkg.s3Package, lambda.fileName) -> s3Key),
-        lambdaArtifact = true
+        allowDeletionByLifecycleRule = true
       )
     }.distinct
   }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -220,7 +220,8 @@ trait Lambda extends DeploymentType with BucketParameters {
       S3Upload(
         lambda.region,
         s3Bucket,
-        Seq(S3Path(pkg.s3Package, lambda.fileName) -> s3Key)
+        Seq(S3Path(pkg.s3Package, lambda.fileName) -> s3Key),
+        lambdaArtifact = true
       )
     }.distinct
   }

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -42,7 +42,7 @@ case class S3Upload(
     surrogateControlPatterns: List[PatternValue] = Nil,
     extensionToMimeType: Map[String, String] = Map.empty,
     publicReadAcl: Boolean = false,
-    lambdaArtifact: Boolean = false,
+    allowDeletionByLifecycleRule: Boolean = false,
     detailedLoggingThreshold: Int = 10
 )(implicit
     val keyRing: KeyRing,
@@ -72,7 +72,7 @@ case class S3Upload(
       surrogateControlLookup(target.key),
       contentTypeLookup(target.key),
       publicReadAcl = publicReadAcl,
-      lambdaArtifact = lambdaArtifact
+      allowDeletionByLifecycleRule = allowDeletionByLifecycleRule
     )
   }
 
@@ -234,7 +234,7 @@ case class PutReq(
     surrogateControl: Option[String],
     contentType: Option[String],
     publicReadAcl: Boolean,
-    lambdaArtifact: Boolean
+    allowDeletionByLifecycleRule: Boolean
 ) {
   import collection.JavaConverters._
 
@@ -258,8 +258,8 @@ case class PutReq(
       .key(target.key)
       .contentType(mimeType)
       .contentLength(source.size)
-    if (lambdaArtifact) {
-      req.tagging("temporary-lambda-artifact=true")
+    if (allowDeletionByLifecycleRule) {
+      req.tagging("allow-deletion-by-lifecycle-rule=true")
     }
     val reqWithCacheControl = (setCacheControl andThen setsurrogateControl)(req)
     if (publicReadAcl)

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -278,7 +278,8 @@ class AutoScalingTest
         p,
         resource,
         DeployTarget(parameters(), stack, region)
-      ) should matchPattern { case List(S3Upload(_, _, _, _, _, _, false, _)) =>
+      ) should matchPattern {
+      case List(S3Upload(_, _, _, _, _, _, false, false, _)) =>
     }
   }
 

--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
@@ -87,7 +87,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
               "test/123/lambda/test-file.zip"
             ) -> s"test/PROD/lambda/test-file.zip"
           ),
-          lambdaArtifact = true
+          allowDeletionByLifecycleRule = true
         )
       )
     )

--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
@@ -86,7 +86,8 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
               "artifact-bucket",
               "test/123/lambda/test-file.zip"
             ) -> s"test/PROD/lambda/test-file.zip"
-          )
+          ),
+          lambdaArtifact = true
         )
       )
     )

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -46,7 +46,8 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
       cacheControl = None,
       surrogateControl = None,
       contentType = None,
-      publicReadAcl = false
+      publicReadAcl = false,
+      lambdaArtifact = false
     )
 
     val awsRequest = putRec.toAwsRequest
@@ -71,7 +72,8 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
       Some("no-cache"),
       None,
       Some("application/json"),
-      publicReadAcl = false
+      publicReadAcl = false,
+      lambdaArtifact = false
     )
 
     val awsRequest = putRec.toAwsRequest
@@ -90,7 +92,8 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
       Some("no-cache"),
       None,
       None,
-      publicReadAcl = false
+      publicReadAcl = false,
+      lambdaArtifact = false
     )
     val putRecTwo = PutReq(
       MagentaS3Object("artifact-bucket", "foo/bar/foo-bar.xpi", 31),
@@ -98,7 +101,8 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
       Some("no-cache"),
       None,
       None,
-      publicReadAcl = false
+      publicReadAcl = false,
+      lambdaArtifact = false
     )
     val putRecThree = PutReq(
       MagentaS3Object("artifact-bucket", "foo/bar/foo-bar.js", 31),
@@ -106,7 +110,8 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
       Some("no-cache"),
       None,
       None,
-      publicReadAcl = false
+      publicReadAcl = false,
+      lambdaArtifact = false
     )
 
     val awsRequestOne = putRecOne.toAwsRequest
@@ -116,6 +121,34 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
     awsRequestOne.contentType should be("text/css")
     awsRequestTwo.contentType should be("application/octet-stream")
     awsRequestThree.contentType should be("application/javascript")
+  }
+
+  it should "not add any S3 object tags by default" in {
+    val putRec = PutReq(
+      MagentaS3Object("artifact-bucket", "foo/bar/foo-bar.jar", 31),
+      S3Path("artifact-bucket", "foo/bar/the-jar.jar"),
+      Some("no-cache"),
+      None,
+      Some("application/json"),
+      publicReadAcl = false,
+      lambdaArtifact = false
+    )
+    val awsRequest = putRec.toAwsRequest
+    awsRequest.tagging should be(null)
+  }
+
+  it should "not add the correct S3 object tags when building requests for Lambda artifacts" in {
+    val putRec = PutReq(
+      MagentaS3Object("artifact-bucket", "foo/bar/foo-bar.jar", 31),
+      S3Path("artifact-bucket", "foo/bar/the-jar.jar"),
+      Some("no-cache"),
+      None,
+      Some("application/json"),
+      publicReadAcl = false,
+      lambdaArtifact = true
+    )
+    val awsRequest = putRec.toAwsRequest
+    awsRequest.tagging should be("temporary-lambda-artifact=true")
   }
 
   "S3Upload" should "upload a single file to S3" in {

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -47,7 +47,7 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
       surrogateControl = None,
       contentType = None,
       publicReadAcl = false,
-      lambdaArtifact = false
+      allowDeletionByLifecycleRule = false
     )
 
     val awsRequest = putRec.toAwsRequest
@@ -73,7 +73,7 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
       None,
       Some("application/json"),
       publicReadAcl = false,
-      lambdaArtifact = false
+      allowDeletionByLifecycleRule = false
     )
 
     val awsRequest = putRec.toAwsRequest
@@ -93,7 +93,7 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
       None,
       None,
       publicReadAcl = false,
-      lambdaArtifact = false
+      allowDeletionByLifecycleRule = false
     )
     val putRecTwo = PutReq(
       MagentaS3Object("artifact-bucket", "foo/bar/foo-bar.xpi", 31),
@@ -102,7 +102,7 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
       None,
       None,
       publicReadAcl = false,
-      lambdaArtifact = false
+      allowDeletionByLifecycleRule = false
     )
     val putRecThree = PutReq(
       MagentaS3Object("artifact-bucket", "foo/bar/foo-bar.js", 31),
@@ -111,7 +111,7 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
       None,
       None,
       publicReadAcl = false,
-      lambdaArtifact = false
+      allowDeletionByLifecycleRule = false
     )
 
     val awsRequestOne = putRecOne.toAwsRequest
@@ -131,13 +131,13 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
       None,
       Some("application/json"),
       publicReadAcl = false,
-      lambdaArtifact = false
+      allowDeletionByLifecycleRule = false
     )
     val awsRequest = putRec.toAwsRequest
     awsRequest.tagging should be(null)
   }
 
-  it should "not add the correct S3 object tags when building requests for Lambda artifacts" in {
+  it should "add the correct S3 object tags when building requests for Lambda artifacts" in {
     val putRec = PutReq(
       MagentaS3Object("artifact-bucket", "foo/bar/foo-bar.jar", 31),
       S3Path("artifact-bucket", "foo/bar/the-jar.jar"),
@@ -145,10 +145,10 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
       None,
       Some("application/json"),
       publicReadAcl = false,
-      lambdaArtifact = true
+      allowDeletionByLifecycleRule = true
     )
     val awsRequest = putRec.toAwsRequest
-    awsRequest.tagging should be("temporary-lambda-artifact=true")
+    awsRequest.tagging should be("allow-deletion-by-lifecycle-rule=true")
   }
 
   "S3Upload" should "upload a single file to S3" in {


### PR DESCRIPTION
## What does this change?

This PR updates Riff-Raff so that it [tags](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html) Lambda artifacts when it uploads them to S3. 

Lambda artifacts are only needed temporarily[^1] and adding these tags will allow us to more easily cleanup unused Lambda artifacts (using lifecycle rules) in the future:

> Object tags enable fine-grained object lifecycle management in which you can specify a tag-based filter, in addition to a key name prefix, in a lifecycle rule.

The main motivation for adding this capability now is the fact that some teams are planning to start using Lambda versioning. This will mean that we have a lot more Lambda artifacts in our distribution buckets (see https://github.com/guardian/cdk/pull/1925 for more detail).

This change relies on an additional IAM permission which has been added via a separate PR: https://github.com/guardian/riff-raff/pull/1207.

## How to test

Unit tests have been added (and updated) where relevant.

I have [deployed this change to `CODE`](https://riffraff.code.dev-gutools.co.uk/deployment/view/6c7fa932-d693-4567-b561-d37873f23b60) and [successfully deployed a project with uses the `lambda` and `autoscaling` deployment types](https://riffraff.code.dev-gutools.co.uk/deployment/view/bc709355-8482-4415-bdcc-8be244e800eb). 

The Lambda artifact has the expected tag:

![image](https://github.com/guardian/riff-raff/assets/19384074/cd755e71-1199-423c-8dac-8d7aff5fde79)

The EC2 artifact has no tags (as expected):

![image](https://github.com/guardian/riff-raff/assets/19384074/643a21cc-2358-43bb-85d1-6039086c9c2d)

## How can we measure success?

We will be able to implement appropriate retention policies for these artifacts once this PR has been merged.

## Have we considered potential risks?

This PR doesn't introduce any particular risks but implementing the lifecycle rules which delete stuff based on these tags will. I have contacted AWS to confirm that there is no need to retain Lambda code in our own S3 buckets, they said:

> It is safe to delete the deployment package from your S3 bucket once the Lambda function code is successfully update after uploading from your S3 bucket and it will not impact your Lambda function's invocations.


[^1]: AWS manages Lambda code via some [internal storage](https://docs.aws.amazon.com/lambda/latest/operatorguide/code-storage.html), so we only need to temporarily store files in our own distribution buckets whilst the deployment takes place.