### PR TITLE
Order builds by start time, not by build ID

### DIFF
--- a/riff-raff/app/ci/Builds.scala
+++ b/riff-raff/app/ci/Builds.scala
@@ -4,6 +4,7 @@ import akka.agent.Agent
 import ci.Context._
 import controllers.Logging
 import lifecycle.Lifecycle
+import org.joda.time.DateTime
 import rx.lang.scala.Subscription
 
 class Builds(ciBuildPoller: CIBuildPoller) extends Lifecycle with Logging {
@@ -33,7 +34,9 @@ class Builds(ciBuildPoller: CIBuildPoller) extends Lifecycle with Logging {
   val buildsAgent = Agent[Set[CIBuild]](BoundedSet(100000))
   val jobsAgent = Agent[Set[Job]](Set())
   def successfulBuilds(jobName: String): List[CIBuild] =
-    all.filter(_.jobName == jobName).sortBy(-_.id)
+    all
+      .filter(_.jobName == jobName)
+      .sortBy(_.startTime)(Ordering[DateTime].reverse)
   def getLastSuccessful(jobName: String): Option[String] =
     successfulBuilds(jobName).headOption.map { latestBuild =>
       latestBuild.number

--- a/riff-raff/app/ci/CIBuild.scala
+++ b/riff-raff/app/ci/CIBuild.scala
@@ -25,7 +25,8 @@ trait CIBuild {
 }
 
 object CIBuild {
-  implicit val ord = Ordering.by[CIBuild, Long](_.id)
+  implicit val ord: Ordering[CIBuild] =
+    Ordering.by[CIBuild, DateTime](_.startTime)
 }
 
 trait Job {

--- a/riff-raff/test/ci/ContinuousDeploymentTest.scala
+++ b/riff-raff/test/ci/ContinuousDeploymentTest.scala
@@ -151,6 +151,33 @@ class ContinuousDeploymentTest extends AnyFlatSpec with Matchers {
     buildTool = Some("guardian/actions-riff-raff")
   )
 
+  val olderBiggerID = S3Build(
+    2,
+    "tools::deploy",
+    "2",
+    "branch",
+    "71",
+    new DateTime(2023, 6, 27, 14, 42, 14),
+    "",
+    "",
+    buildTool = None
+  )
+  val newerSmallerID = S3Build(
+    1,
+    "tools::deploy",
+    "1",
+    "branch",
+    "71",
+    new DateTime(2023, 6, 27, 14, 43, 14),
+    "",
+    "",
+    buildTool = None
+  )
+
+  it should "order builds by start time (not build ID)" in {
+    List(newerSmallerID, olderBiggerID).max(CIBuild.ord).id should be(1)
+  }
+
   it should "retry until finds success" in {
     var i = 0
     def failingFun = {


### PR DESCRIPTION
With Github Actions, newer builds can have smaller IDs. Therefore Riff Raff should order the builds by their start time for CI: recently there was a bug where continuous deployment deployed an older build twice and didn’t deploy the newest build at all.

The implicit ordering on `CIBuild` was the cause: it’s used in `ContinuousDeployment.buildCandidates` by `GreatestSoFar` to order the builds produced by the poller, and currently orders by build ID. This change uses the build start time instead.

I’ve also changed the ordering used in `Builds.successfulBuilds` to match: I don’t think this is currently used anywhere, but it’s good to be consistent in case it’s used in the future.

Writing a meaningful test of `ContinuousDeployment.buildCandidates` to test the ordering seems like a lot of effort, so I haven’t done it. Hopefully the more basic test added here is useful.
