### PR TITLE
Revert "chore(deps): Non-AWS dependency updates"

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,7 +36,7 @@ object Dependencies {
   val magentaLibDeps =
     commonDeps ++ jacksonOverrides ++ akkaSerializationJacksonOverrides ++ Seq(
       "com.squareup.okhttp3" % "okhttp" % "4.11.0",
-      "ch.qos.logback" % "logback-classic" % "1.4.9",
+      "ch.qos.logback" % "logback-classic" % "1.4.8",
       "software.amazon.awssdk" % "core" % Versions.aws,
       "software.amazon.awssdk" % "autoscaling" % Versions.aws,
       "software.amazon.awssdk" % "s3" % Versions.aws,


### PR DESCRIPTION
Reverts guardian/riff-raff#1227, as this change prevented the app from starting.

I've confirmed this to be true by "redeploying"[^1] the previous build of main (3045), which has resolved the issue.

[^1]: With Riff-Raff being down, it is not possible to deploy Riff-Raff, so I manually copied the artifacts across S3 buckets.