### PR TITLE
ci: Adopt `guardian/actions-riff-raff` in favour of deprecated `sbt-riffraff-artifact`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,16 @@ jobs:
           # The GitHub runner has 7GB of RAM, lets give 4GB to Java.
           # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources.
           JAVA_OPTS: -Xmx4g
-        run: |
-          set -e
-          # Ensure we don't overwrite existing (Teamcity) builds.
-          LAST_TEAMCITY_BUILD=2360
-          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
+        run: sbt clean scalafmtCheckAll scalafmtSbtCheck compile lib/test riffraff/test Universal/packageZipTarball
 
-          # Note, lib/test because riffraff/riffRaffUpload only tests the riffraff project.
-          sbt clean scalafmtCheckAll scalafmtSbtCheck compile lib/test riffraff/riffRaffUpload
+      - uses: guardian/actions-riff-raff@v2
+        with:
+          # Ensure we don't overwrite existing (Teamcity) builds.
+          buildNumberOffset: 2360
+
+          projectName: tools::riffraff
+          configPath: riff-raff/riff-raff.yaml
+          contentDirectories: |
+            riff-raff:
+              - riff-raff/bootstrap.sh
+              - riff-raff/target/universal/riff-raff.tgz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
           java-version: 11
 
       - name: build + test
+        env:
+          # The GitHub runner has 7GB of RAM, lets give 4GB to Java.
+          # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources.
+          JAVA_OPTS: -Xmx4g
         run: |
           set -e
           # Ensure we don't overwrite existing (Teamcity) builds.
@@ -41,4 +45,4 @@ jobs:
           export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
 
           # Note, lib/test because riffraff/riffRaffUpload only tests the riffraff project.
-          ./sbt clean scalafmtCheckAll scalafmtSbtCheck compile lib/test riffraff/riffRaffUpload
+          sbt clean scalafmtCheckAll scalafmtSbtCheck compile lib/test riffraff/riffRaffUpload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           distribution: corretto
           java-version: 11
+          cache: sbt
 
       - name: build + test
         env:

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,4 +1,3 @@
 -J-Xms2048m
 -J-Xmx2048m
 -J-XX:ReservedCodeCacheSize=256m
--J-XX:MaxMetaspaceSize=512M

--- a/build.sbt
+++ b/build.sbt
@@ -45,10 +45,13 @@ lazy val lib = project
     )
   )
 
+def env(propName: String): String =
+  sys.env.get(propName).filter(_.trim.nonEmpty).getOrElse("DEV")
+
 lazy val riffraff = project
   .in(file("riff-raff"))
   .dependsOn(lib % "compile->compile;test->test")
-  .enablePlugins(PlayScala, SbtWeb, BuildInfoPlugin, RiffRaffArtifact)
+  .enablePlugins(PlayScala, SbtWeb, BuildInfoPlugin)
   .settings(commonSettings)
   .settings(
     Seq(
@@ -66,8 +69,11 @@ lazy val riffraff = project
         version,
         scalaVersion,
         sbtVersion,
-        "gitCommitId" -> riffRaffBuildInfo.value.revision,
-        "buildNumber" -> riffRaffBuildInfo.value.buildIdentifier
+
+        // These env vars are set by GitHub Actions
+        // See https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+        "gitCommitId" -> env("GITHUB_SHA"),
+        "buildNumber" -> env("GITHUB_RUN_NUMBER")
       ),
       buildInfoOptions += BuildInfoOption.BuildTime,
       buildInfoPackage := "riffraff",
@@ -82,14 +88,6 @@ lazy val riffraff = project
       ),
       Universal / packageName := normalizedName.value,
       Universal / topLevelDirectory := Some(normalizedName.value),
-      riffRaffPackageType := (Universal / packageZipTarball).value,
-      riffRaffArtifactResources := Seq(
-        riffRaffPackageType.value -> s"${name.value}/${name.value}.tgz",
-        baseDirectory.value / "bootstrap.sh" -> s"${name.value}/bootstrap.sh",
-        baseDirectory.value / "riff-raff.yaml" -> "riff-raff.yaml"
-      ),
-      riffRaffManifestProjectName := "tools::riffraff", // explicitly named for continuity following move from TeamCity to GitHub Actions
-
       ivyXML := {
         <dependencies>
         <exclude org="commons-logging"><!-- Conflicts with acl-over-slf4j in Play. --> </exclude>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.0")
 


### PR DESCRIPTION
## What does this change?
Replaces the deprecated [sbt-riffraff-artifact](https://github.com/guardian/sbt-riffraff-artifact) with [guardian/actions-riff-raff](https://github.com/guardian/actions-riff-raff).

Some related changes are also made, including:
- [Setting up caching](https://github.com/actions/setup-java#caching-packages-dependencies)
- Using the native `sbt` that comes with [actions/setup-java](https://github.com/actions/setup-java)

## How to test
This change should be a no-op in terms of the application. Therefore to test:
- Deploy this branch to CODE
- Observe the app still working

Indeed, I have [done just this](https://riffraff.code.dev-gutools.co.uk/deployment/view/b2a39629-32d1-4288-8b21-f5abcaf351a9).

## How can we measure success?
One less repository using a deprecated library.