### PR TITLE
chore(deps): Configure Scala Steward to ignore `logback-classic`

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,7 +36,7 @@ object Dependencies {
   val magentaLibDeps =
     commonDeps ++ jacksonOverrides ++ akkaSerializationJacksonOverrides ++ Seq(
       "com.squareup.okhttp3" % "okhttp" % "4.11.0",
-      "ch.qos.logback" % "logback-classic" % "1.4.8",
+      "ch.qos.logback" % "logback-classic" % "1.4.8", // scala-steward:off
       "software.amazon.awssdk" % "core" % Versions.aws,
       "software.amazon.awssdk" % "autoscaling" % Versions.aws,
       "software.amazon.awssdk" % "s3" % Versions.aws,


### PR DESCRIPTION
## What does this change?
It appears that later versions of `logback-classic` are not compatible with the version of `play-logback` as on app start, we get:

```log
[error] java.lang.NoSuchMethodError: 'void ch.qos.logback.classic.util.ContextInitializer.configureByResource(java.net.URL)'
[error]         at play.api.libs.logback.LogbackLoggerConfigurator.configure(LogbackLoggerConfigurator.scala:125)
[error]         at play.api.libs.logback.LogbackLoggerConfigurator.init(LogbackLoggerConfigurator.scala:31)
[error]         at play.core.server.DevServerStart$.$anonfun$mainDev$1(DevServerStart.scala:106)
[error]         at play.utils.Threads$.withContextClassLoader(Threads.scala:22)
[error]         at play.core.server.DevServerStart$.mainDev(DevServerStart.scala:76)
[error]         at play.core.server.DevServerStart$.mainDevHttpMode(DevServerStart.scala:50)
[error]         at play.core.server.DevServerStart.mainDevHttpMode(DevServerStart.scala)
[error]         at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error]         at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[error]         at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error]         at java.base/java.lang.reflect.Method.invoke(Method.java:566)
[error]         at play.runsupport.Reloader$.startDevMode(Reloader.scala:306)
[error]         at play.sbt.run.PlayRun$.devModeServer$lzycompute$1(PlayRun.scala:100)
[error]         at play.sbt.run.PlayRun$.devModeServer$1(PlayRun.scala:83)
[error]         at play.sbt.run.PlayRun$.$anonfun$playRunTask$3(PlayRun.scala:107)
[error]         at play.sbt.run.PlayRun$.$anonfun$playRunTask$3$adapted(PlayRun.scala:67)
[error]         at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] stack trace is suppressed; run last Compile / run for the full output
[error] (Compile / run) java.lang.reflect.InvocationTargetException
[error] Total time: 5 s, completed 15 Aug 2023, 08:03:13
```

Configure Scala Steward to ignore it, for now, to avoid noisy PRs. We previously merged #1227, and then reverted in #1228. Scala Steward has now raised #1231, which is a duplicate of #1227.

## How to test
N/A

## How can we measure success?
Fewer PRs.

## Have we considered potential risks?
Should a vulnerability be discovered in `logback-classic` our options might be a little limited. To address this, we should remove logback dependencies from this repository entirely and instead adopt [devx-logs](https://github.com/guardian/devx-logs). This should also resolve [this comment](https://github.com/guardian/riff-raff/blob/dc6a5ce9004eecf5febacf07d6cbb26183776a21/project/Dependencies.scala#L91).

---
Closes #1231.