### PR TITLE
add notification case for `SkippedDueToPreviousPartialDeploy`

### DIFF
--- a/riff-raff/app/notification/FailureNotificationContents.scala
+++ b/riff-raff/app/notification/FailureNotificationContents.scala
@@ -6,7 +6,8 @@ import deployment.{
   NoDeploysFoundForStage,
   ScheduledDeployNotificationError,
   SkippedDueToPreviousFailure,
-  SkippedDueToPreviousWaitingDeploy
+  SkippedDueToPreviousWaitingDeploy,
+  SkippedDueToPreviousPartialDeploy
 }
 import magenta.DeployParameters
 
@@ -68,6 +69,18 @@ class FailureNotificationContents(prefix: String) {
           subject,
           scheduledDeployError.message,
           List(viewProblematicDeploy(record.uuid, "failed"), redeployAction)
+        )
+        NotificationContentsWithTargets(
+          contents,
+          teamTargetsSearch(record.uuid, record.parameters)
+        )
+      case SkippedDueToPreviousPartialDeploy(record) =>
+        val redeployAction =
+          Action("Redeploy manually", deployAgainUrl(record.uuid))
+        val contents = NotificationContents(
+          subject,
+          scheduledDeployError.message,
+          List(viewProblematicDeploy(record.uuid, "partial"), redeployAction)
         )
         NotificationContentsWithTargets(
           contents,


### PR DESCRIPTION
getting match errors....
![image](https://github.com/guardian/riff-raff/assets/19289579/263e71a6-34e4-401a-99bb-774efc9491f3)
...when notifying about `SkippedDueToPreviousPartialDeploy` introduced in https://github.com/guardian/riff-raff/pull/1082

In an ideal world, we could catch such exhaustiveness issues at compile time (beyond the scope of this PR though)