### PR TITLE
fail compile on match exhaustiveness warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,8 @@ val commonSettings = Seq(
   scalaVersion := "2.13.12",
   scalacOptions ++= Seq(
     "-feature",
-    "-language:postfixOps,reflectiveCalls,implicitConversions"
+    "-language:postfixOps,reflectiveCalls,implicitConversions",
+    "-Wconf:cat=other-match-analysis:error"
 //    , "-Xfatal-warnings" TODO: Akka Agents have been deprecated. Once they have been replaced we can re-enable, but that's not trivial
   ),
   Compile / doc / scalacOptions ++= Seq(

--- a/riff-raff/app/controllers/Testing.scala
+++ b/riff-raff/app/controllers/Testing.scala
@@ -258,7 +258,7 @@ class Testing(
     Ok(views.html.test.uuidList(config, menu)(request, allDeploys.take(limit)))
   }
 
-  def S3LatencyList(limit: Int, csv: Boolean) = authAction { implicit request =>
+  def S3LatencyList(csv: Boolean) = authAction { implicit request =>
     val filter = DeployFilter.fromRequest
     val pagination = PaginationView.fromRequest
     val allDeploys = documentStoreConverter

--- a/riff-raff/app/utils/Retriable.scala
+++ b/riff-raff/app/utils/Retriable.scala
@@ -1,8 +1,9 @@
 package utils
 
 import play.api.Logger
-import scala.util.{Try, Success, Failure}
-import scala.annotation.tailrec
+
+import scala.util.{Failure, Success, Try}
+import scala.annotation.{nowarn, tailrec}
 
 trait Retriable {
   def log: Logger
@@ -10,6 +11,7 @@ trait Retriable {
   def retryUpTo[T](maxAttempts: Int, message: Option[String] = None)(
       thunk: => T
   ): Try[T] = {
+    @nowarn // It would fail on the following inputs: Cons(), Empty
     @tailrec def go(s: Stream[Try[T]], n: Int): Try[T] = s match {
       case (f @ Failure(t)) #:: tail =>
         val errorMessage = "Caught exception %s (attempt #%d)".format(

--- a/riff-raff/conf/routes
+++ b/riff-raff/conf/routes
@@ -111,8 +111,8 @@ GET         /testing/reportTestPartial                      controllers.Testing.
 GET         /testing/form                                   controllers.Testing.form
 POST        /testing/formPost                               controllers.Testing.formPost
 GET         /testing/uuidList                               controllers.Testing.uuidList(limit:Int ?= 500)
-GET         /testing/s3Latency                              controllers.Testing.S3LatencyList(limit:Int ?= 10, csv:Boolean=false)
-GET         /testing/s3Latency/csv                          controllers.Testing.S3LatencyList(limit:Int ?= 10, csv:Boolean=true)
+GET         /testing/s3Latency                              controllers.Testing.S3LatencyList(csv:Boolean=false)
+GET         /testing/s3Latency/csv                          controllers.Testing.S3LatencyList(csv:Boolean=true)
 POST        /testing/actionUUID                             controllers.Testing.actionUUID
 GET         /testing/view/:uuid                             controllers.Testing.debugLogViewer(uuid)
 GET         /testing/addStringUUID                          controllers.Testing.transferAllUUIDs


### PR DESCRIPTION
Looks like warnings as errors was turned off in 2017 https://github.com/guardian/riff-raff/commit/38ec8bd7104740529c5238a2b5634c0defddb1a0

This reinstates that but just for match exhaustiveness warnings.

Tested and would've caught the issue in #1082 which needed to be fixed in #1262 (yep 180 PRs later).

FIXES required (before this will compile):

- [x] `app/utils/Retriable.scala:13:58`: match may not be exhaustive. 
`[error] It would fail on the following inputs: Cons(), Empty`
- [x] `conf/routes:114:1`: match may not be exhaustive. 
`[error] It would fail on the following input: (_, _)`

