### PR TITLE
Create a new `service_catalogue` user and schema with views to riff-r…

### DIFF
--- a/riff-raff/conf/evolutions/default/4.sql
+++ b/riff-raff/conf/evolutions/default/4.sql
@@ -10,7 +10,7 @@ CREATE USER service_catalogue;
 -- We dont necessarily need/want all data from riff-raff or want the same table names.
 -- The cloudquery postgres plugin doesn't give many options for filtering for specific tables or renaming.
 -- So create a view for only the tables we want and rename to be more user friendly in service-catalogue.
-CREATE SCHEMA AUTHORIZATION service_catalogue;
+CREATE SCHEMA service_catalogue;
 ALTER USER service_catalogue SET search_path TO service_catalogue;
 
 CREATE VIEW service_catalogue.riffraff_deploys AS SELECT * FROM public.deploy;
@@ -18,6 +18,7 @@ CREATE VIEW service_catalogue.riffraff_deploy_logs AS SELECT * FROM public.deplo
 CREATE VIEW service_catalogue.riffraff_authorized_users AS SELECT * FROM public.auth;
 
 REVOKE ALL ON ALL TABLES IN SCHEMA public FROM service_catalogue;
+GRANT USAGE ON SCHEMA service_catalogue TO service_catalogue;
 GRANT SELECT ON ALL TABLES IN SCHEMA service_catalogue TO service_catalogue;
 
 -- !Downs

--- a/riff-raff/conf/evolutions/default/4.sql
+++ b/riff-raff/conf/evolutions/default/4.sql
@@ -1,0 +1,29 @@
+-- Read only user for sourcing service-catalogue data
+
+-- !Ups
+
+-- We cant check-in a password for this user in VCS... for reasons that I hope are fairly obvious!
+-- Therefore after deployment a password must be manually set using the below query
+-- ALTER USER service_catalogue PASSWORD 'new-password'
+CREATE USER service_catalogue;
+
+-- We dont necessarily need/want all data from riff-raff or want the same table names.
+-- The cloudquery postgres plugin doesn't give many options for filtering for specific tables or renaming.
+-- So create a view for only the tables we want and rename to be more user friendly in service-catalogue.
+CREATE SCHEMA AUTHORIZATION service_catalogue;
+ALTER USER service_catalogue SET search_path TO service_catalogue;
+
+CREATE VIEW service_catalogue.riffraff_deploys AS SELECT * FROM public.deploy;
+CREATE VIEW service_catalogue.riffraff_deploy_logs AS SELECT * FROM public.deploylog;
+CREATE VIEW service_catalogue.riffraff_authorized_users AS SELECT * FROM public.auth;
+
+REVOKE ALL ON ALL TABLES IN SCHEMA public FROM service_catalogue;
+GRANT SELECT ON ALL TABLES IN SCHEMA service_catalogue TO service_catalogue;
+
+-- !Downs
+
+DROP VIEW service_catalogue.riffraff_deploys;
+DROP VIEW service_catalogue.riffraff_deploy_logs;
+DROP VIEW service_catalogue.riffraff_authorized_users;
+DROP SCHEMA service_catalogue;
+DROP USER service_catalogue;


### PR DESCRIPTION
## What does this change?

Creates a new `service_catalogue` DB user with access to the `service_catalogue` schema.

We'll be using this new user and views to source riffraff data into our Service Catalogue CloudQuery tables.

## How to test

1. Run riff-raff locally
2. Connect to local DB as `riffraff`
3. Run `ALTER USER service_catalogue PASSWORD 'password';
4. Connect to local DB as `service_catalogue` and the newly set `password` password.
5. Run:

`SELECT * FROM service_catalogue.riffraff_deploys` should run sucessfully
`SELECT * FROM public.deploy` should fail with a permissions error.

<img width="467" alt="image" src="https://github.com/guardian/riff-raff/assets/21217225/84f319c8-7397-49dd-aeaf-915e1b9bf1c4">

<img width="389" alt="image" src="https://github.com/guardian/riff-raff/assets/21217225/a4fd3081-8f29-42df-a6ef-fa390d43233d">

## Before Deployment / Merge

1. Rotate Master credentials on Riff Raff DB and make a note of them
2. SSH onto a riff-raff node to setup a tunnel to the DB `eval $(ssm ssh --profile deployTools -t riff-raff,deploy,(STAGE) --raw --newest) -L (riff raff DB port):(riff raff DB host):(riff raff DB port)`
3. Connect to riff-raff DB and run `ALTER USER (riff raff app username) CREATEROLE;`
    4. 
