### PR TITLE
fix: Report build number correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,15 @@ jobs:
           java-version: 11
           cache: sbt
 
+      # Seed the build number with last number from TeamCity.
+      # This env var is used by the SBT build, and guardian/actions-riff-raff.
+      # Set the value early, rather than `buildNumberOffset` in guardian/actions-riff-raff, to ensure each usage has the same number.
+      # For some reason, it's not possible to mutate GITHUB_RUN_NUMBER, so set BUILD_NUMBER instead.
+      - name: Set BUILD_NUMBER environment variable
+        run: |
+          LAST_TEAMCITY_BUILD=2360
+          echo "BUILD_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))" >> $GITHUB_ENV
+
       - name: build + test
         env:
           # The GitHub runner has 7GB of RAM, lets give 4GB to Java.
@@ -43,9 +52,7 @@ jobs:
 
       - uses: guardian/actions-riff-raff@v2
         with:
-          # Ensure we don't overwrite existing (Teamcity) builds.
-          buildNumberOffset: 2360
-
+          buildNumber: ${{ env.BUILD_NUMBER }}
           projectName: tools::riffraff
           configPath: riff-raff/riff-raff.yaml
           contentDirectories: |

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ lazy val riffraff = project
         // These env vars are set by GitHub Actions
         // See https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
         "gitCommitId" -> env("GITHUB_SHA"),
-        "buildNumber" -> env("GITHUB_RUN_NUMBER")
+        "buildNumber" -> env("BUILD_NUMBER")
       ),
       buildInfoOptions += BuildInfoOption.BuildTime,
       buildInfoPackage := "riffraff",


### PR DESCRIPTION
## What does this change?
We're currently using the environment variable `GITHUB_RUN_NUMBER` to determine the build number for build info. `GITHUB_RUN_NUMBER` is not offset by the number of builds of this project previously performed by TeamCity.

This change creates a new environment variable `BUILD_NUMBER` which is `GITHUB_RUN_NUMBER` + the TeamCity offset.

The screenshot below taken from PROD, suggests we're running build 804, when in fact we are running [build 3164](https://github.com/guardian/riff-raff/actions/runs/6719327251) (804 + 2360).

![image](https://github.com/guardian/riff-raff/assets/836140/b647ba8b-24e9-472f-b72e-80e512c1d1b1)

When [deployed to CODE](https://riffraff.code.dev-gutools.co.uk/deployment/view/5396486b-b4ef-4044-b98c-56bd72d90845), we get the correct number:

![image](https://github.com/guardian/riff-raff/assets/836140/6df7e07b-1d94-4a10-8d9a-40ce0ee75b2c)

---
Builds on https://github.com/guardian/riff-raff/pull/1229.
Inspired by https://github.com/guardian/flexible-content/pull/4382.