### PR TITLE
Ash/vulns

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val aws = "2.20.147"
+    val aws = "2.21.15"
     val jackson = "2.15.2"
     val awsRds = "1.12.578"
     val enumeratumPlay = "1.7.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -79,7 +79,7 @@ object Dependencies {
       "software.amazon.awssdk" % "dynamodb" % Versions.aws,
       "software.amazon.awssdk" % "sns" % Versions.aws,
       "org.quartz-scheduler" % "quartz" % "2.3.2",
-      "com.gu" %% "anghammarad-client" % "1.8.0",
+      "com.gu" %% "anghammarad-client" % "1.8.1",
       "org.webjars" %% "webjars-play" % "2.8.18",
       "org.webjars" % "jquery" % "3.7.1",
       "org.webjars" % "jquery-ui" % "1.13.2",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
 
   val magentaLibDeps =
     commonDeps ++ jacksonOverrides ++ akkaSerializationJacksonOverrides ++ Seq(
-      "com.squareup.okhttp3" % "okhttp" % "4.11.0",
+      "com.squareup.okhttp3" % "okhttp" % "4.12.0",
       "ch.qos.logback" % "logback-classic" % "1.4.8", // scala-steward:off
       "software.amazon.awssdk" % "core" % Versions.aws,
       "software.amazon.awssdk" % "autoscaling" % Versions.aws,


### PR DESCRIPTION
## What does this change?

- Bumps AWS 2.X dependencies to `2.21.15`
- Bumps okhttp to `4.12.0`
- Bumps anghammarad-client to `1.8.1

Resolves 2 high vulnerabilities.

## Before

<img width="665" alt="image" src="https://github.com/guardian/riff-raff/assets/21217225/54106f3f-564c-40ec-8607-fb73719c3484">


## After

<img width="675" alt="image" src="https://github.com/guardian/riff-raff/assets/21217225/7851b564-8122-4ce8-b239-4088be64edac">


## How to test

`sbt test`