### PR TITLE
use a correct url to the guardian

### DIFF
--- a/riff-raff/app/views/page.scala.html
+++ b/riff-raff/app/views/page.scala.html
@@ -49,7 +49,7 @@
             <p>
                 <a href="https://github.com/guardian/deploy">
                     <i>Riff Raff</i>
-                </a> is part of <a href="https://www.grauniad.co.uk">The Grauniad's</a> deployment toolset.
+                </a> is part of <a href="http://www.grauniad.co.uk/">The Grauniad's</a> deployment toolset.
                 <br><small>I would like, if I may, to take you on a strange journey.</small><small class="pull-right">Build @config.version (started @config.startTimeString)</small>
             </p>
         </footer>


### PR DESCRIPTION
At the moment url `https://www.grauniad.co.uk` is not correctly resolving. This change move to using the non `s` url to the guardian.com. Note that we should revert to the `s` url if one day we resolve the DNS problems. @mxdvl pointed this out here: https://github.com/guardian/domains-platform/issues/89