### PR TITLE
feat: Enable deep-linking to deployment form

### DIFF
--- a/riff-raff/app/controllers/DeployController.scala
+++ b/riff-raff/app/controllers/DeployController.scala
@@ -50,7 +50,10 @@ class DeployController(
   def deploy = AuthAction { implicit request =>
     Ok(
       views.html.deploy
-        .form(config, menu)(changeFreeze)(DeployParameterForm.form, prismLookup)
+        .form(config, menu)(changeFreeze)(
+          DeployParameterForm.form.bindFromRequest(),
+          prismLookup
+        )
     )
   }
 


### PR DESCRIPTION
## What does this change?
This change allows supplying query strings to fill in the deployment request form.

For example: `/deployment/request?project=deploy::service-catalogue&build=2000&stage=CODE&updateStrategy=MostlyHarmless`.

This change changes the UX of the `/deployment/request` (no query string) from:

<img width="547" alt="image" src="https://github.com/guardian/riff-raff/assets/836140/91fa7e0f-2e67-47da-8b12-3fac88a3bfc2">

To:
<img width="555" alt="image" src="https://github.com/guardian/riff-raff/assets/836140/8f838bec-265a-4950-b5a9-12249d7f2713">

This does not impact behaviour, but it might cause confusion?

## How to test
TBD.

## How can we measure success?
This change would allow https://github.com/guardian/actions-riff-raff to produce a "Deploy now" link, extending the functionality added in https://github.com/guardian/actions-riff-raff/pull/20.