### PR TITLE
Bump logback-classic to 1.4.14

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,7 +36,7 @@ object Dependencies {
   val magentaLibDeps =
     commonDeps ++ jacksonOverrides ++ akkaSerializationJacksonOverrides ++ Seq(
       "com.squareup.okhttp3" % "okhttp" % "4.12.0",
-      "ch.qos.logback" % "logback-classic" % "1.4.8", // scala-steward:off
+      "ch.qos.logback" % "logback-classic" % "1.4.14", // scala-steward:off
       "software.amazon.awssdk" % "core" % Versions.aws,
       "software.amazon.awssdk" % "autoscaling" % Versions.aws,
       "software.amazon.awssdk" % "s3" % Versions.aws,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Bumps logback-classic to 1.4.14. Resolving 4 high vulnerabilities.