### PR TITLE
Replace `akka-agent` package with a more minimalistic homebrew version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,7 +72,6 @@ object Dependencies {
       "com.gu.play-googleauth" %% "play-v28" % "2.2.7",
       "com.gu.play-secret-rotation" %% "play-v28" % "0.38",
       "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "0.38",
-      "com.typesafe.akka" %% "akka-agent" % "2.5.32",
       "org.pegdown" % "pegdown" % "1.6.0",
       "com.adrianhurt" %% "play-bootstrap" % "1.6.1-P28-B3", // scala-steward:off,
       "org.scanamo" %% "scanamo" % "1.0.0-M11", // scala-steward:off,

--- a/riff-raff/app/ci/Builds.scala
+++ b/riff-raff/app/ci/Builds.scala
@@ -1,10 +1,10 @@
 package ci
 
-import akka.agent.Agent
 import ci.Context._
 import controllers.Logging
 import lifecycle.Lifecycle
 import rx.lang.scala.Subscription
+import utils.Agent
 
 class Builds(ciBuildPoller: CIBuildPoller) extends Lifecycle with Logging {
 
@@ -20,8 +20,8 @@ class Builds(ciBuildPoller: CIBuildPoller) extends Lifecycle with Logging {
     }
   )
 
-  def jobs: Iterable[Job] = jobsAgent.get()
-  def all: List[CIBuild] = buildsAgent.get().toList
+  def jobs: Iterable[Job] = jobsAgent()
+  def all: List[CIBuild] = buildsAgent().toList
   def build(project: String, number: String) =
     all.find(b => b.jobName == project && b.number == number)
   def buildFromRevision(project: String, revision: String) = all.find {

--- a/riff-raff/app/deployment/DeploymentEngine.scala
+++ b/riff-raff/app/deployment/DeploymentEngine.scala
@@ -1,15 +1,14 @@
 package deployment
 
 import java.util.UUID
-
 import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
-import akka.agent.Agent
 import com.typesafe.config.ConfigFactory
 import conf.Config
 import controllers.Logging
 import deployment.actors.{DeployCoordinator, DeployGroupRunner, TasksRunner}
 import magenta.deployment_type.DeploymentType
 import resources.PrismLookup
+import utils.Agent
 
 import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext

--- a/riff-raff/app/deployment/Deployments.scala
+++ b/riff-raff/app/deployment/Deployments.scala
@@ -3,7 +3,6 @@ package deployment
 import java.util.UUID
 
 import akka.actor.ActorSystem
-import akka.agent.Agent
 import akka.util.Switch
 import ci._
 import controllers.Logging
@@ -16,6 +15,7 @@ import play.api.MarkerContext
 import restrictions.RestrictionChecker
 import rx.lang.scala.{Observable, Subject, Subscription}
 import utils.VCSInfo
+import utils.Agent
 
 import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._

--- a/riff-raff/app/deployment/actors/DeployCoordinator.scala
+++ b/riff-raff/app/deployment/actors/DeployCoordinator.scala
@@ -1,7 +1,6 @@
 package deployment.actors
 
 import java.util.UUID
-
 import akka.actor.SupervisorStrategy.Stop
 import akka.actor.{
   Actor,
@@ -10,9 +9,9 @@ import akka.actor.{
   OneForOneStrategy,
   Terminated
 }
-import akka.agent.Agent
 import controllers.Logging
 import deployment.Record
+import utils.Agent
 
 import scala.collection.mutable.ListBuffer
 import scala.util.control.NonFatal

--- a/riff-raff/app/deployment/actors/DeployGroupRunner.scala
+++ b/riff-raff/app/deployment/actors/DeployGroupRunner.scala
@@ -1,7 +1,6 @@
 package deployment.actors
 
 import java.util.UUID
-
 import akka.actor.SupervisorStrategy.Stop
 import akka.actor.{
   Actor,
@@ -10,7 +9,6 @@ import akka.actor.{
   OneForOneStrategy,
   Terminated
 }
-import akka.agent.Agent
 import cats.data.Validated.{Invalid, Valid}
 import conf.Config
 import controllers.Logging
@@ -37,6 +35,7 @@ import resources.PrismLookup
 import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
 import magenta.input.RiffRaffYamlReader
+import utils.Agent
 
 class DeployGroupRunner(
     config: Config,

--- a/riff-raff/app/deployment/actors/TasksRunner.scala
+++ b/riff-raff/app/deployment/actors/TasksRunner.scala
@@ -1,13 +1,12 @@
 package deployment.actors
 
 import java.util.UUID
-
 import akka.actor.Actor
-import akka.agent.Agent
 import controllers.Logging
 import magenta.{DeployReporter, DeployStoppedException, DeploymentResources}
 import magenta.graph.DeploymentTasks
 import org.joda.time.DateTime
+import utils.Agent
 
 import scala.util.control.NonFatal
 

--- a/riff-raff/app/utils/Agent.scala
+++ b/riff-raff/app/utils/Agent.scala
@@ -1,0 +1,73 @@
+package utils
+
+import java.util.concurrent.Semaphore
+import java.util.function.UnaryOperator
+import scala.concurrent.{ExecutionContext, Future}
+
+/** Minimalistic re-implementation of the deperecated akka-agent package to
+  * handle modification of simple state across multiple threads.
+  *
+  * Only functions that riff-raff require have been re-implemented. I've not
+  * based this implementation on the original implementation and have opted to
+  * use Java native libraries to handle locks.
+  *
+  * @param initialState
+  *   initial state to initialize the agent with
+  */
+class Agent[T](initialState: T)(implicit ec: ExecutionContext) {
+
+  // Semaphore (in this case a Binary Semaphore) handles locks on a first-in-first-out basis,
+  // similar to how Actors (and previously Agents) handle incoming messages. This ensures that state is accessed fairly
+  // and in order of first come first served.
+  private def lock = new Semaphore(1, true)
+  var state = initialState
+
+  /** Immediately return state without waiting on locks. This is not thread
+    * safe, and should only be used for reading state.
+    *
+    * @return
+    *   the current state of the agent
+    */
+  def apply(): T = state
+
+  /** Queue an operation to be done to the state and block until completed
+    *
+    * @param operation
+    *   action to be performed on the state
+    */
+  def send(operation: UnaryOperator[T]): Unit = {
+    lock.acquire()
+    try {
+      state = operation(state)
+    } finally {
+      lock.release()
+    }
+  }
+
+  /** Queue an operation to be done asynchronously to the state
+    *
+    * @param operation
+    *   action to be performed on the state
+    */
+  def sendOff(operation: UnaryOperator[T]): Unit = {
+    Future {
+      send(operation)
+    }
+  }
+
+  /** Queue to receive the state once all operations are completed
+    *
+    * @return
+    *   the current state of the agent
+    */
+  def future(): Future[T] = Future {
+    lock.acquire()
+    lock.release()
+    state
+  }
+}
+
+object Agent {
+  def apply[T](initialState: T)(implicit ec: ExecutionContext) =
+    new Agent[T](initialState)
+}

--- a/riff-raff/app/utils/ScheduledAgent.scala
+++ b/riff-raff/app/utils/ScheduledAgent.scala
@@ -1,7 +1,6 @@
 package utils
 
 import akka.actor.{Cancellable, ActorSystem}
-import akka.agent.Agent
 import controllers.Logging
 import lifecycle.Lifecycle
 import scala.concurrent.duration._

--- a/riff-raff/test/deployment/actors/DeployCoordinatorTest.scala
+++ b/riff-raff/test/deployment/actors/DeployCoordinatorTest.scala
@@ -1,9 +1,7 @@
 package deployment.actors
 
 import java.util.UUID
-
 import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
-import akka.agent.Agent
 import akka.testkit.{TestActorRef, TestKit, TestProbe}
 import com.typesafe.config.ConfigFactory
 import deployment.{Fixtures, Record}
@@ -11,6 +9,7 @@ import org.mockito.MockitoSugar
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
+import utils.Agent
 
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable

--- a/riff-raff/test/deployment/actors/DeployGroupRunnerTest.scala
+++ b/riff-raff/test/deployment/actors/DeployGroupRunnerTest.scala
@@ -2,7 +2,6 @@ package deployment.actors
 
 import java.util.UUID
 import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
-import akka.agent.Agent
 import akka.testkit.{TestActorRef, TestKit, TestProbe}
 import conf.Config
 import deployment.{Fixtures, Record}
@@ -11,6 +10,7 @@ import org.joda.time.DateTime
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import play.api.Configuration
+import utils.Agent
 
 import scala.concurrent.ExecutionContext.Implicits.global
 


### PR DESCRIPTION
## What does this change?

Replaces `akka-agent` with a more minimalistic implementation (only has the functions required for riff-raff) powered by Semaphore.

`akka-agent` was deprecated and removed in Akka 2.5, and definitely hasn't been re-added in Pekko so we need to replace this library before we can move to Play 3.

## How to test

Deploy to CODE.

## Have we considered potential risks?

Agents are used extensively in riff-raff for everything from scheduled builds to deployment history. Should this break it might cause a lot of issues in riff-raff.

Theres also a risk of deadlocks now (which may have existed in the previous implementation) if an Agent tries to modify itself during a send operation, eg

```java
agent.send(() => {
   // Lock already acquired by the previous send and not released yet
   agent.send(...)
})
```

The alternative would be to re-implement a lot of riff-raffs functionality using Actors, which is similarly risky(and a lot of work)!

Things seem fine in CODE

<img width="1294" alt="image" src="https://github.com/guardian/riff-raff/assets/21217225/f0476134-9b34-4279-b9b2-7042a17706be">


## Images

It runs! (atleast locally)

<img width="2056" alt="image" src="https://github.com/guardian/riff-raff/assets/21217225/ec95e138-2609-43f3-83d5-7d95b04c8488">
