### PR TITLE
fix: Fail a deployment if an AMI cannot be located

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -214,7 +214,7 @@ object CloudFormationParameters {
           )
         if (ami.isEmpty) {
           val tagsStr = tags.map { case (k, v) => s"$k: $v" }.mkString(", ")
-          reporter.warning(
+          reporter.fail(
             s"Failed to resolve AMI for parameter $name in account $accountNumber with tags $tagsStr"
           )
         }


### PR DESCRIPTION
## What does this change?
Extends the changes of https://github.com/guardian/riff-raff/pull/1141, converting a warning to a failure. With this change, if an AMI cannot be found the deployment is stopped, and marked as failed.

![image](https://github.com/guardian/cdk-playground/assets/836140/90641fa9-18b4-48da-abcf-5cad6acc137c)

## How to test
- [Deploy to CODE](https://riffraff.code.dev-gutools.co.uk/deployment/view/0cae408b-64cb-458b-83de-127a662ad17e)
- Deploy a project that references a non-existent AMI (e.g https://github.com/guardian/cdk-playground/pull/418)