### PR TITLE
Play 3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,19 +7,18 @@ object Dependencies {
     val aws = "2.21.41"
     val jackson = "2.15.2"
     val awsRds = "1.12.629"
-    val enumeratumPlay = "1.7.3"
+    val enumeratumPlay = "1.8.0"
   }
 
   // https://github.com/orgs/playframework/discussions/11222
+  // We no longer have any vulnerabilities through Jackson but still need to define jackson dependencies.
+  // Jackson does not like having different versions of its packages installed.
   private val jacksonOverrides = Seq(
     "com.fasterxml.jackson.core" % "jackson-core",
     "com.fasterxml.jackson.core" % "jackson-annotations",
+    "com.fasterxml.jackson.core" % "jackson-databind",
     "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8",
     "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310",
-    "com.fasterxml.jackson.core" % "jackson-databind"
-  ).map(_ % Versions.jackson)
-
-  private val akkaSerializationJacksonOverrides = Seq(
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor",
     "com.fasterxml.jackson.module" % "jackson-module-parameter-names",
     "com.fasterxml.jackson.module" %% "jackson-module-scala"
@@ -34,9 +33,8 @@ object Dependencies {
   )
 
   val magentaLibDeps =
-    commonDeps ++ jacksonOverrides ++ akkaSerializationJacksonOverrides ++ Seq(
+    commonDeps ++ jacksonOverrides ++ Seq(
       "com.squareup.okhttp3" % "okhttp" % "4.12.0",
-      "ch.qos.logback" % "logback-classic" % "1.4.8", // scala-steward:off
       "software.amazon.awssdk" % "core" % Versions.aws,
       "software.amazon.awssdk" % "autoscaling" % Versions.aws,
       "software.amazon.awssdk" % "s3" % Versions.aws,
@@ -49,8 +47,6 @@ object Dependencies {
       "software.amazon.awssdk" % "ssm" % Versions.aws,
       "com.gu" %% "fastly-api-client" % "0.6.0",
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % Versions.jackson,
-      "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jackson,
-      "com.typesafe.play" %% "play-json" % "2.10.1",
       "com.beachape" %% "enumeratum-play-json" % Versions.enumeratumPlay,
       "com.google.apis" % "google-api-services-deploymentmanager" % "v2-rev20230921-2.0.0",
       "com.google.cloud" % "google-cloud-storage" % "2.28.0",
@@ -66,13 +62,12 @@ object Dependencies {
     )
 
   val riffRaffDeps =
-    commonDeps ++ jacksonOverrides ++ akkaSerializationJacksonOverrides ++ Seq(
+    commonDeps ++ jacksonOverrides ++ Seq(
       evolutions,
       jdbc,
-      "com.gu.play-googleauth" %% "play-v28" % "2.2.7",
-      "com.gu.play-secret-rotation" %% "play-v28" % "0.38",
-      "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "0.38",
-      "com.typesafe.akka" %% "akka-agent" % "2.5.32",
+      "com.gu.play-googleauth" %% "play-v30" % "3.0.6",
+      "com.gu.play-secret-rotation" %% "play-v30" % "6.0.8",
+      "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "6.0.8",
       "org.pegdown" % "pegdown" % "1.6.0",
       "com.adrianhurt" %% "play-bootstrap" % "1.6.1-P28-B3", // scala-steward:off,
       "org.scanamo" %% "scanamo" % "1.0.0-M11", // scala-steward:off,
@@ -80,24 +75,23 @@ object Dependencies {
       "software.amazon.awssdk" % "sns" % Versions.aws,
       "org.quartz-scheduler" % "quartz" % "2.3.2",
       "com.gu" %% "anghammarad-client" % "1.8.1",
-      "org.webjars" %% "webjars-play" % "2.8.18",
+      "org.webjars" %% "webjars-play" % "3.0.0",
       "org.webjars" % "jquery" % "3.7.1",
       "org.webjars" % "jquery-ui" % "1.13.2",
       "org.webjars" % "bootstrap" % "3.4.1", // scala-steward:off
       "org.webjars" % "jasny-bootstrap" % "3.1.3-2", // scala-steward:off
       "org.webjars" % "momentjs" % "2.29.4",
       "net.logstash.logback" % "logstash-logback-encoder" % "7.4",
-      // Similar to logback-classic, update when Play supports logback 1.3+ / SLF4J 2+
-      "org.slf4j" % "jul-to-slf4j" % "1.7.36", // scala-steward:off
-      // We can't update this to 4.0.0 due to an incompatibility with Play 2.8.x, attempt to update along with Play
       "org.scalikejdbc" %% "scalikejdbc" % "3.5.0", // scala-steward:off
       "org.postgresql" % "postgresql" % "42.6.0",
       "com.beachape" %% "enumeratum-play" % Versions.enumeratumPlay,
       filters,
       ws,
-      // We can't update this to 4.0.0 due to an incompatibility with Play 2.8.x, attempt to update along with Play
-      "com.typesafe.akka" %% "akka-testkit" % "2.6.21" % Test,
-      "com.amazonaws" % "aws-java-sdk-rds" % Versions.awsRds
+      "org.apache.pekko" %% "pekko-testkit" % "1.0.1" % Test,
+      "com.amazonaws" % "aws-java-sdk-rds" % Versions.awsRds,
+      "org.scala-stm" %% "scala-stm" % "0.11.1",
+      // Play 3.0 currently uses logback-classic 1.4.11 which is vulnerable to CVE-2023-45960
+      "ch.qos.logback" % "logback-classic" % "1.4.14"
     ).map((m: ModuleID) =>
       // don't even ask why I need to do this
       m.excludeAll(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // keep in sync with the play version in Dependencies
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.2")

--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -29,7 +29,8 @@ import play.api.BuiltInComponentsFromContext
 import play.api.db.evolutions.EvolutionsComponents
 import play.api.db.{DBComponents, HikariCPComponents}
 import play.api.http.DefaultHttpErrorHandler
-import play.api.i18n.I18nComponents
+import play.api.i18n.{I18nComponents, MessagesApi}
+import play.api.libs.ws.WSClient
 import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.Results.InternalServerError
 import play.api.mvc.{AnyContent, RequestHeader, Result}

--- a/riff-raff/app/ci/Builds.scala
+++ b/riff-raff/app/ci/Builds.scala
@@ -1,6 +1,6 @@
 package ci
 
-import akka.agent.Agent
+import org.apache.pekko.agent.Agent
 import ci.Context._
 import controllers.Logging
 import lifecycle.Lifecycle

--- a/riff-raff/app/ci/Context.scala
+++ b/riff-raff/app/ci/Context.scala
@@ -1,6 +1,6 @@
 package ci
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 
 object Context {
   val actorSystem = ActorSystem("build-agents")

--- a/riff-raff/app/controllers/DeployController.scala
+++ b/riff-raff/app/controllers/DeployController.scala
@@ -2,8 +2,8 @@ package controllers
 
 import java.net.{URLDecoder, URLEncoder}
 import java.util.UUID
-import akka.stream.scaladsl.{Source, StreamConverters}
-import akka.util.ByteString
+import org.apache.pekko.stream.scaladsl.{Source, StreamConverters}
+import org.apache.pekko.util.ByteString
 import cats.syntax.either._
 import ci.{Builds, S3Tag, TagClassification}
 import com.gu.googleauth.AuthAction

--- a/riff-raff/app/deployment/DeploymentEngine.scala
+++ b/riff-raff/app/deployment/DeploymentEngine.scala
@@ -2,8 +2,8 @@ package deployment
 
 import java.util.UUID
 
-import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
-import akka.agent.Agent
+import org.apache.pekko.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
+import org.apache.pekko.agent.Agent
 import com.typesafe.config.ConfigFactory
 import conf.Config
 import controllers.Logging
@@ -25,13 +25,13 @@ class DeploymentEngine(
 
   private lazy val dispatcherConfig = ConfigFactory.parseMap(
     Map(
-      "akka.deploy-dispatcher.type" -> "Dispatcher",
-      "akka.deploy-dispatcher.executor" -> "fork-join-executor",
-      "akka.deploy-dispatcher.fork-join-executor.parallelism-min" -> s"$concurrentDeploys",
-      "akka.deploy-dispatcher.fork-join-executor.parallelism-factor" -> s"$concurrentDeploys",
-      "akka.deploy-dispatcher.fork-join-executor.parallelism-max" -> s"${concurrentDeploys * 4}",
-      "akka.deploy-dispatcher.fork-join-executor.task-peeking-mode" -> "FIFO",
-      "akka.deploy-dispatcher.throughput" -> "1"
+      "pekko.deploy-dispatcher.type" -> "Dispatcher",
+      "pekko.deploy-dispatcher.executor" -> "fork-join-executor",
+      "pekko.deploy-dispatcher.fork-join-executor.parallelism-min" -> s"$concurrentDeploys",
+      "pekko.deploy-dispatcher.fork-join-executor.parallelism-factor" -> s"$concurrentDeploys",
+      "pekko.deploy-dispatcher.fork-join-executor.parallelism-max" -> s"${concurrentDeploys * 4}",
+      "pekko.deploy-dispatcher.fork-join-executor.task-peeking-mode" -> "FIFO",
+      "pekko.deploy-dispatcher.throughput" -> "1"
     ).asJava
   )
 
@@ -45,7 +45,7 @@ class DeploymentEngine(
     (context: ActorRefFactory, runnerName: String) =>
       context.actorOf(
         props = Props(new TasksRunner(stopFlagAgent))
-          .withDispatcher("akka.deploy-dispatcher"),
+          .withDispatcher("pekko.deploy-dispatcher"),
         name = s"deploymentRunner-$runnerName"
       )
 
@@ -63,7 +63,7 @@ class DeploymentEngine(
             deploymentTypes,
             ioExecutionContext
           )
-        ).withDispatcher("akka.deploy-dispatcher"),
+        ).withDispatcher("pekko.deploy-dispatcher"),
         name = s"deployGroupRunner-${record.uuid.toString}"
       )
 

--- a/riff-raff/app/deployment/Deployments.scala
+++ b/riff-raff/app/deployment/Deployments.scala
@@ -2,9 +2,9 @@ package deployment
 
 import java.util.UUID
 
-import akka.actor.ActorSystem
-import akka.agent.Agent
-import akka.util.Switch
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.agent.Agent
+import org.apache.pekko.util.Switch
 import ci._
 import controllers.Logging
 import lifecycle.Lifecycle

--- a/riff-raff/app/deployment/actors/DeployCoordinator.scala
+++ b/riff-raff/app/deployment/actors/DeployCoordinator.scala
@@ -2,15 +2,15 @@ package deployment.actors
 
 import java.util.UUID
 
-import akka.actor.SupervisorStrategy.Stop
-import akka.actor.{
+import org.apache.pekko.actor.SupervisorStrategy.Stop
+import org.apache.pekko.actor.{
   Actor,
   ActorRef,
   ActorRefFactory,
   OneForOneStrategy,
   Terminated
 }
-import akka.agent.Agent
+import org.apache.pekko.agent.Agent
 import controllers.Logging
 import deployment.Record
 

--- a/riff-raff/app/deployment/actors/DeployGroupRunner.scala
+++ b/riff-raff/app/deployment/actors/DeployGroupRunner.scala
@@ -2,15 +2,15 @@ package deployment.actors
 
 import java.util.UUID
 
-import akka.actor.SupervisorStrategy.Stop
-import akka.actor.{
+import org.apache.pekko.actor.SupervisorStrategy.Stop
+import org.apache.pekko.actor.{
   Actor,
   ActorRef,
   ActorRefFactory,
   OneForOneStrategy,
   Terminated
 }
-import akka.agent.Agent
+import org.apache.pekko.agent.Agent
 import cats.data.Validated.{Invalid, Valid}
 import conf.Config
 import controllers.Logging

--- a/riff-raff/app/deployment/actors/TasksRunner.scala
+++ b/riff-raff/app/deployment/actors/TasksRunner.scala
@@ -2,8 +2,8 @@ package deployment.actors
 
 import java.util.UUID
 
-import akka.actor.Actor
-import akka.agent.Agent
+import org.apache.pekko.actor.Actor
+import org.apache.pekko.agent.Agent
 import controllers.Logging
 import magenta.{DeployReporter, DeployStoppedException, DeploymentResources}
 import magenta.graph.DeploymentTasks

--- a/riff-raff/app/notification/hooks.scala
+++ b/riff-raff/app/notification/hooks.scala
@@ -3,7 +3,7 @@ package notification
 import java.net.URL
 import java.util.UUID
 
-import akka.actor.{Actor, ActorSystem, Props}
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
 import controllers.Logging
 import lifecycle.Lifecycle
 import magenta.ContextMessage._

--- a/riff-raff/app/persistence/ContinuousDeploymentConfigRepository.scala
+++ b/riff-raff/app/persistence/ContinuousDeploymentConfigRepository.scala
@@ -1,7 +1,6 @@
 package persistence
 
 import java.util.UUID
-
 import ci.{ContinuousDeploymentConfig, Trigger}
 import org.scanamo.syntax._
 import org.scanamo.auto._

--- a/riff-raff/app/persistence/ScheduleRepository.scala
+++ b/riff-raff/app/persistence/ScheduleRepository.scala
@@ -1,7 +1,6 @@
 package persistence
 
 import java.util.UUID
-
 import ci.Trigger
 import org.scanamo.syntax._
 import org.scanamo.{DynamoFormat, Table}

--- a/riff-raff/app/utils/Agent.scala
+++ b/riff-raff/app/utils/Agent.scala
@@ -1,0 +1,251 @@
+/** This file is copied from the Akka project <https://github.com/akka/akka>. It
+  * has been included here as Agents are now deprecated within Akka. It contains
+  * modifications from the original source. License information can be seen in
+  * the project LICENSE file.
+  *
+  * This original source from which this was copied can be found here
+  * <https://github.com/akka/akka/blob/release-2.4/akka-agent/src/main/scala/akka/agent/Agent.scala>
+  *
+  * Modifications:
+  *   - unicode arrow `⇒` is deprecated, use `=>` instead
+  *   - Auto-application to `()` is deprecated. Supply the empty argument list
+  *     `()` explicitly to invoke method
+  */
+
+/** Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+  */
+
+package org.apache.pekko.agent
+
+import scala.concurrent.stm._
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import org.apache.pekko.util.{SerializedSuspendableExecutionContext}
+
+object Agent {
+
+  /** Factory method for creating an Agent.
+    */
+  def apply[T](initialValue: T)(implicit context: ExecutionContext): Agent[T] =
+    new SecretAgent(initialValue, context)
+
+  /** Java API: Factory method for creating an Agent.
+    */
+  def create[T](initialValue: T, context: ExecutionContext): Agent[T] =
+    Agent(initialValue)(context)
+
+  /** Default agent implementation.
+    */
+  private final class SecretAgent[T](initialValue: T, context: ExecutionContext)
+      extends Agent[T] {
+    private val ref = Ref(initialValue)
+    private val updater = SerializedSuspendableExecutionContext(10)(context)
+
+    def get(): T = ref.single.get
+
+    def send(newValue: T): Unit = withinTransaction(new Runnable {
+      def run = ref.single.update(newValue)
+    })
+
+    def send(f: T => T): Unit = withinTransaction(new Runnable {
+      def run = ref.single.transform(f)
+    })
+
+    def sendOff(f: T => T)(implicit ec: ExecutionContext): Unit =
+      withinTransaction(new Runnable {
+        def run =
+          try updater.suspend()
+          finally
+            ec.execute(new Runnable {
+              def run = try ref.single.transform(f)
+              finally updater.resume()
+            })
+      })
+
+    def alter(newValue: T): Future[T] = doAlter({
+      ref.single.update(newValue); newValue
+    })
+
+    def alter(f: T => T): Future[T] = doAlter(ref.single.transformAndGet(f))
+
+    def alterOff(f: T => T)(implicit ec: ExecutionContext): Future[T] = {
+      val result = Promise[T]()
+      withinTransaction(new Runnable {
+        def run = {
+          updater.suspend()
+          result completeWith Future(
+            try ref.single.transformAndGet(f)
+            finally updater.resume()
+          )
+        }
+      })
+      result.future
+    }
+
+    /** Internal helper method
+      */
+    private final def withinTransaction(run: Runnable): Unit = {
+      Txn.findCurrent match {
+        case Some(txn) => Txn.afterCommit(_ => updater.execute(run))(txn)
+        case _         => updater.execute(run)
+      }
+    }
+
+    /** Internal helper method
+      */
+    private final def doAlter(f: => T): Future[T] = {
+      Txn.findCurrent match {
+        case Some(txn) =>
+          val result = Promise[T]()
+          Txn.afterCommit(status => result completeWith Future(f)(updater))(txn)
+          result.future
+        case _ => Future(f)(updater)
+      }
+    }
+
+    def future(): Future[T] = Future(ref.single.get)(updater)
+
+    def map[B](f: T => B): Agent[B] = Agent(f(get()))(updater)
+
+    def flatMap[B](f: T => Agent[B]): Agent[B] = f(get())
+
+    def foreach[U](f: T => U): Unit = f(get())
+  }
+}
+
+/** The Agent class was inspired by agents in Clojure.
+  *
+  * Agents provide asynchronous change of individual locations. Agents are bound
+  * to a single storage location for their lifetime, and only allow mutation of
+  * that location (to a new state) to occur as a result of an action. Update
+  * actions are functions that are asynchronously applied to the Agent's state
+  * and whose return value becomes the Agent's new state. The state of an Agent
+  * should be immutable.
+  *
+  * While updates to Agents are asynchronous, the state of an Agent is always
+  * immediately available for reading by any thread (using ''get'' or ''apply'')
+  * without any messages.
+  *
+  * Agents are reactive. The update actions of all Agents get interleaved
+  * amongst threads in a thread pool. At any point in time, at most one ''send''
+  * action for each Agent is being executed. Actions dispatched to an agent from
+  * another thread will occur in the order they were sent, potentially
+  * interleaved with actions dispatched to the same agent from other sources.
+  *
+  * Example of usage:
+  * {{{
+  * val agent = Agent(5)
+  *
+  * agent send (_ * 2)
+  *
+  * ...
+  *
+  * val result = agent()
+  * // use result ...
+  *
+  * }}}
+  *
+  * Agent is also monadic, which means that you can compose operations using
+  * for-comprehensions. In monadic usage the original agents are not touched but
+  * new agents are created. So the old values (agents) are still available
+  * as-is. They are so-called 'persistent'.
+  *
+  * Example of monadic usage:
+  * {{{
+  * val agent1 = Agent(3)
+  * val agent2 = Agent(5)
+  *
+  * for (value <- agent1) {
+  *   result = value + 1
+  * }
+  *
+  * val agent3 = for (value <- agent1) yield value + 1
+  *
+  * val agent4 = for {
+  *   value1 <- agent1
+  *   value2 <- agent2
+  * } yield value1 + value2
+  *
+  * }}}
+  *
+  * ==DEPRECATED STM SUPPORT==
+  *
+  * Agents participating in enclosing STM transaction is a deprecated feature in
+  * 2.3.
+  *
+  * If an Agent is used within an enclosing transaction, then it will
+  * participate in that transaction. Agents are integrated with the STM - any
+  * dispatches made in a transaction are held until that transaction commits,
+  * and are discarded if it is retried or aborted.
+  */
+abstract class Agent[T] {
+
+  /** Java API: Read the internal state of the agent.
+    */
+  def get(): T
+
+  /** Read the internal state of the agent.
+    */
+  def apply(): T = get()
+
+  /** Dispatch a new value for the internal state. Behaves the same as sending a
+    * function (x => newValue).
+    */
+  def send(newValue: T): Unit
+
+  /** Dispatch a function to update the internal state. In Java, pass in an
+    * instance of `org.apache.pekko.dispatch.Mapper`.
+    */
+  def send(f: T => T): Unit
+
+  /** Dispatch a function to update the internal state but on its own thread.
+    * This does not use the reactive thread pool and can be used for
+    * long-running or blocking operations. Dispatches using either `sendOff` or
+    * `send` will still be executed in order. In Java, pass in an instance of
+    * `org.apache.pekko.dispatch.Mapper`.
+    */
+  def sendOff(f: T => T)(implicit ec: ExecutionContext): Unit
+
+  /** Dispatch an update to the internal state, and return a Future where that
+    * new state can be obtained. In Java, pass in an instance of
+    * `org.apache.pekko.dispatch.Mapper`.
+    */
+  def alter(newValue: T): Future[T]
+
+  /** Dispatch a function to update the internal state, and return a Future
+    * where that new state can be obtained. In Java, pass in an instance of
+    * `org.apache.pekko.dispatch.Mapper`.
+    */
+  def alter(f: T => T): Future[T]
+
+  /** Dispatch a function to update the internal state but on its own thread,
+    * and return a Future where that new state can be obtained. This does not
+    * use the reactive thread pool and can be used for long-running or blocking
+    * operations. Dispatches using either `alterOff` or `alter` will still be
+    * executed in order. In Java, pass in an instance of
+    * `org.apache.pekko.dispatch.Mapper`.
+    */
+  def alterOff(f: T => T)(implicit ec: ExecutionContext): Future[T]
+
+  /** A future to the current value that will be completed after any currently
+    * queued updates.
+    */
+  def future(): Future[T]
+
+  /** Map this agent to a new agent, applying the function to the internal
+    * state. Does not change the value of this agent. In Java, pass in an
+    * instance of `org.apache.pekko.dispatch.Mapper`.
+    */
+  def map[B](f: T => B): Agent[B]
+
+  /** Flatmap this agent to a new agent, applying the function to the internal
+    * state. Does not change the value of this agent. In Java, pass in an
+    * instance of `org.apache.pekko.dispatch.Mapper`.
+    */
+  def flatMap[B](f: T => Agent[B]): Agent[B]
+
+  /** Applies the function to the internal state. Does not change the value of
+    * this agent. In Java, pass in an instance of
+    * `org.apache.pekko.dispatch.Foreach`.
+    */
+  def foreach[U](f: T => U): Unit
+}

--- a/riff-raff/app/utils/ScheduledAgent.scala
+++ b/riff-raff/app/utils/ScheduledAgent.scala
@@ -1,11 +1,14 @@
 package utils
 
-import akka.actor.{Cancellable, ActorSystem}
-import akka.agent.Agent
+import org.apache.pekko.actor.{ActorSystem, Cancellable}
+import org.apache.pekko.agent.Agent
 import controllers.Logging
 import lifecycle.Lifecycle
+
 import scala.concurrent.duration._
 import org.joda.time.{DateTime, Interval, LocalDate, LocalTime}
+
+import scala.concurrent.ExecutionContextExecutor
 
 object ScheduledAgent extends Lifecycle {
   val scheduleSystem = ActorSystem("scheduled-agent")

--- a/riff-raff/test/deployment/actors/DeployCoordinatorTest.scala
+++ b/riff-raff/test/deployment/actors/DeployCoordinatorTest.scala
@@ -2,9 +2,9 @@ package deployment.actors
 
 import java.util.UUID
 
-import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
-import akka.agent.Agent
-import akka.testkit.{TestActorRef, TestKit, TestProbe}
+import org.apache.pekko.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
+import org.apache.pekko.agent.Agent
+import org.apache.pekko.testkit.{TestActorRef, TestKit, TestProbe}
 import com.typesafe.config.ConfigFactory
 import deployment.{Fixtures, Record}
 import org.mockito.MockitoSugar

--- a/riff-raff/test/deployment/actors/DeployGroupRunnerTest.scala
+++ b/riff-raff/test/deployment/actors/DeployGroupRunnerTest.scala
@@ -1,9 +1,9 @@
 package deployment.actors
 
 import java.util.UUID
-import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
-import akka.agent.Agent
-import akka.testkit.{TestActorRef, TestKit, TestProbe}
+import org.apache.pekko.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
+import org.apache.pekko.agent.Agent
+import org.apache.pekko.testkit.{TestActorRef, TestKit, TestProbe}
 import conf.Config
 import deployment.{Fixtures, Record}
 import magenta.graph.{DeploymentTasks, Graph, ValueNode}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Bumps riff-raff to Play 3.x and various other dependencies that were blocked by Play 2.x

This resolves all high vulnerabilities for riff-raff which could not previously be done by Play 2's dependency on logback. 

## How to test

Tests run fine, runs locally. Tested in CODE.


## Have we considered potential risks?

Play 3.x is a major update and could break riff-raff. We should inform teams before we release this change.
