### PR TITLE
chore(deps): Update postgresql to 42.7.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -83,7 +83,7 @@ object Dependencies {
       "org.webjars" % "momentjs" % "2.29.4",
       "net.logstash.logback" % "logstash-logback-encoder" % "7.4",
       "org.scalikejdbc" %% "scalikejdbc" % "3.5.0", // scala-steward:off
-      "org.postgresql" % "postgresql" % "42.7.1",
+      "org.postgresql" % "postgresql" % "42.7.2",
       "com.beachape" %% "enumeratum-play" % Versions.enumeratumPlay,
       filters,
       ws,


### PR DESCRIPTION
## What does this change?
Bump `postgresql` to resolve a [vulnerability flagged as critical by Snyk](https://security.snyk.io/vuln/SNYK-JAVA-ORGPOSTGRESQL-6252740).