### PR TITLE
Add Github repository name to build dropdown

### DIFF
--- a/riff-raff/app/controllers/DeployController.scala
+++ b/riff-raff/app/controllers/DeployController.scala
@@ -184,8 +184,8 @@ class DeployController(
       .filter(p => p.number.contains(term) || p.branchName.contains(term))
       .map { build =>
         val label =
-          "%s [%s] (%s)" format (build.number, build.branchName, shortFormat
-            .print(build.startTime))
+          "%s [%s] (%s) (%s)" format (build.number, build.branchName, shortFormat
+            .print(build.startTime), build.vcsURL.stripPrefix("https://github.com/"))
         Map("label" -> label, "value" -> build.number)
       }
     Ok(Json.toJson(possibleProjects))

--- a/riff-raff/app/controllers/DeployController.scala
+++ b/riff-raff/app/controllers/DeployController.scala
@@ -22,11 +22,10 @@ import play.api.i18n.I18nSupport
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.api.mvc.{AnyContent, BaseController, ControllerComponents}
-import play.utils.UriEncoding
 import resources.PrismLookup
 import restrictions.RestrictionChecker
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
-import utils.{ChangeFreeze, LogAndSquashBehaviour}
+import utils.{ChangeFreeze, LogAndSquashBehaviour, VCSInfo}
 import magenta.input.RiffRaffYamlReader
 
 class DeployController(
@@ -185,7 +184,7 @@ class DeployController(
       .map { build =>
         val label =
           "%s [%s] (%s) (%s)" format (build.number, build.branchName, shortFormat
-            .print(build.startTime), build.vcsURL.stripPrefix("https://github.com/"))
+            .print(build.startTime), VCSInfo.normalise(build.vcsURL).getOrElse(build.vcsURL))
         Map("label" -> label, "value" -> build.number)
       }
     Ok(Json.toJson(possibleProjects))

--- a/riff-raff/app/controllers/DeployController.scala
+++ b/riff-raff/app/controllers/DeployController.scala
@@ -182,11 +182,10 @@ class DeployController(
       .successfulBuilds(project)
       .filter(p => p.number.contains(term) || p.branchName.contains(term))
       .map { build =>
+        val repository = VCSInfo.normalise(build.vcsURL).getOrElse(build.vcsURL)
         val label =
           "%s [%s] (%s) (%s)" format (build.number, build.branchName, shortFormat
-            .print(build.startTime), VCSInfo
-            .normalise(build.vcsURL)
-            .getOrElse(build.vcsURL))
+            .print(build.startTime), repository)
         Map("label" -> label, "value" -> build.number)
       }
     Ok(Json.toJson(possibleProjects))

--- a/riff-raff/app/controllers/DeployController.scala
+++ b/riff-raff/app/controllers/DeployController.scala
@@ -184,7 +184,9 @@ class DeployController(
       .map { build =>
         val label =
           "%s [%s] (%s) (%s)" format (build.number, build.branchName, shortFormat
-            .print(build.startTime), VCSInfo.normalise(build.vcsURL).getOrElse(build.vcsURL))
+            .print(build.startTime), VCSInfo
+            .normalise(build.vcsURL)
+            .getOrElse(build.vcsURL))
         Map("label" -> label, "value" -> build.number)
       }
     Ok(Json.toJson(possibleProjects))


### PR DESCRIPTION
## What does this change?

As per title. We had a team mobbing session on Riff-Raff and we decided to add this  feature to make the mapping between Riff-Raff project and Github repository clearer.

## How to test
Tested locally and on CODE.

## Images
<img width="585" alt="image" src="https://github.com/guardian/riff-raff/assets/57295823/03fe8304-125c-4b80-932d-0d3cac579878">
