### PR TITLE
`autoscaling` deploy: re-enable ASG scaling before final stabilisation check

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -202,12 +202,17 @@ object AutoScaling extends DeploymentType with BucketParameters {
           target.region,
           terminationGrace(pkg, target, reporter)
         ),
-        WaitForStabilization(
+        ResumeAlarmNotifications(autoScalingGroup, target.region),
+        WaitForCullToComplete(
           autoScalingGroup,
           secondsToWait(pkg, target, reporter),
           target.region
         ),
-        ResumeAlarmNotifications(autoScalingGroup, target.region)
+        WaitForStabilization(
+          autoScalingGroup,
+          secondsToWait(pkg, target, reporter),
+          target.region
+        )
       )
     }
     val groupsToUpdate: List[AutoScalingGroupInfo] =

--- a/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ASGTasks.scala
@@ -181,7 +181,7 @@ case class WaitForStabilization(
     ELB.withClient(keyRing, region, resources) { elbClient =>
       check(resources.reporter, stopFlag) {
         try {
-          ASG.isStabilized(ASG.refresh(asg, asgClient), elbClient) match {
+          ASG.isStabilized(ASG.refresh(asg), elbClient) match {
             case Left(reason) =>
               resources.reporter.verbose(reason)
               false
@@ -302,7 +302,9 @@ case class WaitForCullToComplete(
   )(implicit asgClient: AutoScalingClient): Unit =
     withEc2Client(keyRing, region, resources) { implicit ec2Client =>
       check(resources.reporter, stopFlag) {
-        CullSummary.forAsg(asg, resources.reporter).isCullComplete
+        CullSummary
+          .forAsg(ASG.refresh(asg), resources.reporter)
+          .isCullComplete
       }
     }
 

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -403,9 +403,10 @@ object ASG {
 
   def cull(
       asg: AutoScalingGroup,
-      instance: ASGInstance,
-      asgClient: AutoScalingClient,
-      elbClient: ELB.Client
+      instance: ASGInstance
+  )(implicit
+      elbClient: ELB.Client,
+      asgClient: AutoScalingClient
   ): TerminateInstanceInAutoScalingGroupResponse = {
     ELB.deregister(elbNames(asg), elbTargetArns(asg), instance, elbClient)
 

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -420,9 +420,8 @@ object ASG {
   }
 
   def refresh(
-      asg: AutoScalingGroup,
-      client: AutoScalingClient
-  ): AutoScalingGroup =
+      asg: AutoScalingGroup
+  )(implicit client: AutoScalingClient): AutoScalingGroup =
     client
       .describeAutoScalingGroups(
         DescribeAutoScalingGroupsRequest

--- a/magenta-lib/src/main/scala/magenta/tasks/autoscaling/CullSummary.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/autoscaling/CullSummary.scala
@@ -1,0 +1,67 @@
+package magenta.tasks.autoscaling
+
+import magenta.tasks.EC2
+import magenta.tasks.autoscaling.CullSummary.isNotAlreadyTerminating
+import magenta.{DeployReporter, Loggable}
+import software.amazon.awssdk.services.autoscaling.model.{
+  AutoScalingGroup,
+  Instance,
+  LifecycleState
+}
+import software.amazon.awssdk.services.ec2.Ec2Client
+
+import scala.jdk.CollectionConverters._
+
+object CullSummary extends Loggable {
+  // See https://docs.aws.amazon.com/autoscaling/ec2/userguide/lifecycle-hooks.html#lifecycle-hooks-overview
+  val TerminatingStates: Set[LifecycleState] = Set(
+    LifecycleState.TERMINATING,
+    LifecycleState.TERMINATING_WAIT,
+    LifecycleState.TERMINATING_PROCEED,
+    LifecycleState.TERMINATED
+  )
+
+  def isNotAlreadyTerminating(instance: Instance): Boolean =
+    !TerminatingStates(instance.lifecycleState)
+
+  def logIfLifecycleStateUnknown(instance: Instance): Unit = if (
+    instance.lifecycleState == LifecycleState.UNKNOWN_TO_SDK_VERSION
+  )
+    logger.warn(
+      s"Instance lifecycle state ${instance.lifecycleStateAsString} isn't recognised in the AWS SDK. Is there a later version of the AWS SDK available?"
+    )
+
+  def isTaggedForTermination(instance: Instance)(implicit
+      ec2Client: Ec2Client
+  ): Boolean =
+    EC2.hasTag(instance, "Magenta", "Terminate", ec2Client)
+
+  def forAsg(asg: AutoScalingGroup, reporter: DeployReporter)(implicit
+      ec2Client: Ec2Client
+  ): CullSummary = {
+    val allInstances = asg.instances.asScala.toSet
+
+    reporter.verbose(
+      s"Found the following instances: ${allInstances.map(_.instanceId).mkString(", ")}"
+    )
+    allInstances.foreach(logIfLifecycleStateUnknown)
+
+    CullSummary(
+      allInstances,
+      instancesThatMustTerminate = allInstances.filter(isTaggedForTermination)
+    )
+  }
+}
+
+/** Summarises the instances in an ASG that should be culled - which ones are
+  * already terminating, and which ones must be told to terminate.
+  */
+case class CullSummary(
+    allInstances: Set[Instance],
+    instancesThatMustTerminate: Set[Instance]
+) {
+  val instancesToKill: Set[Instance] =
+    instancesThatMustTerminate.filter(isNotAlreadyTerminating)
+
+  val isCullComplete: Boolean = instancesThatMustTerminate.isEmpty
+}

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -143,20 +143,21 @@ class AutoScalingTest
           DeployTarget(parameters(), stack, region)
         )
       val expected = List(
-        WaitForStabilization(testInfo, ofMinutes(5), Region("eu-west-1")),
-        CheckGroupSize(testInfo, Region("eu-west-1")),
-        SuspendAlarmNotifications(testInfo, Region("eu-west-1")),
-        TagCurrentInstancesWithTerminationTag(testInfo, Region("eu-west-1")),
-        ProtectCurrentInstances(testInfo, Region("eu-west-1")),
-        DoubleSize(testInfo, Region("eu-west-1")),
-        HealthcheckGrace(testInfo, Region("eu-west-1"), ofSeconds(20)),
-        WaitForStabilization(testInfo, ofMinutes(15), Region("eu-west-1")),
-        WarmupGrace(testInfo, Region("eu-west-1"), ofSeconds(1)),
-        WaitForStabilization(testInfo, ofMinutes(15), Region("eu-west-1")),
-        CullInstancesWithTerminationTag(testInfo, Region("eu-west-1")),
-        TerminationGrace(testInfo, Region("eu-west-1"), ofSeconds(10)),
-        WaitForStabilization(testInfo, ofMinutes(15), Region("eu-west-1")),
-        ResumeAlarmNotifications(testInfo, Region("eu-west-1"))
+        WaitForStabilization(testInfo, ofMinutes(5), region),
+        CheckGroupSize(testInfo, region),
+        SuspendAlarmNotifications(testInfo, region),
+        TagCurrentInstancesWithTerminationTag(testInfo, region),
+        ProtectCurrentInstances(testInfo, region),
+        DoubleSize(testInfo, region),
+        HealthcheckGrace(testInfo, region, ofSeconds(20)),
+        WaitForStabilization(testInfo, ofMinutes(15), region),
+        WarmupGrace(testInfo, region, ofSeconds(1)),
+        WaitForStabilization(testInfo, ofMinutes(15), region),
+        CullInstancesWithTerminationTag(testInfo, region),
+        TerminationGrace(testInfo, region, ofSeconds(10)),
+        ResumeAlarmNotifications(testInfo, region),
+        WaitForCullToComplete(testInfo, ofMinutes(15), region),
+        WaitForStabilization(testInfo, ofMinutes(15), region)
       )
       actual shouldBe expected
     }
@@ -199,65 +200,37 @@ class AutoScalingTest
         )
       val expected = List(
         // All tasks for testOldCfnAsg
-        WaitForStabilization(testOldCfnAsg, ofMinutes(5), Region("eu-west-1")),
-        CheckGroupSize(testOldCfnAsg, Region("eu-west-1")),
-        SuspendAlarmNotifications(testOldCfnAsg, Region("eu-west-1")),
-        TagCurrentInstancesWithTerminationTag(
-          testOldCfnAsg,
-          Region("eu-west-1")
-        ),
-        ProtectCurrentInstances(testOldCfnAsg, Region("eu-west-1")),
-        DoubleSize(testOldCfnAsg, Region("eu-west-1")),
-        HealthcheckGrace(testOldCfnAsg, Region("eu-west-1"), ofSeconds(20)),
-        WaitForStabilization(
-          testOldCfnAsg,
-          ofMinutes(15),
-          Region("eu-west-1")
-        ),
-        WarmupGrace(testOldCfnAsg, Region("eu-west-1"), ofSeconds(1)),
-        WaitForStabilization(
-          testOldCfnAsg,
-          ofMinutes(15),
-          Region("eu-west-1")
-        ),
-        CullInstancesWithTerminationTag(testOldCfnAsg, Region("eu-west-1")),
-        TerminationGrace(testOldCfnAsg, Region("eu-west-1"), ofSeconds(10)),
-        WaitForStabilization(
-          testOldCfnAsg,
-          ofMinutes(15),
-          Region("eu-west-1")
-        ),
-        ResumeAlarmNotifications(testOldCfnAsg, Region("eu-west-1")),
+        WaitForStabilization(testOldCfnAsg, ofMinutes(5), region),
+        CheckGroupSize(testOldCfnAsg, region),
+        SuspendAlarmNotifications(testOldCfnAsg, region),
+        TagCurrentInstancesWithTerminationTag(testOldCfnAsg, region),
+        ProtectCurrentInstances(testOldCfnAsg, region),
+        DoubleSize(testOldCfnAsg, region),
+        HealthcheckGrace(testOldCfnAsg, region, ofSeconds(20)),
+        WaitForStabilization(testOldCfnAsg, ofMinutes(15), region),
+        WarmupGrace(testOldCfnAsg, region, ofSeconds(1)),
+        WaitForStabilization(testOldCfnAsg, ofMinutes(15), region),
+        CullInstancesWithTerminationTag(testOldCfnAsg, region),
+        TerminationGrace(testOldCfnAsg, region, ofSeconds(10)),
+        ResumeAlarmNotifications(testOldCfnAsg, region),
+        WaitForCullToComplete(testOldCfnAsg, ofMinutes(15), region),
+        WaitForStabilization(testOldCfnAsg, ofMinutes(15), region),
         // All tasks for testNewCdkAsg
-        WaitForStabilization(testNewCdkAsg, ofMinutes(5), Region("eu-west-1")),
-        CheckGroupSize(testNewCdkAsg, Region("eu-west-1")),
-        SuspendAlarmNotifications(testNewCdkAsg, Region("eu-west-1")),
-        TagCurrentInstancesWithTerminationTag(
-          testNewCdkAsg,
-          Region("eu-west-1")
-        ),
-        ProtectCurrentInstances(testNewCdkAsg, Region("eu-west-1")),
-        DoubleSize(testNewCdkAsg, Region("eu-west-1")),
-        HealthcheckGrace(testNewCdkAsg, Region("eu-west-1"), ofSeconds(20)),
-        WaitForStabilization(
-          testNewCdkAsg,
-          ofMinutes(15),
-          Region("eu-west-1")
-        ),
-        WarmupGrace(testNewCdkAsg, Region("eu-west-1"), ofSeconds(1)),
-        WaitForStabilization(
-          testNewCdkAsg,
-          ofMinutes(15),
-          Region("eu-west-1")
-        ),
-        CullInstancesWithTerminationTag(testNewCdkAsg, Region("eu-west-1")),
-        TerminationGrace(testNewCdkAsg, Region("eu-west-1"), ofSeconds(10)),
-        WaitForStabilization(
-          testNewCdkAsg,
-          ofMinutes(15),
-          Region("eu-west-1")
-        ),
-        ResumeAlarmNotifications(testNewCdkAsg, Region("eu-west-1"))
+        WaitForStabilization(testNewCdkAsg, ofMinutes(5), region),
+        CheckGroupSize(testNewCdkAsg, region),
+        SuspendAlarmNotifications(testNewCdkAsg, region),
+        TagCurrentInstancesWithTerminationTag(testNewCdkAsg, region),
+        ProtectCurrentInstances(testNewCdkAsg, region),
+        DoubleSize(testNewCdkAsg, region),
+        HealthcheckGrace(testNewCdkAsg, region, ofSeconds(20)),
+        WaitForStabilization(testNewCdkAsg, ofMinutes(15), region),
+        WarmupGrace(testNewCdkAsg, region, ofSeconds(1)),
+        WaitForStabilization(testNewCdkAsg, ofMinutes(15), region),
+        CullInstancesWithTerminationTag(testNewCdkAsg, region),
+        TerminationGrace(testNewCdkAsg, region, ofSeconds(10)),
+        ResumeAlarmNotifications(testNewCdkAsg, region),
+        WaitForCullToComplete(testNewCdkAsg, ofMinutes(15), region),
+        WaitForStabilization(testNewCdkAsg, ofMinutes(15), region)
       )
       actual shouldBe expected
     }
@@ -335,20 +308,21 @@ class AutoScalingTest
           DeployTarget(parameters(), stack, region)
         )
       val expected = List(
-        WaitForStabilization(testInfo, ofMinutes(5), Region("eu-west-1")),
-        CheckGroupSize(testInfo, Region("eu-west-1")),
-        SuspendAlarmNotifications(testInfo, Region("eu-west-1")),
-        TagCurrentInstancesWithTerminationTag(testInfo, Region("eu-west-1")),
-        ProtectCurrentInstances(testInfo, Region("eu-west-1")),
-        DoubleSize(testInfo, Region("eu-west-1")),
-        HealthcheckGrace(testInfo, Region("eu-west-1"), ofSeconds(30)),
-        WaitForStabilization(testInfo, ofMinutes(3), Region("eu-west-1")),
-        WarmupGrace(testInfo, Region("eu-west-1"), ofSeconds(20)),
-        WaitForStabilization(testInfo, ofMinutes(3), Region("eu-west-1")),
-        CullInstancesWithTerminationTag(testInfo, Region("eu-west-1")),
-        TerminationGrace(testInfo, Region("eu-west-1"), ofSeconds(11)),
-        WaitForStabilization(testInfo, ofMinutes(3), Region("eu-west-1")),
-        ResumeAlarmNotifications(testInfo, Region("eu-west-1"))
+        WaitForStabilization(testInfo, ofMinutes(5), region),
+        CheckGroupSize(testInfo, region),
+        SuspendAlarmNotifications(testInfo, region),
+        TagCurrentInstancesWithTerminationTag(testInfo, region),
+        ProtectCurrentInstances(testInfo, region),
+        DoubleSize(testInfo, region),
+        HealthcheckGrace(testInfo, region, ofSeconds(30)),
+        WaitForStabilization(testInfo, ofMinutes(3), region),
+        WarmupGrace(testInfo, region, ofSeconds(20)),
+        WaitForStabilization(testInfo, ofMinutes(3), region),
+        CullInstancesWithTerminationTag(testInfo, region),
+        TerminationGrace(testInfo, region, ofSeconds(11)),
+        ResumeAlarmNotifications(testInfo, region),
+        WaitForCullToComplete(testInfo, ofMinutes(3), region),
+        WaitForStabilization(testInfo, ofMinutes(3), region)
       )
       actual shouldBe expected
     }

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTasksTest.scala
@@ -41,7 +41,7 @@ class ASGTasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
       .maxSize(10)
       .build()
     val info = AutoScalingGroupInfo(asg, Nil)
-    val asgClientMock = mock[AutoScalingClient]
+    implicit val asgClientMock = mock[AutoScalingClient]
 
     val p = DeploymentPackage(
       "test",
@@ -60,7 +60,7 @@ class ASGTasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
       mock[StsClient],
       global
     )
-    task.execute(asg, resources, stopFlag = false, asgClientMock)
+    task.execute(asg, resources, stopFlag = false)
 
     verify(asgClientMock).setDesiredCapacity(
       SetDesiredCapacityRequest
@@ -81,16 +81,7 @@ class ASGTasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
       .build()
     val info = AutoScalingGroupInfo(asg, Nil)
 
-    val asgClientMock = mock[AutoScalingClient]
-
-    val p = DeploymentPackage(
-      "test",
-      App("app"),
-      Map.empty,
-      "testDeploymentType",
-      S3Path("artifact-bucket", "project/123/test"),
-      deploymentTypes
-    )
+    implicit val asgClientMock = mock[AutoScalingClient]
 
     val task = CheckGroupSize(info, Region("eu-west-1"))
 
@@ -103,7 +94,7 @@ class ASGTasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
     )
 
     val thrown = intercept[FailException](
-      task.execute(asg, resources, stopFlag = false, asgClientMock)
+      task.execute(asg, resources, stopFlag = false)
     )
 
     thrown.getMessage should startWith(


### PR DESCRIPTION
This aims to address, to an extent, issue https://github.com/guardian/riff-raff/issues/1342 - that in an  [`autoscaling`](https://riffraff.gutools.co.uk/docs/magenta-lib/types#autoscaling) deploy, **apps _can not_ auto-scale** until the original number of instances in the ASG is capable of successfully handling the level of traffic, as checked by `WaitForStabilization`. On 22nd May 2024, this inability to auto-scale led to a severe outage in the Ophan Tracker, when a large increase in pageview traffic during a deploy meant the original number of instances could never have handled the load.

![image](https://github.com/guardian/riff-raff/assets/52038/bb2b114a-c2ba-4df3-a036-249ef54e6bf3)

## Disabling auto-scaling

Ever since https://github.com/guardian/riff-raff/pull/83 in April 2013, Riff Raff has disabled ASG scaling alarms at the start of a deploy (`SuspendAlarmNotifications`), and only re-enabled them at the end of the deploy (`ResumeAlarmNotifications`) once deployment has successfully completed.

In December 2016, with https://github.com/guardian/riff-raff/pull/403, an additional `WaitForStabilization` was added as a penultimate deploy step, which served two purposes:

1. Ensure that **the cull of old instances has completed** _before_ the deploy ends
2. Prove that the new boxes can handle their load _without_ the old boxes.

However, the `WaitForStabilization` step was placed _before_ `ResumeAlarmNotifications` - so the original number of EC2 instances in the ASG _must_ be capable of supporting the latest level of traffic, otherwise `WaitForStabilization` and the entire deploy will fail, leaving auto-scaling _indefinitely_ disabled - potentially waiting hours for human intervention to fix the problem.

## The old-instance cull must _complete_

By putting `ResumeAlarmNotifications` _before_ `WaitForStabilization`, the Ophan outage would have been shortened from 1 hour to ~2 minutes, but as @jacobwinch [points out](https://github.com/guardian/riff-raff/issues/1342#issuecomment-2127241818), making _only_ that change could lead to a race condition:

1. Once `ResumeAlarmNotifications` executes, a 'low CPU' alarm could immediately decide to reduce the desired size of the ASG, randomly removing _new_ instances
3. `WaitForStabilization` could then see that the ASG is at its desired size, even if it happens that the termination of the old servers has not yet completed
4. The deploy then reports as 'complete', even though old EC2 instances are potentially still active

Consequently, with this change we are also introducing a new task, `WaitForCullToComplete`, that checks _specifically_ that EC2 instances _tagged_ for termination have been removed from the ASG - more specific than the old assumption with `WaitForStabilization` that the ASG being at desired capacity definitely means all the old instances are gone.

The final sequence of tasks in an `autoscaling` deploy now looks like this:

https://github.com/guardian/riff-raff/blob/0fb840e64ac924ff4b477ccf6d93a80cf0bc56cd/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala#L199-L215

Common logic for _finding_ EC2 instances _tagged_ for termination, used by both `CullInstancesWithTerminationTag` & `WaitForCullToComplete`, has been factored out into the new `CullSummary` class.

# Testing

I've [deployed](https://riffraff.code.dev-gutools.co.uk/deployment/view/2d96ddb0-ed33-4198-b23e-7ee8bf41b83f) this branch to [Riff Raff CODE](https://riffraff.code.dev-gutools.co.uk/) as build 3385, and then used that to [deploy](https://riffraff.code.dev-gutools.co.uk/deployment/view/bb2d6042-44fe-4d8f-b166-b15a421c1743?verbose=1) the Ophan Dashboard to CODE, successfully! You can see that the new `WaitForCullToComplete` step took place after `ResumeAlarmNotifications`, and the `WaitForStabilization` step completed immediately after that:

![image](https://github.com/guardian/riff-raff/assets/52038/294b96be-73c0-4cc0-b37e-4b07409b79a0)

cc @guardian/ophan 