### PR TITLE
Use strongly-typed `Duration`s for time

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/GCS.scala
@@ -9,13 +9,22 @@ object GCS extends DeploymentType {
   val documentation = "For uploading files into a GCS bucket."
 
   val prefixStage =
-    Param("prefixStage", "Prefix the GCS bucket key with the target stage")
+    Param[Boolean](
+      "prefixStage",
+      "Prefix the GCS bucket key with the target stage"
+    )
       .default(true)
   val prefixPackage =
-    Param("prefixPackage", "Prefix the GCS bucket key with the package name")
+    Param[Boolean](
+      "prefixPackage",
+      "Prefix the GCS bucket key with the package name"
+    )
       .default(true)
   val prefixStack =
-    Param("prefixStack", "Prefix the GCS bucket key with the target stack")
+    Param[Boolean](
+      "prefixStack",
+      "Prefix the GCS bucket key with the target stack"
+    )
       .default(true)
   val pathPrefixResource = Param[String](
     "pathPrefixResource",

--- a/magenta-lib/src/main/scala/magenta/deployment_type/GcpDeploymentManager.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/GcpDeploymentManager.scala
@@ -11,7 +11,8 @@ import magenta.tasks.gcp.GCP.DeploymentManagerApi.DeploymentBundle
 import magenta.{DeployReporter, KeyRing}
 import software.amazon.awssdk.services.s3.S3Client
 
-import scala.concurrent.duration._
+import java.time.Duration
+import java.time.Duration.ofMinutes
 
 object GcpDeploymentManager extends DeploymentType {
   val GCP_PROJECT_NAME_PRISM_KEY: String = "gcp:project-name"
@@ -23,12 +24,10 @@ object GcpDeploymentManager extends DeploymentType {
       |
       |""".stripMargin
 
-  val maxWaitParam: Param[Int] = Param[Int](
-    name = "maxWait",
-    documentation = """
-      |Number of seconds to wait for the deployment operations to complete
-      |""".stripMargin
-  ).default(1800) // half an hour
+  val maxWaitParam: Param[Duration] =
+    Param
+      .waitingSecondsFor("maxWait", "the deployment operations to complete")
+      .default(ofMinutes(30))
 
   val deploymentNameParam: Param[String] = Param(
     name = "deploymentName",
@@ -93,7 +92,7 @@ object GcpDeploymentManager extends DeploymentType {
         }
       implicit val artifactClient: S3Client = resources.artifactClient
 
-      val maxWaitDuration = maxWaitParam(pkg, target, reporter).seconds
+      val maxWaitDuration = maxWaitParam(pkg, target, reporter)
       val deploymentName = deploymentNameParam(pkg, target, reporter)
       val upsert = upsertParam(pkg, target, reporter)
       val preview = previewParam(pkg, target, reporter)

--- a/magenta-lib/src/main/scala/magenta/deployment_type/S3ObjectPrefixParameters.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/S3ObjectPrefixParameters.scala
@@ -7,15 +7,24 @@ trait S3ObjectPrefixParameters {
   this: DeploymentType =>
 
   val prefixStage: Param[Boolean] =
-    Param("prefixStage", "Prefix the S3 bucket key with the target stage")
+    Param[Boolean](
+      "prefixStage",
+      "Prefix the S3 bucket key with the target stage"
+    )
       .default(true)
 
   val prefixPackage: Param[Boolean] =
-    Param("prefixPackage", "Prefix the S3 bucket key with the package name")
+    Param[Boolean](
+      "prefixPackage",
+      "Prefix the S3 bucket key with the package name"
+    )
       .default(true)
 
   val prefixStack: Param[Boolean] =
-    Param("prefixStack", "Prefix the S3 bucket key with the target stack")
+    Param[Boolean](
+      "prefixStack",
+      "Prefix the S3 bucket key with the target stack"
+    )
       .default(true)
 
   val prefixApp: Param[Boolean] = Param[Boolean](

--- a/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
@@ -13,6 +13,7 @@ import software.amazon.awssdk.services.cloudformation.model.ChangeSetStatus._
 import software.amazon.awssdk.services.cloudformation.model._
 import software.amazon.awssdk.services.s3.S3Client
 
+import java.time.Duration
 import scala.jdk.CollectionConverters._
 import scala.util.{Success, Try}
 
@@ -150,7 +151,7 @@ class CreateChangeSetTask(
 class CheckChangeSetCreatedTask(
     region: Region,
     stackLookup: CloudFormationStackMetadata,
-    override val duration: Long
+    override val duration: Duration
 )(implicit val keyRing: KeyRing, artifactClient: S3Client)
     extends Task
     with RepeatedPollingCheck {

--- a/magenta-lib/src/main/scala/magenta/tasks/gcp/DeploymentManagerTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/gcp/DeploymentManagerTasks.scala
@@ -7,14 +7,15 @@ import magenta.tasks.{PollingCheck, Task}
 import magenta.tasks.gcp.GCP.DeploymentManagerApi._
 import magenta.tasks.gcp.GCPRetryHelper.Result
 
-import scala.concurrent.duration.FiniteDuration
+import java.time.Duration
+import java.time.Duration.ofSeconds
 
 object DeploymentManagerTasks {
   def updateTask(
       project: String,
       deploymentName: String,
       bundle: DeploymentBundle,
-      maxWait: FiniteDuration,
+      maxWait: Duration,
       upsert: Boolean,
       preview: Boolean
   )(implicit kr: KeyRing): Task = new Task with PollingCheck {
@@ -127,8 +128,9 @@ object DeploymentManagerTasks {
       }
     }
 
-    override def duration: Long = maxWait.toMillis
+    override def duration: Duration = maxWait
 
-    override def calculateSleepTime(currentAttempt: Int): Long = 5000
+    override def calculateSleepTime(currentAttempt: Int): Duration =
+      ofSeconds(5)
   }
 }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -16,8 +16,8 @@ import magenta.tasks.UpdateCloudFormationTask._
 import magenta.tasks._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.{EitherValues, Inside}
-import play.api.libs.json.{JsBoolean, JsString, JsValue, Json}
+import org.scalatest.{EitherValues, Inside, OptionValues}
+import play.api.libs.json.{JsBoolean, JsNumber, JsString, JsValue, Json}
 import software.amazon.awssdk.services.cloudformation.model.{
   Change,
   ChangeSetType
@@ -25,6 +25,7 @@ import software.amazon.awssdk.services.cloudformation.model.{
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sts.StsClient
 
+import java.time.Duration.ofSeconds
 import java.util.UUID
 import scala.concurrent.ExecutionContext.global
 
@@ -35,6 +36,7 @@ class CloudFormationTest
     extends AnyFlatSpec
     with Matchers
     with Inside
+    with OptionValues
     with EitherValues {
   implicit val fakeKeyRing: KeyRing = KeyRing()
   implicit val reporter: DeployReporter =
@@ -85,6 +87,14 @@ class CloudFormationTest
           region
         )
       )
+  }
+
+  "parameters for durations" should "behave as documented and assume integers are in seconds" in {
+    cloudformationDeploymentType.secondsToWaitForChangeSetCreation
+      .parse(
+        JsNumber(30)
+      )
+      .value shouldEqual ofSeconds(30)
   }
 
   it should "generate the tasks in the correct order when manageStackPolicy is false" in {

--- a/magenta-lib/src/test/scala/magenta/deployment_type/ParamTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/ParamTest.scala
@@ -1,20 +1,31 @@
 package magenta.deployment_type
 
 import java.util.UUID
-
 import magenta.artifact.S3Path
 import magenta._
 import magenta.fixtures._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.mockito.MockitoSugar
-import play.api.libs.json.JsString
+import play.api.libs.json.{JsNumber, JsString, JsValue}
 
+import java.time.Duration.ofSeconds
 import scala.collection.mutable
 
-class TestRegister extends ParamRegister {
-  val paramsList = mutable.Map.empty[String, Param[_]]
-  def add(param: Param[_]) = paramsList += param.name -> param
+class ParamRegistrationTest extends AnyFlatSpec with Matchers {
+  class TestRegister extends ParamRegister {
+    val paramsList = mutable.Map.empty[String, Param[_]]
+    def add(param: Param[_]) = paramsList += param.name -> param
+  }
+
+  "Param registration" should "occur when a param is created" in {
+    implicit val register: TestRegister = new TestRegister
+
+    val param = Param[String]("test")
+
+    register.paramsList.size shouldBe 1
+    register.paramsList shouldBe Map("test" -> param)
+  }
 }
 
 class ParamTest extends AnyFlatSpec with Matchers with MockitoSugar {
@@ -31,165 +42,100 @@ class ParamTest extends AnyFlatSpec with Matchers with MockitoSugar {
       actionNames = Seq("testAction")
     )
   )
-
-  "Param" should "register itself with a register" in {
-    implicit val register = new TestRegister
-
-    val param = Param[String]("test")
-
-    register.paramsList.size shouldBe 1
-    register.paramsList shouldBe Map("test" -> param)
-  }
-
-  it should "extract a value from a package using get" in {
-    implicit val register = new TestRegister
-    val pkg = DeploymentPackage(
+  def stubDeploymentPackage(pkgSpecificData: Map[String, JsValue]) =
+    DeploymentPackage(
       "testPackage",
       app1,
-      Map("key" -> JsString("myValue")),
+      pkgSpecificData,
       "testDeploymentType",
       S3Path("test", "test"),
       deploymentTypes
     )
-    val key = Param[String]("key").default("valueDefault")
-    val paramValue = key.get(pkg)
+  val Key = "demoParamName"
+  private val pkgWithEmptyConfig: DeploymentPackage =
+    stubDeploymentPackage(Map.empty)
+
+  implicit val stubRegister: ParamRegister =
+    (_: Param[_]) =>
+      () // We don't care about param registration for these tests
+
+  "Param" should "treat values as seconds when we've been explicit about it" in {
+    val key = Param
+      .waitingSecondsFor(Key, "something important to happen")
+      .default(ofSeconds(7))
+    key.documentation shouldBe "Number of seconds to wait for something important to happen"
+    key.get(stubDeploymentPackage(Map(Key -> JsNumber(15)))) shouldBe Some(
+      ofSeconds(15)
+    )
+  }
+
+  it should "extract a value from a package using get" in {
+    val param = Param[String](Key).default("valueDefault")
+    val paramValue =
+      param.get(stubDeploymentPackage(Map(Key -> JsString("myValue"))))
     paramValue shouldBe Some("myValue")
   }
 
   it should "extract None using get when the value isn't in a package" in {
-    implicit val register = new TestRegister
-    val pkg = DeploymentPackage(
-      "testPackage",
-      app1,
-      Map.empty,
-      "testDeploymentType",
-      S3Path("test", "test"),
-      deploymentTypes
-    )
-    val key = Param[String]("key").default("valueDefault")
-    val paramValue = key.get(pkg)
-    paramValue shouldBe None
+    Param[String](Key).default("d").get(pkgWithEmptyConfig) shouldBe None
   }
 
   it should "extract a value using apply" in {
-    implicit val register = new TestRegister
-    val pkg = DeploymentPackage(
-      "testPackage",
-      app1,
-      Map("key" -> JsString("myValue")),
-      "testDeploymentType",
-      S3Path("test", "test"),
-      deploymentTypes
-    )
-    val key = Param[String]("key").default("valueDefault")
-    val paramValue = key.apply(pkg, target, reporter)
-    paramValue shouldBe "myValue"
+    val pkg = stubDeploymentPackage(Map(Key -> JsString("myValue")))
+    val param = Param[String](Key).default("valueDefault")
+    param.apply(pkg, target, reporter) shouldBe "myValue"
   }
 
   it should "throw an exception if a value is not specified and has no default" in {
-    implicit val register = new TestRegister
-    val pkg = DeploymentPackage(
-      "testPackage",
-      app1,
-      Map.empty,
-      "testDeploymentType",
-      S3Path("test", "test"),
-      deploymentTypes
-    )
-    val key = Param[String]("key")
+    val param = Param[String](Key)
     val thrown = the[NoSuchElementException] thrownBy {
-      key.apply(pkg, target, reporter)
+      param.apply(pkgWithEmptyConfig, target, reporter)
     }
-    thrown.getMessage shouldBe "Package testPackage [testDeploymentType] requires parameter key of type String"
+    thrown.getMessage shouldBe s"Package testPackage [testDeploymentType] requires parameter $Key of type String"
   }
 
   it should "return the param default from apply when no value is specified" in {
-    implicit val register = new TestRegister
-    val pkg = DeploymentPackage(
-      "testPackage",
-      app1,
-      Map.empty,
-      "testDeploymentType",
-      S3Path("test", "test"),
-      deploymentTypes
-    )
-    val key = Param[String]("key").default("valueDefault")
-    val paramValue = key.apply(pkg, target, reporter)
-    paramValue shouldBe "valueDefault"
+    val param = Param[String](Key).default("valueDefault")
+    param.apply(pkgWithEmptyConfig, target, reporter) shouldBe "valueDefault"
   }
 
   it should "return the param context default from apply when no value is specified" in {
-    implicit val register = new TestRegister
-    val pkg = DeploymentPackage(
-      "testPackage",
-      app1,
-      Map.empty,
-      "testDeploymentType",
-      S3Path("test", "test"),
-      deploymentTypes
-    )
-    val key = Param[String]("key").defaultFromContext((pkg, target) =>
+    val param = Param[String](Key).defaultFromContext((_, target) =>
       Right(s"${target.region.name}")
     )
-    val paramValue = key.apply(pkg, target, reporter)
-    paramValue shouldBe "testRegion"
+    val paramValue = param.apply(pkgWithEmptyConfig, target, reporter)
+    paramValue shouldBe target.region.name
   }
 
   it should "throw an exception if defaultFromContext returns a Left value" in {
-    implicit val register = new TestRegister
-    val pkg = DeploymentPackage(
-      "testPackage",
-      app1,
-      Map.empty,
-      "testDeploymentType",
-      S3Path("test", "test"),
-      deploymentTypes
-    )
-    val key = Param[String]("key").defaultFromContext((pkg, target) =>
+    val key = Param[String](Key).defaultFromContext((_, _) =>
       Left("something was wrong")
     )
     val thrown = the[NoSuchElementException] thrownBy {
-      key.apply(pkg, target, reporter)
+      key.apply(pkgWithEmptyConfig, target, reporter)
     }
-    thrown.getMessage shouldBe "Error whilst generating default for parameter key in package testPackage [testDeploymentType]: something was wrong"
+    thrown.getMessage shouldBe s"Error whilst generating default for parameter $Key in package testPackage [testDeploymentType]: something was wrong"
   }
 
   it should "log if the value you've specified is the same as the default" in {
     val mockReporter = mock[DeployReporter]
-    implicit val register = new TestRegister
-    val pkg = DeploymentPackage(
-      "testPackage",
-      app1,
-      Map("key" -> JsString("sameValue")),
-      "testDeploymentType",
-      S3Path("test", "test"),
-      deploymentTypes
-    )
-    val key = Param[String]("key").default("sameValue")
-    val paramValue = key.apply(pkg, target, mockReporter)
+    val pkg = stubDeploymentPackage(Map(Key -> JsString("sameValue")))
+    val paramValue =
+      Param[String](Key).default("sameValue").apply(pkg, target, mockReporter)
     paramValue shouldBe "sameValue"
     verify(mockReporter).info(
-      "Parameter key is unnecessarily explicitly set to the default value of sameValue"
+      s"Parameter $Key is unnecessarily explicitly set to the default value of sameValue"
     )
   }
 
   it should "log if the value you've specified is the same as the default from context" in {
     val mockReporter = mock[DeployReporter]
-    implicit val register = new TestRegister
-    val pkg = DeploymentPackage(
-      "testPackage",
-      app1,
-      Map("key" -> JsString("sameValue")),
-      "testDeploymentType",
-      S3Path("test", "test"),
-      deploymentTypes
-    )
-    val key =
-      Param[String]("key").defaultFromContext((_, _) => Right("sameValue"))
-    val paramValue = key.apply(pkg, target, mockReporter)
-    paramValue shouldBe "sameValue"
+    val pkg = stubDeploymentPackage(Map(Key -> JsString("sameValue")))
+    val param =
+      Param[String](Key).defaultFromContext((_, _) => Right("sameValue"))
+    param.apply(pkg, target, mockReporter) shouldBe "sameValue"
     verify(mockReporter).info(
-      "Parameter key is unnecessarily explicitly set to the default value of sameValue"
+      s"Parameter $Key is unnecessarily explicitly set to the default value of sameValue"
     )
   }
 }

--- a/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTypeResolverTest.scala
+++ b/magenta-lib/src/test/scala/magenta/input/resolver/DeploymentTypeResolverTest.scala
@@ -95,7 +95,7 @@ class DeploymentTypeResolverTest
     val deploymentTypesWithParams = List(
       stubDeploymentType(
         Seq("upload", "deploy"),
-        register => List(Param[String]("param1")(register))
+        implicit register => List(Param[String]("param1"))
       )
     )
     val configErrors = DeploymentTypeResolver
@@ -111,7 +111,7 @@ class DeploymentTypeResolverTest
     val deploymentTypesWithParams = List(
       stubDeploymentType(
         Seq("upload", "deploy"),
-        register => List(Param[String]("param1", optional = true)(register))
+        implicit register => List(Param[String]("param1", optional = true))
       )
     )
     DeploymentTypeResolver
@@ -123,11 +123,9 @@ class DeploymentTypeResolverTest
     val deploymentTypesWithParams = List(
       stubDeploymentType(
         Seq("upload", "deploy"),
-        register =>
+        implicit register =>
           List(
-            Param[String]("param1", defaultValue = Some("defaultValue"))(
-              register
-            )
+            Param[String]("param1", defaultValue = Some("defaultValue"))
           )
       )
     )
@@ -140,12 +138,12 @@ class DeploymentTypeResolverTest
     val deploymentTypesWithParams = List(
       stubDeploymentType(
         Seq("upload", "deploy"),
-        register =>
+        implicit register =>
           List(
             Param[String](
               "param1",
               defaultValueFromContext = Some((pkg, _) => Right(pkg.name))
-            )(register)
+            )
           )
       )
     )


### PR DESCRIPTION
This PR improves time & duration handling in Riff Raff by switching representation from `Int` or `Long` types (types which don't incorporate a time-unit, meaning we have to work out from our _context_ whether we are using seconds, milliseconds, epoch-ms, etc) to using the great `java.time.*` classes `Instant` & `Duration`.

This fixes a lot of things like:

* slightly obscure integer constants like `5 * 60 * 1000` (denoting 5 minutes)
* the inability of the compiler to check we're performing the right kind of operation to change time-units - the compiler can't know if what we're doing with an `Int` makes sense!
* variable names like `durationMillis`, where 'millis' had to be included because the declared type of `Long` isn't _telling_ us what the type is
* frequently multiplying numbers by 1000 to transform a value that we are quite sure is measured in seconds, into milliseconds!
* the risk that integer arithmetic might overflow when making time calculations, silently corrupting the result
 
If you can use a strongly-typed time class instead - like `Duration` or `Instant` - the compiler and library author can do all of that stuff for us, it's much better! You also stand a better chance of avoiding the hallowed [_falsehoods programmers believe about time_](https://gist.github.com/timvisee/fcda9bbdff88d45cc9061606b4b923ca).

### From `Param[Int]` to `Param[Duration]` - durations are still specified in seconds ⏱️ 

  Riff Raff has several parameters which specify durations (eg `healthcheckGrace`, `warmupGrace`, etc). Historically these have all expected integer values and been documented to be duration in **seconds**:

```yaml
    parameters:
      healthcheckGrace: 420
      warmupGrace: 300
```

We don't want to make everyone change their Riff Raff configuration, and so those parameters need to continue to accept the same numeric values and still interpret them as seconds.

The `Param.waitingSecondsFor()` helper method lets us create parameters that are a `Param[Duration]` (which could have been problematic because `java.time.Duration` has no _specified_ time unit) that still _explicitly_ parse their input as seconds, and are tested to do so.

### Migrating from Joda-Time to java.time
We should be using `java.time.*` classes in our codebases, in preference to the wonderful but old Joda-Time library:

https://blog.joda.org/2014/11/converting-from-joda-time-to-javatime.html


### Testing

I've [deployed](https://riffraff.code.dev-gutools.co.uk/deployment/view/98e02d80-825d-4075-865e-bf85dc34df3f) this branch to CODE Riff Raff (https://riffraff.code.dev-gutools.co.uk/) and then used CODE Riff Raff to deploy the Ophan Dashboard to PROD, and DotCom Frontend to CODE, successfully.

Frontend [uses](https://github.com/guardian/frontend/blob/f2c54a6df0344e80468208dd94deb8adf42f45ee/riff-raff.yaml#L14) a custom warmupGrace value of 60 seconds, different to the default of 1 second we normally use:

https://github.com/guardian/riff-raff/blob/feaf4f0661fe50d6b3c9ea0f246c246691622403/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala#L100-L105

We can see in this [successful deploy](https://riffraff.code.dev-gutools.co.uk/deployment/view/fbb157ef-e58b-4fea-8205-eec5a9d45bfa) of Frontend CODE by this branch of Riff Raff, that the warmupGrace value of 60 has still been correctly parsed, and displayed as 60000 milliseconds:

![image](https://github.com/guardian/riff-raff/assets/52038/6b2416f4-b470-4323-86e0-b901b308af9c)


See also:

* https://github.com/guardian/ophan/pull/3988 - another PR achieving a similar thing for Ophan