### PR TITLE
Upgrade to Scanamo v1.1.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -70,7 +70,7 @@ object Dependencies {
       "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "8.3.1",
       "org.pegdown" % "pegdown" % "1.6.0",
       "com.adrianhurt" %% "play-bootstrap" % "1.6.1-P28-B3", // scala-steward:off,
-      "org.scanamo" %% "scanamo" % "1.0.0-M11", // scala-steward:off,
+      "org.scanamo" %% "scanamo" % "1.1.1",
       "software.amazon.awssdk" % "dynamodb" % Versions.aws,
       "software.amazon.awssdk" % "sns" % Versions.aws,
       "org.quartz-scheduler" % "quartz" % "2.3.2",

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -1,6 +1,5 @@
 package conf
 
-import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.profile.{
   ProfileCredentialsProvider => ProfileCredentialsProviderV1
 }
@@ -13,7 +12,6 @@ import com.amazonaws.auth.{
   InstanceProfileCredentialsProvider => InstanceProfileCredentialsProviderV1,
   SystemPropertiesCredentialsProvider => SystemPropertiesCredentialsProviderV1
 }
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClientBuilder
 import com.amazonaws.services.sns.{
   AmazonSNSAsync,
   AmazonSNSAsyncClientBuilder => AmazonSNSAsyncClientBuilderV1
@@ -32,6 +30,7 @@ import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sts.StsClient
 import utils.{DateFormats, UnnaturalOrdering}
 import riffraff.BuildInfo
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.ssm.SsmClient
 
 import scala.jdk.CollectionConverters._
@@ -161,11 +160,10 @@ class Config(configuration: TypesafeConfig, startTime: DateTime)
     lazy val regionName =
       getStringOpt("artifact.aws.region").getOrElse(defaultRegion)
     // Used by Scanamo which is not on the latest version of AWS SDK
-    val client = AmazonDynamoDBAsyncClientBuilder
-      .standard()
-      .withCredentials(legacyCredentialsProviderChain(None, None))
-      .withRegion(regionName)
-      .withClientConfiguration(new ClientConfiguration())
+    val client = DynamoDbClient
+      .builder()
+      .region(AWSRegion.of(regionName))
+      .credentialsProvider(credentialsProviderChain(None, None))
       .build()
   }
 

--- a/riff-raff/app/persistence/ContinuousDeploymentConfigRepository.scala
+++ b/riff-raff/app/persistence/ContinuousDeploymentConfigRepository.scala
@@ -3,9 +3,8 @@ package persistence
 import java.util.UUID
 import ci.{ContinuousDeploymentConfig, Trigger}
 import org.scanamo.syntax._
-import org.scanamo.auto._
+import org.scanamo.generic.auto._
 import org.scanamo.{DynamoFormat, Table}
-import cats.syntax.either._
 import conf.Config
 
 class ContinuousDeploymentConfigRepository(config: Config)
@@ -13,8 +12,9 @@ class ContinuousDeploymentConfigRepository(config: Config)
 
   implicit val triggerModeFormat =
     DynamoFormat.coercedXmap[Trigger.Mode, String, NoSuchElementException](
-      Trigger.withName
-    )(_.toString)
+      Trigger.withName,
+      _.toString
+    )
 
   override val tablePrefix = "continuous-deployment-config"
 

--- a/riff-raff/app/persistence/DynamoRepository.scala
+++ b/riff-raff/app/persistence/DynamoRepository.scala
@@ -17,13 +17,15 @@ abstract class DynamoRepository(config: Config) {
   val stage = if (config.stage == "DEV") "CODE" else config.stage
   lazy val tableName = s"$tablePrefix-$stage"
 
-  implicit val uuidFormat =
+  implicit val uuidFormat: DynamoFormat[UUID] =
     DynamoFormat.coercedXmap[UUID, String, IllegalArgumentException](
-      UUID.fromString
-    )(_.toString)
+      UUID.fromString,
+      _.toString
+    )
 
-  implicit val jodaStringFormat =
+  implicit val jodaStringFormat: DynamoFormat[DateTime] =
     DynamoFormat.coercedXmap[DateTime, String, IllegalArgumentException](
-      DateTime.parse
-    )(_.toString)
+      DateTime.parse,
+      _.toString
+    )
 }

--- a/riff-raff/app/persistence/HookConfigRepository.scala
+++ b/riff-raff/app/persistence/HookConfigRepository.scala
@@ -6,14 +6,15 @@ import org.scanamo.{DynamoFormat, Table}
 import notification.{HookConfig, HttpMethod}
 import cats.syntax.either._
 import conf.Config
-import org.scanamo.auto._
+import org.scanamo.generic.auto._
 
 class HookConfigRepository(config: Config) extends DynamoRepository(config) {
 
   implicit val httpMethodFormat =
     DynamoFormat.coercedXmap[HttpMethod, String, NoSuchElementException](
-      HttpMethod.apply
-    )(_.toString)
+      HttpMethod.apply,
+      _.toString
+    )
 
   override val tablePrefix = "hook-config"
 

--- a/riff-raff/app/persistence/RestrictionConfigDynamoRepository.scala
+++ b/riff-raff/app/persistence/RestrictionConfigDynamoRepository.scala
@@ -6,7 +6,7 @@ import org.scanamo.Table
 import restrictions.{RestrictionConfig, RestrictionsConfigRepository}
 import cats.syntax.either._
 import conf.Config
-import org.scanamo.auto._
+import org.scanamo.generic.auto._
 
 class RestrictionConfigDynamoRepository(config: Config)
     extends DynamoRepository(config)

--- a/riff-raff/app/persistence/ScheduleRepository.scala
+++ b/riff-raff/app/persistence/ScheduleRepository.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 import ci.Trigger
 import org.scanamo.syntax._
 import org.scanamo.{DynamoFormat, Table}
-import org.scanamo.auto._
+import org.scanamo.generic.auto._
 import conf.Config
 import schedule.ScheduleConfig
 
@@ -12,8 +12,9 @@ class ScheduleRepository(config: Config) extends DynamoRepository(config) {
 
   implicit val triggerModeFormat =
     DynamoFormat.coercedXmap[Trigger.Mode, String, NoSuchElementException](
-      Trigger.withName
-    )(_.toString)
+      Trigger.withName,
+      _.toString
+    )
 
   override val tablePrefix = "schedule-config"
 

--- a/riff-raff/app/persistence/TargetDynamoRepository.scala
+++ b/riff-raff/app/persistence/TargetDynamoRepository.scala
@@ -2,11 +2,9 @@ package persistence
 
 import ci.Target
 import org.scanamo.Table
-import org.scanamo.error.DynamoReadError
 import conf.Config
 import org.joda.time.DateTime
-import org.scanamo.auto._
-import org.scanamo.syntax._
+import org.scanamo.generic.auto._
 
 case class TargetId(
     targetKey: String,
@@ -42,7 +40,7 @@ class TargetDynamoRepository(config: Config) extends DynamoRepository(config) {
       target: Target,
       projectName: String,
       lastSeen: DateTime
-  ): Option[Either[DynamoReadError, TargetId]] =
+  ): Unit =
     exec(table.put(TargetId(target, projectName, lastSeen)))
 
   def get(targetKey: String, projectName: String): Option[TargetId] = {
@@ -58,6 +56,4 @@ class TargetDynamoRepository(config: Config) extends DynamoRepository(config) {
         _.matches(target)
       ) // make sure this is not a weird collision due to use of separator in fields
   }
-
-  def getAll: Seq[TargetId] = exec(table.scan()).flatMap(_.toOption)
 }


### PR DESCRIPTION
Here we're moving up from Scanamo [1.0.0-M11](https://github.com/scanamo/scanamo/releases/tag/v1.0.0-M11) to [1.1.1](https://github.com/scanamo/scanamo/releases/tag/v1.1.1), which involves several changes to requirements:

* **AWS SDK v1 → v2** - Scanamo [1.0-M13](https://github.com/scanamo/scanamo/releases/tag/v1.0-M13) and above require AWS SDK v2. AWS SDK v2 is actually used quite widely already in Riff Raff, so this wasn't hard - there does still seem to be _some_ other code in Riff Raff using AWS SDK v1 at the moment.
* **Scanamo API changes**
  - Auto-generated `DynamoFormat` handlers are now created with `org.scanamo.generic.auto._` rather than `org.scanamo.auto._` (https://github.com/scanamo/scanamo/pull/538 - [1.0-M12](https://github.com/scanamo/scanamo/releases/tag/v1.0.0-M12))
  - `DynamoFormat.coercedXmap()` now has a single set of two arguments, rather than curried arguments (https://github.com/scanamo/scanamo/pull/588 - [1.0-M13](https://github.com/scanamo/scanamo/releases/tag/v1.0-M13))
  - `Table.put()` now returns `Unit` rather than the old value- you can use `Table.putAndReturn()` if you want a value returned, which allows you to specify whether it's the prior value or the new one you want (https://github.com/scanamo/scanamo/pull/486 - [1.0-M13](https://github.com/scanamo/scanamo/releases/tag/v1.0-M13))

See also:

* https://github.com/guardian/maintaining-scala-projects/issues/6
