### PR TITLE
feat: Add name of who started a deployment on log page

### DIFF
--- a/riff-raff/app/views/deploy/viewDeploy.scala.html
+++ b/riff-raff/app/views/deploy/viewDeploy.scala.html
@@ -26,18 +26,32 @@
         <div class="col-md-8">
             <h2>Deploy of @record.buildName build @record.buildId@record.metaData.get("branch").map{ branch=> [@branch]} in @record.stage.name</h2>
 
-            @record.metaData.get(deployment.Record.RIFFRAFF_HOSTNAME).map { hostname =>
-                <small>This deploy started at @record.time.toString(DateFormats.Short) on @hostname</small>
-            }
-
-            <p>The update strategy for this deploy @if(record.isRunning) {is} else {was} @record.parameters.updateStrategy.entryName</p>
-
-            @for(vcs <- record.vcsInfo) {
-                <p>
-                    The commit for this deploy @if(record.isRunning) {is} else {was}
-                    <a href="@vcs.commitUrl">@vcs.revision</a>
-                </p>
-            }
+            <table class="table">
+                @record.metaData.get(deployment.Record.RIFFRAFF_HOSTNAME).map { hostname =>
+                    <tr>
+                        <th scope="row">Started</th>
+                        <td>
+                            @record.time.toString(DateFormats.Short) (on @hostname)
+                        </td>
+                    </tr>
+                }
+                <tr>
+                    <th scope="row">Deployer</th>
+                    <td>@record.deployerName</td>
+                </tr>
+                <tr>
+                    <th scope="row">Update Strategy</th>
+                    <td>@record.parameters.updateStrategy.entryName</td>
+                </tr>
+                @for(vcs <- record.vcsInfo) {
+                    <tr>
+                        <th scope="row">Commit</th>
+                        <td>
+                            <a href="@vcs.commitUrl">@vcs.revision (in @vcs.repo)</a>
+                        </td>
+                    </tr>
+                }
+            </table>
         </div>
         <div class="col-md-4">
             @if(record.isStalled) {


### PR DESCRIPTION
## What does this change?
Add the name of who started a deployment on log page. To make it easier to parse the amount of information, tabulate the data.

### Before
![image](https://github.com/guardian/riff-raff/assets/836140/e335c96b-2065-4e20-89a3-0332cf3d754d)

### After (when [deployed to CODE](https://riffraff.code.dev-gutools.co.uk/deployment/view/cd8af48c-e9fb-4249-bc60-09dce369acbc))
![image](https://github.com/guardian/riff-raff/assets/836140/1efad1dc-51bb-4bca-b21d-7d7a21a7b380)

## How can we measure success?
Knowing who triggered a deployment is useful in a number of scenarios. For example, when a scheduled deployment fails due to the previous deployment being a partial deployment, the team is notified thus:

<img width="647" alt="image" src="https://github.com/guardian/riff-raff/assets/836140/60769e44-d602-4640-9d40-98e475602a96">

The `View partial deploy` link goes to the deployment log page; knowing who did this partial deployment makes it easier to triage.