### PR TITLE
Add link to deployment log to grafana logger

### DIFF
--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -222,7 +222,7 @@ class AppComponents(
     deployments,
     builds,
     targetResolver,
-    new GrafanaAnnotationLogger,
+    new GrafanaAnnotationLogger(config.urls.publicPrefix),
     hooksClient,
     new SummariseDeploysHousekeeping(config, datastore),
     continuousDeployment,

--- a/riff-raff/app/notification/GrafanaAnnotationLogger.scala
+++ b/riff-raff/app/notification/GrafanaAnnotationLogger.scala
@@ -19,7 +19,7 @@ trait LogMarker {
   def markerContents: Map[String, Any]
 }
 
-class GrafanaAnnotationLogger extends Lifecycle with Logging {
+class GrafanaAnnotationLogger(riffRaffUrl: String) extends Lifecycle with Logging {
 
   val messageSub: Subscription = DeployReporter.messages.subscribe(message => {
     val deployId = message.context.deployId
@@ -44,8 +44,8 @@ class GrafanaAnnotationLogger extends Lifecycle with Logging {
         "projectBuild" -> parameters.build.id,
         "projectStage" -> parameters.stage.name,
         "projectDeployer" -> parameters.deployer.name,
-        "projectHistoryTag" -> s"<a href=\"https://riffraff.gutools.co.uk/deployment/history?projectName=${parameters.build.projectName}\">${parameters.build.projectName}</a>",
-        "projectDeploymentLink" -> s"<a href=\"https://riffraff.gutools.co.uk/deployment/view/$deployId\">${parameters.build.id}</a>"
+        "projectHistoryTag" -> s"<a href=\"${riffRaffUrl}/deployment/history?projectName=${parameters.build.projectName}\">${parameters.build.projectName}</a>",
+        "projectDeploymentLink" -> s"<a href=\"${riffRaffUrl}/deployment/view/$deployId\">${parameters.build.id}</a>"
       )
     MarkerContext(appendEntries(params.asJava))
   }

--- a/riff-raff/app/notification/GrafanaAnnotationLogger.scala
+++ b/riff-raff/app/notification/GrafanaAnnotationLogger.scala
@@ -19,7 +19,9 @@ trait LogMarker {
   def markerContents: Map[String, Any]
 }
 
-class GrafanaAnnotationLogger(riffRaffUrl: String) extends Lifecycle with Logging {
+class GrafanaAnnotationLogger(riffRaffUrl: String)
+    extends Lifecycle
+    with Logging {
 
   val messageSub: Subscription = DeployReporter.messages.subscribe(message => {
     val deployId = message.context.deployId

--- a/riff-raff/app/notification/GrafanaAnnotationLogger.scala
+++ b/riff-raff/app/notification/GrafanaAnnotationLogger.scala
@@ -46,7 +46,6 @@ class GrafanaAnnotationLogger(riffRaffUrl: String)
         "projectBuild" -> parameters.build.id,
         "projectStage" -> parameters.stage.name,
         "projectDeployer" -> parameters.deployer.name,
-        "projectHistoryTag" -> s"<a href=\"${riffRaffUrl}/deployment/history?projectName=${parameters.build.projectName}\">${parameters.build.projectName}</a>",
         "projectDeploymentLink" -> s"<a target=\"_blank\" href=\"${riffRaffUrl}/deployment/view/$deployId\">${parameters.build.id}</a>"
       )
     MarkerContext(appendEntries(params.asJava))

--- a/riff-raff/app/notification/GrafanaAnnotationLogger.scala
+++ b/riff-raff/app/notification/GrafanaAnnotationLogger.scala
@@ -47,7 +47,7 @@ class GrafanaAnnotationLogger(riffRaffUrl: String)
         "projectStage" -> parameters.stage.name,
         "projectDeployer" -> parameters.deployer.name,
         "projectHistoryTag" -> s"<a href=\"${riffRaffUrl}/deployment/history?projectName=${parameters.build.projectName}\">${parameters.build.projectName}</a>",
-        "projectDeploymentLink" -> s"<a href=\"${riffRaffUrl}/deployment/view/$deployId\">${parameters.build.id}</a>"
+        "projectDeploymentLink" -> s"<a target=\"_blank\" href=\"${riffRaffUrl}/deployment/view/$deployId\">${parameters.build.id}</a>"
       )
     MarkerContext(appendEntries(params.asJava))
   }

--- a/riff-raff/app/notification/GrafanaAnnotationLogger.scala
+++ b/riff-raff/app/notification/GrafanaAnnotationLogger.scala
@@ -38,7 +38,8 @@ class GrafanaAnnotationLogger extends Lifecycle with Logging {
         "projectName" -> parameters.build.projectName,
         "projectBuild" -> parameters.build.id,
         "projectStage" -> parameters.stage.name,
-        "projectDeployer" -> parameters.deployer.name
+        "projectDeployer" -> parameters.deployer.name,
+        "projectHistoryTag" -> s"<a href=\"https://riffraff.gutools.co.uk/deployment/history?projectName=${parameters.deployer.name}\">${parameters.deployer.name}<a/>"
       )
     MarkerContext(appendEntries(params.asJava))
   }

--- a/riff-raff/app/notification/GrafanaAnnotationLogger.scala
+++ b/riff-raff/app/notification/GrafanaAnnotationLogger.scala
@@ -39,7 +39,7 @@ class GrafanaAnnotationLogger extends Lifecycle with Logging {
         "projectBuild" -> parameters.build.id,
         "projectStage" -> parameters.stage.name,
         "projectDeployer" -> parameters.deployer.name,
-        "projectHistoryTag" -> s"<a href=\"https://riffraff.gutools.co.uk/deployment/history?projectName=${parameters.deployer.name}\">${parameters.deployer.name}<a/>"
+        "projectHistoryTag" -> s"<a href=\"https://riffraff.gutools.co.uk/deployment/history?projectName=${parameters.build.projectName}\">${parameters.build.projectName}<a/>"
       )
     MarkerContext(appendEntries(params.asJava))
   }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds a new field to the grafana logger containing an html `a` tag. This is displayed by grafana as an actual link in the annotation, like in the screenshot below.

![c65ae7ecc3f61135368b76028ca3c6ae12a34594](https://github.com/user-attachments/assets/e33f3f29-b741-4c45-b8c7-4b751bf998cd)

The intention is to turn the build number in our annotation to a link to the actual deployment in riff raff

<img width="231" alt="Screenshot 2024-09-23 at 10 41 25" src="https://github.com/user-attachments/assets/ded02e84-e877-4f15-8660-f1d30f4f2b60">

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

We deployed this branch to riff raff code, deployed the cdk playground project, and were able to harcode grafana to display the deployment as an annotation and it seemed to work ok!