### PR TITLE
Revert "Add riff raff project tag"

### DIFF
--- a/riff-raff/app/AppComponents.scala
+++ b/riff-raff/app/AppComponents.scala
@@ -108,8 +108,7 @@ class AppComponents(
 
       Map(
         "gu:build-tool" -> buildTool.getOrElse(default),
-        "gu:repo" -> repoUrl.getOrElse(default),
-        "gu:riff-raff:project" -> projectName
+        "gu:repo" -> repoUrl.getOrElse(default)
       )
     }
   }


### PR DESCRIPTION
Reverts guardian/riff-raff#1374

It's emerged that this change might break deployments for projects that use the ami update functionality. If the stack has enough components that all need to be tagged, the list of events in the cloudformation stack becomes so long that it breaks. 

See
https://github.com/guardian/riff-raff/blob/main/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala#L34


We think that removing this tag should be safe as riff raff should not remove the tags that have already been added. It will just stop adding tags to new deployments, and the ~40 projects that rely on this ami update deployment type should continue to work without issue.