### PR TITLE
feat(cloud-formation): Preserve existing tags

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/SetStackPolicyTask.scala
@@ -211,7 +211,7 @@ class SetStackPolicyTask(
       stopFlag: => Boolean
   ): Unit = {
     CloudFormation.withCfnClient(keyRing, region, resources) { cfnClient =>
-      val (stackName, changeSetType, _) =
+      val (stackName, changeSetType, _, _) =
         stackLookup.lookup(resources.reporter, cfnClient)
       val policyDoc =
         toPolicyDoc(stackPolicy, () => accountResourceTypes(cfnClient))

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -98,7 +98,7 @@ class CloudFormationStackMetadata(
   def lookup(
       reporter: DeployReporter,
       cfnClient: CloudFormationClient
-  ): (String, ChangeSetType, List[ExistingParameter]) = {
+  ): (String, ChangeSetType, List[ExistingParameter], Map[String, String]) = {
     val existingStack = strategy match {
       case LookupByName(name) => CloudFormation.describeStack(name, cfnClient)
       case LookupByTags(tags) =>
@@ -123,7 +123,12 @@ class CloudFormationStackMetadata(
       reporter
     )
 
-    (stackName, changeSetType, stackParameters)
+    val currentTags: Map[String, String] = existingStack match {
+      case Some(stack) => stack.tags().asScala.map(t => t.key -> t.value).toMap
+      case _           => Map.empty
+    }
+
+    (stackName, changeSetType, stackParameters, currentTags)
   }
 }
 


### PR DESCRIPTION
## What does this change?
Update the `cloud-formation` deployment type to preserve any existing tags on the CloudFormation stack.

## How to test
1. Deploy `main` to RIff-Raff CODE
2. Add a random tag [^1] to the stack `playground-PROD-cdk-playground` in the Developer Playground account (from https://github.com/guardian/cdk-playground)
3. Using Riff-Raff CODE, deploy the project `devx::cdk-playground`
4. Observe the tag added in step 2 being removed
5. [Deploy this branch](https://riffraff.code.dev-gutools.co.uk/deployment/view/2c220c29-9af7-4d1d-9a4b-7a8d480727dc) to Riff-Raff CODE
6. Repeat step 2
7. [Repeat step 3](https://riffraff.code.dev-gutools.co.uk/deployment/view/ae594e45-4b99-4494-b29a-42942fa0fdab)
8. Observe the tag added in step 6 remaining, and the deployment log stating as such

<details><summary>Screenshot</summary>
<p>

![image](https://github.com/user-attachments/assets/b3ac1514-0058-4035-a32f-9f5c532df0e9)

</p>
</details> 

[^1]: I added the tag `Month -> September`