### PR TITLE
feat: Set `MinInstancesInService` via CFN parameters

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AmiCloudFormationParameter.scala
@@ -53,6 +53,7 @@ object AmiCloudFormationParameter
       }
 
       val amiLookupFn = getLatestAmi(pkg, target, reporter, resources.lookup)
+      val minInServiceParameterMap = getMinInServiceTagRequirements(pkg, target)
 
       val unresolvedParameters = new CloudFormationParameters(
         target = target,
@@ -61,7 +62,8 @@ object AmiCloudFormationParameter
         latestImage = amiLookupFn,
 
         // Not expecting any user parameters in this deployment type
-        userParameters = Map.empty
+        userParameters = Map.empty,
+        minInServiceParameterMap = minInServiceParameterMap
       )
 
       List(

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -1,6 +1,6 @@
 package magenta.deployment_type
 
-import magenta.Loggable
+import magenta.{Loggable, Strategy}
 import magenta.Strategy.{Dangerous, MostlyHarmless}
 import magenta.artifact.S3Path
 import magenta.deployment_type.CloudFormationDeploymentTypeParameters._
@@ -148,12 +148,15 @@ class CloudFormation(tagger: BuildTags)
 
       val changeSetName = s"${target.stack.name}-${new DateTime().getMillis}"
 
+      val minInServiceParameterMap = getMinInServiceTagRequirements(pkg, target)
+
       val unresolvedParameters = new CloudFormationParameters(
         target,
         stackTags,
         userParams,
         amiParameterMap,
-        amiLookupFn
+        amiLookupFn,
+        minInServiceParameterMap
       )
 
       val createNewStack = createStackIfAbsent(pkg, target, reporter)

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormationDeploymentTypeParameters.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormationDeploymentTypeParameters.scala
@@ -224,13 +224,13 @@ trait CloudFormationDeploymentTypeParameters {
           TagMatch("Stack", target.stack.name),
           TagMatch("Stage", target.parameters.stage.name)
         )
-        params.map({ case (cfnParam, tagRequirements) =>
+        params.map { case (cfnParam, tagRequirements) =>
           cfnParam -> {
-            tagRequirements
-              .map({ case (key, value) => TagMatch(key, value) })
-              .toList ++ stackStageTags
+            tagRequirements.map { case (key, value) =>
+              TagMatch(key, value)
+            }.toList ++ stackStageTags
           }
-        })
+        }
       case _ => Map.empty
     }
   }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormationDeploymentTypeParameters.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormationDeploymentTypeParameters.scala
@@ -1,11 +1,15 @@
 package magenta.deployment_type
 
+import magenta.deployment_type.CloudFormationDeploymentTypeParameters.CfnParam
+import magenta.tasks.ASG
+import magenta.tasks.ASG.TagMatch
 import magenta.tasks.UpdateCloudFormationTask.{
   CloudFormationStackLookupStrategy,
   LookupByName,
   LookupByTags
 }
 import magenta.{DeployReporter, DeployTarget, DeploymentPackage, Lookup}
+import software.amazon.awssdk.services.autoscaling.AutoScalingClient
 
 import java.time.Duration
 import java.time.Duration.ofMinutes
@@ -104,6 +108,24 @@ trait CloudFormationDeploymentTypeParameters {
       """.stripMargin
   ).default(false)
 
+  val minInstancesInServiceParameters = Param[Map[CfnParam, TagCriteria]](
+    "minInstancesInServiceParameters",
+    optional = true,
+    documentation = """Mapping between a CloudFormation parameter controlling the MinInstancesInService property of an ASG UpdatePolicy and the ASG.
+        |
+        |For example:
+        |```
+        |  minInstancesInServiceParameters:
+        |    MinInstancesInServiceForApi:
+        |      App: my-api
+        |    MinInstancesInServiceForFrontend:
+        |      App: my-frontend
+        |```
+        |This instructs Riff-Raff that the CFN parameter `MinInstancesInServiceForApi` relates to an ASG tagged `App=my-api`.
+        |Additional requirements of `Stack=<STACK BEING DEPLOYED>`, `Stage=<STAGE BEING DEPLOYED>` and `aws:cloudformation:stack-name=<CFN STACK BEING DEPLOYED>` are automatically added.
+      """.stripMargin
+  )
+
   val secondsToWaitForChangeSetCreation: Param[Duration] = Param
     .waitingSecondsFor(
       "secondsToWaitForChangeSetCreation",
@@ -190,5 +212,26 @@ trait CloudFormationDeploymentTypeParameters {
           }
         }
       }
+  }
+
+  def getMinInServiceTagRequirements(
+      pkg: DeploymentPackage,
+      target: DeployTarget
+  ): Map[CfnParam, List[TagMatch]] = {
+    minInstancesInServiceParameters.get(pkg) match {
+      case Some(params) =>
+        val stackStageTags = List(
+          TagMatch("Stack", target.stack.name),
+          TagMatch("Stage", target.parameters.stage.name)
+        )
+        params.map({ case (cfnParam, tagRequirements) =>
+          cfnParam -> {
+            tagRequirements
+              .map({ case (key, value) => TagMatch(key, value) })
+              .toList ++ stackStageTags
+          }
+        })
+      case _ => Map.empty
+    }
   }
 }

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -508,23 +508,18 @@ object ASG {
         // Happy path. We have enough headroom to double the instances, then half once healthy.
         if (2 * desired <= max) {
           reporter.info(
-            s"""Deploying new instances all at once.
-               |
-               |Max=$max. Desired=$desired.
-               |Setting MinInstancesInService=$minInstancesInService.
-               |""".stripMargin
+            s"Max=$max. Desired=$desired. Setting MinInstancesInService=$minInstancesInService."
           )
         }
 
-        // We have to take some running instances out of service, at the cost of reduced service availability.
+        // We have to take some running instances out of service, at the cost of possibly reducing service availability.
         else if (minInstancesInService < desired) {
           reporter.warning(
-            s"""Deploying new instances slowly, in multiple batches and impacting availability.
-               |
-               |Max=$max. Desired=$desired.
-               |Setting MinInstancesInService=$minInstancesInService.
-               |This is 75% of max capacity, and less than desired capacity.
-               |Availability will be impacted as ${desired - minInstancesInService} currently running instances will be used to perform this deploy.
+            s"""Max=$max. Desired=$desired. Setting MinInstancesInService=$minInstancesInService.
+               |This deployment will temporarily reduce the number of in-service instances.
+               |The number of instances may go as low as $minInstancesInService, which is less than the current desired capacity of $desired.
+               |To ensure a quick deployment we cannot set "MinInstancesInService" to more than 75% of the maximum number of instances.
+               |You should consider increasing your application's maximum capacity so that we always have at least 25% headroom for deployments.
                |""".stripMargin
           )
         }
@@ -532,10 +527,10 @@ object ASG {
         // There isn't enough room to double capacity, but we don't have to take any instances out of service.
         else {
           reporter.warning(
-            s"""Deploying new instances slowly, in multiple batches.
-               |
-               |Max=$max. Desired=$desired.
-               |Setting MinInstancesInService=$minInstancesInService.
+            s"""Max=$max. Desired=$desired. Setting MinInstancesInService=$minInstancesInService.
+               |This deployment will happen more slowly, in multiple steps.
+               |The current number of in-service instances will be preserved and the application will be updated in batches of at most ${max - minInstancesInService}.
+               |You could consider increasing your application's maximum capacity to double of your expected maximum so that deployments can happen in a single step.
                |""".stripMargin
           )
         }

--- a/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
@@ -125,9 +125,9 @@ class CreateAmiUpdateChangeSetTask(
                   resources.reporter,
                   unresolvedParameters,
                   accountNumber,
-                  existingParameters.map(p =>
+                  existingParameters.map { p =>
                     TemplateParameter(p.key, default = true)
-                  ),
+                  },
                   existingParameters,
                   minInServiceParameters
                 )

--- a/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
@@ -259,10 +259,8 @@ class CreateChangeSetTask(
                   existingParameters
                 )
 
-              resources.reporter.info("Creating Cloudformation change set")
-              resources.reporter.info(s"Stack name: $stackName")
               resources.reporter.info(
-                s"Change set name: ${stackLookup.changeSetName}"
+                s"Creating Cloudformation change set. CloudFormation stack=$stackName. Change set name=${stackLookup.changeSetName}"
               )
 
               val maybeExecutionRole = CloudFormation.getExecutionRole(keyRing)

--- a/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/ChangeSetTasks.scala
@@ -1,6 +1,8 @@
 package magenta.tasks
 
 import magenta.artifact.S3Path
+import magenta.deployment_type.CloudFormationDeploymentTypeParameters.CfnParam
+import magenta.tasks.ASG.TagMatch
 import magenta.tasks.CloudFormationParameters.{
   ExistingParameter,
   InputParameter,
@@ -8,6 +10,7 @@ import magenta.tasks.CloudFormationParameters.{
 }
 import magenta.tasks.UpdateCloudFormationTask._
 import magenta.{DeployReporter, DeploymentResources, KeyRing, Region}
+import software.amazon.awssdk.services.autoscaling.AutoScalingClient
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient
 import software.amazon.awssdk.services.cloudformation.model.ChangeSetStatus._
 import software.amazon.awssdk.services.cloudformation.model._
@@ -82,53 +85,73 @@ class CreateAmiUpdateChangeSetTask(
     if (!stopFlag) {
       CloudFormation.withCfnClient(keyRing, region, resources) { cfnClient =>
         STS.withSTSclient(keyRing, region, resources) { stsClient =>
-          val accountNumber = STS.getAccountNumber(stsClient)
+          ASG.withAsgClient(keyRing, region, resources) { asgClient =>
+            {
+              val accountNumber = STS.getAccountNumber(stsClient)
 
-          val (stackName, _, existingParameters, currentTags) =
-            stackLookup.lookup(resources.reporter, cfnClient)
+              val (stackName, _, existingParameters, currentTags) =
+                stackLookup.lookup(resources.reporter, cfnClient)
 
-          resources.reporter.info(
-            "Creating Cloudformation change set to update AMI parameters"
-          )
-          resources.reporter.info(s"CloudFormation stack name: $stackName")
-          resources.reporter.info(
-            s"Change set name: ${stackLookup.changeSetName}"
-          )
+              resources.reporter.info(
+                "Creating Cloudformation change set to update AMI parameters"
+              )
+              resources.reporter.info(s"CloudFormation stack name: $stackName")
+              resources.reporter.info(
+                s"Change set name: ${stackLookup.changeSetName}"
+              )
 
-          val maybeExecutionRole = CloudFormation.getExecutionRole(keyRing)
-          maybeExecutionRole.foreach(role =>
-            resources.reporter.verbose(s"Using execution role: $role")
-          )
+              val maybeExecutionRole = CloudFormation.getExecutionRole(keyRing)
+              maybeExecutionRole.foreach(role =>
+                resources.reporter.verbose(s"Using execution role: $role")
+              )
 
-          val parameters = CloudFormationParameters
-            .resolve(
-              resources.reporter,
-              unresolvedParameters,
-              accountNumber,
-              existingParameters.map(p =>
-                TemplateParameter(p.key, default = true)
-              ),
-              existingParameters
-            )
-            .fold(
-              resources.reporter.fail(_),
-              identity
-            )
+              val cfnStackNameTag = TagMatch(
+                "aws:cloudformation:stack-name",
+                stackName
+              )
 
-          val awsParameters = convertInputParametersToAwsAndLog(
-            resources.reporter,
-            parameters,
-            existingParameters
-          )
+              val minInServiceParameters =
+                unresolvedParameters.minInServiceParameterMap.map {
+                  case (cfnParam, asgTagRequirements) =>
+                    cfnParam -> ASG.getMinInstancesInService(
+                      asgTagRequirements :+ cfnStackNameTag,
+                      asgClient,
+                      resources.reporter
+                    )
+                }
 
-          CloudFormation.createParameterUpdateChangeSet(
-            client = cfnClient,
-            changeSetName = stackLookup.changeSetName,
-            stackName = stackName,
-            currentStackTags = currentTags,
-            parameters = awsParameters,
-            maybeRole = maybeExecutionRole
-          )
+              val parameters = CloudFormationParameters
+                .resolve(
+                  resources.reporter,
+                  unresolvedParameters,
+                  accountNumber,
+                  existingParameters.map(p =>
+                    TemplateParameter(p.key, default = true)
+                  ),
+                  existingParameters,
+                  minInServiceParameters
+                )
+                .fold(
+                  resources.reporter.fail(_),
+                  identity
+                )
+
+              val awsParameters = convertInputParametersToAwsAndLog(
+                resources.reporter,
+                parameters,
+                existingParameters
+              )
+
+              CloudFormation.createParameterUpdateChangeSet(
+                client = cfnClient,
+                changeSetName = stackLookup.changeSetName,
+                stackName = stackName,
+                currentStackTags = currentTags,
+                parameters = awsParameters,
+                maybeRole = maybeExecutionRole
+              )
+            }
+          }
         }
       }
     }
@@ -153,85 +176,115 @@ class CreateChangeSetTask(
       CloudFormation.withCfnClient(keyRing, region, resources) { cfnClient =>
         S3.withS3client(keyRing, region, resources = resources) { s3Client =>
           STS.withSTSclient(keyRing, region, resources) { stsClient =>
-            val accountNumber = STS.getAccountNumber(stsClient)
+            ASG.withAsgClient(keyRing, region, resources) { asgClient =>
+              val accountNumber = STS.getAccountNumber(stsClient)
 
-            val templateString = templatePath
-              .fetchContentAsString()
-              .right
-              .getOrElse(
-                resources.reporter.fail(
-                  s"Unable to locate cloudformation template s3://${templatePath.bucket}/${templatePath.key}"
+              val templateString = templatePath
+                .fetchContentAsString()
+                .right
+                .getOrElse(
+                  resources.reporter.fail(
+                    s"Unable to locate cloudformation template s3://${templatePath.bucket}/${templatePath.key}"
+                  )
                 )
+
+              val (stackName, changeSetType, existingParameters, currentTags) =
+                stackLookup.lookup(resources.reporter, cfnClient)
+
+              val template = processTemplate(
+                stackName,
+                templateString,
+                s3Client,
+                stsClient,
+                region,
+                resources.reporter
               )
-
-            val (stackName, changeSetType, existingParameters, currentTags) =
-              stackLookup.lookup(resources.reporter, cfnClient)
-
-            val template = processTemplate(
-              stackName,
-              templateString,
-              s3Client,
-              stsClient,
-              region,
-              resources.reporter
-            )
-            val templateParameters = CloudFormation
-              .validateTemplate(template, cfnClient)
-              .parameters
-              .asScala
-              .toList
-              .map(tp =>
-                TemplateParameter(
-                  tp.parameterKey,
-                  Option(tp.defaultValue).isDefined
+              val templateParameters = CloudFormation
+                .validateTemplate(template, cfnClient)
+                .parameters
+                .asScala
+                .toList
+                .map(tp =>
+                  TemplateParameter(
+                    tp.parameterKey,
+                    Option(tp.defaultValue).isDefined
+                  )
                 )
+
+              val minInServiceParameters: Map[CfnParam, Int] =
+                changeSetType match {
+                  case ChangeSetType.UPDATE =>
+                    val cfnStackNameTag = TagMatch(
+                      "aws:cloudformation:stack-name",
+                      stackName
+                    )
+                    unresolvedParameters.minInServiceParameterMap.map {
+                      case (cfnParam, asgTagRequirements) =>
+                        cfnParam -> ASG.getMinInstancesInService(
+                          asgTagRequirements :+ cfnStackNameTag,
+                          asgClient,
+                          resources.reporter
+                        )
+                    }
+                  case ChangeSetType.CREATE =>
+                    resources.reporter.verbose(
+                      s"Creating a new CFN stack; using minInService parameters from template."
+                    )
+                    Map.empty
+                  case _ =>
+                    // This code path should never be reached. See `CloudFormationStackMetadata.getChangeSetType`.
+                    resources.reporter.fail(
+                      s"Unsupported change set type: $changeSetType"
+                    )
+                }
+
+              val parameters = CloudFormationParameters
+                .resolve(
+                  resources.reporter,
+                  unresolvedParameters,
+                  accountNumber,
+                  templateParameters,
+                  existingParameters,
+                  minInServiceParameters
+                )
+                .fold(
+                  resources.reporter.fail(_),
+                  identity
+                )
+
+              val awsParameters =
+                convertInputParametersToAwsAndLog(
+                  resources.reporter,
+                  parameters,
+                  existingParameters
+                )
+
+              resources.reporter.info("Creating Cloudformation change set")
+              resources.reporter.info(s"Stack name: $stackName")
+              resources.reporter.info(
+                s"Change set name: ${stackLookup.changeSetName}"
               )
 
-            val parameters = CloudFormationParameters
-              .resolve(
+              val maybeExecutionRole = CloudFormation.getExecutionRole(keyRing)
+              maybeExecutionRole.foreach(role =>
+                resources.reporter.verbose(s"Using execution role $role")
+              )
+
+              val mergedTags = currentTags ++ stackTags
+              resources.reporter.info("Tags: " + mergedTags.mkString(", "))
+
+              CloudFormation.createChangeSet(
                 resources.reporter,
-                unresolvedParameters,
-                accountNumber,
-                templateParameters,
-                existingParameters
+                stackLookup.changeSetName,
+                changeSetType,
+                stackName,
+                Some(mergedTags),
+                template,
+                awsParameters,
+                maybeExecutionRole,
+                cfnClient
               )
-              .fold(
-                resources.reporter.fail(_),
-                identity
-              )
-
-            val awsParameters =
-              convertInputParametersToAwsAndLog(
-                resources.reporter,
-                parameters,
-                existingParameters
-              )
-
-            resources.reporter.info("Creating Cloudformation change set")
-            resources.reporter.info(s"Stack name: $stackName")
-            resources.reporter.info(
-              s"Change set name: ${stackLookup.changeSetName}"
-            )
-
-            val maybeExecutionRole = CloudFormation.getExecutionRole(keyRing)
-            maybeExecutionRole.foreach(role =>
-              resources.reporter.verbose(s"Using execution role $role")
-            )
-
-            val mergedTags = currentTags ++ stackTags
-            resources.reporter.info("Tags: " + mergedTags.mkString(", "))
-
-            CloudFormation.createChangeSet(
-              resources.reporter,
-              stackLookup.changeSetName,
-              changeSetType,
-              stackName,
-              Some(mergedTags),
-              template,
-              awsParameters,
-              maybeExecutionRole,
-              cfnClient
-            )
+            }
           }
         }
       }

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -240,11 +240,9 @@ object CloudFormationParameters {
       deployParameters = deploymentParameters,
       existingParameters = existingParameters,
       templateParameters = templateParameters,
-      specifiedParameters = {
-        cfnParameters.userParameters ++
-          resolvedAmiParameters ++
-          minInServiceParameters.map({ case (k, v) => k -> v.toString })
-      }
+      specifiedParameters = cfnParameters.userParameters ++
+        resolvedAmiParameters ++
+        minInServiceParameters.view.mapValues(_.toString)
     )
     combined.map(convertParameters)
   }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/CloudFormationTest.scala
@@ -568,7 +568,8 @@ class CloudFormationTest
       Map.empty,
       Map.empty,
       (_: CfnParam) =>
-        (_: String) => (_: String) => (_: Map[String, String]) => None
+        (_: String) => (_: String) => (_: Map[String, String]) => None,
+      Map.empty
     )
 
     val params = resolve(
@@ -580,7 +581,8 @@ class CloudFormationTest
         TemplateParameter("param3", default = true),
         TemplateParameter("Stage", default = true)
       ),
-      Nil
+      Nil,
+      Map.empty
     )
 
     params.right.value shouldBe List(InputParameter("Stage", "PROD"))
@@ -602,7 +604,8 @@ class CloudFormationTest
       Map.empty,
       Map.empty,
       (_: CfnParam) =>
-        (_: String) => (_: String) => (_: Map[String, String]) => None
+        (_: String) => (_: String) => (_: Map[String, String]) => None,
+      Map.empty
     )
 
     val params = resolve(
@@ -618,7 +621,8 @@ class CloudFormationTest
         ExistingParameter("param1", "value1", None),
         ExistingParameter("param3", "value3", None),
         ExistingParameter("Stage", "BOB", None)
-      )
+      ),
+      Map.empty
     )
 
     params.right.value should contain theSameElementsAs (List(
@@ -644,7 +648,8 @@ class CloudFormationTest
       Map.empty,
       Map.empty,
       (_: CfnParam) =>
-        (_: String) => (_: String) => (_: Map[String, String]) => None
+        (_: String) => (_: String) => (_: Map[String, String]) => None,
+      Map.empty
     )
 
     val params = resolve(
@@ -659,7 +664,8 @@ class CloudFormationTest
       List(
         ExistingParameter("param3", "value3", None),
         ExistingParameter("Stage", "PROD", None)
-      )
+      ),
+      Map.empty
     )
 
     params.right.value should contain theSameElementsAs (List(
@@ -686,7 +692,8 @@ class CloudFormationTest
       userParameters,
       Map.empty,
       (_: CfnParam) =>
-        (_: String) => (_: String) => (_: Map[String, String]) => None
+        (_: String) => (_: String) => (_: Map[String, String]) => None,
+      Map.empty
     )
 
     val params = resolve(
@@ -701,7 +708,8 @@ class CloudFormationTest
       List(
         ExistingParameter("param3", "value3", None),
         ExistingParameter("Stage", "PROD", None)
-      )
+      ),
+      Map.empty
     )
 
     params.right.value should contain theSameElementsAs (List(
@@ -727,7 +735,8 @@ class CloudFormationTest
       Map.empty,
       Map.empty,
       (_: CfnParam) =>
-        (_: String) => (_: String) => (_: Map[String, String]) => None
+        (_: String) => (_: String) => (_: Map[String, String]) => None,
+      Map.empty
     )
 
     val params = resolve(
@@ -742,7 +751,8 @@ class CloudFormationTest
       List(
         ExistingParameter("param3", "value3", None),
         ExistingParameter("Stage", "PROD", None)
-      )
+      ),
+      Map.empty
     )
 
     params.left.value should startWith("Missing parameters for param1:")

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
@@ -398,6 +398,150 @@ class ASGTest extends AnyFlatSpec with Matchers with MockitoSugar {
     ) shouldBe Right(())
   }
 
+  it should "calculate MinInstancesInService as desired when there is capacity to double" in {
+    val asgClientMock = mock[AutoScalingClient]
+    val asgDescribeIterableMock = mock[DescribeAutoScalingGroupsIterable]
+
+    when(asgDescribeIterableMock.autoScalingGroups()) thenReturn toSdkIterable(
+      List(
+        AutoScalingGroupWithTags(
+          min = 3,
+          max = 6,
+          desired = 3,
+          "Stack" -> "playground",
+          "Stage" -> "PROD",
+          "App" -> "api",
+          "aws:cloudformation:stack-name" -> "playground-PROD-api"
+        )
+      ).asJava
+    )
+    when(
+      asgClientMock.describeAutoScalingGroupsPaginator()
+    ) thenReturn asgDescribeIterableMock
+
+    val minInstancesInService =
+      ASG.getMinInstancesInService(
+        List(
+          TagMatch("Stack", "playground"),
+          TagMatch("Stage", "PROD"),
+          TagMatch("App", "api"),
+          TagMatch("aws:cloudformation:stack-name", "playground-PROD-api")
+        ),
+        asgClientMock,
+        reporter
+      )
+
+    minInstancesInService shouldBe 3
+  }
+
+  it should "calculate MinInstancesInService as desired when partially scaled out" in {
+    val asgClientMock = mock[AutoScalingClient]
+    val asgDescribeIterableMock = mock[DescribeAutoScalingGroupsIterable]
+
+    when(asgDescribeIterableMock.autoScalingGroups()) thenReturn toSdkIterable(
+      List(
+        AutoScalingGroupWithTags(
+          min = 3,
+          max = 9,
+          desired = 5,
+          "Stack" -> "playground",
+          "Stage" -> "PROD",
+          "App" -> "api",
+          "aws:cloudformation:stack-name" -> "playground-PROD-api"
+        )
+      ).asJava
+    )
+    when(
+      asgClientMock.describeAutoScalingGroupsPaginator()
+    ) thenReturn asgDescribeIterableMock
+
+    val minInstancesInService =
+      ASG.getMinInstancesInService(
+        List(
+          TagMatch("Stack", "playground"),
+          TagMatch("Stage", "PROD"),
+          TagMatch("App", "api"),
+          TagMatch("aws:cloudformation:stack-name", "playground-PROD-api")
+        ),
+        asgClientMock,
+        reporter
+      )
+
+    minInstancesInService shouldBe 5
+  }
+
+  it should "calculate MinInstancesInService as 75% of max when desired is high" in {
+    val asgClientMock = mock[AutoScalingClient]
+    val asgDescribeIterableMock = mock[DescribeAutoScalingGroupsIterable]
+
+    when(asgDescribeIterableMock.autoScalingGroups()) thenReturn toSdkIterable(
+      List(
+        AutoScalingGroupWithTags(
+          min = 10,
+          max = 100,
+          desired = 80,
+          "Stack" -> "playground",
+          "Stage" -> "PROD",
+          "App" -> "api",
+          "aws:cloudformation:stack-name" -> "playground-PROD-api"
+        )
+      ).asJava
+    )
+    when(
+      asgClientMock.describeAutoScalingGroupsPaginator()
+    ) thenReturn asgDescribeIterableMock
+
+    val minInstancesInService =
+      ASG.getMinInstancesInService(
+        List(
+          TagMatch("Stack", "playground"),
+          TagMatch("Stage", "PROD"),
+          TagMatch("App", "api"),
+          TagMatch("aws:cloudformation:stack-name", "playground-PROD-api")
+        ),
+        asgClientMock,
+        reporter
+      )
+
+    minInstancesInService shouldBe 75
+  }
+
+  it should "calculate MinInstancesInService as 75% of max when fully scaled out" in {
+    val asgClientMock = mock[AutoScalingClient]
+    val asgDescribeIterableMock = mock[DescribeAutoScalingGroupsIterable]
+
+    when(asgDescribeIterableMock.autoScalingGroups()) thenReturn toSdkIterable(
+      List(
+        AutoScalingGroupWithTags(
+          min = 10,
+          max = 100,
+          desired = 100,
+          "Stack" -> "playground",
+          "Stage" -> "PROD",
+          "App" -> "api",
+          "aws:cloudformation:stack-name" -> "playground-PROD-api"
+        )
+      ).asJava
+    )
+    when(
+      asgClientMock.describeAutoScalingGroupsPaginator()
+    ) thenReturn asgDescribeIterableMock
+
+    val minInstancesInService =
+      ASG.getMinInstancesInService(
+        List(
+          TagMatch("Stack", "playground"),
+          TagMatch("Stage", "PROD"),
+          TagMatch("App", "api"),
+          TagMatch("aws:cloudformation:stack-name", "playground-PROD-api")
+        ),
+        asgClientMock,
+        reporter
+      )
+
+    minInstancesInService shouldBe 75
+  }
+
   object AutoScalingGroupWithTags {
     def apply(tags: (String, String)*): AutoScalingGroup = {
       val awsTags = tags map { case (key, value) =>
@@ -413,6 +557,23 @@ class ASGTest extends AnyFlatSpec with Matchers with MockitoSugar {
         .builder()
         .tags(awsTags.asJava)
         .loadBalancerNames(elbName)
+        .build()
+    }
+    def apply(
+        min: Int,
+        max: Int,
+        desired: Int,
+        tags: (String, String)*
+    ): AutoScalingGroup = {
+      val awsTags = tags map { case (key, value) =>
+        TagDescription.builder().key(key).value(value).build()
+      }
+      AutoScalingGroup
+        .builder()
+        .tags(awsTags.asJava)
+        .minSize(min)
+        .maxSize(max)
+        .desiredCapacity(desired)
         .build()
     }
   }

--- a/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/ASGTest.scala
@@ -565,7 +565,7 @@ class ASGTest extends AnyFlatSpec with Matchers with MockitoSugar {
         desired: Int,
         tags: (String, String)*
     ): AutoScalingGroup = {
-      val awsTags = tags map { case (key, value) =>
+      val awsTags = tags.map { case (key, value) =>
         TagDescription.builder().key(key).value(value).build()
       }
       AutoScalingGroup


### PR DESCRIPTION
## Context
In https://github.com/guardian/cdk/pull/2417 support was added to `@guardian/cdk` (GuCDK) to deploy application updates to an autoscaling group (ASG) via CloudFormation (CFN) with the [`AutoScalingRollingUpdate` update policy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-rollingupdate).

During the [testing](https://github.com/guardian/testing-asg-rolling-update), we [observed](https://github.com/guardian/testing-asg-rolling-update/tree/main?tab=readme-ov-file#mininstancesinservice) that for a service that horizontally scales, the `MinInstanceInService` property should be set relative to the current state of the ASG. Consequently when an autoscaling group has scaling policies, GuCDK adds a parameter to the CFN template in the form `MinInstancesInServiceFor<APP>`:

> To support this dynamic property, services that horizontally scale should expose a CloudFormation parameter for Riff-Raff to set during deployment.
> 
> – https://github.com/guardian/testing-asg-rolling-update/blob/main/README.md

## What does this change?
This change adds a new `riff-raff.yaml` property to the `ami-cloudformation-parameter` and `cloud-formation` deployment types called `minInstancesInServiceParameters`.

The CFN parameter added by GuCDK does not provide a direct connection the to ASG it relates to. The new `minInstancesInServiceParameters` property attempts to provide this connection via tag lookups. That is, it is a map of CFN parameter -> ASG tags.

In the below example, we're telling Riff-Raff to expect a CFN parameter named `MinInstancesInServiceForcdkplayground` in the `CdkPlayground.template.json` CFN template and to set it's value from the desired capacity of an ASG tagged `App=cdk-playground`, `Stage=PROD`, `Stack=playground`.

```yaml
allowedStages:
  - PROD
stacks:
  - playground
regions:
  - eu-west-1
deployments:
  cfn-deployment:
    type: cloud-formation
    parameters:
      templateStagePaths:
        PROD: CdkPlayground.template.json
      minInstancesInServiceParameters:
        MinInstancesInServiceForcdkplayground:
          App: cdk-playground
```

Once the ASG has been found, the `MinInstancesInService` property to whichever is lower between desired or 75% of max, meaning:
- When running normally, then we double capacity and half it again once healthy
- When partially or fully scaled, we rotate instances in batches, which is slightly slower

This contrasts with the recommendation from https://github.com/guardian/testing-asg-rolling-update:

> - If the service is running at "normal" capacity (e.g. desired = min), then `MinInstancesInService` can be set to match min.
> - If the service is partially scaled, then `MinInstancesInService` should be set to match the current desired capacity.
> - If the service is fully scaled, then `MinInstancesInService` should be set to (at least) max -1.
> 
> – https://github.com/guardian/testing-asg-rolling-update/blob/main/README.md

This is because being percentage based offers faster deployment.
## How to test
See added unit tests.

We can also perform some practical tests. Each of the following have been performed on https://github.com/guardian/cdk-playground.

### "Normal" capacity (i.e. `desired = min`)
https://github.com/guardian/cdk-playground/pull/548 tests this scenario. It demonstrates the CFN parameter was correctly set to `desired`.

<details><summary>Deployment log showing value of CFN parameter</summary>
<p>

![image](https://github.com/user-attachments/assets/f99291ef-05ea-4a15-a3d0-88c607b6971c)

</p>
</details> 

### Partial scaled (i.e. `min < desired < max`)
https://github.com/guardian/cdk-playground/pull/548 tests this scenario. It demonstrates the CFN parameter was correctly set to `desired`.

<details><summary>Deployment log showing value of CFN parameter</summary>
<p>

![image](https://github.com/user-attachments/assets/fafbe9b8-0975-4c9e-b07d-f24716ca4c2d)

</p>
</details> 


### Fully scaled (i.e. `desired = max`)
https://github.com/guardian/cdk-playground/pull/548 tests this scenario. It demonstrates the CFN parameter was set to 7 (75% of 10, rounded down).

<details><summary>Deployment log showing value of CFN parameter</summary>
<p>

![image](https://github.com/user-attachments/assets/b26ac64b-10dc-4c35-894e-2da004a869b1)

</p>
</details> 

### No scaling policy (i.e. our typical ASG)
This test amounts to omitting the `minInstancesInServiceParameters` property in the `riff-raff.yaml` file.

This has been done (https://github.com/guardian/cdk-playground/pull/547), and the [deployment](https://riffraff.code.dev-gutools.co.uk/deployment/view/cb8577e0-7717-4f34-a126-454f32de5e52?verbose=1) behaved as expected: CFN doubled the ASG capacity, waited for `SUCCESS` signals, then removed old instances by halving the ASG capacity.

This can be seen on [the dashboard](https://metrics.gutools.co.uk/d/adyqx5hf3w1s0e/cdk-playground?orgId=1&from=1728653082346&to=1728653334575) (note: this link might not work in future).

### `minInstancesInServiceParameters` describes a CFN parameter that does not exist
https://github.com/guardian/cdk-playground/pull/549 tests this scenario.

The deployment should fail when referencing a CFN parameter that does not exist in the CFN template.

<details><summary>Deployment log showing deployment error</summary>
<p>

![image](https://github.com/user-attachments/assets/9bc09400-4b41-4d5a-8238-62d85ff79656)

</p>
</details> 

### `minInstancesInServiceParameters` describes an ASG that does not exist
https://github.com/guardian/cdk-playground/pull/550 tests this scenario.

The deployment should fail when referencing an ASG that does not exist.

<details><summary>Deployment log showing deployment error</summary>
<p>

![image](https://github.com/user-attachments/assets/363cc09f-a88c-4fd8-bac7-7391e9e622c5)

</p>
</details>

### Initial deployment (i.e. CFN stack does not yet exist)
This code path is the same as the "`minInstancesInServiceParameters` describes an ASG that does not exist" test.

## How can we measure success?
This change means we're able to use the `AutoScalingRollingUpdate` deployment mechanism on all ASG architectures: those that horizontally scale and those that do not horizontally scale.