### PR TITLE
ci: Use `guardian/setup-scala` GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: corretto
-          java-version: 11
-          cache: sbt
+      - uses: guardian/setup-scala@v1
 
       # Seed the build number with last number from TeamCity.
       # This env var is used by the SBT build, and guardian/actions-riff-raff.

--- a/.github/workflows/sbt-dependency-graph.yaml
+++ b/.github/workflows/sbt-dependency-graph.yaml
@@ -11,15 +11,7 @@ jobs:
       - name: Checkout branch
         id: checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - name: Install Java
-        id: java
-        uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4.2.0
-        with:
-          distribution: corretto
-          java-version: 17
-      - name: Install sbt
-        id: sbt
-        uses: sbt/setup-sbt@50a38cca700907fb9df65ecabcefb85ebaa424a7 # v1.1.4
+      - uses: guardian/setup-scala@v1
       - name: Submit dependencies
         id: submit
         uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-11.0.25.9.1


### PR DESCRIPTION
## What does this change?
[From 05 December 2024](https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/) the `ubuntu-latest` runner provided by GitHub will no longer contain `sbt` (https://github.com/actions/runner-images/issues/10636).

This change swaps usage of the `actions/setup-java` GitHub Action and the implicit presence of `sbt` for the [`guardian/setup-scala`](https://github.com/guardian/setup-scala) GitHub Action, which is described as:

> Combining [setup-java](https://github.com/actions/setup-java) & [setup-sbt](https://github.com/sbt/setup-sbt) with good defaults for the Guardian

A requirement of `guardian/setup-scala` is the presence of:

> an [asdf](https://asdf-vm.com/)-formatted .tool-versions file.

Thus, one is added in this PR using the latest version of Java 11[^1] available obtained via:

```console
❯ asdf list-all java | grep corretto-11 | tail -n 1
corretto-11.0.25.9.1
```

## How to test
Observe CI. It should pass.

## What is the value of this?
Builds continue to run after the update of the `ubuntu-latest` runner.

[^1]: Java 11 as that's what CI is currently using.

---

See also https://github.com/guardian/amigo/pull/1587.