### PR TITLE
Update fastly-api-client to latest

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,7 +45,7 @@ object Dependencies {
       "software.amazon.awssdk" % "cloudformation" % Versions.aws,
       "software.amazon.awssdk" % "sts" % Versions.aws,
       "software.amazon.awssdk" % "ssm" % Versions.aws,
-      "com.gu" %% "fastly-api-client" % "0.6.0",
+      "com.gu" %% "fastly-api-client" % "1.0.0",
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % Versions.jackson,
       "com.beachape" %% "enumeratum-play-json" % Versions.enumeratumPlay,
       "com.google.apis" % "google-api-services-deploymentmanager" % "v2-rev20241031-2.0.0",


### PR DESCRIPTION

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Latest version should no longer rely on org.asynchttpclient:async-http-client:2.12.3, which has a critical vulnerability flagged by our dependency tree scanning.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
