### PR TITLE
Fix/fewer calls to update deploy info

### DIFF
--- a/riff-raff/app/assets/javascripts/form-autocomplete.coffee
+++ b/riff-raff/app/assets/javascripts/form-autocomplete.coffee
@@ -82,7 +82,9 @@ setupFavouriteHandlers = () ->
 
     elemProjectInput = $('#projectInput')
     elemProjectInput.val(project)
-    updateDeployInfo()
+
+    $('#buildInput').val('') # clear build input when project changed
+    updateStageInfo()
 
 renderFavourites = () ->
   container = $('#favourites-container')
@@ -121,6 +123,8 @@ $ ->
     input.on('keyup', updateFavouriteButton)
 
   $('#projectInput').blur -> updateDeployInfo()
+
+  $('#projectInput').change -> $('#buildInput').val('') # clear build input when project changed
 
   $('#buildInput').each ->
     input = $(this)

--- a/riff-raff/app/assets/javascripts/form-autocomplete.coffee
+++ b/riff-raff/app/assets/javascripts/form-autocomplete.coffee
@@ -146,21 +146,17 @@ $ ->
         updateStageInfo()
       minLength:0
 
-  $('#buildInput').on('input keyup',
+  $('#buildInput').on('input',
     ->
       input = $(this)
       updateBuildInfo( input.val() )
+      updateStageInfo()
+      updateDeployInfo()
   )
 
   $('#buildInput').focus (e) ->
     if (!menuOpen)
       $(e.target).autocomplete("search")
-
-  $('#buildInput').on('input keyup',
-    ->
-      updateStageInfo()
-      updateDeployInfo()
-  )
 
   $('#buildInput').blur -> updateDeployInfo()
 

--- a/riff-raff/app/assets/javascripts/form-autocomplete.coffee
+++ b/riff-raff/app/assets/javascripts/form-autocomplete.coffee
@@ -151,7 +151,6 @@ $ ->
       input = $(this)
       updateBuildInfo( input.val() )
       updateStageInfo()
-      updateDeployInfo()
   )
 
   $('#buildInput').focus (e) ->


### PR DESCRIPTION
Since https://github.com/guardian/riff-raff/pull/1385 there has been the odd bit of janky behaviour, neatly captured by @akash1810 in https://github.com/guardian/riff-raff/pull/1385#issuecomment-2541932562 ...

https://github.com/user-attachments/assets/65752c50-c947-42c0-b16a-4a86a337cae2

I suspected this was a race condition where too many things are now calling `updateDeployInfo` which aren't guaranteed to return in order and hence occasionally loads with a incorrect/stale values.

Using the chrome debugger (logpoints specifically) I noticed that the change handler on `#buildInput` is always firing twice in very quick succession (because it was both `input` and `keyup` event) this is unnecessary, so removed the `keyup` part of the `on` and consolidated the two change handlers.

I also thought it prudent to clear `#buildInput` when `#projectInput` is changed as it doesn't make sense to attempt to load deploy history etc. for a build which may or may not exist on the new project selection, it also probably removes the likelihood of deploying a build unintentionally.

Lastly, don't call `updateDeployInfo` on change of `#buildInput`, since it already calls `updateStageInfo` which in turn calls `updateDeployInfo` once it has loaded the stages.