### PR TITLE
Revert "chore(deps): Non-AWS dependency updates"

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,6 +6,3 @@ a538fda77c86a371c80891851432d7fca3aa78cc
 
 # Scala Steward: Reformat with scalafmt 3.8.2
 c3c7edb40313eecefe157f89e4f218d269c16d0a
-
-# Scala Steward: Reformat with scalafmt 3.8.3
-80662885638c62108ba5c88640f4890b9fc67fb8

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.8.3
+version = 3.8.2
 
 runner.dialect = scala213
 maxColumn = 80

--- a/magenta-lib/src/main/scala/magenta/package.scala
+++ b/magenta-lib/src/main/scala/magenta/package.scala
@@ -69,5 +69,5 @@ object `package` extends Loggable {
   /** This can be used when you have high confidence it will never be reached.
     * An example might be exhaustive cases in a match statement.
     */
-  def `wtf?`: Nothing = throw new IllegalStateException("WTF?")
+  def `wtf?` : Nothing = throw new IllegalStateException("WTF?")
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,9 +5,9 @@ object Dependencies {
 
   object Versions {
     val aws = "2.29.40"
-    val jackson = "2.17.3"
+    val jackson = "2.17.2"
     val awsRds = "1.12.780"
-    val enumeratumPlay = "1.8.2"
+    val enumeratumPlay = "1.8.1"
   }
 
   // https://github.com/orgs/playframework/discussions/11222
@@ -49,8 +49,8 @@ object Dependencies {
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % Versions.jackson,
       "com.beachape" %% "enumeratum-play-json" % Versions.enumeratumPlay,
       "com.google.apis" % "google-api-services-deploymentmanager" % "v2-rev20241122-2.0.0",
-      "com.google.cloud" % "google-cloud-storage" % "2.46.0",
-      "org.scala-lang.modules" %% "scala-parallel-collections" % "1.1.0"
+      "com.google.cloud" % "google-cloud-storage" % "2.40.1",
+      "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4"
     ).map((m: ModuleID) =>
       // don't even ask why I need to do this
       m.excludeAll(
@@ -65,33 +65,33 @@ object Dependencies {
     commonDeps ++ jacksonOverrides ++ Seq(
       evolutions,
       jdbc,
-      "com.gu.play-googleauth" %% "play-v30" % "17.1.0",
-      "com.gu.play-secret-rotation" %% "play-v30" % "13.1.1",
-      "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "13.1.1",
+      "com.gu.play-googleauth" %% "play-v30" % "10.0.1",
+      "com.gu.play-secret-rotation" %% "play-v30" % "8.4.5",
+      "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "8.4.5",
       "org.pegdown" % "pegdown" % "1.6.0",
       "com.adrianhurt" %% "play-bootstrap" % "1.6.1-P28-B3", // scala-steward:off,
-      "org.scanamo" %% "scanamo" % "3.0.0",
+      "org.scanamo" %% "scanamo" % "1.1.1",
       "software.amazon.awssdk" % "dynamodb" % Versions.aws,
       "software.amazon.awssdk" % "sns" % Versions.aws,
-      "org.quartz-scheduler" % "quartz" % "2.5.0",
+      "org.quartz-scheduler" % "quartz" % "2.3.2",
       "com.gu" %% "anghammarad-client" % "4.0.0",
-      "org.webjars" %% "webjars-play" % "3.0.2",
+      "org.webjars" %% "webjars-play" % "3.0.1",
       "org.webjars" % "jquery" % "3.7.1",
-      "org.webjars" % "jquery-ui" % "1.14.1",
+      "org.webjars" % "jquery-ui" % "1.13.3",
       "org.webjars" % "bootstrap" % "3.4.1", // scala-steward:off
       "org.webjars" % "jasny-bootstrap" % "3.1.3-2", // scala-steward:off
       "org.webjars" % "momentjs" % "2.30.1",
-      "net.logstash.logback" % "logstash-logback-encoder" % "8.0",
+      "net.logstash.logback" % "logstash-logback-encoder" % "7.4",
       "org.scalikejdbc" %% "scalikejdbc" % "3.5.0", // scala-steward:off
-      "org.postgresql" % "postgresql" % "42.7.4",
+      "org.postgresql" % "postgresql" % "42.7.3",
       "com.beachape" %% "enumeratum-play" % Versions.enumeratumPlay,
       filters,
       ws,
-      "org.apache.pekko" %% "pekko-testkit" % "1.0.3" % Test,
+      "org.apache.pekko" %% "pekko-testkit" % "1.0.2" % Test,
       "com.amazonaws" % "aws-java-sdk-rds" % Versions.awsRds,
       "org.scala-stm" %% "scala-stm" % "0.11.1",
       // Play 3.0 currently uses logback-classic 1.4.11 which is vulnerable to CVE-2023-45960
-      "ch.qos.logback" % "logback-classic" % "1.5.15"
+      "ch.qos.logback" % "logback-classic" % "1.5.6"
     ).map((m: ModuleID) =>
       // don't even ask why I need to do this
       m.excludeAll(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.7
+sbt.version=1.10.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // keep in sync with the play version in Dependencies
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.6")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.4")
 
 addSbtPlugin("com.github.sbt" % "sbt-coffeescript" % "2.0.1")
 
@@ -8,8 +8,8 @@ addSbtPlugin("com.github.sbt" % "sbt-coffeescript" % "2.0.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.2") // scala-steward:off
 addSbtPlugin("com.github.sbt" % "sbt-digest" % "2.0.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.13.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.12.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.1")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 


### PR DESCRIPTION
## What does this change?
Reverts #1407.

PROD was failing to start with the following error:

```
Jan 02 14:16:24 ip-10-248-50-120 riff-raff[1962]: Oops, cannot start the server.
Jan 02 14:16:24 ip-10-248-50-120 riff-raff[1962]: java.lang.RuntimeException: CronExpression '0 00 10 ? * TUE * (Europe/London)' is invalid.
Jan 02 14:16:24 ip-10-248-50-120 riff-raff[1962]:         at org.quartz.CronScheduleBuilder.cronSchedule(CronScheduleBuilder.java:112)
Jan 02 14:16:24 ip-10-248-50-120 riff-raff[1962]:         at schedule.DeployScheduler.scheduleDeploy(DeployScheduler.scala:54)
Jan 02 14:16:24 ip-10-248-50-120 riff-raff[1962]:         at schedule.DeployScheduler.$anonfun$initialise$1(DeployScheduler.scala:25)
Jan 02 14:16:24 ip-10-248-50-120 riff-raff[1962]:         at schedule.DeployScheduler.$anonfun$initialise$1$adapted(DeployScheduler.scala:25)
Jan 02 14:16:24 ip-10-248-50-120 riff-raff[1962]:         at scala.collection.immutable.List.foreach(List.scala:334)
Jan 02 14:16:24 ip-10-248-50-120 riff-raff[1962]:         at schedule.DeployScheduler.initialise(DeployScheduler.scala:25)
Jan 02 14:16:24 ip-10-248-50-120 riff-raff[1962]:         at AppComponents.<init>(AppComponents.scala:211)
Jan 02 14:16:24 ip-10-248-50-120 riff-raff[1962]:         at AppLoader.load(AppLoader.scala:55)
Jan 02 14:16:24 ip-10-248-50-120 riff-raff[1962]:         at play.core.server.ProdServerStart$.start(ProdServerStart.scala:52)
Jan 02 14:16:24 ip-10-248-50-120 riff-raff[1962]:         at play.core.server.ProdServerStart$.main(ProdServerStart.scala:28)
Jan 02 14:16:24 ip-10-248-50-120 riff-raff[1962]:         at play.core.server.ProdServerStart.main(ProdServerStart.scala)
Jan 02 14:16:24 ip-10-248-50-120 riff-raff[1962]: Caused by: java.text.ParseException: Invalid expression has too many terms: 0 00 10 ? * TUE * (EUROPE/LONDON)
Jan 02 14:16:24 ip-10-248-50-120 riff-raff[1962]:         at org.quartz.CronExpression.buildExpression(CronExpression.java:483)
Jan 02 14:16:24 ip-10-248-50-120 riff-raff[1962]:         at org.quartz.CronExpression.<init>(CronExpression.java:286)
Jan 02 14:16:24 ip-10-248-50-120 riff-raff[1962]:         at org.quartz.CronScheduleBuilder.cronSchedule(CronScheduleBuilder.java:108)
Jan 02 14:16:24 ip-10-248-50-120 riff-raff[1962]:         ... 10 more
```

This cron expression is seen at runtime from the [scheduled deployments](https://riffraff.gutools.co.uk/deployment/schedule). This wasn't seen on [CODE](https://riffraff.code.dev-gutools.co.uk/deployment/view/b2f1696c-f1e8-4ba7-ae2e-8298f8a4ea25) as CODE does not have any active [schedules](https://riffraff.code.dev-gutools.co.uk/deployment/schedule).

I suspect the update to `"org.quartz-scheduler" % "quartz"` made in #1407 is the issue here. For safety though, revert the lot.

We should add a unit-test for cron parsing with quartz to catch similar issues in future.