### PR TITLE
Revert "chore(deps): AWS dependency updates"

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val aws = "2.30.16"
+    val aws = "2.29.52"
     val jackson = "2.18.2"
     val awsRds = "1.12.780"
     val enumeratumPlay = "1.8.2"


### PR DESCRIPTION
Reverts guardian/riff-raff#1418 as this appears to be causing `OutOfMemoryError` issues when deploying [ophan:dashboard-es7-arm](https://riffraff.gutools.co.uk/deployment/view/858ba744-87ba-4768-b05b-84947b211f9d). This behaviour is not seen on a previous build of `main`. Therefore this issue is most likely related to a change in this AWS SDK update.