### PR TITLE
Update GrafanaAnnotationLogger.scala

### DIFF
--- a/riff-raff/app/notification/GrafanaAnnotationLogger.scala
+++ b/riff-raff/app/notification/GrafanaAnnotationLogger.scala
@@ -47,7 +47,10 @@ class GrafanaAnnotationLogger(riffRaffUrl: String)
         "projectStage" -> parameters.stage.name,
         "projectDeployer" -> parameters.deployer.name,
         "projectDeploymentLink" -> s"<a target=\"_blank\" href=\"${riffRaffUrl}/deployment/view/$deployId\">${parameters.build.id}</a>",
-        "tagsArray" -> List(parameters.build.projectName, parameters.deployer.name)
+        "tagsArray" -> List(
+          parameters.build.projectName,
+          parameters.deployer.name
+        )
       )
     MarkerContext(appendEntries(params.asJava))
   }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The current annotation works and looks like the screenshot below. It's useful, but it's missing data to be more useful. 

![Screenshot 2025-02-25 at 16 32 04](https://github.com/user-attachments/assets/43f33009-96f9-4bf9-8551-d3c11064d73f)

Apparently we should be able to [pass an array of multiple tags](https://community.grafana.com/t/annotations-with-multiple-tags/5346), so this change adds a new property that is an array. Deployed this [branch in code](https://riffraff.code.dev-gutools.co.uk/deployment/view/7150565e-89d0-4380-a8d5-95604068c2f9), and it works ok, it looks like this in grafana.

<img width="259" alt="Screenshot 2025-02-26 at 12 01 28" src="https://github.com/user-attachments/assets/149fe561-08e1-458e-ae84-f65fdbc2d1c4" />

The thing that we're missing still is the branch name, but that's not immediately available in this logging function so needs more development work.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
