### PR TITLE
Link to project history from deployment page

### DIFF
--- a/riff-raff/app/views/deploy/viewDeploy.scala.html
+++ b/riff-raff/app/views/deploy/viewDeploy.scala.html
@@ -24,7 +24,7 @@
 
     <div class="row">
         <div class="col-md-8">
-            <h2>Deploy of @record.buildName build @record.buildId@record.metaData.get("branch").map{ branch=> [@branch]} in @record.stage.name</h2>
+            <h2>Deploy of <a href="@routes.DeployController.deployHistory(record.buildName, None, Some(true))">@record.buildName</a> build @record.buildId@record.metaData.get("branch").map{ branch=> [@branch]} in @record.stage.name</h2>
 
             <table class="table">
                 @record.metaData.get(deployment.Record.RIFFRAFF_HOSTNAME).map { hostname =>


### PR DESCRIPTION
## What does this change?

I sometimes want to navigate from the page for an individual deployment back to the history of deployments for the same project, and I usually do this manually. This PR updates that page to link to the history, to save me (and hopefully others) some manual navigating.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
