### PR TITLE
feat: Display all ASG CloudFormation updates by default

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -426,7 +426,16 @@ class CloudFormationStackEventPoller(
     reporter.info(
       s"${e.logicalResourceId} (${e.resourceType}): ${e.resourceStatusAsString}"
     )
-    if (e.resourceStatusReason != null) reporter.verbose(e.resourceStatusReason)
+
+    if (e.resourceStatusReason != null) {
+      // Surface detailed ASG messages by default. Particularly useful for when using the new RollingUpdate deployment mechanism.
+      if (e.resourceType == "AWS::AutoScaling::AutoScalingGroup") {
+        reporter.info(e.resourceStatusReason)
+      } else {
+        // Display all other messages in verbose mode.
+        reporter.verbose(e.resourceStatusReason)
+      }
+    }
   }
   private[this] def isStackEvent(stackName: String)(e: StackEvent): Boolean =
     e.resourceType == "AWS::CloudFormation::Stack" && e.logicalResourceId == stackName


### PR DESCRIPTION
## What does this change?
When using the [new deployment mechanism](https://docs.google.com/document/d/18M6nW6bknvFYjICMaSmDwkIisAuHsn4y_HSTdKu7Z-o/edit?tab=t.0) (CFN Rolling Update), CloudFormation events for the ASG are very useful.

They include details of percentage completion, success/failure reasons, etc. Surface these by default to improve the DX when using the new deployment mechanism.

## How to test
I've [deployed to CODE](https://riffraff.code.dev-gutools.co.uk/deployment/view/334779e6-c454-4332-b8ea-7a1bf31f8ce9) and deployed [cdk-playground](https://riffraff.code.dev-gutools.co.uk/deployment/view/62a9c346-1812-450b-8729-8c152f712619) (uses the new deployment mechanism) and [Grafana](https://riffraff.code.dev-gutools.co.uk/deployment/view/629718e0-df02-447b-abd5-dcbe0b85be70) (uses the legacy `autoscaling` deployment). There is no significant change to the deployment log for Grafana. For cdk-playground, the CloudFormation event logs show ASG activity by default.

## [Before](https://riffraff.gutools.co.uk/deployment/view/24656298-b40a-4cd2-ac4e-f7785d963856)
<img width="798" alt="image" src="https://github.com/user-attachments/assets/b2236781-ca71-466f-b7a2-c094cf4bdc00" />

## [After](https://riffraff.code.dev-gutools.co.uk/deployment/view/62a9c346-1812-450b-8729-8c152f712619)
<img width="1091" alt="image" src="https://github.com/user-attachments/assets/03745985-8065-4e94-a3a0-cc4df435ae31" />