### PR TITLE
docs: Hint towards using the new deployment mechanism

### DIFF
--- a/riff-raff/public/docs/howto/fix-a-failed-deploy.md
+++ b/riff-raff/public/docs/howto/fix-a-failed-deploy.md
@@ -1,5 +1,9 @@
 # Fixing a failed deploy
 
+> [!NOTE]
+> This guide is only necessary when using the legacy `autoscaling` deployment type.
+> When using the new [RollingUpdate deployment mechanism](https://docs.google.com/document/d/18M6nW6bknvFYjICMaSmDwkIisAuHsn4y_HSTdKu7Z-o/edit?tab=t.0), a failed deployment will automatically roll back.
+
 ## Background
 
 Normally your Auto-Scaling Group will be configured with a maximum capacity that is _twice_ (or sometimes _four times_) the 'desired'

--- a/riff-raff/public/docs/howto/fix-a-failed-deploy.md
+++ b/riff-raff/public/docs/howto/fix-a-failed-deploy.md
@@ -1,7 +1,7 @@
 # Fixing a failed deploy
 
 > [!NOTE]
-> This guide is only necessary when using the legacy `autoscaling` deployment type.
+> This guide is only necessary when using the legacy [`autoscaling` deployment type](https://riffraff.gutools.co.uk/docs/magenta-lib/types#autoscaling).
 > When using the new [RollingUpdate deployment mechanism](https://docs.google.com/document/d/18M6nW6bknvFYjICMaSmDwkIisAuHsn4y_HSTdKu7Z-o/edit?tab=t.0), a failed deployment will automatically roll back.
 
 ## Background


### PR DESCRIPTION
## What does this change?
Update the "fixing a failed deploy" page with a nudge towards the new deployment mechanism.