### PR TITLE
Fix high vulnerability CVE-2025-49146

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -83,7 +83,7 @@ object Dependencies {
       "org.webjars" % "momentjs" % "2.30.1",
       "net.logstash.logback" % "logstash-logback-encoder" % "8.0",
       "org.scalikejdbc" %% "scalikejdbc" % "3.5.0", // scala-steward:off
-      "org.postgresql" % "postgresql" % "42.7.5",
+      "org.postgresql" % "postgresql" % "42.7.7",
       "com.beachape" %% "enumeratum-play" % Versions.enumeratumPlay,
       filters,
       ws,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We've received a security alert for a high severity vulnerability in the postgres library, which can be fixed by a minor version update.