### PR TITLE
Add warning for non-standard PROD deployments

### DIFF
--- a/riff-raff/public/docs/index.md
+++ b/riff-raff/public/docs/index.md
@@ -22,5 +22,6 @@ Using Riff-Raff
  - [Continuous Integration and Deployment](riffraff/hooksAndCD.md) - guide to the Riff-Raff hooks available to make continuous
  deployment easy
  - [External deploy requests](riffraff/externalRequest.md) - how to help a user start a deploy
+ - [Manually deploying feature branches to PROD](riffraff/prod-feature-branches.md) - guidance on which branches should be deployed to `PROD`
  - [Administration](riffraff/administration/) - details on how to configure Riff-Raff
  - [Restrictions](riffraff/restrictions.md) - how to restrict deployments

--- a/riff-raff/public/docs/riffraff/prod-feature-branches.md
+++ b/riff-raff/public/docs/riffraff/prod-feature-branches.md
@@ -1,0 +1,19 @@
+Manually deploying feature branches to PROD
+===========================================
+
+Deploying feature branches (i.e. not `main`) to `PROD` is **strongly** discouraged due to:
+
+1. **Increased risk**: deploying feature branches can bypass peer review and test automation, which significantly 
+  increases risk for users and the organisation.
+2. **Operational complexity**: most projects at The Guardian use continuous deployment (CD) to deploy the HEAD of `main`
+  to `PROD`. Our tooling, processes and colleagues rely on this behaviour. For example, if you deploy a feature branch
+  to `PROD` it might be accidentally overridden when another PR is merged. This creates unnecessary complexity.
+
+In some rare scenarios, we might reasonably choose to deploy a feature branch despite these drawbacks. For example, if a
+high priority application is experiencing a severity 1 incident and two engineers from the team who own the application
+have paired on a fix, we might choose to deploy their branch (once built) rather than waiting for `main` to build after
+merging the PR. This should only be done when the team is in agreement that the benefits outweigh the risks.
+
+In rare scenarios like this we might also need to take additional actions, such as sending comms to other engineers who
+might be working on the service or temporarily pausing CD. We should also aim to restore normal operations as quickly
+as possible (i.e. re-enable CD, merge the change and allow Riff-Raff to deploy `main` to `PROD` as soon as this is safe).


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds a warning when non-standard branches are deployed to `PROD`.

This warning can be seen in the deployment log:

<img width="1920" height="725" alt="image" src="https://github.com/user-attachments/assets/36680d47-9e9c-4ecf-9d30-aab4aadbbcfd" />

And on the history page:

<img width="1140" height="147" alt="image" src="https://github.com/user-attachments/assets/88f37d5a-4b22-4c69-97b5-ff433e1848fd" />

## How to test

I've deployed this to `CODE` and tested various cases[^1]. The warning is only shown in the expected cases.

## How can we measure success?

We will have better visibility of cases where non-standard branches are deployed to `PROD` and a clearer explanation of why this is undesirable.

## Have we considered potential risks?

I don't think there are any particular risks associated with this PR.

[^1]: I had to break the rules to test this change; I promise that [my feature branch was really safe](https://github.com/guardian/amiable/pull/795/files)!