### PR TITLE
Add an expand-all button to the deploy log

### DIFF
--- a/riff-raff/app/views/deploy/logContent.scala.html
+++ b/riff-raff/app/views/deploy/logContent.scala.html
@@ -7,9 +7,24 @@
 @if(!record.isSummarised) {
     @record.report match {
         case report : DeployReportTree => {
-            <ul class="magenta-reporttree">
+            <div class="clearfix">
+                <div class="pull-right">
+                    <button
+                    type="button"
+                    aria-expanded="false"
+                    class="btn btn-default"
+                    data-toggle="collapse"
+                    role="button"
+                    data-target=".collapsing-node.magenta-reporttree:not(.in)"
+                    >
+                        🔽 expand all
+                    </button>
+                </div>
+
+                <ul class="magenta-reporttree">
                 @snippets.reportTree(report, 0)
-            </ul>
+                </ul>
+            </div>
             @logSummary(record)
         }
         case EmptyDeployReport => {


### PR DESCRIPTION

## What does this change?

Adds an expand-all button to Riff Raff's deploy log UI, so that colleagues can then easily scan the logs to visually identify any warnings.

## Background

Please refer to https://github.com/guardian/riff-raff/issues/1459, which provides much more context and detail.

Riff Raff often emits warnings that are very challenging to find in the deploy log. We add an "expand all" button that ensures the UI is showing all log entries, which makes it much easier for a human to quickly scan the output to find warnings (which are highlighted in the UI).

This isn't a perfect solution to the problem, because it depends on someone being able to visually parse the error warning. It's an easy fix though, and very significantly improves these situations.

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

This is a simple markup change, which I have tested by editing the page in PROD. We can confirm this works in-situ after release.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

People will find it much easier to locate deployment warnings.

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

I've already addressed a layout bug where the new button runs over other content.

The approach has two weaknesses:

1. it still depends on the user being able to visually scan the expanded log lines
2. this really is an "expand all" button, it can't also be used to contract elements

The first is ok becavuse it's a big improvement for a simple change. We aren't trying to do something perfect here.

The second point is ok because someone can simply reload the page to restore the contracted view. The issue is that the bootstrap functionality we're using here would **toggle** all sections, which causes very confusing behaviour for the user if some items had been manually contracted / expanded prior to hitting the expand all button. It's much clearer to have a simple "expand all" button.

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<img width="2344" height="658" alt="expand-all" src="https://github.com/user-attachments/assets/8d72f77d-b115-40a0-a446-341e8866a5b4" />
