### PR TITLE
chore(deps): Update dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -74,7 +74,7 @@ object Dependencies {
       "software.amazon.awssdk" % "dynamodb" % Versions.aws,
       "software.amazon.awssdk" % "sns" % Versions.aws,
       "org.quartz-scheduler" % "quartz" % "2.3.2",
-      "com.gu" %% "anghammarad-client" % "5.0.0",
+      "com.gu" %% "anghammarad-client" % "6.0.0",
       "org.webjars" %% "webjars-play" % "3.0.2",
       "org.webjars" % "jquery" % "3.7.1",
       "org.webjars" % "jquery-ui" % "1.14.1",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val aws = "2.31.75"
+    val aws = "2.32.26"
     val jackson = "2.18.2"
     val awsRds = "1.12.788"
     val enumeratumPlay = "1.8.2"


### PR DESCRIPTION
## What does this change?
Updates anghammarad-client to [6.0.0](https://github.com/guardian/anghammarad/releases/tag/v6.0.0) and the AWS SDK to [2.32.26](https://github.com/aws/aws-sdk-java-v2/releases/tag/2.32.26). Included in this version (well [2.32.25](https://github.com/aws/aws-sdk-java-v2/releases/tag/2.32.25)) is an update to netty 4.1.124, which should work towards resolving https://github.com/guardian/riff-raff/security/dependabot/16. We'd also need to update the following once available:
- https://github.com/scanamo/scanamo
- https://github.com/guardian/play-secret-rotation
