### PR TITLE
feat: Set `RiffRaffDeploymentId` CFN template parameter (when available)

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -30,10 +30,11 @@ class CloudFormation(tagger: BuildTags)
   def documentation =
     """Update an AWS CloudFormation template by creating and executing a change set.
       |
-      |This type will populate the following parameters in a cloudformation template:
+      |This type will populate the following parameters if specified in the cloudformation template:
       |  - Stage (e.g. `CODE` or `PROD`)
       |  - Stack (e.g. `deploy` or `frontend`)
       |  - BuildId (i.e. the number of the build such as `543`)
+      |  - RiffRaffDeploymentId (i.e. the unique ID of the deployment)
       |
       |NOTE: It is strongly recommended you do _NOT_ set a desired-capacity on auto-scaling groups, managed
       |with CloudFormation templates deployed in this way, as otherwise any deployment will reset the

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -233,7 +233,8 @@ object CloudFormationParameters {
     val deploymentParameters = Map(
       "Stage" -> cfnParameters.target.parameters.stage.name,
       "Stack" -> cfnParameters.target.stack.name,
-      "BuildId" -> cfnParameters.target.parameters.build.id
+      "BuildId" -> cfnParameters.target.parameters.build.id,
+      "RiffRaffDeploymentId" -> reporter.messageContext.deployId.toString
     )
 
     val combined = combineParameters(


### PR DESCRIPTION
## What does this change?
If a CloudFormation template has a `RiffRaffDeploymentId` parameter, Riff-Raff will set it to the deployment's GUID. If a CloudFormation template does not have a `RiffRaffDeploymentId` parameter, nothing happens. See also https://github.com/guardian/riff-raff/pull/573.

Paired with https://github.com/guardian/cdk/pull/2723, this improves the DX when using the new CFN-based ASG deployment mechanism. Previously a redeployment of the same build was a no-op - no instances were cycled. To force instances to be cycled, a new build was required, which can be slow. With this change[^1], a redeployment of the same build cycles instances (provided the `RiffRaffDeploymentId` parameter is echoed in the user data).

## How to test
There are two tests required.

1. Deploying a CFN template without a `RiffRaffDeploymentId` parameter is a no-op.
   See https://riffraff.code.dev-gutools.co.uk/deployment/view/22884da7-76ad-4c52-87d8-3eb3bcbd5c25.
2. Deploying a CFN template with a `RiffRaffDeploymentId` parameter creates a changeset.
   See https://github.com/guardian/cdk-playground/pull/796.

## How can we measure success?
Improved DX of the new deployment mechanism.

[^1]: If `RiffRaffDeploymentId` is also echoed in the user data

---
Co-authored-by: @jacobwinch.