### PR TITLE
Remove placeholders for unused config

### DIFF
--- a/riff-raff/conf/application.conf
+++ b/riff-raff/conf/application.conf
@@ -26,10 +26,6 @@ logger.application=DEBUG
 auth.openIdUrl="https://www.google.com/accounts/o8/id"
 # comma separated list of e-mail domains allowed to log in
 auth.domains="guardian.co.uk"
-# comma separated list of e-mail addresses allowed to log in
-#auth.allowlist.addresses=
-# whether to use the database backed email address allowlist
-#auth.allowlist.useDatabase=false
 
 # e-mail domain allowed to log in (optional)
 auth.domain="guardian.co.uk"


### PR DESCRIPTION
Small follow-up to https://github.com/guardian/riff-raff/pull/1471. 

We've [stopped using these 2 fields](https://github.com/guardian/riff-raff/pull/1471/files#diff-abbc4453b35099ef0c6e4cf77a76bf9470a2a8af0e64f6a76a52165718a57648L97-L103) and have removed them from the private config in S3, so this PR just removes a couple of old references to them.