### PR TITLE
Remove auth table and service catalogue view of it

### DIFF
--- a/riff-raff/conf/evolutions/default/5.sql
+++ b/riff-raff/conf/evolutions/default/5.sql
@@ -1,0 +1,9 @@
+-- !Ups
+
+DROP TABLE auth;
+DROP VIEW service_catalogue.riffraff_authorized_users;
+
+-- !Downs
+
+CREATE TABLE auth (email VARCHAR(100) PRIMARY KEY, content jsonb NOT NULL);
+CREATE VIEW service_catalogue.riffraff_authorized_users AS SELECT * FROM public.auth;

--- a/riff-raff/conf/evolutions/default/5.sql
+++ b/riff-raff/conf/evolutions/default/5.sql
@@ -1,7 +1,7 @@
 -- !Ups
 
-DROP TABLE auth;
 DROP VIEW service_catalogue.riffraff_authorized_users;
+DROP TABLE auth;
 
 -- !Downs
 


### PR DESCRIPTION
## What does this change?

This PR removes the `auth` table from the database using [Play's evolutions feature](https://www.playframework.com/documentation/3.0.x/Evolutions). This table has been unused since https://github.com/guardian/riff-raff/pull/1471 was merged.

The PR also removes a view that was made available to Service Catalogue (in https://github.com/guardian/riff-raff/pull/1273). For more context on that change, see https://github.com/guardian/service-catalogue/pull/1645.

Note that to get this to work we first need to manually run: `ALTER TABLE auth OWNER TO riffraff_app;` against the DB.

This is because these tables were created by the `riffraff` user, rather than the `riffraff_app` user that we [moved to when we started using IAM auth for RDS](https://github.com/guardian/deploy-tools-platform/pull/166). In Postgres [the user that creates a table is the owner](https://www.postgresql.org/docs/13/ddl-priv.html).

## How to test

I've tested this in `CODE` and confirmed that the `auth` table and view are dropped as expected.

## How can we measure success?

We've finished cleaning up after https://github.com/guardian/riff-raff/pull/1464 and https://github.com/guardian/riff-raff/pull/1471.

## Have we considered potential risks?

The main risk here is the fact that we'll need to connect to / modify the `PROD` DB manually as part of the rollout. We should pair on this to minimise risk.