### PR TITLE
Automatically rollback failed DB evolutions

### DIFF
--- a/riff-raff/bootstrap.sh
+++ b/riff-raff/bootstrap.sh
@@ -74,6 +74,7 @@ CONFIG_DESTINATION=${HOME}/.gu/riff-raff.conf
 aws s3 cp ${CONFIG_ORIGIN} ${CONFIG_DESTINATION} --region ${REGION}
 
 # Install the application that was packaged by the sbt-native-packager
+rm -rf ${HOME}/${APP}
 aws --region ${REGION} s3 cp s3://${APP_BUCKET}/${STACK}/${STAGE}/${APP}/${APP}.tgz /tmp/
 tar -C ${HOME} -xzf /tmp/${APP}.tgz
 

--- a/riff-raff/bootstrap.sh
+++ b/riff-raff/bootstrap.sh
@@ -73,8 +73,12 @@ mkdir -p ${HOME}/.gu
 CONFIG_DESTINATION=${HOME}/.gu/riff-raff.conf
 aws s3 cp ${CONFIG_ORIGIN} ${CONFIG_DESTINATION} --region ${REGION}
 
-# Install the application that was packaged by the sbt-native-packager
+# This script is designed to run multiple times on the same instance, so we need to delete all traces of the previous
+# build artifact before we extract the new one.
+# If we don't do this then config files from the previous build - such as evolutions - can remain on disk despite
+# deploying a new build.
 rm -rf ${HOME}/${APP}
+# Install the application that was packaged by the sbt-native-packager
 aws --region ${REGION} s3 cp s3://${APP_BUCKET}/${STACK}/${STAGE}/${APP}/${APP}.tgz /tmp/
 tar -C ${HOME} -xzf /tmp/${APP}.tgz
 

--- a/riff-raff/conf/application.conf
+++ b/riff-raff/conf/application.conf
@@ -39,6 +39,9 @@ auth.clientSecret="5uLmlI8afy5vufKFWXWS2GPw"
 play.evolutions.enabled=true
 play.evolutions.autoApply=true
 play.evolutions.autoApplyDowns=false
+# Automatically roll back problematic evolutions to prevent the DB from getting into an inconsistent state
+# https://www.playframework.com/documentation/3.0.x/Evolutions#Transactional-DDL
+play.evolutions.autocommit=false
 
 db.default {
   driver=org.postgresql.Driver


### PR DESCRIPTION
## What does this change?

Prior to this change, applying a 'bad' [Play evolution](https://www.playframework.com/documentation/3.0.x/Evolutions) put the DB into an inconsistent state.

When this happens the application won't start and - as Riff-Raff runs as a singleton - we have a complete outage until we:

1. [Manually fix the DB](https://www.playframework.com/documentation/3.0.x/Evolutions#Inconsistent-states)
2. Upload the previous working build (i.e. one without the bad evolution) to S3
3. Launch a new instance to drop the 'bad' evolution

Connecting to the DB is non-trivial and we'd prefer not to do this at all (especially in `PROD`), so this PR [modifies the evolutions config so that 'bad' evolutions are automatically rolled back](https://www.playframework.com/documentation/3.0.x/Evolutions#Transactional-DDL). 

We already take this approach for a couple of other applications at the Guardian (see [`birthdays`](https://github.com/guardian/birthdays/blob/c86edbd5a967ce8b211a17f62cdcab65eef28961/conf/application.conf#L32) & [`facia-tool`](https://github.com/guardian/facia-tool/blob/53f1424edfb86b679947b8cf4b1557f60e2206f3/conf/application.conf#L51)).

Unfortunately in the context of a singleton like Riff-Raff, deploying a bad evolution still leads to an outage, but after this PR the recovery steps are:

1. Upload the previous working build (i.e. one without the bad evolution) to S3
 
Importantly, we no longer need to connect to the DB and run manual fixes. We also no longer need to launch a new instance because the `bootstrap` script has been patched to tidy up the old version of the application (including all evolutions) before the new version is extracted.

## How to test

1. Deployed this branch to `CODE`
2. Deployed [a test branch containing a known bad evolution](https://github.com/guardian/riff-raff/pull/1478)
3. Confirmed that we could recover as expected by re-uploading the build produced by this branch

I've also tested the 'normal' deployment scenario by deploying this branch to `CODE` and then [deploying a test branch which makes a trivial change](https://github.com/guardian/riff-raff/pull/1477) over the top. This also worked as expected.

## How can we measure success?

This PR significantly shortens our recovery time and reduces risk in certain failure scenarios.

## Have we considered potential risks?

I don't think there are any particular risks associated with this PR.