### PR TITLE
Send Anghammarad notifications via Chat, with email fallback

### DIFF
--- a/riff-raff/app/lifecycle/ShutdownWhenInactive.scala
+++ b/riff-raff/app/lifecycle/ShutdownWhenInactive.scala
@@ -94,7 +94,7 @@ class TerminateInstanceWhenInactive(
         sourceSystem = "riff-raff",
         target = List(Stack("deploy"), App("riff-raff"), Stage(config.stage)),
         actions = List.empty,
-        channel = All,
+        channel = Preferred(HangoutsChat),
         topicArn = config.anghammarad.topicArn,
         client = config.anghammarad.snsClient
       )

--- a/riff-raff/app/notification/DeployFailureNotifications.scala
+++ b/riff-raff/app/notification/DeployFailureNotifications.scala
@@ -113,7 +113,7 @@ class DeployFailureNotifications(
         subject = notificationContents.subject,
         message = notificationContents.message,
         sourceSystem = "riff-raff",
-        channel = All,
+        channel = Preferred(HangoutsChat),
         target = targets,
         actions = notificationContents.actions,
         topicArn = config.anghammarad.topicArn,


### PR DESCRIPTION
We currently send deployment failure notifications via email _and_ Chat. This is very noisy and sometimes leads to duplicated effort.

Let's [send via Chat if possible and use email as a fallback](https://github.com/guardian/anghammarad/blob/85fcbcca49317639b3a5c5483626c32280a0a828/anghammarad/src/test/scala/com/gu/anghammarad/common/ContactsTest.scala#L494-L500).

