### PR TITLE
Bump AWS SDK to 2.42.26 to fix Netty CVEs

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val aws = "2.42.10"
+    val aws = "2.42.26"
     val jackson = "2.21.1"
     val enumeratumPlay = "1.9.6"
   }


### PR DESCRIPTION
## What does this change?

Bumps aws sdk to latest version to fix GHSA-pwqr-wmgm-9rr8 and GHSA-w9fj-cfpg-grvv.