### PR TITLE
Add io.nettynetty-codec-http4.2.12.Final as library dependency 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,9 +113,7 @@ lazy val riffraff = project
       ),
       buildInfoOptions += BuildInfoOption.BuildTime,
       buildInfoPackage := "riffraff",
-      libraryDependencies ++= riffRaffDeps ++ Seq(
-        "io.netty" % "netty-codec-http" % "4.2.12.Final"
-      ),
+      libraryDependencies ++= riffRaffDeps,
       Universal / javaOptions ++= Seq(
         s"-Dpidfile.path=/dev/null",
         "-J-XX:MaxRAMFraction=2",

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,9 @@ lazy val lib = project
   .settings(commonSettings)
   .settings(
     Seq(
-      libraryDependencies ++= magentaLibDeps,
+      libraryDependencies ++= magentaLibDeps ++ Seq(
+        "io.netty" % "netty-codec-http" % "4.2.12.Final"
+      ),
       Test / testOptions += Tests.Argument("-oF")
     )
   )
@@ -111,7 +113,9 @@ lazy val riffraff = project
       ),
       buildInfoOptions += BuildInfoOption.BuildTime,
       buildInfoPackage := "riffraff",
-      libraryDependencies ++= riffRaffDeps,
+      libraryDependencies ++= riffRaffDeps ++ Seq(
+        "io.netty" % "netty-codec-http" % "4.2.12.Final"
+      ),
       Universal / javaOptions ++= Seq(
         s"-Dpidfile.path=/dev/null",
         "-J-XX:MaxRAMFraction=2",


### PR DESCRIPTION
## What does this change?

Add io.nettynetty-codec-http4.2.12.Final as library dependency to resolve vulnerability

in order to resolve remaining transitive dependency remaining [from the first PR](https://github.com/guardian/riff-raff/pull/1578)
com.gu:lib_2.13 1.0  ...  io.netty:netty-codec-http 4.2.9.Final

[Not using using dependencyOverrides since it's often harmful & confusing](https://github.com/guardian/maintaining-scala-projects/issues/20)

