### PR TITLE
Update Dependabot schedule interval to quarterly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "quarterly"
     commit-message:
       prefix: "chore(deps): "
     labels:


### PR DESCRIPTION
## What does this change?

Updates the Dependabot schedule interval from the current value to `quarterly`, so dependency update PRs are raised on the first day of each quarter (January, April, July, October).

## How has this change been tested?



## Have we considered potential risks?

