### PR TITLE
Fix flaky tests

### DIFF
--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
@@ -41,6 +41,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
   implicit val stsClient: StsClient = mock[StsClient]
   val region = Region("eu-west-1")
   val deploymentTypes: Seq[Lambda.type] = Seq(Lambda)
+  private def ssmMockClient = mock[SsmClient](RETURNS_DEEP_STUBS)
 
   behavior of "Lambda deployment action uploadLambda"
 
@@ -317,7 +318,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
       deploymentTypes
     )
 
-    val ssmClient = mock[SsmClient](RETURNS_DEEP_STUBS)
+    val ssmClient = ssmMockClient
 
     when(
       ssmClient.getParameter(ArgumentMatchers.any(classOf[GetParameterRequest]))
@@ -367,7 +368,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
       deploymentTypes
     )
 
-    val ssmClient = mock[SsmClient](RETURNS_DEEP_STUBS)
+    val ssmClient = ssmMockClient
 
     when(
       ssmClient.getParameter(ArgumentMatchers.any(classOf[GetParameterRequest]))
@@ -424,7 +425,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
       deploymentTypes
     )
 
-    val ssmClient = mock[SsmClient](RETURNS_DEEP_STUBS)
+    val ssmClient = ssmMockClient
 
     when(
       ssmClient.getParameter(ArgumentMatchers.any(classOf[GetParameterRequest]))

--- a/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/LambdaTest.scala
@@ -16,6 +16,7 @@ import magenta.{
   fixtures
 }
 import org.mockito.{ArgumentMatchers, MockitoSugar}
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.{JsBoolean, JsString, JsValue, Json}
@@ -316,7 +317,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
       deploymentTypes
     )
 
-    val ssmClient = mock[SsmClient]
+    val ssmClient = mock[SsmClient](RETURNS_DEEP_STUBS)
 
     when(
       ssmClient.getParameter(ArgumentMatchers.any(classOf[GetParameterRequest]))
@@ -366,7 +367,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
       deploymentTypes
     )
 
-    val ssmClient = mock[SsmClient]
+    val ssmClient = mock[SsmClient](RETURNS_DEEP_STUBS)
 
     when(
       ssmClient.getParameter(ArgumentMatchers.any(classOf[GetParameterRequest]))
@@ -423,7 +424,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with MockitoSugar {
       deploymentTypes
     )
 
-    val ssmClient = mock[SsmClient]
+    val ssmClient = mock[SsmClient](RETURNS_DEEP_STUBS)
 
     when(
       ssmClient.getParameter(ArgumentMatchers.any(classOf[GetParameterRequest]))

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -34,6 +34,7 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
   implicit val fakeKeyRing: KeyRing = KeyRing()
   val reporter =
     DeployReporter.rootReporterFor(UUID.randomUUID(), fixtures.parameters())
+  private def s3MockClient = mock[S3Client](RETURNS_DEEP_STUBS)
 
   "PutRec" should "create an upload request with correct permissions" in {
     val putRec = PutReq(
@@ -148,7 +149,7 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
   }
 
   "S3Upload" should "upload a single file to S3" in {
-    val artifactClient = mock[S3Client](RETURNS_DEEP_STUBS)
+    val artifactClient = s3MockClient
     val s3Client = mock[S3Client]
 
     val sourceBucket = "artifact-bucket"
@@ -225,7 +226,7 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
   }
 
   it should "upload a directory to S3" in {
-    val artifactClient = mock[S3Client](RETURNS_DEEP_STUBS)
+    val artifactClient = s3MockClient
     val s3Client = mock[S3Client]
 
     val fileOne =
@@ -288,7 +289,7 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
   }
 
   it should "upload a directory to S3 with no prefix" in {
-    val artifactClient = mock[S3Client](RETURNS_DEEP_STUBS)
+    val artifactClient = s3MockClient
     val s3Client = mock[S3Client]
 
     val fileOne =
@@ -346,7 +347,7 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
   }
 
   it should "use different cache control" in {
-    val artifactClient = mock[S3Client](RETURNS_DEEP_STUBS)
+    val artifactClient = s3MockClient
     val fileOne =
       MagentaS3Object("artifact-bucket", "test/123/package/one.txt", 31)
     val fileTwo =
@@ -382,7 +383,7 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
   }
 
   it should "use overridden mime type" in {
-    val artifactClient = mock[S3Client](RETURNS_DEEP_STUBS)
+    val artifactClient = s3MockClient
     val fileOne =
       MagentaS3Object("artifact-bucket", "test/123/package/one.test.txt", 31)
     val fileTwo =

--- a/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
+++ b/magenta-lib/src/test/scala/magenta/tasks/TasksTest.scala
@@ -10,6 +10,7 @@ import magenta.deployment_type.param_reads.PatternValue
 import magenta.input.All
 import org.mockito.{ArgumentCaptor, ArgumentMatchers, MockitoSugar}
 import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.flatspec.AnyFlatSpec
@@ -147,7 +148,7 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
   }
 
   "S3Upload" should "upload a single file to S3" in {
-    val artifactClient = mock[S3Client]
+    val artifactClient = mock[S3Client](RETURNS_DEEP_STUBS)
     val s3Client = mock[S3Client]
 
     val sourceBucket = "artifact-bucket"
@@ -224,7 +225,7 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
   }
 
   it should "upload a directory to S3" in {
-    val artifactClient = mock[S3Client]
+    val artifactClient = mock[S3Client](RETURNS_DEEP_STUBS)
     val s3Client = mock[S3Client]
 
     val fileOne =
@@ -287,7 +288,7 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
   }
 
   it should "upload a directory to S3 with no prefix" in {
-    val artifactClient = mock[S3Client]
+    val artifactClient = mock[S3Client](RETURNS_DEEP_STUBS)
     val s3Client = mock[S3Client]
 
     val fileOne =
@@ -345,7 +346,7 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
   }
 
   it should "use different cache control" in {
-    val artifactClient = mock[S3Client]
+    val artifactClient = mock[S3Client](RETURNS_DEEP_STUBS)
     val fileOne =
       MagentaS3Object("artifact-bucket", "test/123/package/one.txt", 31)
     val fileTwo =
@@ -381,7 +382,7 @@ class TasksTest extends AnyFlatSpec with Matchers with MockitoSugar {
   }
 
   it should "use overridden mime type" in {
-    val artifactClient = mock[S3Client]
+    val artifactClient = mock[S3Client](RETURNS_DEEP_STUBS)
     val fileOne =
       MagentaS3Object("artifact-bucket", "test/123/package/one.test.txt", 31)
     val fileTwo =


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR fixes the flakyness of the tests that consistently causes CI failures, and have been for a very long time now (as noted in [CONTRIBUTING.md](https://github.com/guardian/riff-raff/blob/main/CONTRIBUTING.md?plain=1#L40-L46))

The fix itself is quite simple, but understanding the problem and why this patch is a valid solution is quite involved!

For disclosure, I investigated this issue and developed the patch using Copilot/Opus 4.6.

### The problem

When the tests fail, it's due to a `scala.reflect.internal.Symbols$CyclicReference` error. 

According to my test results
- 47/100 test runs fail with this error cause by `ssm.model.GetParameterResponse` in the `magenta.deployment_type.LambdaTest` package  ([CI example](https://github.com/guardian/riff-raff/actions/runs/24722776852/job/72315685020))
- 2/100 by `s3.model.ListObjectsV2Response` in the `magenta.tasks.TasksTest` package ([CI example](https://github.com/guardian/riff-raff/actions/runs/25166877444)).

The fact that we're using Mockito to mock those methods leads to a stacktrace that is extremely deep and hard to make sense of.

### Proposed solution

Out of the box, when we call a method on an object mocked by mockito that has not been stubbed yet, the object will return null (this is called the [_answer_ of a mock](https://site.mockito.org/javadoc/current/org/mockito/Answers.html#RETURNS_DEFAULTS)).

Consider the following code. Before initialising the stub using `when(...).thenReturn(...)`, calling `artifactClient.listObjectsV2()` returns `null`

```scala
import org.mockito.mock

val artifactClient = mock[S3Client]
val objectResult = mockListObjectsResponse(
       List(MagentaS3Object(sourceBucket, sourceKey, 31))
)
println(artifactClient.listObjectsV2(any[ListObjectsV2Request]))
// $ null

when(artifactClient.listObjectsV2(any[ListObjectsV2Request]))
  .thenReturn(objectResult)

println(artifactClient.listObjectsV2(any[ListObjectsV2Request]))
// $ ListObjectsV2Response(Contents=[S3Object(Key=foo/bar/the-jar.jar, Size=31)])
```

Mockito can be configured to work differently though. Settings the answer to `RETURNS_DEEP_STUBS` returns a mock object of type `ListObjectsV2Response`

```scala
import org.mockito.mock
val artifactClient = mock[S3Client](RETURNS_DEEP_STUBS)
val objectResult = mockListObjectsResponse(
       List(MagentaS3Object(sourceBucket, sourceKey, 31))
)
println(artifactClient.listObjectsV2(any[ListObjectsV2Request]))
// $ Mock for ListObjectsV2Response, hashCode: 185158293

when(artifactClient.listObjectsV2(any[ListObjectsV2Request]))
  .thenReturn(objectResult)

println(artifactClient.listObjectsV2(any[ListObjectsV2Request]))
// $ ListObjectsV2Response(Contents=[S3Object(Key=foo/bar/the-jar.jar, Size=31)])
```

In my tests, switching the answer mode used in the flaky tests to `RETURNS_DEEP_STUBS` makes the test pass 100/100 runs.

### Root cause

The way scala runs code, the following
```scala
when(artifactClient.listObjectsV2(any[ListObjectsV2Request]))
  .thenReturn(objectResult)
```

Will be evaluated to
```scala
when(null)
  .thenReturn(objectResult)
```

To avoid throwing a null-ponter exception, mockito-scala's `when` first handles the input argument using `ScalaNullResultGuardian`, which tries to infer using scala runtime reflection what the type of the method that returned null is, to then replace it with a default. For example, if the method that returned `null` is found to return an `Int`, the `null` will be replaced with `0`.

This scala runtime reflection lookup fails non-deterministically when trying to determine the return type for these aws sdk methods.

This can be seen in the following lines in the exception. `S3Client.listObjectsV2` leads to `ScalaNullResultGuardian `, which calls`org.mockito.ReflectionUtils$.returnsValueClass`, which leads to a failure to determine the symbol, due to a cyclic reference

```java
scala.reflect.internal.Symbols$CyclicReference: illegal cyclic reference involving class ListObjectsV2Response
(...)
java.lang.AssertionError: assertion failed: no symbol could be loaded from interface software.amazon.awssdk.services.s3.model.ListObjectsV2Response$Builder in class ListObjectsV2Response with name Builder and classloader sbt.internal.LayeredClassLoader@189bad74
(...)
at org.mockito.ReflectionUtils$.returnsValueClass(ReflectionUtils.scala:31)
at org.mockito.package$InvocationOnMockOps.returnsValueClass(mockito.scala:35)
at org.mockito.internal.handler.ScalaNullResultGuardian.handle(ScalaNullResultGuardian.scala:16)
at org.mockito.internal.handler.InvocationNotifierHandler.handle(InvocationNotifierHandler.java:34)
at org.mockito.internal.creation.bytebuddy.access.MockMethodInterceptor.doIntercept(MockMethodInterceptor.java:84)
at org.mockito.internal.creation.bytebuddy.MockMethodAdvice.handle(MockMethodAdvice.java:143)
at software.amazon.awssdk.services.s3.S3Client.listObjectsV2(S3Client.java:18081)
```

I'm not 100% sure why is it that this is non-deterministic. My best guess is that this in a bug in the way scala does reflection with classes that use some kind of recursive type definition, which apparently is the way AWS works. This recursiveness may be the cyclical reference that makes it fail.

## How has this change been tested?

By running the tests 100s of times locally! But the ultimate proof is if CI stops failing.

I've also checked if this change in mock initialisation doesn't undermine the test assertions' ability to actually do their job and detect breaking changes in the code. So for example, if this code that finds a bucket

https://github.com/guardian/riff-raff/blob/c7cf57abbdfba2064e59925ff505e9a94f9cb52c/magenta-lib/src/main/scala/magenta/tasks/AWS.scala#L200-L206

Is patched to return not `resolvedBucket` but `resolvedBucket + "-FAILFAST"`, we get the following failure, which says expected bucket `bobbins` but got bucket `bobbins-FAILFAST`
```
[info] - should default to lookup bucket from SSM when bucket name is not provided and bucketSsmLookup is false *** FAILED ***
[info]   List(UpdateS3Lambda(LambdaFunctionName("some-stackMyFunction-PROD"), "bobbins-FAILFAST", "some-stack/PROD/lambda/lambda.zip", Region("eu-west-1"))) was not equal to List(UpdateS3Lambda(LambdaFunctionName("some-stackMyFunction-PROD"), "bobbins", "some-stack/PROD/lambda/lambda.zip", Region("eu-west-1"))) (LambdaTest.scala:402)
````
