### PR TITLE
chore(deps): Update `com.gu.fastly-api-client` from v4.0.1 to v5.0.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,7 +34,7 @@ object Dependencies {
       "software.amazon.awssdk" % "cloudformation" % Versions.aws,
       "software.amazon.awssdk" % "sts" % Versions.aws,
       "software.amazon.awssdk" % "ssm" % Versions.aws,
-      "com.gu" %% "fastly-api-client" % "4.0.1",
+      "com.gu" %% "fastly-api-client" % "5.0.1",
       "joda-time" % "joda-time" % "2.14.2",
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % Versions.jackson,
       "com.beachape" %% "enumeratum-play-json" % Versions.enumeratumPlay,


### PR DESCRIPTION
## What does this change?
Following https://github.com/guardian/fastly-api-client/pull/137 which updated some dependencies, this change should resolve:
- https://github.com/guardian/riff-raff/security/dependabot/40
- https://github.com/guardian/riff-raff/security/dependabot/49