### PR TITLE
Use dynamodb container for local dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,9 @@ services:
   dynamodb-local:
     container_name: riffraff-dynamodb
     image: amazon/dynamodb-local:latest
+    command: "-jar DynamoDBLocal.jar -sharedDb"
     ports:
     - 8000:8000
-    command: ["-jar", "DynamoDBLocal.jar", "-sharedDb", "-inMemory"]
     healthcheck:
       test: ["CMD-SHELL", "curl -s -o /dev/null http://localhost:8000 || exit 1"]
       interval: 10s
@@ -45,28 +45,28 @@ services:
       aws dynamodb create-table $$ENDPOINT --table-name riffraff-target-ids-DEV \
         --attribute-definitions AttributeName=targetKey,AttributeType=S AttributeName=projectName,AttributeType=S \
         --key-schema AttributeName=targetKey,KeyType=HASH AttributeName=projectName,KeyType=RANGE \
-        --billing-mode PAY_PER_REQUEST 2>/dev/null || true
+        --billing-mode PAY_PER_REQUEST
 
       aws dynamodb create-table $$ENDPOINT --table-name riffraff-restriction-config-DEV \
         --attribute-definitions AttributeName=id,AttributeType=S AttributeName=projectName,AttributeType=S \
         --key-schema AttributeName=id,KeyType=HASH \
         --billing-mode PAY_PER_REQUEST \
-        --global-secondary-indexes 'IndexName=restriction-config-projectName,KeySchema=[{AttributeName=projectName,KeyType=HASH},{AttributeName=id,KeyType=RANGE}],Projection={ProjectionType=ALL}' 2>/dev/null || true
+        --global-secondary-indexes 'IndexName=restriction-config-projectName,KeySchema=[{AttributeName=projectName,KeyType=HASH},{AttributeName=id,KeyType=RANGE}],Projection={ProjectionType=ALL}'
 
       aws dynamodb create-table $$ENDPOINT --table-name hook-config-DEV \
         --attribute-definitions AttributeName=id,AttributeType=S AttributeName=projectName,AttributeType=S \
         --key-schema AttributeName=id,KeyType=HASH \
         --billing-mode PAY_PER_REQUEST \
-        --global-secondary-indexes 'IndexName=hook-config-project,KeySchema=[{AttributeName=projectName,KeyType=HASH},{AttributeName=id,KeyType=RANGE}],Projection={ProjectionType=ALL}' 2>/dev/null || true
+        --global-secondary-indexes 'IndexName=hook-config-project,KeySchema=[{AttributeName=projectName,KeyType=HASH},{AttributeName=id,KeyType=RANGE}],Projection={ProjectionType=ALL}'
 
       aws dynamodb create-table $$ENDPOINT --table-name continuous-deployment-config-DEV \
         --attribute-definitions AttributeName=id,AttributeType=S \
         --key-schema AttributeName=id,KeyType=HASH \
-        --billing-mode PAY_PER_REQUEST 2>/dev/null || true
+        --billing-mode PAY_PER_REQUEST
 
       aws dynamodb create-table $$ENDPOINT --table-name schedule-config-DEV \
         --attribute-definitions AttributeName=id,AttributeType=S \
         --key-schema AttributeName=id,KeyType=HASH \
-        --billing-mode PAY_PER_REQUEST 2>/dev/null || true
+        --billing-mode PAY_PER_REQUEST
 
       echo "All DynamoDB tables ready."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,60 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+  dynamodb-local:
+    container_name: riffraff-dynamodb
+    image: amazon/dynamodb-local:latest
+    ports:
+    - 8000:8000
+    command: ["-jar", "DynamoDBLocal.jar", "-sharedDb", "-inMemory"]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -o /dev/null http://localhost:8000 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  dynamodb-init:
+    container_name: riffraff-dynamodb-init
+    image: amazon/aws-cli:latest
+    depends_on:
+      dynamodb-local:
+        condition: service_healthy
+    environment:
+    - AWS_ACCESS_KEY_ID=dummy
+    - AWS_SECRET_ACCESS_KEY=dummy
+    - AWS_DEFAULT_REGION=eu-west-1
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+    - |
+      set -e
+      ENDPOINT="--endpoint-url http://dynamodb-local:8000"
+
+      aws dynamodb create-table $$ENDPOINT --table-name riffraff-target-ids-DEV \
+        --attribute-definitions AttributeName=targetKey,AttributeType=S AttributeName=projectName,AttributeType=S \
+        --key-schema AttributeName=targetKey,KeyType=HASH AttributeName=projectName,KeyType=RANGE \
+        --billing-mode PAY_PER_REQUEST 2>/dev/null || true
+
+      aws dynamodb create-table $$ENDPOINT --table-name riffraff-restriction-config-DEV \
+        --attribute-definitions AttributeName=id,AttributeType=S AttributeName=projectName,AttributeType=S \
+        --key-schema AttributeName=id,KeyType=HASH \
+        --billing-mode PAY_PER_REQUEST \
+        --global-secondary-indexes 'IndexName=restriction-config-projectName,KeySchema=[{AttributeName=projectName,KeyType=HASH},{AttributeName=id,KeyType=RANGE}],Projection={ProjectionType=ALL}' 2>/dev/null || true
+
+      aws dynamodb create-table $$ENDPOINT --table-name hook-config-DEV \
+        --attribute-definitions AttributeName=id,AttributeType=S AttributeName=projectName,AttributeType=S \
+        --key-schema AttributeName=id,KeyType=HASH \
+        --billing-mode PAY_PER_REQUEST \
+        --global-secondary-indexes 'IndexName=hook-config-project,KeySchema=[{AttributeName=projectName,KeyType=HASH},{AttributeName=id,KeyType=RANGE}],Projection={ProjectionType=ALL}' 2>/dev/null || true
+
+      aws dynamodb create-table $$ENDPOINT --table-name continuous-deployment-config-DEV \
+        --attribute-definitions AttributeName=id,AttributeType=S \
+        --key-schema AttributeName=id,KeyType=HASH \
+        --billing-mode PAY_PER_REQUEST 2>/dev/null || true
+
+      aws dynamodb create-table $$ENDPOINT --table-name schedule-config-DEV \
+        --attribute-definitions AttributeName=id,AttributeType=S \
+        --key-schema AttributeName=id,KeyType=HASH \
+        --billing-mode PAY_PER_REQUEST 2>/dev/null || true
+
+      echo "All DynamoDB tables ready."

--- a/riff-raff/app/conf/context.scala
+++ b/riff-raff/app/conf/context.scala
@@ -18,6 +18,8 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.sns.SnsAsyncClient
 import software.amazon.awssdk.services.ssm.SsmClient
 
+import java.net.URI
+
 import scala.jdk.CollectionConverters._
 import scala.util.{Success, Try}
 
@@ -138,12 +140,21 @@ class Config(configuration: TypesafeConfig, startTime: DateTime)
   object dynamoDb {
     lazy val regionName =
       getStringOpt("artifact.aws.region").getOrElse(defaultRegion)
-    // Used by Scanamo which is not on the latest version of AWS SDK
-    val client = DynamoDbClient
-      .builder()
-      .region(AWSRegion.of(regionName))
-      .credentialsProvider(credentialsProviderChain())
-      .build()
+    val client = stage match {
+      case "DEV" =>
+        DynamoDbClient
+          .builder()
+          .region(AWSRegion.of(regionName))
+          .credentialsProvider(credentialsProviderChain())
+          .endpointOverride(URI.create("http://localhost:8000"))
+          .build()
+      case _ =>
+        DynamoDbClient
+          .builder()
+          .region(AWSRegion.of(regionName))
+          .credentialsProvider(credentialsProviderChain())
+          .build()
+    }
   }
 
   object freeze {

--- a/riff-raff/app/persistence/DynamoRepository.scala
+++ b/riff-raff/app/persistence/DynamoRepository.scala
@@ -13,8 +13,7 @@ abstract class DynamoRepository(config: Config) {
   def exec[A](ops: ScanamoOps[A]): A = Scanamo(client).exec(ops)
   def tablePrefix: String
 
-  // TODO set up Dynamo local
-  val stage = if (config.stage == "DEV") "CODE" else config.stage
+  val stage = config.stage
   lazy val tableName = s"$tablePrefix-$stage"
 
   implicit val uuidFormat: DynamoFormat[UUID] =


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Running riff-raff locally has always had this slightly counterintuive set up where it runs against a local postgres server running in a docker container, but connect to a real dynamodb tables from CODE.

This PR adds a local dynamodb service running in a docker container as well, and patches the dynamodb client initialisation code so it connects to `localhost:8000`.

Paired on this with @akash1810 and used Opus 4.6 to make the bulk of the changes.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

Tested locally by adding and removing entries to the dynamodb tables (like schedules). This same testing was done in CODE.
