### PR TITLE
chore: Match local Postgres version to AWS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   riffraff-db:
     container_name: riffraff-db
-    image: postgres:10.6
+    image: postgres:14.4
     ports:
     - 7432:5432
     environment:


### PR DESCRIPTION
## What does this change?
We're [currently running Postgres 14.4 in AWS](https://github.com/guardian/deploy-tools-platform/blob/a0973d849fba0a88b0ea325edfa85cb8e223836b/cloudformation/riffraff/riffraff-postgres-db.yaml#L106). This change aligns the local environment to that.

## How has this change been tested?
In CI, the `docker-composer.yml` file is used to launch Postgres for the unit tests. Therefore, CI passing should suffice.