### PR TITLE
feat: Update local Postgres to v18

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   riffraff-db:
     container_name: riffraff-db
-    image: postgres:14.4
+    image: postgres:18
     ports:
     - 7432:5432
     environment:


### PR DESCRIPTION
## What does this change?
Update the version of Postgres used locally to v18.

## How has this change been tested?
Similar to #1615, CI passing should suffice and will demonstrate compatibility with v18 before upgrading the version in AWS RDS.