### PR TITLE
Try to allow query parameters on deploy page

### DIFF
--- a/riff-raff/app/controllers/DeployController.scala
+++ b/riff-raff/app/controllers/DeployController.scala
@@ -52,10 +52,13 @@ class DeployController(
     with LogAndSquashBehaviour {
 
   def deploy = authAction { implicit request =>
-    val form = DeployParameterForm.form.bindFromRequest()
+    val form = DeployParameterForm.form
     Ok(
       views.html.deploy
-        .form(config, menu)(changeFreeze)(form, prismLookup)
+        .form(config, menu)(changeFreeze)(
+          if (request.queryString.isEmpty) form else form.bindFromRequest(),
+          prismLookup
+        )
     )
   }
 

--- a/riff-raff/app/controllers/DeployController.scala
+++ b/riff-raff/app/controllers/DeployController.scala
@@ -52,9 +52,10 @@ class DeployController(
     with LogAndSquashBehaviour {
 
   def deploy = authAction { implicit request =>
+    val form = DeployParameterForm.form.bindFromRequest()
     Ok(
       views.html.deploy
-        .form(config, menu)(changeFreeze)(DeployParameterForm.form, prismLookup)
+        .form(config, menu)(changeFreeze)(form, prismLookup)
     )
   }
 

--- a/riff-raff/app/views/deploy/deployConfirmation.scala.html
+++ b/riff-raff/app/views/deploy/deployConfirmation.scala.html
@@ -1,7 +1,7 @@
 @import conf.Config
 @(config: Config, menu: Menu)(deployForm: Form[controllers.forms.DeployParameterForm], isExternal: Boolean)(implicit request: Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], messages: Messages)
 @import helper.CSRF
-@main("Deploy confirmation", request) {
+@main("Deploy confirmation", request, List("form-autocomplete")) {
 
     <h2>Deploy confirmation</h2>
 
@@ -42,4 +42,8 @@
     }
     }
 
+    <div class="col-md-6">
+        <div id="deploy-info"></div>
+        <div id="build-info"></div>
+    </div>
 }(config, menu)


### PR DESCRIPTION
## What does this change?

The deployAgain page allows (requires?) specifying form values from query parameters, which I think is why it’s used in actions-riff-raff as the “deploy this to CODE” link in the helpful PR comments that action provides.

However, the lack of history on the deployAgain page means it’s less convenient than that deploy page: frequently I follow that link and think “Am I ok to deploy this? What’s currently on CODE?”, and then go back to the PR comment to follow the other link to find out what’s currently on CODE.

This commit copies the form handling from the deployAgain page into the deploy page, in the hope that this would allow form values to be prefilled from query parameters, thereby enabling actions-riff-raff to switch to the main deploy page and benefit from the deploy history shown on that page.

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
