### PR TITLE
feat: List `AWS::ElasticLoadBalancingV2::TargetGroup` as a stateful resource

### DIFF
--- a/magenta-lib/src/main/scala/magenta/tasks/stackSetPolicy/SetStackPolicyTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/stackSetPolicy/SetStackPolicyTask.scala
@@ -113,6 +113,7 @@ object StackPolicy {
       // loadbalancers
       "AWS::ElasticLoadBalancing::LoadBalancer",
       "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "AWS::ElasticLoadBalancingV2::TargetGroup",
       // cloudfront
       "AWS::CloudFront::Distribution",
       // API gateway


### PR DESCRIPTION
## What does this change?
A target group does not hold state per se, however it does produce metrics which tell a story of how a service is performing. If the target group was to be accidentally recreated, it would be difficult to view historical performance metrics of a service.

See https://github.com/guardian/riff-raff/pull/623 for a background on this feature.