### PR TITLE
Fix: expanded deploy log steps collapse again on every auto-refresh

### DIFF
--- a/riff-raff/app/assets/javascripts/auto-refresh.coffee
+++ b/riff-raff/app/assets/javascripts/auto-refresh.coffee
@@ -1,7 +1,6 @@
 intervalId = null
 
 callbackList = $.Callbacks()
-preRefreshCallbackList = $.Callbacks()
 
 visibleHeight = ->
   window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight
@@ -38,19 +37,16 @@ enableRefresh = (interval=1000) ->
           wrapper = $(this)
           loading = wrapper.find(".loading")
           err = wrapper.find(".error")
-          content = wrapper.find(".content")
 
           loading.show()
 
-          preRefreshCallbackList.fire(content)
-
-          content.load(
+          $(this).find(".content").load(
             $(this).data("ajax-refresh"),
             (response, status) ->
               loading.hide()
               if status == "success"
                 err.hide()
-                callbackList.fire(content)
+                callbackList.fire()
                 if divBottomWasInView && wrapper.data("ajax-autoscroll") == true
                   scrollToBottom(wrapper.get(-1))
               else
@@ -74,15 +70,7 @@ addPostRefreshCallback = (callback) ->
 removePostRefreshCallBack = (callback) ->
   callbackList.remove callback
 
-addPreRefreshCallback = (callback) ->
-  preRefreshCallbackList.add callback
-
-removePreRefreshCallback = (callback) ->
-  preRefreshCallbackList.remove callback
-
 @autoRefresh = {
   postRefresh : addPostRefreshCallback
   remove: removePostRefreshCallBack
-  preRefresh: addPreRefreshCallback
-  removePreRefresh: removePreRefreshCallback
 }

--- a/riff-raff/app/assets/javascripts/auto-refresh.coffee
+++ b/riff-raff/app/assets/javascripts/auto-refresh.coffee
@@ -1,6 +1,7 @@
 intervalId = null
 
 callbackList = $.Callbacks()
+preRefreshCallbackList = $.Callbacks()
 
 visibleHeight = ->
   window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight
@@ -37,16 +38,19 @@ enableRefresh = (interval=1000) ->
           wrapper = $(this)
           loading = wrapper.find(".loading")
           err = wrapper.find(".error")
+          content = wrapper.find(".content")
 
           loading.show()
 
-          $(this).find(".content").load(
+          preRefreshCallbackList.fire(content)
+
+          content.load(
             $(this).data("ajax-refresh"),
             (response, status) ->
               loading.hide()
               if status == "success"
                 err.hide()
-                callbackList.fire()
+                callbackList.fire(content)
                 if divBottomWasInView && wrapper.data("ajax-autoscroll") == true
                   scrollToBottom(wrapper.get(-1))
               else
@@ -70,7 +74,15 @@ addPostRefreshCallback = (callback) ->
 removePostRefreshCallBack = (callback) ->
   callbackList.remove callback
 
+addPreRefreshCallback = (callback) ->
+  preRefreshCallbackList.add callback
+
+removePreRefreshCallback = (callback) ->
+  preRefreshCallbackList.remove callback
+
 @autoRefresh = {
   postRefresh : addPostRefreshCallback
   remove: removePostRefreshCallBack
+  preRefresh: addPreRefreshCallback
+  removePreRefresh: removePreRefreshCallback
 }

--- a/riff-raff/app/assets/javascripts/collapsing.coffee
+++ b/riff-raff/app/assets/javascripts/collapsing.coffee
@@ -1,44 +1,35 @@
+setIcon = (id, expanded) ->
+  icon = $('#'+id+'-icon')
+  if expanded
+    icon.removeClass('glyphicon-chevron-right').addClass('glyphicon-chevron-down')
+  else
+    icon.removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-right')
+
+# Remembers only nodes the user has explicitly expanded/collapsed (via a
+# click, not the tree's default open/closed state), so that choice survives
+# the periodic ajax refresh of the log content, which otherwise re-renders
+# the whole tree - and its default state - from scratch every time.
+userToggledState = {}
+
 setupCallbacks = ->
-  console.log 'setting up'
   $(".collapsing-node").on 'show.bs.collapse', (e) ->
-    iconId = e.target.id+'-icon'
-    element = $('#'+iconId)
-    element.removeClass('glyphicon-chevron-right')
-    element.addClass('glyphicon-chevron-down')
+    userToggledState[e.target.id] = true
+    setIcon(e.target.id, true)
   $(".collapsing-node").on 'hide.bs.collapse', (e) ->
-    iconId = e.target.id+'-icon'
-    element = $('#'+iconId)
-    element.removeClass('glyphicon-chevron-down')
-    element.addClass('glyphicon-chevron-right')
+    userToggledState[e.target.id] = false
+    setIcon(e.target.id, false)
 
-# Remembers which report-tree nodes the user has expanded/collapsed so that
-# state survives the periodic ajax refresh of the log content, which
-# otherwise re-renders the tree from scratch every time.
-collapseState = {}
-
-captureCollapseState = (content) ->
-  content.find(".collapsing-node").each ->
-    collapseState[$(this).attr('id')] = $(this).hasClass('in')
-
-restoreCollapseState = (content) ->
-  content.find(".collapsing-node").each ->
+applyUserToggledState = ->
+  $(".collapsing-node").each ->
     id = $(this).attr('id')
-    expanded = collapseState[id]
+    expanded = userToggledState[id]
     if expanded?
-      node = $(this)
-      icon = $('#'+id+'-icon')
-      if expanded
-        node.addClass('in')
-        icon.removeClass('glyphicon-chevron-right').addClass('glyphicon-chevron-down')
-      else
-        node.removeClass('in')
-        icon.removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-right')
+      if expanded then $(this).addClass('in') else $(this).removeClass('in')
+      setIcon(id, expanded)
 
 $ ->
   setupCallbacks()
   if (window.autoRefresh)
-    window.autoRefresh.preRefresh (content) ->
-      captureCollapseState(content)
-    window.autoRefresh.postRefresh (content) ->
-      restoreCollapseState(content)
+    window.autoRefresh.postRefresh ->
+      applyUserToggledState()
       setupCallbacks()

--- a/riff-raff/app/assets/javascripts/collapsing.coffee
+++ b/riff-raff/app/assets/javascripts/collapsing.coffee
@@ -11,9 +11,34 @@ setupCallbacks = ->
     element.removeClass('glyphicon-chevron-down')
     element.addClass('glyphicon-chevron-right')
 
+# Remembers which report-tree nodes the user has expanded/collapsed so that
+# state survives the periodic ajax refresh of the log content, which
+# otherwise re-renders the tree from scratch every time.
+collapseState = {}
+
+captureCollapseState = (content) ->
+  content.find(".collapsing-node").each ->
+    collapseState[$(this).attr('id')] = $(this).hasClass('in')
+
+restoreCollapseState = (content) ->
+  content.find(".collapsing-node").each ->
+    id = $(this).attr('id')
+    expanded = collapseState[id]
+    if expanded?
+      node = $(this)
+      icon = $('#'+id+'-icon')
+      if expanded
+        node.addClass('in')
+        icon.removeClass('glyphicon-chevron-right').addClass('glyphicon-chevron-down')
+      else
+        node.removeClass('in')
+        icon.removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-right')
 
 $ ->
   setupCallbacks()
   if (window.autoRefresh)
-    window.autoRefresh.postRefresh ->
+    window.autoRefresh.preRefresh (content) ->
+      captureCollapseState(content)
+    window.autoRefresh.postRefresh (content) ->
+      restoreCollapseState(content)
       setupCallbacks()


### PR DESCRIPTION
NB - AI PR, reviewed and tested manually

### Problem
When viewing the progress of a deploy, the log content is replaced every second by an ajax refresh to keep it up to date. Since the report tree HTML is fully re-rendered from the server on each refresh, any step the user had manually expanded via the collapse toggle would revert to its default state (collapsed, unless it's the currently-running step) a second later.

### Fix
collapsing.coffee now remembers a node's expand/collapse state only when the user actually triggers it — via the toggle click or the "expand all" button — by hooking into Bootstrap's `show.bs.collapse`/`hide.bs.collapse` events. After each ajax refresh (using the existing `postRefresh` hook), those recorded overrides are reapplied to the matching nodes (keyed by their stable message id), and the toggle listeners are rebound to the new DOM.

Nodes the user hasn't interacted with are left alone and keep following the server-rendered default (open while running, collapsed once done) — so, e.g., the previously-running step still collapses naturally once the next step starts.

### Testing
- Manually verified: expanding a completed step's detail persists across refresh cycles until the user collapses it again, while untouched steps still collapse automatically once complete. ✅ 